### PR TITLE
[Rgen] Add a new struc that will represent the needed trivia for a symbol.

### DIFF
--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Microsoft.Macios.Bindings.Analyzer.csproj
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Microsoft.Macios.Bindings.Analyzer.csproj
@@ -60,6 +60,9 @@
         <Compile Include="../Microsoft.Macios.Generator/Attributes/UnsupportedOSPlatformData.cs" >
             <Link>Generator/Attributes/UnsupportedOSPlatformData.cs</Link>
         </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/Extensions/ApplePlatformExtensions.cs" >
+            <Link>Generator/Extensions/ApplePlatformExtensions.cs</Link>
+        </Compile>
         <Compile Include="../Microsoft.Macios.Generator/Extensions/CompilationExtensions.cs" >
             <Link>Generator/Extensions/CompilationExtensions.cs</Link>
         </Compile>
@@ -72,17 +75,8 @@
         <Compile Include="../Microsoft.Macios.Generator/Extensions/StringExtensions.cs" >
             <Link>Generator/Extensions/StringExtensions.cs</Link>
         </Compile>
-        <Compile Include="../Microsoft.Macios.Generator/Availability/PlatformAvailability.cs" >
-            <Link>Generator/Availability/PlatformAvailability.cs</Link>
-        </Compile>
-        <Compile Include="../Microsoft.Macios.Generator/Availability/PlatformAvailabilityBuilder.cs" >
-            <Link>Generator/Availability/PlatformAvailabilityBuilder.cs</Link>
-        </Compile>
-        <Compile Include="../Microsoft.Macios.Generator/Availability/SymbolAvailability.cs" >
-            <Link>Generator/Availability/SymbolAvailability.cs</Link>
-        </Compile>
-        <Compile Include="../Microsoft.Macios.Generator/Availability/SymbolAvailabilityBuilder.cs" >
-            <Link>Generator/Availability/SymbolAvailabilityBuilder.cs</Link>
+        <Compile Include="../Microsoft.Macios.Generator/Availability/*.cs" >
+            <Link>Generator/Availability/*.cs</Link>
         </Compile>
         <Compile Update="Resources.Designer.cs">
           <DesignTime>True</DesignTime>

--- a/src/rgen/Microsoft.Macios.Generator/Availability/AvailabilityTrivia.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Availability/AvailabilityTrivia.cs
@@ -13,7 +13,7 @@ readonly struct AvailabilityTrivia {
 	/// Retrieve the trivia to add before the symbol declaration.
 	/// </summary>
 	public string? Start { get; }
-	
+
 	/// <summary>
 	/// Retrieve the trivia to add after the symbol declaration.
 	/// </summary>
@@ -29,13 +29,13 @@ readonly struct AvailabilityTrivia {
 			var platformDefine = platformAvailability.Platform.ToPlatformDefine ();
 			if (platformDefine is null)
 				continue;
-			
+
 			if (platformAvailability.IsSupported)
 				supportedPlatforms.Add (platformDefine);
 			else
 				unsupportedPlatforms.Add (platformDefine);
 		}
-		
+
 		// if all platforms are supported, we don't need any trivia
 		if (unsupportedPlatforms.Count == 0) {
 			// all platforms are supported
@@ -53,7 +53,7 @@ readonly struct AvailabilityTrivia {
 			// we have more unsupported platforms than supported ones
 			// we will use #if to include the supported platforms
 			Start = $"#if {string.Join (" || ", supportedPlatforms)}";
-			End = "#endif";	
-		} 
-	}	
+			End = "#endif";
+		}
+	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Availability/AvailabilityTrivia.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Availability/AvailabilityTrivia.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.Macios.Generator.Extensions;
+using Xamarin.Utils;
+
+namespace Microsoft.Macios.Generator.Availability;
+
+readonly struct AvailabilityTrivia {
+
+	/// <summary>
+	/// Retrieve the trivia to add before the symbol declaration.
+	/// </summary>
+	public string? Start { get; }
+	
+	/// <summary>
+	/// Retrieve the trivia to add after the symbol declaration.
+	/// </summary>
+	public string? End { get; }
+
+	public AvailabilityTrivia (SymbolAvailability availability)
+	{
+		// trivia is calculated based on the availability of the symbol in each platform 
+		// we will check each of the platforms and decide for the shorts #if possible
+		var supportedPlatforms = new HashSet<string> ();
+		var unsupportedPlatforms = new HashSet<string> ();
+		foreach (var platformAvailability in availability.PlatformAvailabilities) {
+			var platformDefine = platformAvailability.Platform.ToPlatformDefine ();
+			if (platformDefine is null)
+				continue;
+			
+			if (platformAvailability.IsSupported)
+				supportedPlatforms.Add (platformDefine);
+			else
+				unsupportedPlatforms.Add (platformDefine);
+		}
+		
+		// if all platforms are supported, we don't need any trivia
+		if (unsupportedPlatforms.Count == 0) {
+			// all platforms are supported
+			Start = null;
+			End = null;
+			return;
+		}
+
+		if (supportedPlatforms.Count > unsupportedPlatforms.Count) {
+			// we have more supported platforms than unsupported ones
+			// we will use #if to exclude the unsupported platforms
+			Start = $"#if !{string.Join (" && !", unsupportedPlatforms)}";
+			End = "#endif";
+		} else {
+			// we have more unsupported platforms than supported ones
+			// we will use #if to include the supported platforms
+			Start = $"#if {string.Join (" || ", supportedPlatforms)}";
+			End = "#endif";	
+		} 
+	}	
+}

--- a/src/rgen/Microsoft.Macios.Generator/Availability/PlatformAvailability.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Availability/PlatformAvailability.cs
@@ -64,7 +64,7 @@ readonly partial struct PlatformAvailability : IEquatable<PlatformAvailability> 
 	/// <param name="version">Version being tested.</param>
 	/// <returns>True if the version is default.</returns>
 	public static bool IsDefaultVersion (Version version) => version == defaultVersion;
-	
+
 
 	PlatformAvailability (ApplePlatform platform, Version? supportedVersion,
 		SortedDictionary<Version, string?> unsupportedVersions,

--- a/src/rgen/Microsoft.Macios.Generator/Availability/PlatformAvailability.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Availability/PlatformAvailability.cs
@@ -36,14 +36,26 @@ readonly partial struct PlatformAvailability : IEquatable<PlatformAvailability> 
 	/// <summary>
 	/// Dictionary that contains all the obsoleted versions and their optional data.
 	/// </summary>
-	public readonly IReadOnlyDictionary<Version, string?> UnsupportedVersions => unsupported;
+	public IReadOnlyDictionary<Version, string?> UnsupportedVersions => unsupported;
 
 	readonly SortedDictionary<Version, (string? Message, string? Url)> obsoleted = new ();
 
 	/// <summary>
 	/// The Dictionary which contains all the unsupported versions and their optional data.
 	/// </summary>
-	public readonly IReadOnlyDictionary<Version, (string? Message, string? Url)> ObsoletedVersions => obsoleted;
+	public IReadOnlyDictionary<Version, (string? Message, string? Url)> ObsoletedVersions => obsoleted;
+
+	/// <summary>
+	/// Return if the platform is supported.
+	/// </summary>
+	public bool IsSupported {
+		get {
+			// a platform is supported if:
+			// 1. The supported version is not null, either the default version or a specific one
+			// 2. The default version is not in the unsupported list
+			return SupportedVersion is not null && !unsupported.ContainsKey (defaultVersion);
+		}
+	}
 
 
 	/// <summary>
@@ -52,6 +64,7 @@ readonly partial struct PlatformAvailability : IEquatable<PlatformAvailability> 
 	/// <param name="version">Version being tested.</param>
 	/// <returns>True if the version is default.</returns>
 	public static bool IsDefaultVersion (Version version) => version == defaultVersion;
+	
 
 	PlatformAvailability (ApplePlatform platform, Version? supportedVersion,
 		SortedDictionary<Version, string?> unsupportedVersions,

--- a/src/rgen/Microsoft.Macios.Generator/Availability/SymbolAvailability.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Availability/SymbolAvailability.cs
@@ -34,6 +34,19 @@ readonly partial struct SymbolAvailability : IEquatable<SymbolAvailability> {
 	}
 
 	/// <summary>
+	/// Return the symbol trivia if it has any.
+	/// </summary>
+	public AvailabilityTrivia? Trivia {
+		get {
+			// just returns the trivia if it has any, null otherwise
+			var trivia = new AvailabilityTrivia (this);
+			if (trivia.Start is not null || trivia.End is not null)
+				return trivia;
+			return null;
+		}
+	}
+
+	/// <summary>
 	/// Copy constructor.
 	/// </summary>
 	/// <param name="other">Symbol availability to copy,</param>

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/ApplePlatformExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/ApplePlatformExtensions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Xamarin.Utils;
+
+namespace Microsoft.Macios.Generator.Extensions;
+
+public static class ApplePlatformExtensions {
+	
+	/// <summary>
+	/// Return the platform define for the given ApplePlatform for use in #if directives.
+	/// </summary>
+	/// <param name="self">Apple platform.</param>
+	/// <returns>the platform define</returns>
+	public static string? ToPlatformDefine (this ApplePlatform self) => self switch {
+		ApplePlatform.iOS => "IOS",
+		ApplePlatform.TVOS => "TVOS",
+		ApplePlatform.MacOSX => "MONOMAC",
+		ApplePlatform.MacCatalyst => "__MACCATALYST__",
+		_ => null
+	};
+}

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/ApplePlatformExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/ApplePlatformExtensions.cs
@@ -6,7 +6,7 @@ using Xamarin.Utils;
 namespace Microsoft.Macios.Generator.Extensions;
 
 public static class ApplePlatformExtensions {
-	
+
 	/// <summary>
 	/// Return the platform define for the given ApplePlatform for use in #if directives.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Transformer/Microsoft.Macios.Transformer.csproj
+++ b/src/rgen/Microsoft.Macios.Transformer/Microsoft.Macios.Transformer.csproj
@@ -37,6 +37,9 @@
         <Compile Include="../Microsoft.Macios.Generator/Availability/*.cs" >
             <Link>Availability/*.cs</Link>
         </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/Extensions/ApplePlatformExtensions.cs" >
+            <Link>Extensions/ApplePlatformExtensions.cs</Link>
+        </Compile>
         <Compile Include="../Microsoft.Macios.Generator/Extensions/StringExtensions.cs" >
             <Link>Extensions/StringExtensions.cs</Link>
         </Compile>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Availability/AvailabilityTriviaTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Availability/AvailabilityTriviaTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace Microsoft.Macios.Generator.Tests.Availability;
 
 public class AvailabilityTriviaTests {
-	
+
 	[Fact]
 	public void AllSupportedPlatforms ()
 	{
@@ -26,7 +26,8 @@ public class AvailabilityTriviaTests {
 	}
 
 	[Fact]
-	public void SomeUnsupportedVersions () {
+	public void SomeUnsupportedVersions ()
+	{
 		SymbolAvailability.Builder builder = SymbolAvailability.CreateBuilder ();
 		builder.Add (new SupportedOSPlatformData ("ios12.0"));
 		builder.Add (new UnsupportedOSPlatformData ("ios9.0"));
@@ -39,9 +40,10 @@ public class AvailabilityTriviaTests {
 		Assert.Null (trivia.End);
 		Assert.Null (availability.Trivia);
 	}
-	
+
 	[Fact]
-	public void SingleFullyUnsupportedPlatform () {
+	public void SingleFullyUnsupportedPlatform ()
+	{
 		SymbolAvailability.Builder builder = SymbolAvailability.CreateBuilder ();
 		builder.Add (new UnsupportedOSPlatformData ("ios"));
 		builder.Add (new SupportedOSPlatformData ("tvos12.0"));
@@ -53,9 +55,10 @@ public class AvailabilityTriviaTests {
 		Assert.Equal ("#endif", trivia.End);
 		Assert.NotNull (availability.Trivia);
 	}
-	
+
 	[Fact]
-	public void DoubleUnsupportedPlatform () {
+	public void DoubleUnsupportedPlatform ()
+	{
 		SymbolAvailability.Builder builder = SymbolAvailability.CreateBuilder ();
 		builder.Add (new SupportedOSPlatformData ("ios"));
 		builder.Add (new SupportedOSPlatformData ("tvos12.0"));
@@ -67,12 +70,13 @@ public class AvailabilityTriviaTests {
 		Assert.Equal ("#endif", trivia.End);
 		Assert.NotNull (availability.Trivia);
 	}
-	
+
 	[Fact]
-	public void SingleSupportedPlatform () {
+	public void SingleSupportedPlatform ()
+	{
 		SymbolAvailability.Builder builder = SymbolAvailability.CreateBuilder ();
 		builder.Add (new SupportedOSPlatformData ("ios"));
-		builder.Add (new UnsupportedOSPlatformData( "tvos"));
+		builder.Add (new UnsupportedOSPlatformData ("tvos"));
 		builder.Add (new UnsupportedOSPlatformData ("macos"));
 		builder.Add (new UnsupportedOSPlatformData ("maccatalyst"));
 		var availability = builder.ToImmutable ();

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Availability/AvailabilityTriviaTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Availability/AvailabilityTriviaTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.Availability;
+using Xunit;
+
+namespace Microsoft.Macios.Generator.Tests.Availability;
+
+public class AvailabilityTriviaTests {
+	
+	[Fact]
+	public void AllSupportedPlatforms ()
+	{
+		SymbolAvailability.Builder builder = SymbolAvailability.CreateBuilder ();
+		builder.Add (new SupportedOSPlatformData ("ios12.0"));
+		builder.Add (new SupportedOSPlatformData ("tvos12.0"));
+		builder.Add (new SupportedOSPlatformData ("macos10.14"));
+		builder.Add (new SupportedOSPlatformData ("macCatalyst13.0"));
+		var availability = builder.ToImmutable ();
+		var trivia = new AvailabilityTrivia (availability);
+		Assert.Null (trivia.Start);
+		Assert.Null (trivia.End);
+		Assert.Null (availability.Trivia);
+	}
+
+	[Fact]
+	public void SomeUnsupportedVersions () {
+		SymbolAvailability.Builder builder = SymbolAvailability.CreateBuilder ();
+		builder.Add (new SupportedOSPlatformData ("ios12.0"));
+		builder.Add (new UnsupportedOSPlatformData ("ios9.0"));
+		builder.Add (new SupportedOSPlatformData ("tvos12.0"));
+		builder.Add (new SupportedOSPlatformData ("macos10.14"));
+		builder.Add (new SupportedOSPlatformData ("maccatalyst13.0"));
+		var availability = builder.ToImmutable ();
+		var trivia = new AvailabilityTrivia (availability);
+		Assert.Null (trivia.Start);
+		Assert.Null (trivia.End);
+		Assert.Null (availability.Trivia);
+	}
+	
+	[Fact]
+	public void SingleFullyUnsupportedPlatform () {
+		SymbolAvailability.Builder builder = SymbolAvailability.CreateBuilder ();
+		builder.Add (new UnsupportedOSPlatformData ("ios"));
+		builder.Add (new SupportedOSPlatformData ("tvos12.0"));
+		builder.Add (new SupportedOSPlatformData ("macos10.14"));
+		builder.Add (new SupportedOSPlatformData ("maccatalyst13.0"));
+		var availability = builder.ToImmutable ();
+		var trivia = new AvailabilityTrivia (availability);
+		Assert.Equal ("#if !IOS", trivia.Start);
+		Assert.Equal ("#endif", trivia.End);
+		Assert.NotNull (availability.Trivia);
+	}
+	
+	[Fact]
+	public void DoubleUnsupportedPlatform () {
+		SymbolAvailability.Builder builder = SymbolAvailability.CreateBuilder ();
+		builder.Add (new SupportedOSPlatformData ("ios"));
+		builder.Add (new SupportedOSPlatformData ("tvos12.0"));
+		builder.Add (new UnsupportedOSPlatformData ("macos"));
+		builder.Add (new UnsupportedOSPlatformData ("maccatalyst"));
+		var availability = builder.ToImmutable ();
+		var trivia = new AvailabilityTrivia (availability);
+		Assert.Equal ("#if IOS || TVOS", trivia.Start);
+		Assert.Equal ("#endif", trivia.End);
+		Assert.NotNull (availability.Trivia);
+	}
+	
+	[Fact]
+	public void SingleSupportedPlatform () {
+		SymbolAvailability.Builder builder = SymbolAvailability.CreateBuilder ();
+		builder.Add (new SupportedOSPlatformData ("ios"));
+		builder.Add (new UnsupportedOSPlatformData( "tvos"));
+		builder.Add (new UnsupportedOSPlatformData ("macos"));
+		builder.Add (new UnsupportedOSPlatformData ("maccatalyst"));
+		var availability = builder.ToImmutable ();
+		var trivia = new AvailabilityTrivia (availability);
+		Assert.Equal ("#if IOS", trivia.Start);
+		Assert.Equal ("#endif", trivia.End);
+		Assert.NotNull (availability.Trivia);
+	}
+
+}


### PR DESCRIPTION


If we are generating code, specially in the transformer, that does not have a specific platform, we need to generate the correct trivia to ensure that methods are not generated in the wrong platform.