### PR TITLE
[Rgen] Share DataModel between the generator and the transformer.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.Generator.cs
@@ -9,7 +9,7 @@ using Microsoft.Macios.Generator.Availability;
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly partial struct Accessor {
-	
+
 	/// <summary>
 	/// The data of the field attribute used to mark the value as a property binding. 
 	/// </summary>
@@ -17,7 +17,7 @@ readonly partial struct Accessor {
 
 	public bool MarshalNativeExceptions
 		=> ExportPropertyData is not null && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.MarshalNativeExceptions);
-	
+
 	/// <summary>
 	/// Create a new code change in a property accessor.
 	/// </summary>
@@ -71,5 +71,5 @@ readonly partial struct Accessor {
 	/// <returns>True if either the accessor or the property were marked with the MarshalNativeExceptions flag.</returns>
 	public bool ShouldMarshalNativeExceptions (in Property property)
 		=> MarshalNativeExceptions || property.MarshalNativeExceptions;
-	
+
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.Generator.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.Availability;
+
+namespace Microsoft.Macios.Generator.DataModel;
+
+readonly partial struct Accessor {
+	
+	/// <summary>
+	/// The data of the field attribute used to mark the value as a property binding. 
+	/// </summary>
+	public ExportData<ObjCBindings.Property>? ExportPropertyData { get; init; }
+
+	public bool MarshalNativeExceptions
+		=> ExportPropertyData is not null && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.MarshalNativeExceptions);
+	
+	/// <summary>
+	/// Create a new code change in a property accessor.
+	/// </summary>
+	/// <param name="accessorKind">The kind of accessor.</param>
+	/// <param name="symbolAvailability">The os availability of the symbol.</param>
+	/// <param name="exportPropertyData">The data of the export attribute found in the accessor.</param>
+	/// <param name="attributes">The list of attributes attached to the accessor.</param>
+	/// <param name="modifiers">The list of visibility modifiers of the accessor.</param>
+	public Accessor (AccessorKind accessorKind,
+		SymbolAvailability symbolAvailability,
+		ExportData<ObjCBindings.Property>? exportPropertyData,
+		ImmutableArray<AttributeCodeChange> attributes,
+		ImmutableArray<SyntaxToken> modifiers)
+	{
+		Kind = accessorKind;
+		SymbolAvailability = symbolAvailability;
+		ExportPropertyData = exportPropertyData;
+		Attributes = attributes;
+		Modifiers = modifiers;
+	}
+
+	/// <summary>
+	/// Retrieve the selector to be used with the associated property.
+	/// </summary>
+	/// <param name="associatedProperty">The property associated with the accessor.</param>
+	/// <returns>The selector to use for the accessor.</returns>
+	public string? GetSelector (in Property associatedProperty)
+	{
+		// this is not a property but a field, we cannot retrieve a selector.
+		if (!associatedProperty.IsProperty)
+			return null;
+
+		// There are two possible cases, the current accessor has an export attribute, if that
+		// is the case, we will use the selector in that attribute. Otherwise, we have:
+		//
+		// * getter: return the property selector.
+		// * setter: use the registrar code (it has the right logic) to get the setter.
+		if (ExportPropertyData is null) {
+			return Kind == AccessorKind.Getter
+				? associatedProperty.ExportPropertyData.Value.Selector
+				: Registrar.Registrar.CreateSetterSelector (associatedProperty.ExportPropertyData.Value.Selector);
+		}
+
+		return ExportPropertyData.Value.Selector;
+	}
+
+	/// <summary>
+	/// Returns if the accessor should marshal native exceptions with the associated property.
+	/// </summary>
+	/// <param name="property">The property associated with the accessor.</param>
+	/// <returns>True if either the accessor or the property were marked with the MarshalNativeExceptions flag.</returns>
+	public bool ShouldMarshalNativeExceptions (in Property property)
+		=> MarshalNativeExceptions || property.MarshalNativeExceptions;
+	
+}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.cs
@@ -10,7 +10,7 @@ using Microsoft.Macios.Generator.Availability;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
-[StructLayout(LayoutKind.Auto)]
+[StructLayout (LayoutKind.Auto)]
 readonly partial struct Accessor : IEquatable<Accessor> {
 	/// <summary>
 	/// The kind of accessor.
@@ -31,7 +31,7 @@ readonly partial struct Accessor : IEquatable<Accessor> {
 	/// List of modifiers of the accessor.
 	/// </summary>
 	public ImmutableArray<SyntaxToken> Modifiers { get; }
-	
+
 	/// <inheritdoc />
 	public bool Equals (Accessor other)
 	{

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Accessor.cs
@@ -3,14 +3,15 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Availability;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
-readonly struct Accessor : IEquatable<Accessor> {
+[StructLayout(LayoutKind.Auto)]
+readonly partial struct Accessor : IEquatable<Accessor> {
 	/// <summary>
 	/// The kind of accessor.
 	/// </summary>
@@ -22,14 +23,6 @@ readonly struct Accessor : IEquatable<Accessor> {
 	public SymbolAvailability SymbolAvailability { get; }
 
 	/// <summary>
-	/// The data of the field attribute used to mark the value as a property binding. 
-	/// </summary>
-	public ExportData<ObjCBindings.Property>? ExportPropertyData { get; init; }
-
-	public bool MarshalNativeExceptions
-		=> ExportPropertyData is not null && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.MarshalNativeExceptions);
-
-	/// <summary>
 	/// List of attribute code changes of the accessor.
 	/// </summary>
 	public ImmutableArray<AttributeCodeChange> Attributes { get; }
@@ -38,61 +31,7 @@ readonly struct Accessor : IEquatable<Accessor> {
 	/// List of modifiers of the accessor.
 	/// </summary>
 	public ImmutableArray<SyntaxToken> Modifiers { get; }
-
-	/// <summary>
-	/// Create a new code change in a property accessor.
-	/// </summary>
-	/// <param name="accessorKind">The kind of accessor.</param>
-	/// <param name="symbolAvailability">The os availability of the symbol.</param>
-	/// <param name="exportPropertyData">The data of the export attribute found in the accessor.</param>
-	/// <param name="attributes">The list of attributes attached to the accessor.</param>
-	/// <param name="modifiers">The list of visibility modifiers of the accessor.</param>
-	public Accessor (AccessorKind accessorKind,
-		SymbolAvailability symbolAvailability,
-		ExportData<ObjCBindings.Property>? exportPropertyData,
-		ImmutableArray<AttributeCodeChange> attributes,
-		ImmutableArray<SyntaxToken> modifiers)
-	{
-		Kind = accessorKind;
-		SymbolAvailability = symbolAvailability;
-		ExportPropertyData = exportPropertyData;
-		Attributes = attributes;
-		Modifiers = modifiers;
-	}
-
-	/// <summary>
-	/// Retrieve the selector to be used with the associated property.
-	/// </summary>
-	/// <param name="associatedProperty">The property associated with the accessor.</param>
-	/// <returns>The selector to use for the accessor.</returns>
-	public string? GetSelector (in Property associatedProperty)
-	{
-		// this is not a property but a field, we cannot retrieve a selector.
-		if (!associatedProperty.IsProperty)
-			return null;
-
-		// There are two possible cases, the current accessor has an export attribute, if that
-		// is the case, we will use the selector in that attribute. Otherwise, we have:
-		//
-		// * getter: return the property selector.
-		// * setter: use the registrar code (it has the right logic) to get the setter.
-		if (ExportPropertyData is null) {
-			return Kind == AccessorKind.Getter
-				? associatedProperty.ExportPropertyData.Value.Selector
-				: Registrar.Registrar.CreateSetterSelector (associatedProperty.ExportPropertyData.Value.Selector);
-		}
-
-		return ExportPropertyData.Value.Selector;
-	}
-
-	/// <summary>
-	/// Returns if the accessor should marshal native exceptions with the associated property.
-	/// </summary>
-	/// <param name="property">The property associated with the accessor.</param>
-	/// <returns>True if either the accessor or the property were marked with the MarshalNativeExceptions flag.</returns>
-	public bool ShouldMarshalNativeExceptions (in Property property)
-		=> MarshalNativeExceptions || property.MarshalNativeExceptions;
-
+	
 	/// <inheritdoc />
 	public bool Equals (Accessor other)
 	{

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.Generator.cs
@@ -1,0 +1,287 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Availability;
+using Microsoft.Macios.Generator.Context;
+using Microsoft.Macios.Generator.Extensions;
+
+namespace Microsoft.Macios.Generator.DataModel;
+
+readonly partial struct CodeChanges {
+	
+	/// <summary>
+	/// Represents the type of binding that the code changes are for.
+	/// </summary>
+	public BindingType BindingType => BindingInfo.BindingType;
+
+	readonly BindingInfo bindingInfo = default;
+	/// <summary>
+	/// Represents the binding data that will be used to generate the code.
+	/// </summary>
+	public BindingInfo BindingInfo => bindingInfo;
+	
+	/// <summary>
+	/// Returns all the library names and paths that are needed by the native code represented by the code change.
+	/// </summary>
+	public IEnumerable<(string LibraryName, string? LibraryPath)> LibraryPaths {
+		get {
+			// we want to return unique values, A library name should always point to the
+			// same library path (either null or with a value). We keep track of the ones we already
+			// returned in a set and skip if we already returned it.
+			var visited = new HashSet<string> ();
+
+			// return those libs needed by smart enums
+			foreach (var enumMember in EnumMembers) {
+				if (enumMember.FieldInfo is null)
+					continue;
+				var (_, libraryName, libraryPath) = enumMember.FieldInfo.Value;
+				if (visited.Add (libraryName)) // if already visited, we cannot add it
+					yield return (libraryName, libraryPath);
+			}
+
+			// return those libs needed by field properties
+			foreach (var property in Properties) {
+				if (property.ExportFieldData is null)
+					continue;
+				var (_, libraryName, libraryPath) = property.ExportFieldData.Value;
+				if (visited.Add (libraryName)) // if already visited, we cannot add it
+					yield return (libraryName, libraryPath);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Decide if an enum value should be ignored as a change.
+	/// </summary>
+	/// <param name="enumMemberDeclarationSyntax">The enum declaration under test.</param>
+	/// <param name="semanticModel">The semantic model of the compilation.</param>
+	/// <returns>True if the enum value should be ignored. False otherwise.</returns>
+	internal static bool Skip (EnumMemberDeclarationSyntax enumMemberDeclarationSyntax, SemanticModel semanticModel)
+	{
+		// for smart enums, we are only interested in the field that has a Field<EnumValue> attribute
+		return !enumMemberDeclarationSyntax.HasAttribute (semanticModel, AttributesNames.EnumFieldAttribute);
+	}
+
+	/// <summary>
+	/// Decide if a property should be ignored as a change.
+	/// </summary>
+	/// <param name="propertyDeclarationSyntax">The property declaration under test.</param>
+	/// <param name="semanticModel">The semantic model of the compilation.</param>
+	/// <returns>True if the property should be ignored. False otherwise.</returns>
+	internal static bool Skip (PropertyDeclarationSyntax propertyDeclarationSyntax, SemanticModel semanticModel)
+	{
+		// valid properties are: 
+		// 1. Partial
+		// 2. One of the following:
+		//	  1. Field properties
+		//    2. Exported properties
+		if (propertyDeclarationSyntax.Modifiers.Any (SyntaxKind.PartialKeyword)) {
+			return !propertyDeclarationSyntax.HasAtLeastOneAttribute (semanticModel,
+				AttributesNames.FieldPropertyAttribute, AttributesNames.ExportPropertyAttribute);
+		}
+
+		return true;
+	}
+
+	internal static bool Skip (ConstructorDeclarationSyntax constructorDeclarationSyntax, SemanticModel semanticModel)
+	{
+		// TODO: we need to confirm this when we have support from the roslyn team.
+		return false;
+	}
+
+	internal static bool Skip (EventDeclarationSyntax eventDeclarationSyntax, SemanticModel semanticModel)
+	{
+		// TODO: we need to confirm this when we have support from the roslyn team.
+		return false;
+	}
+
+	internal static bool Skip (MethodDeclarationSyntax methodDeclarationSyntax, SemanticModel semanticModel)
+	{
+		// Valid methods are:
+		// 1. Partial
+		// 2. Contain the export attribute
+		if (methodDeclarationSyntax.Modifiers.Any (SyntaxKind.PartialKeyword)) {
+			return !methodDeclarationSyntax.HasAttribute (semanticModel, AttributesNames.ExportMethodAttribute);
+		}
+
+		return true;
+	}
+
+	delegate bool SkipDelegate<in T> (T declarationSyntax, SemanticModel semanticModel);
+
+	delegate bool TryCreateDelegate<in T, TR> (T declaration, RootBindingContext context,
+		[NotNullWhen (true)] out TR? change)
+		where T : MemberDeclarationSyntax
+		where TR : struct;
+
+	static void GetMembers<T, TR> (TypeDeclarationSyntax baseDeclarationSyntax, RootBindingContext context,
+		SkipDelegate<T> skip, TryCreateDelegate<T, TR> tryCreate, out ImmutableArray<TR> members)
+		where T : MemberDeclarationSyntax
+		where TR : struct
+	{
+		var bucket = ImmutableArray.CreateBuilder<TR> ();
+		var declarations = baseDeclarationSyntax.Members.OfType<T> ();
+		foreach (var declaration in declarations) {
+			if (skip (declaration, context.SemanticModel))
+				continue;
+			if (tryCreate (declaration, context, out var change))
+				bucket.Add (change.Value);
+		}
+
+		members = bucket.ToImmutable ();
+	}
+
+	/// <summary>
+	/// Internal constructor added for testing purposes.
+	/// </summary>
+	/// <param name="bindingInfo">The binding data of binding for the given code changes.</param>
+	/// <param name="name">The name of the named type that created the code change.</param>
+	/// <param name="namespace">The namespace that contains the named type.</param>
+	/// <param name="fullyQualifiedSymbol">The fully qualified name of the symbol.</param>
+	/// <param name="symbolAvailability">The platform availability of the named symbol.</param>
+	internal CodeChanges (BindingInfo bindingInfo, string name, ImmutableArray<string> @namespace,
+		string fullyQualifiedSymbol, SymbolAvailability symbolAvailability)
+	{
+		this.bindingInfo = bindingInfo;
+		this.name = name;
+		this.namespaces = @namespace;
+		FullyQualifiedSymbol = fullyQualifiedSymbol;
+		this.availability = symbolAvailability;
+	}
+
+	/// <summary>
+	/// Creates a new instance of the <see cref="CodeChanges"/> struct for a given enum declaration.
+	/// </summary>
+	/// <param name="enumDeclaration">The enum declaration that triggered the change.</param>
+	/// <param name="context">The root binding context of the current compilation.</param>
+	CodeChanges (EnumDeclarationSyntax enumDeclaration, RootBindingContext context)
+	{
+		context.SemanticModel.GetSymbolData (
+			declaration: enumDeclaration,
+			bindingType: BindingType.SmartEnum,
+			name: out name,
+			baseClass: out baseClass,
+			interfaces: out interfaces,
+			namespaces: out namespaces,
+			symbolAvailability: out availability,
+			bindingInfo: out bindingInfo);
+		FullyQualifiedSymbol = enumDeclaration.GetFullyQualifiedIdentifier ();
+		Attributes = enumDeclaration.GetAttributeCodeChanges (context.SemanticModel);
+		UsingDirectives = enumDeclaration.SyntaxTree.CollectUsingStatements ();
+		Modifiers = [.. enumDeclaration.Modifiers];
+		var bucket = ImmutableArray.CreateBuilder<EnumMember> ();
+		// loop over the fields and add those that contain a FieldAttribute
+		var enumValueDeclarations = enumDeclaration.Members.OfType<EnumMemberDeclarationSyntax> ();
+		foreach (var enumValueDeclaration in enumValueDeclarations) {
+			if (Skip (enumValueDeclaration, context.SemanticModel))
+				continue;
+			if (context.SemanticModel.GetDeclaredSymbol (enumValueDeclaration) is not IFieldSymbol enumValueSymbol) {
+				continue;
+			}
+
+			var fieldData = enumValueSymbol.GetFieldData ();
+			// try and compute the library for this enum member
+			if (fieldData is null || !context.TryComputeLibraryName (fieldData.Value.LibraryName, Namespace [^1],
+					out string? libraryName, out string? libraryPath))
+				// could not calculate the library for the enum, do not add it
+				continue;
+			var enumMember = new EnumMember (
+				name: enumValueDeclaration.Identifier.ToFullString ().Trim (),
+				libraryName: libraryName,
+				libraryPath: libraryPath,
+				fieldData: enumValueSymbol.GetFieldData (),
+				symbolAvailability: enumValueSymbol.GetSupportedPlatforms (),
+				attributes: enumValueDeclaration.GetAttributeCodeChanges (context.SemanticModel)
+			);
+			bucket.Add (enumMember);
+		}
+
+		EnumMembers = bucket.ToImmutable ();
+	}
+
+	/// <summary>
+	/// Creates a new instance of the <see cref="CodeChanges"/> struct for a given class declaration.
+	/// </summary>
+	/// <param name="classDeclaration">The class declaration that triggered the change.</param>
+	/// <param name="context">The root binding context of the current compilation.</param>
+	CodeChanges (ClassDeclarationSyntax classDeclaration, RootBindingContext context)
+	{
+		context.SemanticModel.GetSymbolData (
+			declaration: classDeclaration,
+			bindingType: BindingType.Class,
+			name: out name,
+			baseClass: out baseClass,
+			interfaces: out interfaces,
+			namespaces: out namespaces,
+			symbolAvailability: out availability,
+			bindingInfo: out bindingInfo);
+		FullyQualifiedSymbol = classDeclaration.GetFullyQualifiedIdentifier ();
+		Attributes = classDeclaration.GetAttributeCodeChanges (context.SemanticModel);
+		UsingDirectives = classDeclaration.SyntaxTree.CollectUsingStatements ();
+		Modifiers = [.. classDeclaration.Modifiers];
+
+		// use the generic method to get the members, we are using an out param to try an minimize the number of times
+		// the value types are copied
+		GetMembers<ConstructorDeclarationSyntax, Constructor> (classDeclaration, context, Skip,
+			Constructor.TryCreate, out constructors);
+		GetMembers<PropertyDeclarationSyntax, Property> (classDeclaration, context, Skip, Property.TryCreate,
+			out properties);
+		GetMembers<EventDeclarationSyntax, Event> (classDeclaration, context, Skip, Event.TryCreate, out events);
+		GetMembers<MethodDeclarationSyntax, Method> (classDeclaration, context, Skip, Method.TryCreate,
+			out methods);
+	}
+
+	/// <summary>
+	/// Creates a new instance of the <see cref="CodeChanges"/> struct for a given interface declaration.
+	/// </summary>
+	/// <param name="interfaceDeclaration">The interface declaration that triggered the change.</param>
+	/// <param name="context">The root binding context of the current compilation.</param>
+	CodeChanges (InterfaceDeclarationSyntax interfaceDeclaration, RootBindingContext context)
+	{
+		context.SemanticModel.GetSymbolData (
+			declaration: interfaceDeclaration,
+			bindingType: BindingType.Protocol,
+			name: out name,
+			baseClass: out baseClass,
+			interfaces: out interfaces,
+			namespaces: out namespaces,
+			symbolAvailability: out availability,
+			bindingInfo: out bindingInfo);
+		FullyQualifiedSymbol = interfaceDeclaration.GetFullyQualifiedIdentifier ();
+		Attributes = interfaceDeclaration.GetAttributeCodeChanges (context.SemanticModel);
+		UsingDirectives = interfaceDeclaration.SyntaxTree.CollectUsingStatements ();
+		Modifiers = [.. interfaceDeclaration.Modifiers];
+		// we do not init the constructors, we use the default empty array
+
+		GetMembers<PropertyDeclarationSyntax, Property> (interfaceDeclaration, context.SemanticModel, Skip, Property.TryCreate,
+			out properties);
+		GetMembers<EventDeclarationSyntax, Event> (interfaceDeclaration, context.SemanticModel, Skip, Event.TryCreate,
+			out events);
+		GetMembers<MethodDeclarationSyntax, Method> (interfaceDeclaration, context.SemanticModel, Skip, Method.TryCreate,
+			out methods);
+	}
+
+	/// <summary>
+	/// Create a CodeChange from the provide base type declaration syntax. If the syntax is not supported,
+	/// it will return null.
+	/// </summary>
+	/// <param name="baseTypeDeclarationSyntax">The declaration syntax whose change we want to calculate.</param>
+	/// <param name="context">The root binding context of the current compilation.</param>
+	/// <returns>A code change or null if it could not be calculated.</returns>
+	public static CodeChanges? FromDeclaration (BaseTypeDeclarationSyntax baseTypeDeclarationSyntax,
+		RootBindingContext context)
+		=> baseTypeDeclarationSyntax switch {
+			EnumDeclarationSyntax enumDeclarationSyntax => new CodeChanges (enumDeclarationSyntax, context),
+			InterfaceDeclarationSyntax interfaceDeclarationSyntax => new CodeChanges (interfaceDeclarationSyntax,
+				context),
+			ClassDeclarationSyntax classDeclarationSyntax => new CodeChanges (classDeclarationSyntax, context),
+			_ => null
+		};
+}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.Generator.cs
@@ -15,7 +15,7 @@ using Microsoft.Macios.Generator.Extensions;
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly partial struct CodeChanges {
-	
+
 	/// <summary>
 	/// Represents the type of binding that the code changes are for.
 	/// </summary>
@@ -26,7 +26,7 @@ readonly partial struct CodeChanges {
 	/// Represents the binding data that will be used to generate the code.
 	/// </summary>
 	public BindingInfo BindingInfo => bindingInfo;
-	
+
 	/// <summary>
 	/// Returns all the library names and paths that are needed by the native code represented by the code change.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
@@ -2,15 +2,12 @@
 // Licensed under the MIT License.
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.Availability;
-using Microsoft.Macios.Generator.Context;
-using Microsoft.Macios.Generator.Extensions;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
@@ -18,17 +15,8 @@ namespace Microsoft.Macios.Generator.DataModel;
 /// Structure that represents a set of changes that were made by the user that need to be applied to the
 /// generated code.
 /// </summary>
-readonly struct CodeChanges {
-	/// <summary>
-	/// Represents the type of binding that the code changes are for.
-	/// </summary>
-	public BindingType BindingType => BindingInfo.BindingType;
-
-	readonly BindingInfo bindingInfo = default;
-	/// <summary>
-	/// Represents the binding data that will be used to generate the code.
-	/// </summary>
-	public BindingInfo BindingInfo => bindingInfo;
+[StructLayout(LayoutKind.Auto)]
+readonly partial struct CodeChanges {
 
 	readonly string name = string.Empty;
 	/// <summary>
@@ -166,265 +154,7 @@ readonly struct CodeChanges {
 		get => methods;
 		init => methods = value;
 	}
-
-	/// <summary>
-	/// Returns all the library names and paths that are needed by the native code represented by the code change.
-	/// </summary>
-	public IEnumerable<(string LibraryName, string? LibraryPath)> LibraryPaths {
-		get {
-			// we want to return unique values, A library name should always point to the
-			// same library path (either null or with a value). We keep track of the ones we already
-			// returned in a set and skip if we already returned it.
-			var visited = new HashSet<string> ();
-
-			// return those libs needed by smart enums
-			foreach (var enumMember in EnumMembers) {
-				if (enumMember.FieldInfo is null)
-					continue;
-				var (_, libraryName, libraryPath) = enumMember.FieldInfo.Value;
-				if (visited.Add (libraryName)) // if already visited, we cannot add it
-					yield return (libraryName, libraryPath);
-			}
-
-			// return those libs needed by field properties
-			foreach (var property in Properties) {
-				if (property.ExportFieldData is null)
-					continue;
-				var (_, libraryName, libraryPath) = property.ExportFieldData.Value;
-				if (visited.Add (libraryName)) // if already visited, we cannot add it
-					yield return (libraryName, libraryPath);
-			}
-		}
-	}
-
-	/// <summary>
-	/// Decide if an enum value should be ignored as a change.
-	/// </summary>
-	/// <param name="enumMemberDeclarationSyntax">The enum declaration under test.</param>
-	/// <param name="semanticModel">The semantic model of the compilation.</param>
-	/// <returns>True if the enum value should be ignored. False otherwise.</returns>
-	internal static bool Skip (EnumMemberDeclarationSyntax enumMemberDeclarationSyntax, SemanticModel semanticModel)
-	{
-		// for smart enums, we are only interested in the field that has a Field<EnumValue> attribute
-		return !enumMemberDeclarationSyntax.HasAttribute (semanticModel, AttributesNames.EnumFieldAttribute);
-	}
-
-	/// <summary>
-	/// Decide if a property should be ignored as a change.
-	/// </summary>
-	/// <param name="propertyDeclarationSyntax">The property declaration under test.</param>
-	/// <param name="semanticModel">The semantic model of the compilation.</param>
-	/// <returns>True if the property should be ignored. False otherwise.</returns>
-	internal static bool Skip (PropertyDeclarationSyntax propertyDeclarationSyntax, SemanticModel semanticModel)
-	{
-		// valid properties are: 
-		// 1. Partial
-		// 2. One of the following:
-		//	  1. Field properties
-		//    2. Exported properties
-		if (propertyDeclarationSyntax.Modifiers.Any (SyntaxKind.PartialKeyword)) {
-			return !propertyDeclarationSyntax.HasAtLeastOneAttribute (semanticModel,
-				AttributesNames.FieldPropertyAttribute, AttributesNames.ExportPropertyAttribute);
-		}
-
-		return true;
-	}
-
-	internal static bool Skip (ConstructorDeclarationSyntax constructorDeclarationSyntax, SemanticModel semanticModel)
-	{
-		// TODO: we need to confirm this when we have support from the roslyn team.
-		return false;
-	}
-
-	internal static bool Skip (EventDeclarationSyntax eventDeclarationSyntax, SemanticModel semanticModel)
-	{
-		// TODO: we need to confirm this when we have support from the roslyn team.
-		return false;
-	}
-
-	internal static bool Skip (MethodDeclarationSyntax methodDeclarationSyntax, SemanticModel semanticModel)
-	{
-		// Valid methods are:
-		// 1. Partial
-		// 2. Contain the export attribute
-		if (methodDeclarationSyntax.Modifiers.Any (SyntaxKind.PartialKeyword)) {
-			return !methodDeclarationSyntax.HasAttribute (semanticModel, AttributesNames.ExportMethodAttribute);
-		}
-
-		return true;
-	}
-
-	delegate bool SkipDelegate<in T> (T declarationSyntax, SemanticModel semanticModel);
-
-	delegate bool TryCreateDelegate<in T, TR> (T declaration, RootBindingContext context,
-		[NotNullWhen (true)] out TR? change)
-		where T : MemberDeclarationSyntax
-		where TR : struct;
-
-	static void GetMembers<T, TR> (TypeDeclarationSyntax baseDeclarationSyntax, RootBindingContext context,
-		SkipDelegate<T> skip, TryCreateDelegate<T, TR> tryCreate, out ImmutableArray<TR> members)
-		where T : MemberDeclarationSyntax
-		where TR : struct
-	{
-		var bucket = ImmutableArray.CreateBuilder<TR> ();
-		var declarations = baseDeclarationSyntax.Members.OfType<T> ();
-		foreach (var declaration in declarations) {
-			if (skip (declaration, context.SemanticModel))
-				continue;
-			if (tryCreate (declaration, context, out var change))
-				bucket.Add (change.Value);
-		}
-
-		members = bucket.ToImmutable ();
-	}
-
-	/// <summary>
-	/// Internal constructor added for testing purposes.
-	/// </summary>
-	/// <param name="bindingInfo">The binding data of binding for the given code changes.</param>
-	/// <param name="name">The name of the named type that created the code change.</param>
-	/// <param name="namespace">The namespace that contains the named type.</param>
-	/// <param name="fullyQualifiedSymbol">The fully qualified name of the symbol.</param>
-	/// <param name="symbolAvailability">The platform availability of the named symbol.</param>
-	internal CodeChanges (BindingInfo bindingInfo, string name, ImmutableArray<string> @namespace,
-		string fullyQualifiedSymbol, SymbolAvailability symbolAvailability)
-	{
-		this.bindingInfo = bindingInfo;
-		this.name = name;
-		this.namespaces = @namespace;
-		FullyQualifiedSymbol = fullyQualifiedSymbol;
-		this.availability = symbolAvailability;
-	}
-
-	/// <summary>
-	/// Creates a new instance of the <see cref="CodeChanges"/> struct for a given enum declaration.
-	/// </summary>
-	/// <param name="enumDeclaration">The enum declaration that triggered the change.</param>
-	/// <param name="context">The root binding context of the current compilation.</param>
-	CodeChanges (EnumDeclarationSyntax enumDeclaration, RootBindingContext context)
-	{
-		context.SemanticModel.GetSymbolData (
-			declaration: enumDeclaration,
-			bindingType: BindingType.SmartEnum,
-			name: out name,
-			baseClass: out baseClass,
-			interfaces: out interfaces,
-			namespaces: out namespaces,
-			symbolAvailability: out availability,
-			bindingInfo: out bindingInfo);
-		FullyQualifiedSymbol = enumDeclaration.GetFullyQualifiedIdentifier ();
-		Attributes = enumDeclaration.GetAttributeCodeChanges (context.SemanticModel);
-		UsingDirectives = enumDeclaration.SyntaxTree.CollectUsingStatements ();
-		Modifiers = [.. enumDeclaration.Modifiers];
-		var bucket = ImmutableArray.CreateBuilder<EnumMember> ();
-		// loop over the fields and add those that contain a FieldAttribute
-		var enumValueDeclarations = enumDeclaration.Members.OfType<EnumMemberDeclarationSyntax> ();
-		foreach (var enumValueDeclaration in enumValueDeclarations) {
-			if (Skip (enumValueDeclaration, context.SemanticModel))
-				continue;
-			if (context.SemanticModel.GetDeclaredSymbol (enumValueDeclaration) is not IFieldSymbol enumValueSymbol) {
-				continue;
-			}
-
-			var fieldData = enumValueSymbol.GetFieldData ();
-			// try and compute the library for this enum member
-			if (fieldData is null || !context.TryComputeLibraryName (fieldData.Value.LibraryName, Namespace [^1],
-					out string? libraryName, out string? libraryPath))
-				// could not calculate the library for the enum, do not add it
-				continue;
-			var enumMember = new EnumMember (
-				name: enumValueDeclaration.Identifier.ToFullString ().Trim (),
-				libraryName: libraryName,
-				libraryPath: libraryPath,
-				fieldData: enumValueSymbol.GetFieldData (),
-				symbolAvailability: enumValueSymbol.GetSupportedPlatforms (),
-				attributes: enumValueDeclaration.GetAttributeCodeChanges (context.SemanticModel)
-			);
-			bucket.Add (enumMember);
-		}
-
-		EnumMembers = bucket.ToImmutable ();
-	}
-
-	/// <summary>
-	/// Creates a new instance of the <see cref="CodeChanges"/> struct for a given class declaration.
-	/// </summary>
-	/// <param name="classDeclaration">The class declaration that triggered the change.</param>
-	/// <param name="context">The root binding context of the current compilation.</param>
-	CodeChanges (ClassDeclarationSyntax classDeclaration, RootBindingContext context)
-	{
-		context.SemanticModel.GetSymbolData (
-			declaration: classDeclaration,
-			bindingType: BindingType.Class,
-			name: out name,
-			baseClass: out baseClass,
-			interfaces: out interfaces,
-			namespaces: out namespaces,
-			symbolAvailability: out availability,
-			bindingInfo: out bindingInfo);
-		FullyQualifiedSymbol = classDeclaration.GetFullyQualifiedIdentifier ();
-		Attributes = classDeclaration.GetAttributeCodeChanges (context.SemanticModel);
-		UsingDirectives = classDeclaration.SyntaxTree.CollectUsingStatements ();
-		Modifiers = [.. classDeclaration.Modifiers];
-
-		// use the generic method to get the members, we are using an out param to try an minimize the number of times
-		// the value types are copied
-		GetMembers<ConstructorDeclarationSyntax, Constructor> (classDeclaration, context, Skip,
-			Constructor.TryCreate, out constructors);
-		GetMembers<PropertyDeclarationSyntax, Property> (classDeclaration, context, Skip, Property.TryCreate,
-			out properties);
-		GetMembers<EventDeclarationSyntax, Event> (classDeclaration, context, Skip, Event.TryCreate, out events);
-		GetMembers<MethodDeclarationSyntax, Method> (classDeclaration, context, Skip, Method.TryCreate,
-			out methods);
-	}
-
-	/// <summary>
-	/// Creates a new instance of the <see cref="CodeChanges"/> struct for a given interface declaration.
-	/// </summary>
-	/// <param name="interfaceDeclaration">The interface declaration that triggered the change.</param>
-	/// <param name="context">The root binding context of the current compilation.</param>
-	CodeChanges (InterfaceDeclarationSyntax interfaceDeclaration, RootBindingContext context)
-	{
-		context.SemanticModel.GetSymbolData (
-			declaration: interfaceDeclaration,
-			bindingType: BindingType.Protocol,
-			name: out name,
-			baseClass: out baseClass,
-			interfaces: out interfaces,
-			namespaces: out namespaces,
-			symbolAvailability: out availability,
-			bindingInfo: out bindingInfo);
-		FullyQualifiedSymbol = interfaceDeclaration.GetFullyQualifiedIdentifier ();
-		Attributes = interfaceDeclaration.GetAttributeCodeChanges (context.SemanticModel);
-		UsingDirectives = interfaceDeclaration.SyntaxTree.CollectUsingStatements ();
-		Modifiers = [.. interfaceDeclaration.Modifiers];
-		// we do not init the constructors, we use the default empty array
-
-		GetMembers<PropertyDeclarationSyntax, Property> (interfaceDeclaration, context.SemanticModel, Skip, Property.TryCreate,
-			out properties);
-		GetMembers<EventDeclarationSyntax, Event> (interfaceDeclaration, context.SemanticModel, Skip, Event.TryCreate,
-			out events);
-		GetMembers<MethodDeclarationSyntax, Method> (interfaceDeclaration, context.SemanticModel, Skip, Method.TryCreate,
-			out methods);
-	}
-
-	/// <summary>
-	/// Create a CodeChange from the provide base type declaration syntax. If the syntax is not supported,
-	/// it will return null.
-	/// </summary>
-	/// <param name="baseTypeDeclarationSyntax">The declaration syntax whose change we want to calculate.</param>
-	/// <param name="context">The root binding context of the current compilation.</param>
-	/// <returns>A code change or null if it could not be calculated.</returns>
-	public static CodeChanges? FromDeclaration (BaseTypeDeclarationSyntax baseTypeDeclarationSyntax,
-		RootBindingContext context)
-		=> baseTypeDeclarationSyntax switch {
-			EnumDeclarationSyntax enumDeclarationSyntax => new CodeChanges (enumDeclarationSyntax, context),
-			InterfaceDeclarationSyntax interfaceDeclarationSyntax => new CodeChanges (interfaceDeclarationSyntax,
-				context),
-			ClassDeclarationSyntax classDeclarationSyntax => new CodeChanges (classDeclarationSyntax, context),
-			_ => null
-		};
-
+	
 	/// <inheritdoc/>
 	public override string ToString ()
 	{
@@ -453,4 +183,5 @@ readonly struct CodeChanges {
 		sb.Append ("] }");
 		return sb.ToString ();
 	}
+
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/CodeChanges.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Macios.Generator.DataModel;
 /// Structure that represents a set of changes that were made by the user that need to be applied to the
 /// generated code.
 /// </summary>
-[StructLayout(LayoutKind.Auto)]
+[StructLayout (LayoutKind.Auto)]
 readonly partial struct CodeChanges {
 
 	readonly string name = string.Empty;
@@ -154,7 +154,7 @@ readonly partial struct CodeChanges {
 		get => methods;
 		init => methods = value;
 	}
-	
+
 	/// <inheritdoc/>
 	public override string ToString ()
 	{

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.Generator.cs
@@ -11,7 +11,7 @@ using Microsoft.Macios.Generator.Extensions;
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly partial struct Constructor {
-	
+
 	public static bool TryCreate (ConstructorDeclarationSyntax declaration, RootBindingContext context,
 		[NotNullWhen (true)] out Constructor? change)
 	{

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.Generator.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Context;
+using Microsoft.Macios.Generator.Extensions;
+
+namespace Microsoft.Macios.Generator.DataModel;
+
+readonly partial struct Constructor {
+	
+	public static bool TryCreate (ConstructorDeclarationSyntax declaration, RootBindingContext context,
+		[NotNullWhen (true)] out Constructor? change)
+	{
+		if (context.SemanticModel.GetDeclaredSymbol (declaration) is not IMethodSymbol constructor) {
+			change = null;
+			return false;
+		}
+
+		var attributes = declaration.GetAttributeCodeChanges (context.SemanticModel);
+		var parametersBucket = ImmutableArray.CreateBuilder<Parameter> ();
+		// loop over the parameters of the construct since changes on those implies a change in the generated code
+		foreach (var parameter in constructor.Parameters) {
+			var parameterDeclaration = declaration.ParameterList.Parameters [parameter.Ordinal];
+			if (!Parameter.TryCreate (parameter, parameterDeclaration, context.SemanticModel, out var parameterChange))
+				continue;
+			parametersBucket.Add (parameterChange.Value);
+		}
+
+		change = new (
+			type: constructor.ContainingSymbol.Name, // we DO NOT want the full name
+			symbolAvailability: constructor.GetSupportedPlatforms (),
+			attributes: attributes,
+			modifiers: [.. declaration.Modifiers],
+			parameters: parametersBucket.ToImmutable ());
+		return true;
+	}
+}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.cs
@@ -2,18 +2,14 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.Availability;
-using Microsoft.Macios.Generator.Context;
-using Microsoft.Macios.Generator.Extensions;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
-readonly struct Constructor : IEquatable<Constructor> {
+readonly partial struct Constructor : IEquatable<Constructor> {
 	/// <summary>
 	/// Type name that owns the constructor.
 	/// </summary>
@@ -50,33 +46,6 @@ readonly struct Constructor : IEquatable<Constructor> {
 		Attributes = attributes;
 		Modifiers = modifiers;
 		Parameters = parameters;
-	}
-
-	public static bool TryCreate (ConstructorDeclarationSyntax declaration, RootBindingContext context,
-		[NotNullWhen (true)] out Constructor? change)
-	{
-		if (context.SemanticModel.GetDeclaredSymbol (declaration) is not IMethodSymbol constructor) {
-			change = null;
-			return false;
-		}
-
-		var attributes = declaration.GetAttributeCodeChanges (context.SemanticModel);
-		var parametersBucket = ImmutableArray.CreateBuilder<Parameter> ();
-		// loop over the parameters of the construct since changes on those implies a change in the generated code
-		foreach (var parameter in constructor.Parameters) {
-			var parameterDeclaration = declaration.ParameterList.Parameters [parameter.Ordinal];
-			if (!Parameter.TryCreate (parameter, parameterDeclaration, context.SemanticModel, out var parameterChange))
-				continue;
-			parametersBucket.Add (parameterChange.Value);
-		}
-
-		change = new (
-			type: constructor.ContainingSymbol.Name, // we DO NOT want the full name
-			symbolAvailability: constructor.GetSupportedPlatforms (),
-			attributes: attributes,
-			modifiers: [.. declaration.Modifiers],
-			parameters: parametersBucket.ToImmutable ());
-		return true;
 	}
 
 	/// <inheritdoc/>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.Generator.cs
@@ -9,12 +9,12 @@ using ObjCBindings;
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly partial struct EnumMember {
-	
+
 	/// <summary>
 	/// The data of the field attribute used to mark the value as a binding.
 	/// </summary>
 	public FieldInfo<EnumValue>? FieldInfo { get; }
-	
+
 	/// <summary>
 	/// Create a new change that happened on a member.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.Generator.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.Availability;
+using ObjCBindings;
+
+namespace Microsoft.Macios.Generator.DataModel;
+
+readonly partial struct EnumMember {
+	
+	/// <summary>
+	/// The data of the field attribute used to mark the value as a binding.
+	/// </summary>
+	public FieldInfo<EnumValue>? FieldInfo { get; }
+	
+	/// <summary>
+	/// Create a new change that happened on a member.
+	/// </summary>
+	/// <param name="name">The name of the changed member.</param>
+	/// <param name="libraryName">The library name of the smart enum.</param>
+	/// <param name="libraryPath">The library path to the library, null if it is a known frameworl.</param>
+	/// <param name="fieldData">The binding data attached to this enum value.</param>
+	/// <param name="symbolAvailability">The symbol availability of the member.</param>
+	/// <param name="attributes">The list of attribute changes in the member.</param>
+	public EnumMember (string name,
+		string libraryName,
+		string? libraryPath,
+		FieldData<EnumValue>? fieldData,
+		SymbolAvailability symbolAvailability,
+		ImmutableArray<AttributeCodeChange> attributes)
+	{
+		Name = name;
+		FieldInfo = fieldData is null ? null : new (fieldData.Value, libraryName, libraryPath);
+		SymbolAvailability = symbolAvailability;
+		Attributes = attributes;
+	}
+
+}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Immutable;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Availability;
@@ -13,7 +15,8 @@ namespace Microsoft.Macios.Generator.DataModel;
 /// Structure that represents a change that was made by the user on enum members that has to be
 /// reflected in the generated code.
 /// </summary>
-readonly struct EnumMember : IEquatable<EnumMember> {
+[StructLayout(LayoutKind.Auto)]
+readonly partial struct EnumMember : IEquatable<EnumMember> {
 	/// <summary>
 	/// Get the name of the member.
 	/// </summary>
@@ -25,37 +28,10 @@ readonly struct EnumMember : IEquatable<EnumMember> {
 	public SymbolAvailability SymbolAvailability { get; }
 
 	/// <summary>
-	/// The data of the field attribute used to mark the value as a binding.
-	/// </summary>
-	public FieldInfo<EnumValue>? FieldInfo { get; }
-
-	/// <summary>
 	/// Get the attributes added to the member.
 	/// </summary>
 	public ImmutableArray<AttributeCodeChange> Attributes { get; }
-
-	/// <summary>
-	/// Create a new change that happened on a member.
-	/// </summary>
-	/// <param name="name">The name of the changed member.</param>
-	/// <param name="libraryName">The library name of the smart enum.</param>
-	/// <param name="libraryPath">The library path to the library, null if it is a known frameworl.</param>
-	/// <param name="fieldData">The binding data attached to this enum value.</param>
-	/// <param name="symbolAvailability">The symbol availability of the member.</param>
-	/// <param name="attributes">The list of attribute changes in the member.</param>
-	public EnumMember (string name,
-		string libraryName,
-		string? libraryPath,
-		FieldData<EnumValue>? fieldData,
-		SymbolAvailability symbolAvailability,
-		ImmutableArray<AttributeCodeChange> attributes)
-	{
-		Name = name;
-		FieldInfo = fieldData is null ? null : new (fieldData.Value, libraryName, libraryPath);
-		SymbolAvailability = symbolAvailability;
-		Attributes = attributes;
-	}
-
+	
 	/// <summary>
 	/// Create a new change that happened on a member.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/EnumMember.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Macios.Generator.DataModel;
 /// Structure that represents a change that was made by the user on enum members that has to be
 /// reflected in the generated code.
 /// </summary>
-[StructLayout(LayoutKind.Auto)]
+[StructLayout (LayoutKind.Auto)]
 readonly partial struct EnumMember : IEquatable<EnumMember> {
 	/// <summary>
 	/// Get the name of the member.
@@ -31,7 +31,7 @@ readonly partial struct EnumMember : IEquatable<EnumMember> {
 	/// Get the attributes added to the member.
 	/// </summary>
 	public ImmutableArray<AttributeCodeChange> Attributes { get; }
-	
+
 	/// <summary>
 	/// Create a new change that happened on a member.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Event.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Event.Generator.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Context;
+using Microsoft.Macios.Generator.Extensions;
+
+namespace Microsoft.Macios.Generator.DataModel;
+
+readonly partial struct Event {
+	
+	public static bool TryCreate (EventDeclarationSyntax declaration, RootBindingContext context,
+		[NotNullWhen (true)] out Event? change)
+	{
+		var memberName = declaration.Identifier.ToFullString ().Trim ();
+		// get the symbol from the property declaration
+		if (context.SemanticModel.GetDeclaredSymbol (declaration) is not IEventSymbol eventSymbol) {
+			change = null;
+			return false;
+		}
+
+		var type = eventSymbol.Type.ToDisplayString ().Trim ();
+		var attributes = declaration.GetAttributeCodeChanges (context.SemanticModel);
+		ImmutableArray<Accessor> accessorCodeChanges = [];
+		if (declaration.AccessorList is not null && declaration.AccessorList.Accessors.Count > 0) {
+			// calculate any possible changes in the accessors of the property
+			var accessorsBucket = ImmutableArray.CreateBuilder<Accessor> ();
+			foreach (var accessorDeclaration in declaration.AccessorList.Accessors) {
+				if (context.SemanticModel.GetDeclaredSymbol (accessorDeclaration) is not ISymbol accessorSymbol)
+					continue;
+				var kind = accessorDeclaration.Kind ().ToAccessorKind ();
+				var accessorAttributeChanges = accessorDeclaration.GetAttributeCodeChanges (context.SemanticModel);
+				accessorsBucket.Add (new (
+					accessorKind: kind,
+					symbolAvailability: accessorSymbol.GetSupportedPlatforms (),
+					exportPropertyData: null,
+					attributes: accessorAttributeChanges,
+					modifiers: [.. accessorDeclaration.Modifiers]));
+			}
+
+			accessorCodeChanges = accessorsBucket.ToImmutable ();
+		}
+
+		change = new (memberName, type, eventSymbol.GetSupportedPlatforms (), attributes,
+			[.. declaration.Modifiers], accessorCodeChanges);
+		return true;
+	}
+}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Event.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Event.Generator.cs
@@ -11,7 +11,7 @@ using Microsoft.Macios.Generator.Extensions;
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly partial struct Event {
-	
+
 	public static bool TryCreate (EventDeclarationSyntax declaration, RootBindingContext context,
 		[NotNullWhen (true)] out Event? change)
 	{

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Event.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Event.cs
@@ -96,7 +96,7 @@ readonly partial struct Event : IEquatable<Event> {
 	{
 		return !left.Equals (right);
 	}
-	
+
 	/// <inheritdoc />
 	public override string ToString ()
 	{

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Event.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Event.cs
@@ -2,18 +2,14 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.Availability;
-using Microsoft.Macios.Generator.Context;
-using Microsoft.Macios.Generator.Extensions;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
-readonly struct Event : IEquatable<Event> {
+readonly partial struct Event : IEquatable<Event> {
 	/// <summary>
 	/// Name of the property.
 	/// </summary>
@@ -100,44 +96,7 @@ readonly struct Event : IEquatable<Event> {
 	{
 		return !left.Equals (right);
 	}
-
-	public static bool TryCreate (EventDeclarationSyntax declaration, RootBindingContext context,
-		[NotNullWhen (true)] out Event? change)
-	{
-		var memberName = declaration.Identifier.ToFullString ().Trim ();
-		// get the symbol from the property declaration
-		if (context.SemanticModel.GetDeclaredSymbol (declaration) is not IEventSymbol eventSymbol) {
-			change = null;
-			return false;
-		}
-
-		var type = eventSymbol.Type.ToDisplayString ().Trim ();
-		var attributes = declaration.GetAttributeCodeChanges (context.SemanticModel);
-		ImmutableArray<Accessor> accessorCodeChanges = [];
-		if (declaration.AccessorList is not null && declaration.AccessorList.Accessors.Count > 0) {
-			// calculate any possible changes in the accessors of the property
-			var accessorsBucket = ImmutableArray.CreateBuilder<Accessor> ();
-			foreach (var accessorDeclaration in declaration.AccessorList.Accessors) {
-				if (context.SemanticModel.GetDeclaredSymbol (accessorDeclaration) is not ISymbol accessorSymbol)
-					continue;
-				var kind = accessorDeclaration.Kind ().ToAccessorKind ();
-				var accessorAttributeChanges = accessorDeclaration.GetAttributeCodeChanges (context.SemanticModel);
-				accessorsBucket.Add (new (
-					accessorKind: kind,
-					symbolAvailability: accessorSymbol.GetSupportedPlatforms (),
-					exportPropertyData: null,
-					attributes: accessorAttributeChanges,
-					modifiers: [.. accessorDeclaration.Modifiers]));
-			}
-
-			accessorCodeChanges = accessorsBucket.ToImmutable ();
-		}
-
-		change = new (memberName, type, eventSymbol.GetSupportedPlatforms (), attributes,
-			[.. declaration.Modifiers], accessorCodeChanges);
-		return true;
-	}
-
+	
 	/// <inheritdoc />
 	public override string ToString ()
 	{

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.Availability;
+using Microsoft.Macios.Generator.Context;
+using Microsoft.Macios.Generator.Extensions;
+using ObjCRuntime;
+
+namespace Microsoft.Macios.Generator.DataModel;
+
+readonly partial struct Method {
+	
+	/// <summary>
+	/// The data of the export attribute used to mark the value as a property binding. 
+	/// </summary>
+	public ExportData<ObjCBindings.Method> ExportMethodData { get; }
+
+	/// <summary>
+	/// True if the method was exported with the MarshalNativeExceptions flag allowing it to support native exceptions.
+	/// </summary>
+	public bool MarshalNativeExceptions => ExportMethodData.Flags.HasFlag (ObjCBindings.Method.MarshalNativeExceptions);
+	
+	public Method (string type, string name, TypeInfo returnType,
+		SymbolAvailability symbolAvailability,
+		ExportData<ObjCBindings.Method> exportMethodData,
+		ImmutableArray<AttributeCodeChange> attributes,
+		ImmutableArray<SyntaxToken> modifiers,
+		ImmutableArray<Parameter> parameters)
+	{
+		Type = type;
+		Name = name;
+		ReturnType = returnType;
+		SymbolAvailability = symbolAvailability;
+		ExportMethodData = exportMethodData;
+		Attributes = attributes;
+		Modifiers = modifiers;
+		Parameters = parameters;
+	}
+	
+	public static bool TryCreate (MethodDeclarationSyntax declaration, RootBindingContext context,
+		[NotNullWhen (true)] out Method? change)
+	{
+		if (context.SemanticModel.GetDeclaredSymbol (declaration) is not IMethodSymbol method) {
+			change = null;
+			return false;
+		}
+
+		var attributes = declaration.GetAttributeCodeChanges (context.SemanticModel);
+		var parametersBucket = ImmutableArray.CreateBuilder<Parameter> ();
+		// loop over the parameters of the construct since changes on those implies a change in the generated code
+		foreach (var parameter in method.Parameters) {
+			var parameterDeclaration = declaration.ParameterList.Parameters [parameter.Ordinal];
+			if (!Parameter.TryCreate (parameter, parameterDeclaration, context.SemanticModel, out var parameterChange))
+				continue;
+			parametersBucket.Add (parameterChange.Value);
+		}
+
+		// DO NOT USE default if null, the reason is that it will set the ArgumentSemantics to be value 0, when
+		// none is value 1. The reason for that is that the default of an enum is 0, that was a mistake 
+		// in the old binding code.
+		var exportData = method.GetExportData<ObjCBindings.Method> ()
+						 ?? new (null, ArgumentSemantic.None, ObjCBindings.Method.Default);
+		
+		change = new (
+			type: method.ContainingSymbol.ToDisplayString ().Trim (), // we want the full name
+			name: method.Name,
+			returnType: new TypeInfo (method.ReturnType),
+			symbolAvailability: method.GetSupportedPlatforms (),
+			exportMethodData: exportData,
+			attributes: attributes,
+			modifiers: [.. declaration.Modifiers],
+			parameters: parametersBucket.ToImmutableArray ());
+	
+		return true;
+	}
+}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
@@ -14,7 +14,7 @@ using ObjCRuntime;
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly partial struct Method {
-	
+
 	/// <summary>
 	/// The data of the export attribute used to mark the value as a property binding. 
 	/// </summary>
@@ -24,7 +24,7 @@ readonly partial struct Method {
 	/// True if the method was exported with the MarshalNativeExceptions flag allowing it to support native exceptions.
 	/// </summary>
 	public bool MarshalNativeExceptions => ExportMethodData.Flags.HasFlag (ObjCBindings.Method.MarshalNativeExceptions);
-	
+
 	public Method (string type, string name, TypeInfo returnType,
 		SymbolAvailability symbolAvailability,
 		ExportData<ObjCBindings.Method> exportMethodData,
@@ -41,7 +41,7 @@ readonly partial struct Method {
 		Modifiers = modifiers;
 		Parameters = parameters;
 	}
-	
+
 	public static bool TryCreate (MethodDeclarationSyntax declaration, RootBindingContext context,
 		[NotNullWhen (true)] out Method? change)
 	{
@@ -65,7 +65,7 @@ readonly partial struct Method {
 		// in the old binding code.
 		var exportData = method.GetExportData<ObjCBindings.Method> ()
 						 ?? new (null, ArgumentSemantic.None, ObjCBindings.Method.Default);
-		
+
 		change = new (
 			type: method.ContainingSymbol.ToDisplayString ().Trim (), // we want the full name
 			name: method.Name,
@@ -75,7 +75,7 @@ readonly partial struct Method {
 			attributes: attributes,
 			modifiers: [.. declaration.Modifiers],
 			parameters: parametersBucket.ToImmutableArray ());
-	
+
 		return true;
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
@@ -10,7 +10,7 @@ using Microsoft.Macios.Generator.Availability;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
-[StructLayout(LayoutKind.Auto)]
+[StructLayout (LayoutKind.Auto)]
 readonly partial struct Method : IEquatable<Method> {
 
 	/// <summary>
@@ -47,7 +47,7 @@ readonly partial struct Method : IEquatable<Method> {
 	/// Parameters list.
 	/// </summary>
 	public ImmutableArray<Parameter> Parameters { get; } = [];
-	
+
 	/// <inheritdoc/>
 	public bool Equals (Method other)
 	{

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
@@ -2,20 +2,16 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Availability;
-using Microsoft.Macios.Generator.Context;
-using Microsoft.Macios.Generator.Extensions;
-using ObjCRuntime;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
-readonly struct Method : IEquatable<Method> {
+[StructLayout(LayoutKind.Auto)]
+readonly partial struct Method : IEquatable<Method> {
 
 	/// <summary>
 	/// Type name that owns the method.
@@ -38,16 +34,6 @@ readonly struct Method : IEquatable<Method> {
 	public SymbolAvailability SymbolAvailability { get; }
 
 	/// <summary>
-	/// The data of the export attribute used to mark the value as a property binding. 
-	/// </summary>
-	public ExportData<ObjCBindings.Method> ExportMethodData { get; }
-
-	/// <summary>
-	/// True if the method was exported with the MarshalNativeExceptions flag allowing it to support native exceptions.
-	/// </summary>
-	public bool MarshalNativeExceptions => ExportMethodData.Flags.HasFlag (ObjCBindings.Method.MarshalNativeExceptions);
-
-	/// <summary>
 	/// Get the attributes added to the constructor.
 	/// </summary>
 	public ImmutableArray<AttributeCodeChange> Attributes { get; } = [];
@@ -61,59 +47,7 @@ readonly struct Method : IEquatable<Method> {
 	/// Parameters list.
 	/// </summary>
 	public ImmutableArray<Parameter> Parameters { get; } = [];
-
-	public Method (string type, string name, TypeInfo returnType,
-		SymbolAvailability symbolAvailability,
-		ExportData<ObjCBindings.Method> exportMethodData,
-		ImmutableArray<AttributeCodeChange> attributes,
-		ImmutableArray<SyntaxToken> modifiers,
-		ImmutableArray<Parameter> parameters)
-	{
-		Type = type;
-		Name = name;
-		ReturnType = returnType;
-		SymbolAvailability = symbolAvailability;
-		ExportMethodData = exportMethodData;
-		Attributes = attributes;
-		Modifiers = modifiers;
-		Parameters = parameters;
-	}
-
-	public static bool TryCreate (MethodDeclarationSyntax declaration, RootBindingContext context,
-		[NotNullWhen (true)] out Method? change)
-	{
-		if (context.SemanticModel.GetDeclaredSymbol (declaration) is not IMethodSymbol method) {
-			change = null;
-			return false;
-		}
-
-		var attributes = declaration.GetAttributeCodeChanges (context.SemanticModel);
-		var parametersBucket = ImmutableArray.CreateBuilder<Parameter> ();
-		// loop over the parameters of the construct since changes on those implies a change in the generated code
-		foreach (var parameter in method.Parameters) {
-			var parameterDeclaration = declaration.ParameterList.Parameters [parameter.Ordinal];
-			if (!Parameter.TryCreate (parameter, parameterDeclaration, context.SemanticModel, out var parameterChange))
-				continue;
-			parametersBucket.Add (parameterChange.Value);
-		}
-
-		// DO NOT USE default if null, the reason is that it will set the ArgumentSemantics to be value 0, when
-		// none is value 1. The reason for that is that the default of an enum is 0, that was a mistake 
-		// in the old binding code.
-		var exportData = method.GetExportData<ObjCBindings.Method> ()
-						 ?? new (null, ArgumentSemantic.None, ObjCBindings.Method.Default);
-		change = new (
-			type: method.ContainingSymbol.ToDisplayString ().Trim (), // we want the full name
-			name: method.Name,
-			returnType: new (method.ReturnType),
-			symbolAvailability: method.GetSupportedPlatforms (),
-			exportMethodData: exportData,
-			attributes: attributes,
-			modifiers: [.. declaration.Modifiers],
-			parameters: parametersBucket.ToImmutableArray ());
-		return true;
-	}
-
+	
 	/// <inheritdoc/>
 	public bool Equals (Method other)
 	{

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.Context;
+using Microsoft.Macios.Generator.Extensions;
+
+namespace Microsoft.Macios.Generator.DataModel;
+
+readonly partial struct Property {
+	
+	/// <summary>
+	/// The data of the field attribute used to mark the value as a field binding. 
+	/// </summary>
+	public FieldInfo<ObjCBindings.Property>? ExportFieldData { get; init; }
+
+	/// <summary>
+	/// True if the property represents a Objc field.
+	/// </summary>
+	[MemberNotNullWhen (true, nameof (ExportFieldData))]
+	public bool IsField => ExportFieldData is not null;
+
+	public bool IsNotification
+		=> IsField && ExportFieldData.Value.FieldData.Flags.HasFlag (ObjCBindings.Property.Notification);
+
+	/// <summary>
+	/// The data of the field attribute used to mark the value as a property binding. 
+	/// </summary>
+	public ExportData<ObjCBindings.Property>? ExportPropertyData { get; init; }
+
+	/// <summary>
+	/// True if the property represents a Objc property.
+	/// </summary>
+	[MemberNotNullWhen (true, nameof (ExportPropertyData))]
+	public bool IsProperty => ExportPropertyData is not null;
+	
+	/// <summary>
+	/// True if the method was exported with the MarshalNativeExceptions flag allowing it to support native exceptions.
+	/// </summary>
+	public bool MarshalNativeExceptions
+		=> IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.MarshalNativeExceptions);
+	
+	static FieldInfo<ObjCBindings.Property>? GetFieldInfo (RootBindingContext context, IPropertySymbol propertySymbol)
+	{
+		// grab the last port of the namespace
+		var ns = propertySymbol.ContainingNamespace.Name.Split ('.') [^1];
+		var fieldData = propertySymbol.GetFieldData<ObjCBindings.Property> ();
+		FieldInfo<ObjCBindings.Property>? fieldInfo = null;
+		if (fieldData is not null && context.TryComputeLibraryName (fieldData.Value.LibraryName, ns,
+				out string? libraryName, out string? libraryPath)) {
+			fieldInfo = new FieldInfo<ObjCBindings.Property> (fieldData.Value, libraryName, libraryPath);
+		}
+
+		return fieldInfo;
+	}
+
+	public static bool TryCreate (PropertyDeclarationSyntax declaration, RootBindingContext context,
+		[NotNullWhen (true)] out Property? change)
+	{
+		var memberName = declaration.Identifier.ToFullString ().Trim ();
+		// get the symbol from the property declaration
+		if (context.SemanticModel.GetDeclaredSymbol (declaration) is not IPropertySymbol propertySymbol) {
+			change = null;
+			return false;
+		}
+
+		var propertySupportedPlatforms = propertySymbol.GetSupportedPlatforms ();
+		var attributes = declaration.GetAttributeCodeChanges (context.SemanticModel);
+
+		ImmutableArray<Accessor> accessorCodeChanges = [];
+		if (declaration.AccessorList is not null && declaration.AccessorList.Accessors.Count > 0) {
+			// calculate any possible changes in the accessors of the property
+			var accessorsBucket = ImmutableArray.CreateBuilder<Accessor> ();
+			foreach (var accessorDeclaration in declaration.AccessorList.Accessors) {
+				if (context.SemanticModel.GetDeclaredSymbol (accessorDeclaration) is not ISymbol accessorSymbol)
+					continue;
+				var kind = accessorDeclaration.Kind ().ToAccessorKind ();
+				var accessorAttributeChanges =
+					accessorDeclaration.GetAttributeCodeChanges (context.SemanticModel);
+				accessorsBucket.Add (new (
+					accessorKind: kind,
+					exportPropertyData: accessorSymbol.GetExportData<ObjCBindings.Property> (),
+					symbolAvailability: accessorSymbol.GetSupportedPlatforms (),
+					attributes: accessorAttributeChanges,
+					modifiers: [.. accessorDeclaration.Modifiers]));
+			}
+
+			accessorCodeChanges = accessorsBucket.ToImmutable ();
+		}
+
+		if (declaration.ExpressionBody is not null) {
+			// an expression body == a getter with no attrs or modifiers; that means that the accessor does not have
+			// extra availability, but the ones form the property
+			accessorCodeChanges = [new (
+				accessorKind: AccessorKind.Getter,
+				symbolAvailability: propertySupportedPlatforms,
+				exportPropertyData: null,
+				attributes: [],
+				modifiers: [])
+			];
+		}
+
+		change = new (
+			name: memberName,
+			returnType: new (propertySymbol.Type),
+			symbolAvailability: propertySupportedPlatforms,
+			attributes: attributes,
+			modifiers: [.. declaration.Modifiers],
+			accessors: accessorCodeChanges) {
+			ExportFieldData = GetFieldInfo (context, propertySymbol),
+			ExportPropertyData = propertySymbol.GetExportData<ObjCBindings.Property> (),
+		};
+		return true;
+	}
+}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
@@ -12,7 +12,7 @@ using Microsoft.Macios.Generator.Extensions;
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly partial struct Property {
-	
+
 	/// <summary>
 	/// The data of the field attribute used to mark the value as a field binding. 
 	/// </summary>
@@ -37,13 +37,13 @@ readonly partial struct Property {
 	/// </summary>
 	[MemberNotNullWhen (true, nameof (ExportPropertyData))]
 	public bool IsProperty => ExportPropertyData is not null;
-	
+
 	/// <summary>
 	/// True if the method was exported with the MarshalNativeExceptions flag allowing it to support native exceptions.
 	/// </summary>
 	public bool MarshalNativeExceptions
 		=> IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.MarshalNativeExceptions);
-	
+
 	static FieldInfo<ObjCBindings.Property>? GetFieldInfo (RootBindingContext context, IPropertySymbol propertySymbol)
 	{
 		// grab the last port of the namespace

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -2,22 +2,19 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Availability;
-using Microsoft.Macios.Generator.Context;
-using Microsoft.Macios.Generator.Extensions;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
 /// <summary>
 /// Readonly struct that represent the changes that a user has made in a property.
 /// </summary>
-readonly struct Property : IEquatable<Property> {
+[StructLayout(LayoutKind.Auto)]
+readonly partial struct Property : IEquatable<Property> {
 	/// <summary>
 	/// Name of the property.
 	/// </summary>
@@ -49,43 +46,12 @@ readonly struct Property : IEquatable<Property> {
 	/// The platform availability of the property.
 	/// </summary>
 	public SymbolAvailability SymbolAvailability { get; }
-
-	/// <summary>
-	/// The data of the field attribute used to mark the value as a field binding. 
-	/// </summary>
-	public FieldInfo<ObjCBindings.Property>? ExportFieldData { get; init; }
-
-	/// <summary>
-	/// True if the property represents a Objc field.
-	/// </summary>
-	[MemberNotNullWhen (true, nameof (ExportFieldData))]
-	public bool IsField => ExportFieldData is not null;
-
-	public bool IsNotification
-		=> IsField && ExportFieldData.Value.FieldData.Flags.HasFlag (ObjCBindings.Property.Notification);
-
-	/// <summary>
-	/// The data of the field attribute used to mark the value as a property binding. 
-	/// </summary>
-	public ExportData<ObjCBindings.Property>? ExportPropertyData { get; init; }
-
-	/// <summary>
-	/// True if the property represents a Objc property.
-	/// </summary>
-	[MemberNotNullWhen (true, nameof (ExportPropertyData))]
-	public bool IsProperty => ExportPropertyData is not null;
-
+	
 	/// <summary>
 	/// Get the attributes added to the member.
 	/// </summary>
 	public ImmutableArray<AttributeCodeChange> Attributes { get; } = [];
-
-	/// <summary>
-	/// True if the method was exported with the MarshalNativeExceptions flag allowing it to support native exceptions.
-	/// </summary>
-	public bool MarshalNativeExceptions
-		=> IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.MarshalNativeExceptions);
-
+	
 	/// <summary>
 	/// Get the modifiers of the property.
 	/// </summary>
@@ -174,80 +140,7 @@ readonly struct Property : IEquatable<Property> {
 	{
 		return !left.Equals (right);
 	}
-
-	static FieldInfo<ObjCBindings.Property>? GetFieldInfo (RootBindingContext context, IPropertySymbol propertySymbol)
-	{
-		// grab the last port of the namespace
-		var ns = propertySymbol.ContainingNamespace.Name.Split ('.') [^1];
-		var fieldData = propertySymbol.GetFieldData<ObjCBindings.Property> ();
-		FieldInfo<ObjCBindings.Property>? fieldInfo = null;
-		if (fieldData is not null && context.TryComputeLibraryName (fieldData.Value.LibraryName, ns,
-				out string? libraryName, out string? libraryPath)) {
-			fieldInfo = new FieldInfo<ObjCBindings.Property> (fieldData.Value, libraryName, libraryPath);
-		}
-
-		return fieldInfo;
-	}
-
-	public static bool TryCreate (PropertyDeclarationSyntax declaration, RootBindingContext context,
-		[NotNullWhen (true)] out Property? change)
-	{
-		var memberName = declaration.Identifier.ToFullString ().Trim ();
-		// get the symbol from the property declaration
-		if (context.SemanticModel.GetDeclaredSymbol (declaration) is not IPropertySymbol propertySymbol) {
-			change = null;
-			return false;
-		}
-
-		var propertySupportedPlatforms = propertySymbol.GetSupportedPlatforms ();
-		var attributes = declaration.GetAttributeCodeChanges (context.SemanticModel);
-
-		ImmutableArray<Accessor> accessorCodeChanges = [];
-		if (declaration.AccessorList is not null && declaration.AccessorList.Accessors.Count > 0) {
-			// calculate any possible changes in the accessors of the property
-			var accessorsBucket = ImmutableArray.CreateBuilder<Accessor> ();
-			foreach (var accessorDeclaration in declaration.AccessorList.Accessors) {
-				if (context.SemanticModel.GetDeclaredSymbol (accessorDeclaration) is not ISymbol accessorSymbol)
-					continue;
-				var kind = accessorDeclaration.Kind ().ToAccessorKind ();
-				var accessorAttributeChanges =
-					accessorDeclaration.GetAttributeCodeChanges (context.SemanticModel);
-				accessorsBucket.Add (new (
-					accessorKind: kind,
-					exportPropertyData: accessorSymbol.GetExportData<ObjCBindings.Property> (),
-					symbolAvailability: accessorSymbol.GetSupportedPlatforms (),
-					attributes: accessorAttributeChanges,
-					modifiers: [.. accessorDeclaration.Modifiers]));
-			}
-
-			accessorCodeChanges = accessorsBucket.ToImmutable ();
-		}
-
-		if (declaration.ExpressionBody is not null) {
-			// an expression body == a getter with no attrs or modifiers; that means that the accessor does not have
-			// extra availability, but the ones form the property
-			accessorCodeChanges = [new (
-				accessorKind: AccessorKind.Getter,
-				symbolAvailability: propertySupportedPlatforms,
-				exportPropertyData: null,
-				attributes: [],
-				modifiers: [])
-			];
-		}
-
-		change = new (
-			name: memberName,
-			returnType: new (propertySymbol.Type),
-			symbolAvailability: propertySupportedPlatforms,
-			attributes: attributes,
-			modifiers: [.. declaration.Modifiers],
-			accessors: accessorCodeChanges) {
-			ExportFieldData = GetFieldInfo (context, propertySymbol),
-			ExportPropertyData = propertySymbol.GetExportData<ObjCBindings.Property> (),
-		};
-		return true;
-	}
-
+	
 	/// <inheritdoc />
 	public override string ToString ()
 	{

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Macios.Generator.DataModel;
 /// <summary>
 /// Readonly struct that represent the changes that a user has made in a property.
 /// </summary>
-[StructLayout(LayoutKind.Auto)]
+[StructLayout (LayoutKind.Auto)]
 readonly partial struct Property : IEquatable<Property> {
 	/// <summary>
 	/// Name of the property.
@@ -46,12 +46,12 @@ readonly partial struct Property : IEquatable<Property> {
 	/// The platform availability of the property.
 	/// </summary>
 	public SymbolAvailability SymbolAvailability { get; }
-	
+
 	/// <summary>
 	/// Get the attributes added to the member.
 	/// </summary>
 	public ImmutableArray<AttributeCodeChange> Attributes { get; } = [];
-	
+
 	/// <summary>
 	/// Get the modifiers of the property.
 	/// </summary>
@@ -140,7 +140,7 @@ readonly partial struct Property : IEquatable<Property> {
 	{
 		return !left.Equals (right);
 	}
-	
+
 	/// <inheritdoc />
 	public override string ToString ()
 	{

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
@@ -7,7 +7,7 @@ using Microsoft.Macios.Generator.Extensions;
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly partial struct TypeInfo {
-	
+
 	internal TypeInfo (ITypeSymbol symbol) :
 		this (
 			symbol is IArrayTypeSymbol arrayTypeSymbol
@@ -50,5 +50,5 @@ readonly partial struct TypeInfo {
 		}
 
 	}
-	
+
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.Macios.Generator.Extensions;
+
+namespace Microsoft.Macios.Generator.DataModel;
+
+readonly partial struct TypeInfo {
+	
+	internal TypeInfo (ITypeSymbol symbol) :
+		this (
+			symbol is IArrayTypeSymbol arrayTypeSymbol
+				? arrayTypeSymbol.ElementType.ToDisplayString ()
+				: symbol.ToDisplayString ().Trim ('?', '[', ']'),
+			symbol.SpecialType)
+	{
+		IsNullable = symbol.NullableAnnotation == NullableAnnotation.Annotated;
+		IsBlittable = symbol.IsBlittable ();
+		IsSmartEnum = symbol.IsSmartEnum ();
+		IsArray = symbol is IArrayTypeSymbol;
+		IsReferenceType = symbol.IsReferenceType;
+		IsInterface = symbol.TypeKind == TypeKind.Interface;
+		IsNativeIntegerType = symbol.IsNativeIntegerType;
+		IsNativeEnum = symbol.HasAttribute (AttributesNames.NativeEnumAttribute);
+
+		// data that we can get from the symbol without being INamedType
+		symbol.GetInheritance (
+			isNSObject: out isNSObject,
+			isNativeObject: out isINativeObject,
+			parents: out parents,
+			interfaces: out interfaces);
+
+		// try to get the named type symbol to have more educated decisions
+		var namedTypeSymbol = symbol as INamedTypeSymbol;
+
+		// store the enum special type, useful when generate code that needs to cast
+		EnumUnderlyingType = namedTypeSymbol?.EnumUnderlyingType?.SpecialType;
+
+		if (!IsReferenceType && IsNullable && namedTypeSymbol is not null) {
+			// get the type argument for nullable, which we know is the data that was boxed and use it to 
+			// overwrite the SpecialType 
+			var typeArgument = namedTypeSymbol.TypeArguments [0];
+			SpecialType = typeArgument.SpecialType;
+			MetadataName = SpecialType is SpecialType.None or SpecialType.System_Void
+				? null : typeArgument.MetadataName;
+		} else {
+			MetadataName = SpecialType is SpecialType.None or SpecialType.System_Void
+				? null : symbol.MetadataName;
+		}
+
+	}
+	
+}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -134,7 +134,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		IsArray = isArray;
 		IsReferenceType = isReferenceType;
 	}
-	
+
 	/// <inheritdoc/>
 	public bool Equals (TypeInfo other)
 	{

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/ExportData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/ExportData.cs
@@ -4,12 +4,12 @@
 namespace Microsoft.Macios.Transformer.Attributes;
 
 public struct ExportData : IEquatable<ExportData> {
-	
+
 	public bool Equals (ExportData other)
 	{
-		throw new NotImplementedException();
+		throw new NotImplementedException ();
 	}
-	
+
 	/// <inheritdoc />
 	public override bool Equals (object? obj)
 	{
@@ -19,7 +19,7 @@ public struct ExportData : IEquatable<ExportData> {
 	/// <inheritdoc />
 	public override int GetHashCode ()
 	{
-		throw new NotImplementedException();
+		throw new NotImplementedException ();
 	}
 
 	public static bool operator == (ExportData x, ExportData y)

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/ExportData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/ExportData.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Macios.Transformer.Attributes;
+
+public struct ExportData : IEquatable<ExportData> {
+	
+	public bool Equals (ExportData other)
+	{
+		throw new NotImplementedException();
+	}
+	
+	/// <inheritdoc />
+	public override bool Equals (object? obj)
+	{
+		return obj is ExportData other && Equals (other);
+	}
+
+	/// <inheritdoc />
+	public override int GetHashCode ()
+	{
+		throw new NotImplementedException();
+	}
+
+	public static bool operator == (ExportData x, ExportData y)
+	{
+		return x.Equals (y);
+	}
+
+	public static bool operator != (ExportData x, ExportData y)
+	{
+		return !(x == y);
+	}
+}

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/FieldData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/FieldData.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Macios.Transformer.Attributes;
+
+public struct FieldData : IEquatable<FieldData> {
+	
+	public bool Equals (FieldData other)
+	{
+		throw new NotImplementedException();
+	}
+	
+	/// <inheritdoc />
+	public override bool Equals (object? obj)
+	{
+		return obj is ExportData other && Equals (other);
+	}
+
+	/// <inheritdoc />
+	public override int GetHashCode ()
+	{
+		throw new NotImplementedException();
+	}
+
+	public static bool operator == (FieldData x, FieldData y)
+	{
+		return x.Equals (y);
+	}
+
+	public static bool operator != (FieldData x, FieldData y)
+	{
+		return !(x == y);
+	}
+}

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/FieldData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/FieldData.cs
@@ -4,12 +4,12 @@
 namespace Microsoft.Macios.Transformer.Attributes;
 
 public struct FieldData : IEquatable<FieldData> {
-	
+
 	public bool Equals (FieldData other)
 	{
-		throw new NotImplementedException();
+		throw new NotImplementedException ();
 	}
-	
+
 	/// <inheritdoc />
 	public override bool Equals (object? obj)
 	{
@@ -19,7 +19,7 @@ public struct FieldData : IEquatable<FieldData> {
 	/// <inheritdoc />
 	public override int GetHashCode ()
 	{
-		throw new NotImplementedException();
+		throw new NotImplementedException ();
 	}
 
 	public static bool operator == (FieldData x, FieldData y)

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Accessor.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Accessor.Transformer.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Macios.Transformer.Attributes;
+
+namespace Microsoft.Macios.Generator.DataModel;
+
+readonly partial struct Accessor {
+	
+	public ExportData? ExportPropertyData { get; init; }
+}

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Accessor.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Accessor.Transformer.cs
@@ -6,6 +6,6 @@ using Microsoft.Macios.Transformer.Attributes;
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly partial struct Accessor {
-	
+
 	public ExportData? ExportPropertyData { get; init; }
 }

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/BindingInfo.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/BindingInfo.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Macios.Generator.DataModel;
+
+/// <summary>
+/// This struct works as a union to store the possible BindingTypeData that can be present in the bindings.
+/// </summary>
+readonly struct BindingInfo : IEquatable<BindingInfo> {
+	
+	/// <inheritdoc />
+	public bool Equals (BindingInfo other)
+	{
+		throw new NotImplementedException();
+	}
+	
+	/// <inheritdoc />
+	public override bool Equals (object? obj)
+	{
+		return obj is BindingInfo other && Equals (other);
+	}
+
+	/// <inheritdoc />
+	public override int GetHashCode ()
+	{
+		throw new NotImplementedException ();
+	}
+	
+	public static bool operator == (BindingInfo x, BindingInfo y)
+	{
+		return x.Equals (y);
+	}
+
+	public static bool operator != (BindingInfo x, BindingInfo y)
+	{
+		return !(x == y);
+	}
+}

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/BindingInfo.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/BindingInfo.cs
@@ -7,13 +7,13 @@ namespace Microsoft.Macios.Generator.DataModel;
 /// This struct works as a union to store the possible BindingTypeData that can be present in the bindings.
 /// </summary>
 readonly struct BindingInfo : IEquatable<BindingInfo> {
-	
+
 	/// <inheritdoc />
 	public bool Equals (BindingInfo other)
 	{
-		throw new NotImplementedException();
+		throw new NotImplementedException ();
 	}
-	
+
 	/// <inheritdoc />
 	public override bool Equals (object? obj)
 	{
@@ -25,7 +25,7 @@ readonly struct BindingInfo : IEquatable<BindingInfo> {
 	{
 		throw new NotImplementedException ();
 	}
-	
+
 	public static bool operator == (BindingInfo x, BindingInfo y)
 	{
 		return x.Equals (y);

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/CodeChanges.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/CodeChanges.Transformer.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Macios.Generator.DataModel;
+
+readonly partial struct CodeChanges {
+
+	/// <summary>
+	/// Represents the type of binding that the code changes are for.
+	/// </summary>
+	public BindingType BindingType => throw new NotImplementedException ();
+	
+	public BindingInfo BindingInfo => throw new NotImplementedException ();
+	
+	public CodeChanges ()
+	{
+		FullyQualifiedSymbol = "";
+		IsStatic = false;
+		IsPartial = false;
+		IsAbstract = false;
+	}
+}

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/CodeChanges.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/CodeChanges.Transformer.cs
@@ -9,9 +9,9 @@ readonly partial struct CodeChanges {
 	/// Represents the type of binding that the code changes are for.
 	/// </summary>
 	public BindingType BindingType => throw new NotImplementedException ();
-	
+
 	public BindingInfo BindingInfo => throw new NotImplementedException ();
-	
+
 	public CodeChanges ()
 	{
 		FullyQualifiedSymbol = "";

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/EnumMember.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/EnumMember.Transformer.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Microsoft.Macios.Generator.Availability;
+using Microsoft.Macios.Transformer.Attributes;
+
+namespace Microsoft.Macios.Generator.DataModel;
+
+readonly partial struct EnumMember {
+	
+	/// <summary>
+	/// The data of the field attribute used to mark the value as a binding.
+	/// </summary>
+	public FieldData? FieldInfo { get; }
+	
+	/// <summary>
+	/// Create a new change that happened on a member.
+	/// </summary>
+	/// <param name="name">The name of the changed member.</param>
+	/// <param name="libraryName">The library name of the smart enum.</param>
+	/// <param name="libraryPath">The library path to the library, null if it is a known frameworl.</param>
+	/// <param name="fieldData">The binding data attached to this enum value.</param>
+	/// <param name="symbolAvailability">The symbol availability of the member.</param>
+	/// <param name="attributes">The list of attribute changes in the member.</param>
+	public EnumMember (string name,
+		string libraryName,
+		string? libraryPath,
+		FieldData? fieldData,
+		SymbolAvailability symbolAvailability,
+		ImmutableArray<AttributeCodeChange> attributes)
+	{
+		throw new NotImplementedException ();
+	}
+	
+}

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/EnumMember.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/EnumMember.Transformer.cs
@@ -8,12 +8,12 @@ using Microsoft.Macios.Transformer.Attributes;
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly partial struct EnumMember {
-	
+
 	/// <summary>
 	/// The data of the field attribute used to mark the value as a binding.
 	/// </summary>
 	public FieldData? FieldInfo { get; }
-	
+
 	/// <summary>
 	/// Create a new change that happened on a member.
 	/// </summary>
@@ -32,5 +32,5 @@ readonly partial struct EnumMember {
 	{
 		throw new NotImplementedException ();
 	}
-	
+
 }

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Method.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Method.Transformer.cs
@@ -9,7 +9,7 @@ using Microsoft.Macios.Transformer.Attributes;
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly partial struct Method {
-	
+
 	/// <summary>
 	/// The data of the export attribute used to mark the value as a property binding. 
 	/// </summary>
@@ -19,7 +19,7 @@ readonly partial struct Method {
 	/// True if the method was exported with the MarshalNativeExceptions flag allowing it to support native exceptions.
 	/// </summary>
 	public bool MarshalNativeExceptions => throw new NotImplementedException ();
-	
+
 	public Method (string type, string name, TypeInfo returnType,
 		SymbolAvailability symbolAvailability,
 		ExportData exportMethodData,

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Method.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Method.Transformer.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.Macios.Generator.Availability;
+using Microsoft.Macios.Transformer.Attributes;
+
+namespace Microsoft.Macios.Generator.DataModel;
+
+readonly partial struct Method {
+	
+	/// <summary>
+	/// The data of the export attribute used to mark the value as a property binding. 
+	/// </summary>
+	public ExportData ExportMethodData { get; }
+
+	/// <summary>
+	/// True if the method was exported with the MarshalNativeExceptions flag allowing it to support native exceptions.
+	/// </summary>
+	public bool MarshalNativeExceptions => throw new NotImplementedException ();
+	
+	public Method (string type, string name, TypeInfo returnType,
+		SymbolAvailability symbolAvailability,
+		ExportData exportMethodData,
+		ImmutableArray<AttributeCodeChange> attributes,
+		ImmutableArray<SyntaxToken> modifiers,
+		ImmutableArray<Parameter> parameters)
+	{
+		Type = type;
+		Name = name;
+		ReturnType = returnType;
+		SymbolAvailability = symbolAvailability;
+		ExportMethodData = exportMethodData;
+		Attributes = attributes;
+		Modifiers = modifiers;
+		Parameters = parameters;
+	}
+}

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Property.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Property.Transformer.cs
@@ -7,7 +7,7 @@ using Microsoft.Macios.Transformer.Attributes;
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly partial struct Property {
-	
+
 	/// <summary>
 	/// The data of the field attribute used to mark the value as a field binding. 
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Property.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Property.Transformer.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Macios.Transformer.Attributes;
+
+namespace Microsoft.Macios.Generator.DataModel;
+
+readonly partial struct Property {
+	
+	/// <summary>
+	/// The data of the field attribute used to mark the value as a field binding. 
+	/// </summary>
+	public FieldData? ExportFieldData { get; init; }
+
+	/// <summary>
+	/// True if the property represents a Objc field.
+	/// </summary>
+	[MemberNotNullWhen (true, nameof (ExportFieldData))]
+	public bool IsField => ExportFieldData is not null;
+
+	public bool IsNotification => throw new NotImplementedException ();
+
+	/// <summary>
+	/// The data of the field attribute used to mark the value as a property binding. 
+	/// </summary>
+	public ExportData? ExportPropertyData { get; init; }
+
+	/// <summary>
+	/// True if the property represents a Objc property.
+	/// </summary>
+	[MemberNotNullWhen (true, nameof (ExportPropertyData))]
+	public bool IsProperty => ExportPropertyData is not null;
+
+	/// <summary>
+	/// True if the method was exported with the MarshalNativeExceptions flag allowing it to support native exceptions.
+	/// </summary>
+	public bool MarshalNativeExceptions => throw new NotImplementedException ();
+}

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/TypeInfo.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/TypeInfo.Transformer.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Macios.Generator.DataModel;
+
+readonly partial struct TypeInfo {
+
+	internal TypeInfo (ITypeSymbol symbol) :
+		this (
+			symbol is IArrayTypeSymbol arrayTypeSymbol
+				? arrayTypeSymbol.ElementType.ToDisplayString ()
+				: symbol.ToDisplayString ().Trim ('?', '[', ']'),
+			symbol.SpecialType)
+	{
+		throw new NotImplementedException ();
+	}
+}

--- a/src/rgen/Microsoft.Macios.Transformer/Extensions/TypeSymbolExtensions.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Extensions/TypeSymbolExtensions.Transformer.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Macios.Generator.Extensions;
+
+static partial class TypeSymbolExtensions {
+	
+	public static bool IsSmartEnum (this ITypeSymbol symbol)
+	{
+		throw new NotImplementedException ();
+	}
+}

--- a/src/rgen/Microsoft.Macios.Transformer/Extensions/TypeSymbolExtensions.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Extensions/TypeSymbolExtensions.Transformer.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis;
 namespace Microsoft.Macios.Generator.Extensions;
 
 static partial class TypeSymbolExtensions {
-	
+
 	public static bool IsSmartEnum (this ITypeSymbol symbol)
 	{
 		throw new NotImplementedException ();

--- a/src/rgen/Microsoft.Macios.Transformer/Microsoft.Macios.Transformer.csproj
+++ b/src/rgen/Microsoft.Macios.Transformer/Microsoft.Macios.Transformer.csproj
@@ -25,6 +25,9 @@
         <Compile Include="../Microsoft.Macios.Generator/DictionaryComparer.cs" >
             <Link>DictionaryComparer.cs</Link>
         </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/CollectionComparer.cs" >
+            <Link>CollectionComparer.cs</Link>
+        </Compile>
         <Compile Include="../Microsoft.Macios.Generator/Attributes/ObsoletedOSPlatformData.cs" >
             <Link>Attributes/ObsoletedOSPlatformData.cs</Link>
         </Compile>
@@ -37,12 +40,28 @@
         <Compile Include="../Microsoft.Macios.Generator/Availability/*.cs" >
             <Link>Availability/*.cs</Link>
         </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/Extensions/ParameterSyntaxExtensions.cs" >
+            <Link>Extensions/ParameterSyntaxExtensions.cs</Link>
+        </Compile>
         <Compile Include="../Microsoft.Macios.Generator/Extensions/StringExtensions.cs" >
             <Link>Extensions/StringExtensions.cs</Link>
         </Compile>
         <Compile Include="../Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs" >
             <Link>Extensions/TypeSymbolExtensions.Core.cs</Link>
         </Compile>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Compile Include="../Microsoft.Macios.Generator/DataModel/*.cs" >
+            <Link>DataModel/*.cs</Link>
+        </Compile>
+        <!-- Remove those files that are just used by the generator -->
+        <None Remove="../Microsoft.Macios.Generator/DataModel/BindingInfo.cs" />
+        <Compile Remove="../Microsoft.Macios.Generator/DataModel/BindingInfo.cs" />
+        <None Remove="../Microsoft.Macios.Generator/DataModel/FieldInfo.cs" />
+        <Compile Remove="../Microsoft.Macios.Generator/DataModel/FieldInfo.cs" />
+        <None Remove="../Microsoft.Macios.Generator/DataModel/*.Generator.cs" />
+        <Compile Remove="../Microsoft.Macios.Generator/DataModel/*.Generator.cs" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
In this change we are making the necesary changes to share the data model code between the generator and the transformer.

When we talk about sharing code in C# the average dotnet developer would create a csproj with the shared code and would reference it. In normal circumtances this is not a bad option, but our case is different and here are some of the reasons we cannot take that path:

1. Roslyn code generators with more than one dll are problematic to distribute. You can already see how bad it is by looking at the dll shared between the code generator and the analyzer. The shared library has to be added as an analyzer so that it loads with the generator. We want to keep the number of dlls to a minimun.
2. While the data models are similar, they are not identical. The attributes used by the code generator and the old api defintions are different. We would around this by splitting the definitions in 2 files: 
  a - A common file with all date that does not depend on the attributes. 
  b - A application specific file that contains the properties needed by the common parts BUT that uses structures specific for the application. An example is the ExportData. The ExportData is a generic in the generator (which contains flags) while it is not in the transformer. We also split the TryCreate and Constructor methods since those need to init the application specific parths.

In this commit we do not implement the transformer parts since that would make the diff hader. We are only moving code around and adding dummy implementations for the transformer project to compile.