### PR TITLE
[Rgen] Add the needed code to make the objc_msgSend signatures.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Attributes/MarshalDirective.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/MarshalDirective.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.Macios.Generator.Attributes;
+
+record CustomMarshalDirective (string? NativePrefix, string? NativeSuffix, string? Library);
+
+static class ExportDataExtensions {
+
+	public static bool ShouldMarshalNativeExceptions<T> (this ExportData<T> self) where T : Enum
+		=> self switch {
+			ExportData<ObjCBindings.Property> property => property.Flags.HasFlag (ObjCBindings.Property
+				.CustomMarshalDirective),
+			ExportData<ObjCBindings.Method> method => method.Flags.HasFlag (
+				ObjCBindings.Property.CustomMarshalDirective),
+			_ => false,
+		};
+	
+	public static CustomMarshalDirective? ToCustomMarshalDirective<T> (this ExportData<T> self) where T : Enum
+	{
+		var present = self switch {
+			ExportData<ObjCBindings.Property> property => property.Flags.HasFlag (ObjCBindings.Property
+				.CustomMarshalDirective),
+			ExportData<ObjCBindings.Method> method => method.Flags.HasFlag (
+				ObjCBindings.Property.CustomMarshalDirective),
+			_ => false,
+		};
+		if (present) {
+			return new (self.NativePrefix, self.NativeSuffix, self.Library);
+		}
+
+		return null;
+	}
+	
+}

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/MarshalDirective.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/MarshalDirective.cs
@@ -17,7 +17,7 @@ static class ExportDataExtensions {
 				ObjCBindings.Property.CustomMarshalDirective),
 			_ => false,
 		};
-	
+
 	public static CustomMarshalDirective? ToCustomMarshalDirective<T> (this ExportData<T> self) where T : Enum
 	{
 		var present = self switch {
@@ -33,5 +33,5 @@ static class ExportDataExtensions {
 
 		return null;
 	}
-	
+
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -31,7 +31,7 @@ readonly partial struct Property : IEquatable<Property> {
 		get => returnType;
 		private init {
 			returnType = value;
-			ValueParameter = new Parameter(0, returnType, "value");
+			ValueParameter = new Parameter (0, returnType, "value");
 		}
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -22,10 +22,18 @@ readonly partial struct Property : IEquatable<Property> {
 
 	public string BackingField { get; private init; }
 
+	readonly TypeInfo returnType;
+
 	/// <summary>
 	/// Representation of the property type.
 	/// </summary>
-	public TypeInfo ReturnType { get; } = default;
+	public TypeInfo ReturnType {
+		get => returnType;
+		private init {
+			returnType = value;
+			ValueParameter = new Parameter(0, returnType, "value");
+		}
+	}
 
 	/// <summary>
 	/// Returns if the property type is bittable.
@@ -61,6 +69,8 @@ readonly partial struct Property : IEquatable<Property> {
 	/// Get the list of accessor changes of the property.
 	/// </summary>
 	public ImmutableArray<Accessor> Accessors { get; } = [];
+
+	public Parameter ValueParameter { get; private init; }
 
 	public Accessor? GetAccessor (AccessorKind accessorKind)
 	{

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
@@ -20,6 +20,7 @@ readonly partial struct TypeInfo {
 		IsSmartEnum = symbol.IsSmartEnum ();
 		IsArray = symbol is IArrayTypeSymbol;
 		IsReferenceType = symbol.IsReferenceType;
+		IsStruct = symbol.TypeKind == TypeKind.Struct;
 		IsInterface = symbol.TypeKind == TypeKind.Interface;
 		IsNativeIntegerType = symbol.IsNativeIntegerType;
 		IsNativeEnum = symbol.HasAttribute (AttributesNames.NativeEnumAttribute);

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -228,24 +228,31 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 
 	public string? ToMarshallType (ReferenceKind referenceKind)
 	{
+#pragma warning disable format
 		var type = this switch {
 			// special cases based on name
-			{ Name: "nfloat" or "NFloat" } => "nfloat", { Name: "nint" or "nuint" } => MetadataName,
+			{ Name: "nfloat" or "NFloat" } => "nfloat", 
+			{ Name: "nint" or "nuint" } => MetadataName,
 			// special string case
 			{ SpecialType: SpecialType.System_String } => NativeHandle, // use a NSString when we get a string
 
 			// NSObject should use the native handle
-			{ IsNSObject: true } => NativeHandle, { IsINativeObject: true } => NativeHandle,
+			{ IsNSObject: true } => NativeHandle, 
+			{ IsINativeObject: true } => NativeHandle,
 
 			// structs will use their name
-			{ IsStruct: true, SpecialType: SpecialType.System_Double } => "Double", { IsStruct: true } => Name,
+			{ IsStruct: true, SpecialType: SpecialType.System_Double } => "Double", 
+			{ IsStruct: true } => Name,
 
 			// enums:
 			// IsSmartEnum: We are using a nsstring, so it should be a native handle.
 			// IsNativeEnum: Depends on the enum backing field kind.
 			// GeneralEnum: Depends on the EnumUnderlyingType
 
-			{ IsSmartEnum: true } => NativeHandle, { IsNativeEnum: true, EnumUnderlyingType: SpecialType.System_Int64 } => IntPtr, { IsNativeEnum: true, EnumUnderlyingType: SpecialType.System_UInt64 } => UIntPtr, { IsEnum: true, EnumUnderlyingType: not null } => EnumUnderlyingType.GetKeyword (),
+			{ IsSmartEnum: true } => NativeHandle, 
+			{ IsNativeEnum: true, EnumUnderlyingType: SpecialType.System_Int64 } => IntPtr, 
+			{ IsNativeEnum: true, EnumUnderlyingType: SpecialType.System_UInt64 } => UIntPtr, 
+			{ IsEnum: true, EnumUnderlyingType: not null } => EnumUnderlyingType.GetKeyword (),
 
 			// special type that is a keyword (none would be a ref type)
 			{ SpecialType: SpecialType.System_Void } => SpecialType.GetKeyword (),
@@ -256,6 +263,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 
 			_ => null,
 		};
+#pragma warning restore format
 		return type;
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -230,31 +230,25 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	{
 		var type = this switch {
 			// special cases based on name
-			{ Name: "nfloat" or "NFloat" } => "nfloat", 
-			{ Name: "nint" or "nuint" } => MetadataName,
+			{ Name: "nfloat" or "NFloat" } => "nfloat", { Name: "nint" or "nuint" } => MetadataName,
 			// special string case
 			{ SpecialType: SpecialType.System_String } => NativeHandle, // use a NSString when we get a string
 
 			// NSObject should use the native handle
-			{ IsNSObject: true } => NativeHandle, 
-			{ IsINativeObject: true } => NativeHandle,
+			{ IsNSObject: true } => NativeHandle, { IsINativeObject: true } => NativeHandle,
 
 			// structs will use their name
-			{ IsStruct: true, SpecialType: SpecialType.System_Double } => "Double", 
-			{ IsStruct: true } => Name,
+			{ IsStruct: true, SpecialType: SpecialType.System_Double } => "Double", { IsStruct: true } => Name,
 
 			// enums:
 			// IsSmartEnum: We are using a nsstring, so it should be a native handle.
 			// IsNativeEnum: Depends on the enum backing field kind.
 			// GeneralEnum: Depends on the EnumUnderlyingType
 
-			{ IsSmartEnum: true } => NativeHandle, 
-			{ IsNativeEnum: true, EnumUnderlyingType: SpecialType.System_Int64 } => IntPtr, 
-			{ IsNativeEnum: true, EnumUnderlyingType: SpecialType.System_UInt64 } => UIntPtr, 
-			{ IsEnum: true, EnumUnderlyingType: not null } => EnumUnderlyingType.GetKeyword (),
+			{ IsSmartEnum: true } => NativeHandle, { IsNativeEnum: true, EnumUnderlyingType: SpecialType.System_Int64 } => IntPtr, { IsNativeEnum: true, EnumUnderlyingType: SpecialType.System_UInt64 } => UIntPtr, { IsEnum: true, EnumUnderlyingType: not null } => EnumUnderlyingType.GetKeyword (),
 
 			// special type that is a keyword (none would be a ref type)
-			{ SpecialType: SpecialType.System_Void } => SpecialType.GetKeyword (), 
+			{ SpecialType: SpecialType.System_Void } => SpecialType.GetKeyword (),
 
 			// This should not happen in bindings because all of the types should either be native objects
 			// nsobjects, or structs 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -230,26 +230,31 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	{
 		var type = this switch {
 			// special cases based on name
-			{ Name: "nfloat" or "NFloat" } => "nfloat", { Name: "nint" or "nuint" } => MetadataName,
+			{ Name: "nfloat" or "NFloat" } => "nfloat", 
+			{ Name: "nint" or "nuint" } => MetadataName,
 			// special string case
 			{ SpecialType: SpecialType.System_String } => NativeHandle, // use a NSString when we get a string
 
 			// NSObject should use the native handle
-			{ IsNSObject: true } => NativeHandle, { IsINativeObject: true } => NativeHandle,
+			{ IsNSObject: true } => NativeHandle, 
+			{ IsINativeObject: true } => NativeHandle,
 
 			// structs will use their name
-			{ IsStruct: true, SpecialType: SpecialType.System_Double } => "Double", { IsStruct: true } => Name,
+			{ IsStruct: true, SpecialType: SpecialType.System_Double } => "Double", 
+			{ IsStruct: true } => Name,
 
 			// enums:
 			// IsSmartEnum: We are using a nsstring, so it should be a native handle.
-			// IsNativeEnum: Depends if the enum backing field kind.
+			// IsNativeEnum: Depends on the enum backing field kind.
 			// GeneralEnum: Depends on the EnumUnderlyingType
 
-			{ IsSmartEnum: true } => NativeHandle, { IsNativeEnum: true, EnumUnderlyingType: SpecialType.System_Int64 } => IntPtr, { IsNativeEnum: true, EnumUnderlyingType: SpecialType.System_UInt64 } => UIntPtr, { IsEnum: true, EnumUnderlyingType: not null } => EnumUnderlyingType.GetKeyword (),
+			{ IsSmartEnum: true } => NativeHandle, 
+			{ IsNativeEnum: true, EnumUnderlyingType: SpecialType.System_Int64 } => IntPtr, 
+			{ IsNativeEnum: true, EnumUnderlyingType: SpecialType.System_UInt64 } => UIntPtr, 
+			{ IsEnum: true, EnumUnderlyingType: not null } => EnumUnderlyingType.GetKeyword (),
 
 			// special type that is a keyword (none would be a ref type)
-			{ SpecialType: SpecialType.System_Void } => SpecialType.GetKeyword (), { SpecialType: not SpecialType.None } => MetadataName,
-
+			{ SpecialType: SpecialType.System_Void } => SpecialType.GetKeyword (), 
 
 			// This should not happen in bindings because all of the types should either be native objects
 			// nsobjects, or structs 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -19,7 +19,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 
 	readonly string fullyQualifiedName = string.Empty;
 	/// <summary>
-	/// Type of the parameter.
+	/// The fully qualified name of the type.
 	/// </summary>
 	public string FullyQualifiedName {
 		get => fullyQualifiedName;

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Macios.Generator.DataModel;
 /// Readonly structure that represents a change in a method return type.
 /// </summary>
 readonly partial struct TypeInfo : IEquatable<TypeInfo> {
-	
+
 	public static TypeInfo Void = new ("void", SpecialType.System_Void) { Parents = ["System.ValueType", "object"], };
 
 	readonly string fullyQualifiedName = string.Empty;
@@ -26,8 +26,8 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		init {
 			fullyQualifiedName = value;
 			var index = fullyQualifiedName.LastIndexOf ('.');
-			Name = index != -1 
-				? fullyQualifiedName.Substring (index + 1) 
+			Name = index != -1
+				? fullyQualifiedName.Substring (index + 1)
 				: fullyQualifiedName;
 		}
 	}
@@ -80,7 +80,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// Returns if the return type is a reference type.
 	/// </summary>
 	public bool IsReferenceType { get; }
-	
+
 	/// <summary>
 	/// Returns if the type is a struct.
 	/// </summary>
@@ -225,43 +225,36 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	const string NativeHandle = "NativeHandle";
 	const string IntPtr = "IntPtr";
 	const string UIntPtr = "UIntPtr";
-	
+
 	public string? ToMarshallType (ReferenceKind referenceKind)
 	{
 		var type = this switch {
 			// special cases based on name
-			{ Name: "nfloat" or "NFloat" } => "nfloat",
-			{ Name: "nint" or "nuint"} => MetadataName, 
+			{ Name: "nfloat" or "NFloat" } => "nfloat", { Name: "nint" or "nuint" } => MetadataName,
 			// special string case
-			{ SpecialType: SpecialType.System_String} => NativeHandle, // use a NSString when we get a string
-			
+			{ SpecialType: SpecialType.System_String } => NativeHandle, // use a NSString when we get a string
+
 			// NSObject should use the native handle
-			{ IsNSObject: true } => NativeHandle, 
-			{ IsINativeObject: true } => NativeHandle,
-			
+			{ IsNSObject: true } => NativeHandle, { IsINativeObject: true } => NativeHandle,
+
 			// structs will use their name
-			{ IsStruct: true, SpecialType: SpecialType.System_Double } => "Double",
-			{ IsStruct: true } => Name,
-			
+			{ IsStruct: true, SpecialType: SpecialType.System_Double } => "Double", { IsStruct: true } => Name,
+
 			// enums:
 			// IsSmartEnum: We are using a nsstring, so it should be a native handle.
 			// IsNativeEnum: Depends if the enum backing field kind.
 			// GeneralEnum: Depends on the EnumUnderlyingType
-			
-			{ IsSmartEnum: true } => NativeHandle,
-			{ IsNativeEnum: true, EnumUnderlyingType: SpecialType.System_Int64 } => IntPtr,
-			{ IsNativeEnum: true, EnumUnderlyingType: SpecialType.System_UInt64 } => UIntPtr,
-			{ IsEnum: true, EnumUnderlyingType: not null } => EnumUnderlyingType.GetKeyword (), 
-			
+
+			{ IsSmartEnum: true } => NativeHandle, { IsNativeEnum: true, EnumUnderlyingType: SpecialType.System_Int64 } => IntPtr, { IsNativeEnum: true, EnumUnderlyingType: SpecialType.System_UInt64 } => UIntPtr, { IsEnum: true, EnumUnderlyingType: not null } => EnumUnderlyingType.GetKeyword (),
+
 			// special type that is a keyword (none would be a ref type)
-			{ SpecialType: SpecialType.System_Void } => SpecialType.GetKeyword (),
-			{ SpecialType: not SpecialType.None } => MetadataName,
-			
-			
+			{ SpecialType: SpecialType.System_Void } => SpecialType.GetKeyword (), { SpecialType: not SpecialType.None } => MetadataName,
+
+
 			// This should not happen in bindings because all of the types should either be native objects
 			// nsobjects, or structs 
 			{ IsReferenceType: false } => Name,
-			
+
 			_ => null,
 		};
 		return type;

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -5,6 +5,8 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.Extensions;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
@@ -12,11 +14,25 @@ namespace Microsoft.Macios.Generator.DataModel;
 /// Readonly structure that represents a change in a method return type.
 /// </summary>
 readonly partial struct TypeInfo : IEquatable<TypeInfo> {
+	
+	public static TypeInfo Void = new ("void", SpecialType.System_Void) { Parents = ["System.ValueType", "object"], };
 
+	readonly string fullyQualifiedName = string.Empty;
 	/// <summary>
 	/// Type of the parameter.
 	/// </summary>
-	public string Name { get; }
+	public string FullyQualifiedName {
+		get => fullyQualifiedName;
+		init {
+			fullyQualifiedName = value;
+			var index = fullyQualifiedName.LastIndexOf ('.');
+			Name = index != -1 
+				? fullyQualifiedName.Substring (index + 1) 
+				: fullyQualifiedName;
+		}
+	}
+
+	public string Name { get; private init; } = string.Empty;
 
 	/// <summary>
 	/// The metadata name of the type. This is normally the same as name except
@@ -64,6 +80,11 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// Returns if the return type is a reference type.
 	/// </summary>
 	public bool IsReferenceType { get; }
+	
+	/// <summary>
+	/// Returns if the type is a struct.
+	/// </summary>
+	public bool IsStruct { get; }
 
 	/// <summary>
 	/// Returns if the return type is void.
@@ -116,7 +137,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 
 	internal TypeInfo (string name, SpecialType specialType)
 	{
-		Name = name;
+		FullyQualifiedName = name;
 		SpecialType = specialType;
 	}
 
@@ -126,19 +147,21 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		bool isBlittable = false,
 		bool isSmartEnum = false,
 		bool isArray = false,
-		bool isReferenceType = false) : this (name, specialType)
+		bool isReferenceType = false,
+		bool isStruct = false) : this (name, specialType)
 	{
 		IsNullable = isNullable;
 		IsBlittable = isBlittable;
 		IsSmartEnum = isSmartEnum;
 		IsArray = isArray;
 		IsReferenceType = isReferenceType;
+		IsStruct = isStruct;
 	}
 
 	/// <inheritdoc/>
 	public bool Equals (TypeInfo other)
 	{
-		if (Name != other.Name)
+		if (FullyQualifiedName != other.FullyQualifiedName)
 			return false;
 		if (SpecialType != other.SpecialType)
 			return false;
@@ -153,6 +176,8 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		if (IsArray != other.IsArray)
 			return false;
 		if (IsReferenceType != other.IsReferenceType)
+			return false;
+		if (IsStruct != other.IsStruct)
 			return false;
 		if (IsVoid != other.IsVoid)
 			return false;
@@ -184,7 +209,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	/// <inheritdoc/>
 	public override int GetHashCode ()
 	{
-		return HashCode.Combine (Name, IsNullable, IsBlittable, IsSmartEnum, IsArray, IsReferenceType, IsVoid);
+		return HashCode.Combine (FullyQualifiedName, IsNullable, IsBlittable, IsSmartEnum, IsArray, IsReferenceType, IsVoid);
 	}
 
 	public static bool operator == (TypeInfo left, TypeInfo right)
@@ -197,11 +222,56 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		return !left.Equals (right);
 	}
 
+	const string NativeHandle = "NativeHandle";
+	const string IntPtr = "IntPtr";
+	const string UIntPtr = "UIntPtr";
+	
+	public string? ToMarshallType (ReferenceKind referenceKind)
+	{
+		var type = this switch {
+			// special cases based on name
+			{ Name: "nfloat" or "NFloat" } => "nfloat",
+			{ Name: "nint" or "nuint"} => MetadataName, 
+			// special string case
+			{ SpecialType: SpecialType.System_String} => NativeHandle, // use a NSString when we get a string
+			
+			// NSObject should use the native handle
+			{ IsNSObject: true } => NativeHandle, 
+			{ IsINativeObject: true } => NativeHandle,
+			
+			// structs will use their name
+			{ IsStruct: true, SpecialType: SpecialType.System_Double } => "Double",
+			{ IsStruct: true } => Name,
+			
+			// enums:
+			// IsSmartEnum: We are using a nsstring, so it should be a native handle.
+			// IsNativeEnum: Depends if the enum backing field kind.
+			// GeneralEnum: Depends on the EnumUnderlyingType
+			
+			{ IsSmartEnum: true } => NativeHandle,
+			{ IsNativeEnum: true, EnumUnderlyingType: SpecialType.System_Int64 } => IntPtr,
+			{ IsNativeEnum: true, EnumUnderlyingType: SpecialType.System_UInt64 } => UIntPtr,
+			{ IsEnum: true, EnumUnderlyingType: not null } => EnumUnderlyingType.GetKeyword (), 
+			
+			// special type that is a keyword (none would be a ref type)
+			{ SpecialType: SpecialType.System_Void } => SpecialType.GetKeyword (),
+			{ SpecialType: not SpecialType.None } => MetadataName,
+			
+			
+			// This should not happen in bindings because all of the types should either be native objects
+			// nsobjects, or structs 
+			{ IsReferenceType: false } => Name,
+			
+			_ => null,
+		};
+		return type;
+	}
+
 	/// <inheritdoc/>
 	public override string ToString ()
 	{
 		var sb = new StringBuilder ("{");
-		sb.Append ($"Name: '{Name}', ");
+		sb.Append ($"Name: '{FullyQualifiedName}', ");
 		sb.Append ($"MetadataName: '{MetadataName}', ");
 		sb.Append ($"SpecialType: '{SpecialType}', ");
 		sb.Append ($"IsNullable: {IsNullable}, ");

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -277,6 +277,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		sb.Append ($"IsSmartEnum: {IsSmartEnum}, ");
 		sb.Append ($"IsArray: {IsArray}, ");
 		sb.Append ($"IsReferenceType: {IsReferenceType}, ");
+		sb.Append ($"IsStruct: {IsStruct}, ");
 		sb.Append ($"IsVoid : {IsVoid}, ");
 		sb.Append ($"IsNSObject : {IsNSObject}, ");
 		sb.Append ($"IsNativeObject: {IsINativeObject}, ");

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfoComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfoComparer.cs
@@ -10,7 +10,7 @@ class TypeInfoComparer : IComparer<TypeInfo> {
 	/// <inheritdoc/>
 	public int Compare (TypeInfo x, TypeInfo y)
 	{
-		var returnTypeComparison = String.Compare (x.Name, y.Name, StringComparison.Ordinal);
+		var returnTypeComparison = String.Compare (x.FullyQualifiedName, y.FullyQualifiedName, StringComparison.Ordinal);
 		if (returnTypeComparison != 0)
 			return returnTypeComparison;
 		var isNullableComparison = x.IsNullable.CompareTo (y.IsNullable);

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Dlfcn.cs
@@ -597,7 +597,7 @@ static partial class BindingSyntaxFactory {
 		if (!property.IsField)
 			throw new NotSupportedException ("Cannot retrieve getter for non field property.");
 
-		var fieldType = property.ReturnType.Name;
+		var fieldType = property.ReturnType.FullyQualifiedName;
 		var underlyingEnumType = property.ReturnType.EnumUnderlyingType.GetKeyword ();
 
 		Func<string, string, CompilationUnitSyntax> WrapGenericCall (string genericType,
@@ -621,12 +621,12 @@ static partial class BindingSyntaxFactory {
 #pragma warning disable format
 		if (property.ReturnType.IsNSObject) {
 			return property.ReturnType switch { 
-				{ Name: "Foundation.NSString" } => (Getter: GetStringConstant, Setter: SetString), 
-				{ Name: "Foundation.NSArray" } => (
-					Getter: WrapGenericCall (property.ReturnType.Name, GetNSObjectField),
+				{ FullyQualifiedName: "Foundation.NSString" } => (Getter: GetStringConstant, Setter: SetString), 
+				{ FullyQualifiedName: "Foundation.NSArray" } => (
+					Getter: WrapGenericCall (property.ReturnType.FullyQualifiedName, GetNSObjectField),
 					Setter: SetArray),
 				_ => (
-					Getter: WrapGenericCall (property.ReturnType.Name, GetNSObjectField),
+					Getter: WrapGenericCall (property.ReturnType.FullyQualifiedName, GetNSObjectField),
 					Setter: SetObject)
 			};
 		}
@@ -634,15 +634,15 @@ static partial class BindingSyntaxFactory {
 		// use the return type and the special type of the property to decide what getter we are going to us
 		return property.ReturnType switch {
 			// special types
-			{ Name: "CoreGraphics.CGSize" } => (Getter: GetCGSize, Setter: SetCGSize),
-			{ Name: "CoreMedia.CMTag" } => (
+			{ FullyQualifiedName: "CoreGraphics.CGSize" } => (Getter: GetCGSize, Setter: SetCGSize),
+			{ FullyQualifiedName: "CoreMedia.CMTag" } => (
 				Getter: WrapGenericCall ("CoreMedia.CMTag", GetStruct),
 				Setter: WrapThrow ()),
-			{ Name: "nfloat" } => (Getter: GetNFloat, Setter: SetNFloat),
+			{ FullyQualifiedName: "nfloat" } => (Getter: GetNFloat, Setter: SetNFloat),
 
 			// Blittable types 
-			{ Name: "CoreMedia.CMTime" or "AVFoundation.AVCaptureWhiteBalanceGains" }
-				=> (Getter: WrapGenericCall (property.ReturnType.Name, GetBlittableField),
+			{ FullyQualifiedName: "CoreMedia.CMTime" or "AVFoundation.AVCaptureWhiteBalanceGains" }
+				=> (Getter: WrapGenericCall (property.ReturnType.FullyQualifiedName, GetBlittableField),
 					Setter: WrapThrow ()),
 
 			// enum types, decide based on its enum backing field, smart enums have to be done in the binding

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -26,7 +26,7 @@ static partial class BindingSyntaxFactory {
 
 		// the name of the objcSend method is calculated in the following way	
 		// {CustomMarshallPrefix}_{MarshallTypeOfReturnType}_{objcSendMsg}{stret?_stret}_{string.Join('_', MarshallTypeArgs)}{nativeException?_exception}{CustomMarsahllPostfix}
-		// we will sue a sb to make things easy to follow
+		// we will use a sb to make things easy to follow
 		var sb = new StringBuilder ();
 
 		// first, decide if the user created a custom marshalling by checking the flags of the export data
@@ -70,9 +70,9 @@ static partial class BindingSyntaxFactory {
 	public static (string? Getter, string? Setter) GetObjCMessageSendMethods (in Property property, bool isSuper = false, bool isStret = false)
 	{
 		if (property.IsProperty) {
-			// the getter and the setter depend of the accessors that have been ser for the property, we do not want
-			// to calculate things that we wont use. The export data used will aslo depend if the getter/setter has a
-			// export attr attached
+			// the getter and the setter depend of the accessors that have been set for the property, we do not want
+			// to calculate things that we won't use. The export data used will also depend if the getter/setter has a
+			// export attribute attached
 			var getter = property.GetAccessor (AccessorKind.Getter);
 			string? getterMsgSend = null;
 			if (getter is not null) {

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -12,7 +12,7 @@ using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 
 namespace Microsoft.Macios.Generator.Emitters;
 
-static partial class BindingSyntaxFactory{
+static partial class BindingSyntaxFactory {
 	readonly static string objc_msgSend = "objc_msgSend";
 	readonly static string objc_msgSendSuper = "objc_msgSendSuper";
 
@@ -23,12 +23,12 @@ static partial class BindingSyntaxFactory{
 		if (flags is null)
 			// flags are not set, should be a bug, but we will return null
 			return null;
-		
+
 		// the name of the objcSend method is calculated in the following way	
 		// {CustomMarshallPrefix}_{MarshallTypeOfReturnType}_{objcSendMsg}{stret?_stret}_{string.Join('_', MarshallTypeArgs)}{nativeException?_exception}{CustomMarsahllPostfix}
 		// we will sue a sb to make things easy to follow
 		var sb = new StringBuilder ();
-		
+
 		// first, decide if the user created a custom marshalling by checking the flags of the export data
 		CustomMarshalDirective? customMarshalDirective = null;
 		if (flags.HasCustomMarshalDirective ()) {
@@ -43,7 +43,7 @@ static partial class BindingSyntaxFactory{
 
 		// return types do not have a reference kind
 		sb.Append (returnType.ToMarshallType (ReferenceKind.None));
-		sb.Append ('_');	
+		sb.Append ('_');
 		// append the msg method based if it is for super or not, do not append '_' intimidatingly, since if we do
 		// not have parameters, we are done
 		sb.Append (isSuper ? objc_msgSendSuper : objc_msgSend);
@@ -53,11 +53,11 @@ static partial class BindingSyntaxFactory{
 		// loop over params and get their native handler name
 		if (parameters.Length > 0) {
 			sb.Append ('_');
-			sb.AppendJoin ('_', parameters.Select ( p => p.Type.ToMarshallType (p.ReferenceKind)));
+			sb.AppendJoin ('_', parameters.Select (p => p.Type.ToMarshallType (p.ReferenceKind)));
 		}
 
 		// check if we do have a custom marshall exception set for the export
-		
+
 		// check any possible custom postfix naming
 		if (customMarshalDirective?.NativeSuffix is not null) {
 			sb.Append (customMarshalDirective.NativeSuffix);
@@ -76,17 +76,17 @@ static partial class BindingSyntaxFactory{
 			var getter = property.GetAccessor (AccessorKind.Getter);
 			string? getterMsgSend = null;
 			if (getter is not null) {
-				var  getterExportData = getter.Value.ExportPropertyData ?? property.ExportPropertyData;
+				var getterExportData = getter.Value.ExportPropertyData ?? property.ExportPropertyData;
 				if (getterExportData is not null) {
 					getterMsgSend = GetObjCMessageSendMethodName (getterExportData.Value, property.ReturnType, [],
 						isSuper, isStret);
 				}
 			}
-			
+
 			var setter = property.GetAccessor (AccessorKind.Setter);
 			string? setterMsgSend = null;
 			if (setter is not null) {
-				var  setterExportData = setter.Value.ExportPropertyData ?? property.ExportPropertyData;
+				var setterExportData = setter.Value.ExportPropertyData ?? property.ExportPropertyData;
 				if (setterExportData is not null) {
 					setterMsgSend = GetObjCMessageSendMethodName (setterExportData.Value, TypeInfo.Void,
 						[property.ValueParameter], isSuper, isStret);
@@ -99,6 +99,6 @@ static partial class BindingSyntaxFactory{
 	}
 
 	public static string? GetObjCMessageSendMethod (in Method method, bool isSuper = false, bool isStret = false)
-		=> 	GetObjCMessageSendMethodName (method.ExportMethodData, method.ReturnType, method.Parameters, isSuper, isStret);
-	
+		=> GetObjCMessageSendMethodName (method.ExportMethodData, method.ReturnType, method.Parameters, isSuper, isStret);
+
 }

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.DataModel;
+using Microsoft.Macios.Generator.Extensions;
+using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
+
+namespace Microsoft.Macios.Generator.Emitters;
+
+static partial class BindingSyntaxFactory{
+	readonly static string objc_msgSend = "objc_msgSend";
+	readonly static string objc_msgSendSuper = "objc_msgSendSuper";
+
+	static string? GetObjCMessageSendMethodName<T> (ExportData<T> exportData,
+		TypeInfo returnType, ImmutableArray<Parameter> parameters, bool isSuper = false, bool isStret = false) where T : Enum
+	{
+		var flags = exportData.Flags;
+		if (flags is null)
+			// flags are not set, should be a bug, but we will return null
+			return null;
+		
+		// the name of the objcSend method is calculated in the following way	
+		// {CustomMarshallPrefix}_{MarshallTypeOfReturnType}_{objcSendMsg}{stret?_stret}_{string.Join('_', MarshallTypeArgs)}{nativeException?_exception}{CustomMarsahllPostfix}
+		// we will sue a sb to make things easy to follow
+		var sb = new StringBuilder ();
+		
+		// first, decide if the user created a custom marshalling by checking the flags of the export data
+		CustomMarshalDirective? customMarshalDirective = null;
+		if (flags.HasCustomMarshalDirective ()) {
+			customMarshalDirective = exportData.ToCustomMarshalDirective ();
+		}
+
+		if (customMarshalDirective?.NativePrefix is not null) {
+			sb.Append (customMarshalDirective.NativePrefix);
+		} else if (flags.HasMarshalNativeExceptions ()) {
+			sb.Append ("xamarin_");
+		}
+
+		// return types do not have a reference kind
+		sb.Append (returnType.ToMarshallType (ReferenceKind.None));
+		sb.Append ('_');	
+		// append the msg method based if it is for super or not, do not append '_' intimidatingly, since if we do
+		// not have parameters, we are done
+		sb.Append (isSuper ? objc_msgSendSuper : objc_msgSend);
+		if (isStret) {
+			sb.Append ("_stret");
+		}
+		// loop over params and get their native handler name
+		if (parameters.Length > 0) {
+			sb.Append ('_');
+			sb.AppendJoin ('_', parameters.Select ( p => p.Type.ToMarshallType (p.ReferenceKind)));
+		}
+
+		// check if we do have a custom marshall exception set for the export
+		
+		// check any possible custom postfix naming
+		if (customMarshalDirective?.NativeSuffix is not null) {
+			sb.Append (customMarshalDirective.NativeSuffix);
+		} else if (flags.HasMarshalNativeExceptions ()) {
+			sb.Append ("_exception");
+		}
+		return sb.ToString ();
+	}
+
+	public static (string? Getter, string? Setter) GetObjCMessageSendMethods (in Property property, bool isSuper = false, bool isStret = false)
+	{
+		if (property.IsProperty) {
+			// the getter and the setter depend of the accessors that have been ser for the property, we do not want
+			// to calculate things that we wont use. The export data used will aslo depend if the getter/setter has a
+			// export attr attached
+			var getter = property.GetAccessor (AccessorKind.Getter);
+			string? getterMsgSend = null;
+			if (getter is not null) {
+				var  getterExportData = getter.Value.ExportPropertyData ?? property.ExportPropertyData;
+				if (getterExportData is not null) {
+					getterMsgSend = GetObjCMessageSendMethodName (getterExportData.Value, property.ReturnType, [],
+						isSuper, isStret);
+				}
+			}
+			
+			var setter = property.GetAccessor (AccessorKind.Setter);
+			string? setterMsgSend = null;
+			if (setter is not null) {
+				var  setterExportData = setter.Value.ExportPropertyData ?? property.ExportPropertyData;
+				if (setterExportData is not null) {
+					setterMsgSend = GetObjCMessageSendMethodName (setterExportData.Value, TypeInfo.Void,
+						[property.ValueParameter], isSuper, isStret);
+				}
+			}
+			return (Getter: getterMsgSend, Setter: setterMsgSend);
+		}
+
+		return default;
+	}
+
+	public static string? GetObjCMessageSendMethod (in Method method, bool isSuper = false, bool isStret = false)
+		=> 	GetObjCMessageSendMethodName (method.ExportMethodData, method.ReturnType, method.Parameters, isSuper, isStret);
+	
+}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
@@ -96,7 +96,7 @@ static partial class BindingSyntaxFactory {
 	/// <returns>The variable declaration syntax.</returns>
 	public static CompilationUnitSyntax FieldPropertyBackingVariable (in Property property)
 	{
-		var variableType = property.ReturnType.Name;
+		var variableType = property.ReturnType.FullyQualifiedName;
 		if (property.ReturnType.SpecialType is SpecialType.System_IntPtr or SpecialType.System_UIntPtr
 			&& property.ReturnType.MetadataName is not null) {
 			variableType = property.ReturnType.MetadataName;

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/EnumExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/EnumExtensions.cs
@@ -10,7 +10,7 @@ static class EnumExtensions {
 	public static bool HasCustomMarshalDirective (this Enum self)
 	{
 		return self switch {
-			// cast two the flags we know that could have the value and return it
+			// cast to the flags we know that could have the value and return it
 			ObjCBindings.Method methodFlag => methodFlag.HasFlag (ObjCBindings.Method.CustomMarshalDirective),
 			ObjCBindings.Property propertyFlag => propertyFlag.HasFlag (ObjCBindings.Property.CustomMarshalDirective),
 			_ => false
@@ -20,7 +20,7 @@ static class EnumExtensions {
 	public static bool HasMarshalNativeExceptions (this Enum self)
 	{
 		return self switch {
-			// cast two the flags we know that could have the value and return it
+			// cast to the flags we know that could have the value and return it
 			ObjCBindings.Method methodFlag => methodFlag.HasFlag (ObjCBindings.Method.MarshalNativeExceptions),
 			ObjCBindings.Property propertyFlag => propertyFlag.HasFlag (ObjCBindings.Property.MarshalNativeExceptions),
 			_ => false

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/EnumExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/EnumExtensions.cs
@@ -6,7 +6,7 @@ using System;
 namespace Microsoft.Macios.Generator.Extensions;
 
 static class EnumExtensions {
-	
+
 	public static bool HasCustomMarshalDirective (this Enum self)
 	{
 		return self switch {
@@ -16,8 +16,9 @@ static class EnumExtensions {
 			_ => false
 		};
 	}
-	
-	public static bool HasMarshalNativeExceptions (this Enum self) {
+
+	public static bool HasMarshalNativeExceptions (this Enum self)
+	{
 		return self switch {
 			// cast two the flags we know that could have the value and return it
 			ObjCBindings.Method methodFlag => methodFlag.HasFlag (ObjCBindings.Method.MarshalNativeExceptions),

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/EnumExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/EnumExtensions.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.Macios.Generator.Extensions;
+
+static class EnumExtensions {
+	
+	public static bool HasCustomMarshalDirective (this Enum self)
+	{
+		return self switch {
+			// cast two the flags we know that could have the value and return it
+			ObjCBindings.Method methodFlag => methodFlag.HasFlag (ObjCBindings.Method.CustomMarshalDirective),
+			ObjCBindings.Property propertyFlag => propertyFlag.HasFlag (ObjCBindings.Property.CustomMarshalDirective),
+			_ => false
+		};
+	}
+	
+	public static bool HasMarshalNativeExceptions (this Enum self) {
+		return self switch {
+			// cast two the flags we know that could have the value and return it
+			ObjCBindings.Method methodFlag => methodFlag.HasFlag (ObjCBindings.Method.MarshalNativeExceptions),
+			ObjCBindings.Property propertyFlag => propertyFlag.HasFlag (ObjCBindings.Property.MarshalNativeExceptions),
+			_ => false
+		};
+	}
+}

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/SpecialTypeExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/SpecialTypeExtensions.cs
@@ -11,7 +11,7 @@ static class SpecialTypeExtensions {
 
 	public static string? GetKeyword (this SpecialType? self)
 		=> self?.GetKeyword ();
-	
+
 	/// <summary>
 	/// Return the keyword for a given special type.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/SpecialTypeExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/SpecialTypeExtensions.cs
@@ -2,25 +2,43 @@
 // Licensed under the MIT License.
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.Macios.Generator.Extensions;
 
 static class SpecialTypeExtensions {
 
+	public static string? GetKeyword (this SpecialType? self)
+		=> self?.GetKeyword ();
+	
 	/// <summary>
 	/// Return the keyword for a given special type.
 	/// </summary>
 	/// <param name="self">The special type to convert.</param>
 	/// <returns>The string representation of the keyword.</returns>
-	public static string? GetKeyword (this SpecialType? self) => self switch {
-		SpecialType.System_SByte => "sbyte",
-		SpecialType.System_Byte => "byte",
-		SpecialType.System_Int16 => "short",
-		SpecialType.System_UInt16 => "ushort",
-		SpecialType.System_Int32 => "int",
-		SpecialType.System_UInt32 => "uint",
-		SpecialType.System_Int64 => "long",
-		SpecialType.System_UInt64 => "ulong",
-		_ => null
-	};
+	public static string? GetKeyword (this SpecialType self)
+	{
+		var kind = self switch {
+			SpecialType.System_Void => SyntaxKind.VoidKeyword,
+			SpecialType.System_Boolean => SyntaxKind.BoolKeyword,
+			SpecialType.System_Byte => SyntaxKind.ByteKeyword,
+			SpecialType.System_SByte => SyntaxKind.SByteKeyword,
+			SpecialType.System_Int16 => SyntaxKind.ShortKeyword,
+			SpecialType.System_UInt16 => SyntaxKind.UShortKeyword,
+			SpecialType.System_Int32 => SyntaxKind.IntKeyword,
+			SpecialType.System_UInt32 => SyntaxKind.UIntKeyword,
+			SpecialType.System_Int64 => SyntaxKind.LongKeyword,
+			SpecialType.System_UInt64 => SyntaxKind.ULongKeyword,
+			SpecialType.System_Double => SyntaxKind.DoubleKeyword,
+			SpecialType.System_Single => SyntaxKind.FloatKeyword,
+			SpecialType.System_Decimal => SyntaxKind.DecimalKeyword,
+			SpecialType.System_String => SyntaxKind.StringKeyword,
+			SpecialType.System_Char => SyntaxKind.CharKeyword,
+			SpecialType.System_Object => SyntaxKind.ObjectKeyword,
+			// Note that "dynamic" is a contextual keyword, so it should never show up here.
+			_ => SyntaxKind.None
+		};
+		return Token (kind).Text;
+	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/Formatters/ParameterFormatter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Formatters/ParameterFormatter.cs
@@ -39,7 +39,7 @@ static class ParameterFormatter {
 	{
 		if (parameter.Type.IsArray) {
 			// could be a params array or simply an array
-			var arrayType = ArrayType (IdentifierName (parameter.Type.Name))
+			var arrayType = ArrayType (IdentifierName (parameter.Type.FullyQualifiedName))
 				.WithRankSpecifiers (SingletonList (
 					ArrayRankSpecifier (
 						SingletonSeparatedList<ExpressionSyntax> (OmittedArraySizeExpression ()))));
@@ -50,8 +50,8 @@ static class ParameterFormatter {
 
 		// dealing with a non-array type
 		return parameter.Type.IsNullable
-			? NullableType (IdentifierName (parameter.Type.Name))
-			: IdentifierName (parameter.Type.Name);
+			? NullableType (IdentifierName (parameter.Type.FullyQualifiedName))
+			: IdentifierName (parameter.Type.FullyQualifiedName);
 	}
 
 	public static ParameterSyntax ToDeclaration (this in ParameterDataModel parameter)

--- a/src/rgen/Microsoft.Macios.Generator/Formatters/TypeInfoFormatter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Formatters/TypeInfoFormatter.cs
@@ -17,7 +17,7 @@ static class TypeInfoFormatter {
 		// reduce the surprise factor for a customer debugging the generated code.
 		var name = typeInfo.SpecialType is SpecialType.System_IntPtr or SpecialType.System_UIntPtr
 			? typeInfo.MetadataName! // we know is not null
-			: typeInfo.Name;
+			: typeInfo.FullyQualifiedName;
 
 		if (typeInfo.IsArray) {
 			// could be a params array or simply an array

--- a/src/rgen/Microsoft.Macios.Transformer/Microsoft.Macios.Transformer.csproj
+++ b/src/rgen/Microsoft.Macios.Transformer/Microsoft.Macios.Transformer.csproj
@@ -54,6 +54,9 @@
         <Compile Include="../Microsoft.Macios.Generator/Extensions/ParameterSyntaxExtensions.cs" >
             <Link>Extensions/ParameterSyntaxExtensions.cs</Link>
         </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/Extensions/SpecialTypeExtensions.cs" >
+            <Link>Extensions/SpecialTypeExtensions.cs</Link>
+        </Compile>
         <Compile Include="../Microsoft.Macios.Generator/Extensions/StringExtensions.cs" >
             <Link>Extensions/StringExtensions.cs</Link>
         </Compile>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoComparerTests.cs
@@ -15,7 +15,7 @@ public class TypeInfoComparerTests {
 	{
 		var x = new TypeInfo ("string");
 		var y = new TypeInfo ("int");
-		Assert.Equal (String.Compare (x.Name, y.Name, StringComparison.Ordinal), compare.Compare (x, y));
+		Assert.Equal (String.Compare (x.FullyQualifiedName, y.FullyQualifiedName, StringComparison.Ordinal), compare.Compare (x, y));
 	}
 
 	[Fact]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoToMarshallTypeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoToMarshallTypeTests.cs
@@ -30,7 +30,7 @@ public class Example {
 }
 ";
 			yield return [nfloatProperty, "nfloat"];
-			
+
 			const string otherNfloatProperty = @"
 using System;
 using System.Runtime.InteropServices;
@@ -56,9 +56,9 @@ public class Example {
 	public string Texturing { get; set; }
 }
 ";
-			
+
 			yield return [systemString, "NativeHandle"];
-			
+
 			const string nsstring = @"
 using System;
 using Foundation;
@@ -70,11 +70,11 @@ public class Example {
 	public NSString Texturing { get; set; }
 }
 ";
-			
+
 			yield return [nsstring, "NativeHandle"];
-			
+
 			//const string nsobject 
-			
+
 			const string nativeEnumInt64 = @"
 using System;
 using ObjCRuntime;
@@ -93,7 +93,7 @@ public class Example {
 }
 ";
 			yield return [nativeEnumInt64, "IntPtr"];
-			
+
 			const string nativeEnumUInt64 = @"
 using System;
 using ObjCRuntime;
@@ -149,7 +149,7 @@ public class Example {
 ";
 
 			yield return [normalEnum, "ulong"];
-			
+
 			const string boolProperty = @"
 using System;
 
@@ -188,7 +188,7 @@ public class Example {
 ";
 			yield return [structureProperty, "Point"];
 		}
-		
+
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoToMarshallTypeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/TypeInfoToMarshallTypeTests.cs
@@ -1,0 +1,212 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.DataModel;
+using Xamarin.Tests;
+using Xamarin.Utils;
+using Xunit;
+
+namespace Microsoft.Macios.Generator.Tests.DataModel;
+
+public class TypeInfoToMarshallTypeTests : BaseGeneratorTestClass {
+
+	class TestDataToMarshallType : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			const string nfloatProperty = @"
+using System;
+using System.Runtime.InteropServices;
+using Foundation;
+using ObjCRuntime;
+
+namespace NS;
+
+public class Example {
+	public nfloat Texturing { get; set; }
+}
+";
+			yield return [nfloatProperty, "nfloat"];
+			
+			const string otherNfloatProperty = @"
+using System;
+using System.Runtime.InteropServices;
+using Foundation;
+using ObjCRuntime;
+
+namespace NS;
+
+public class Example {
+	public NFloat Texturing { get; set; }
+}
+";
+			yield return [otherNfloatProperty, "nfloat"];
+
+			const string systemString = @"
+using System;
+using Foundation;
+using ObjCRuntime;
+
+namespace NS;
+
+public class Example {
+	public string Texturing { get; set; }
+}
+";
+			
+			yield return [systemString, "NativeHandle"];
+			
+			const string nsstring = @"
+using System;
+using Foundation;
+using ObjCRuntime;
+
+namespace NS;
+
+public class Example {
+	public NSString Texturing { get; set; }
+}
+";
+			
+			yield return [nsstring, "NativeHandle"];
+			
+			//const string nsobject 
+			
+			const string nativeEnumInt64 = @"
+using System;
+using ObjCRuntime;
+
+namespace NS;
+
+[Native]
+public enum AREnvironmentTexturing : long {
+	None,
+	Manual,
+	Automatic,
+}
+
+public class Example {
+	public AREnvironmentTexturing Texturing { get; set; }
+}
+";
+			yield return [nativeEnumInt64, "IntPtr"];
+			
+			const string nativeEnumUInt64 = @"
+using System;
+using ObjCRuntime;
+
+namespace NS;
+
+[Native]
+public enum AREnvironmentTexturing : ulong {
+	None,
+	Manual,
+	Automatic,
+}
+
+public class Example {
+	public AREnvironmentTexturing Texturing { get; set; }
+}
+";
+			yield return [nativeEnumUInt64, "UIntPtr"];
+
+			const string smartEnum = @"
+using System;
+using ObjCRuntime;
+using ObjCBindings;
+
+namespace NS;
+
+[BindingType]
+public enum AREnvironmentTexturing : ulong {
+	[Field<EnumValue> (""AVCaptureDeviceTypeBuiltInMicrophone"")]
+	None,
+}
+
+public class Example {
+	public AREnvironmentTexturing Texturing { get; set; }
+}
+";
+			yield return [smartEnum, "NativeHandle"];
+
+			const string normalEnum = @"
+using System;
+using ObjCRuntime;
+using ObjCBindings;
+
+namespace NS;
+
+public enum AREnvironmentTexturing : ulong {
+	None,
+}
+
+public class Example {
+	public AREnvironmentTexturing Texturing { get; set; }
+}
+";
+
+			yield return [normalEnum, "ulong"];
+			
+			const string boolProperty = @"
+using System;
+
+namespace NS;
+
+public class Example {
+	public bool Texturing { get; set; }
+}
+";
+			yield return [boolProperty, "bool"];
+
+			const string intProperty = @"
+using System;
+
+namespace NS;
+
+public class Example {
+	public int Texturing { get; set; }
+}
+";
+			yield return [intProperty, "int"];
+
+			const string structureProperty = @"
+using System;
+
+namespace NS;
+
+public struct Point {
+	int x;
+	int y;
+}
+
+public class Example {
+	public Point Centre { get; set; }
+}
+";
+			yield return [structureProperty, "Point"];
+		}
+		
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataToMarshallType>]
+	void ToMarshallType (ApplePlatform platform, string inputText, string expectedTypeName)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ().OfType<PropertyDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		Assert.True (Property.TryCreate (declaration, semanticModel, out var changes));
+		Assert.NotNull (changes);
+		var marshall = changes.Value.ReturnType.ToMarshallType (ReferenceKind.None);
+		Assert.NotNull (marshall);
+		Assert.Equal (expectedTypeName, marshall);
+	}
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/GetObjCMessageSendMethodNameTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/GetObjCMessageSendMethodNameTests.cs
@@ -36,7 +36,7 @@ class ARAnchor {
 }
 ";
 			yield return [propertyNSObjectGetter, "NativeHandle_objc_msgSend", null!, false, false];
-			
+
 			const string propertyNSObjectGetterSetter = @"
 using System;
 using ARKit;
@@ -71,9 +71,9 @@ class ARAnchor {
 	public string Name { get; }
 }
 ";
-			
+
 			yield return [propertyNSStringGetter, "NativeHandle_objc_msgSend", null!, false, false];
-			
+
 			const string propertyNSStringGetterSetter = @"
 using System;
 using ARKit;
@@ -90,7 +90,7 @@ class ARAnchor {
 	public string Name { get; set; }
 }
 ";
-			
+
 			yield return [propertyNSStringGetterSetter, "NativeHandle_objc_msgSend", "void_objc_msgSend_NativeHandle", false, false];
 
 			const string customMarshall = @"
@@ -117,7 +117,7 @@ class ARAnchor {
 	}
 }
 ";
-		
+
 			yield return [customMarshall, "xamarin_simd__NMatrix4_objc_msgSend", null!, false, false];
 
 			const string floatPropertyGetterSetter = @"
@@ -191,7 +191,7 @@ class ARAnchor {
 
 }
 ";
-			
+
 			yield return [nativeEnumUnsigned, "UIntPtr_objc_msgSend", "void_objc_msgSend_UIntPtr", false, false];
 
 			const string boolProperty = @"
@@ -212,9 +212,9 @@ class ARAnchor {
 
 }
 ";
-			
+
 			yield return [boolProperty, "bool_objc_msgSend", "void_objc_msgSend_bool", false, false];
-			
+
 			const string nfloatProperty = @"
 using System;
 using ARKit;
@@ -233,7 +233,7 @@ class ARAnchor {
 
 }
 ";
-			
+
 			yield return [nfloatProperty, "nfloat_objc_msgSend", "void_objc_msgSend_nfloat", false, false];
 
 			const string nintProperty = @"
@@ -254,9 +254,9 @@ class ARAnchor {
 
 }
 ";
-			
+
 			yield return [nintProperty, "IntPtr_objc_msgSend", "void_objc_msgSend_IntPtr", false, false];
-			
+
 			const string nuintProperty = @"
 using System;
 using ARKit;
@@ -275,9 +275,9 @@ class ARAnchor {
 
 }
 ";
-			
+
 			yield return [nuintProperty, "UIntPtr_objc_msgSend", "void_objc_msgSend_UIntPtr", false, false];
-			
+
 			const string cgsizeProperty = @"
 using System;
 using ARKit;
@@ -296,9 +296,9 @@ class ARAnchor {
 
 }
 ";
-			
+
 			yield return [cgsizeProperty, "CGSize_objc_msgSend", "void_objc_msgSend_CGSize", false, false];
-			
+
 			const string doubleProperty = @"
 using System;
 using ARKit;
@@ -317,13 +317,13 @@ class ARAnchor {
 
 }
 ";
-			
+
 			yield return [doubleProperty, "Double_objc_msgSend", "void_objc_msgSend_Double", false, false];
 		}
-		
+
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
-	
+
 	class TestDataGetObjCMessageSendMethodNameSuper : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -331,30 +331,30 @@ class ARAnchor {
 			foreach (var args in simple) {
 				// modify the first argument to be the correct msg send 
 				args [1] = ((string) args [1]).Replace ("objc_msgSend", "objc_msgSendSuper");
-				if (args[2] is not null)
+				if (args [2] is not null)
 					args [2] = ((string) args [2]).Replace ("objc_msgSend", "objc_msgSendSuper");
 				args [3] = true;
 				yield return args;
 			}
 		}
-		
+
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
-	
-	class TestDataGetObjCMessageSendMethodNameStret: IEnumerable<object []> {
+
+	class TestDataGetObjCMessageSendMethodNameStret : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
 			var simple = new TestDataGetObjCMessageSendMethodName ();
 			foreach (var args in simple) {
 				// modify the first argument to be the correct msg send 
 				args [1] = ((string) args [1]).Replace ("objc_msgSend", "objc_msgSend_stret");
-				if (args[2] is not null)
+				if (args [2] is not null)
 					args [2] = ((string) args [2]).Replace ("objc_msgSend", "objc_msgSend_stret");
 				args [4] = true;
 				yield return args;
 			}
 		}
-		
+
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/GetObjCMessageSendMethodNameTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/GetObjCMessageSendMethodNameTests.cs
@@ -1,0 +1,380 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.IO.Compression;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.DataModel;
+using Xamarin.Tests;
+using Xamarin.Utils;
+using Xunit;
+using static Microsoft.Macios.Generator.Emitters.BindingSyntaxFactory;
+
+namespace Microsoft.Macios.Generator.Tests.Emitters;
+
+public class GetObjCMessageSendMethodNameTests : BaseGeneratorTestClass {
+
+	class TestDataGetObjCMessageSendMethodName : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			const string propertyNSObjectGetter = @"
+using System;
+using ARKit;
+using Foundation;
+using ObjCRuntime;
+using ObjCBindings;
+
+namepsace NS;
+
+[BindingType<ObjCBindings.Class>]
+class ARAnchor {
+
+	[Export<ObjCBindings.Property>(""identifier"")]
+	public NSUuid Identifier { get; }
+}
+";
+			yield return [propertyNSObjectGetter, "NativeHandle_objc_msgSend", null!, false, false];
+			
+			const string propertyNSObjectGetterSetter = @"
+using System;
+using ARKit;
+using Foundation;
+using ObjCRuntime;
+using ObjCBindings;
+
+namepsace NS;
+
+[BindingType<ObjCBindings.Class>]
+class ARAnchor {
+
+	[Export<ObjCBindings.Property>(""identifier"")]
+	public NSUuid Identifier { get; set; }
+}
+";
+			yield return [propertyNSObjectGetterSetter, "NativeHandle_objc_msgSend", "void_objc_msgSend_NativeHandle", false, false];
+
+			const string propertyNSStringGetter = @"
+using System;
+using ARKit;
+using Foundation;
+using ObjCRuntime;
+using ObjCBindings;
+
+namepsace NS;
+
+[BindingType<ObjCBindings.Class>]
+class ARAnchor {
+
+	[Export<ObjCBindings.Property>(""name"")]
+	public string Name { get; }
+}
+";
+			
+			yield return [propertyNSStringGetter, "NativeHandle_objc_msgSend", null!, false, false];
+			
+			const string propertyNSStringGetterSetter = @"
+using System;
+using ARKit;
+using Foundation;
+using ObjCRuntime;
+using ObjCBindings;
+
+namepsace NS;
+
+[BindingType<ObjCBindings.Class>]
+class ARAnchor {
+
+	[Export<ObjCBindings.Property>(""name"")]
+	public string Name { get; set; }
+}
+";
+			
+			yield return [propertyNSStringGetterSetter, "NativeHandle_objc_msgSend", "void_objc_msgSend_NativeHandle", false, false];
+
+			const string customMarshall = @"
+using System;
+using ARKit;
+using Foundation;
+using CoreGraphics;
+using ObjCRuntime;
+using ObjCBindings;
+
+namepsace NS;
+
+[BindingType<ObjCBindings.Class>]
+class ARAnchor {
+
+	[Export<ObjCBindings.Property> (""transform"")]
+	NMatrix4 Transform {
+		[Export<ObjCBindings.Property> (
+			""transform"", 
+			Flags = ObjCBindings.Property.CustomMarshalDirective, 
+			NativePrefix = ""xamarin_simd__"", 
+			Library = ""__Internal"")]
+		get;
+	}
+}
+";
+		
+			yield return [customMarshall, "xamarin_simd__NMatrix4_objc_msgSend", null!, false, false];
+
+			const string floatPropertyGetterSetter = @"
+using System;
+using ARKit;
+using Foundation;
+using CoreGraphics;
+using ObjCRuntime;
+using ObjCBindings;
+
+namepsace NS;
+
+[BindingType<ObjCBindings.Class>]
+class ARAnchor {
+		[Export<ObjCBindings.Property> (""radius"")]
+		float Radius { get; set; }	
+}
+";
+			yield return [floatPropertyGetterSetter, "float_objc_msgSend", "void_objc_msgSend_float", false, false];
+
+			const string nativeEnum = @"
+using System;
+using ARKit;
+using Foundation;
+using CoreGraphics;
+using ObjCRuntime;
+using ObjCBindings;
+
+namepsace NS;
+
+[Native]
+public enum ARAppClipCodeUrlDecodingState : long {
+	Decoding,
+	Failed,
+	Decoded,
+}
+
+[BindingType<ObjCBindings.Class>]
+class ARAnchor {
+
+	[Export<ObjCBindings.Property> (""urlDecodingState"")]
+	ARAppClipCodeUrlDecodingState UrlDecodingState { get; set; }
+
+}
+";
+
+			yield return [nativeEnum, "IntPtr_objc_msgSend", "void_objc_msgSend_IntPtr", false, false];
+
+			const string nativeEnumUnsigned = @"
+using System;
+using ARKit;
+using Foundation;
+using CoreGraphics;
+using ObjCRuntime;
+using ObjCBindings;
+
+namepsace NS;
+
+[Native]
+public enum ARAppClipCodeUrlDecodingState : ulong {
+	Decoding,
+	Failed,
+	Decoded,
+}
+
+[BindingType<ObjCBindings.Class>]
+class ARAnchor {
+
+	[Export<ObjCBindings.Property> (""urlDecodingState"")]
+	ARAppClipCodeUrlDecodingState UrlDecodingState { get; set; }
+
+}
+";
+			
+			yield return [nativeEnumUnsigned, "UIntPtr_objc_msgSend", "void_objc_msgSend_UIntPtr", false, false];
+
+			const string boolProperty = @"
+using System;
+using ARKit;
+using Foundation;
+using CoreGraphics;
+using ObjCRuntime;
+using ObjCBindings;
+
+namepsace NS;
+
+[BindingType<ObjCBindings.Class>]
+class ARAnchor {
+
+	[Export<ObjCBindings.Property> (""tracked"")]
+	bool IsTracked { get; set; }
+
+}
+";
+			
+			yield return [boolProperty, "bool_objc_msgSend", "void_objc_msgSend_bool", false, false];
+			
+			const string nfloatProperty = @"
+using System;
+using ARKit;
+using Foundation;
+using CoreGraphics;
+using ObjCRuntime;
+using ObjCBindings;
+
+namepsace NS;
+
+[BindingType<ObjCBindings.Class>]
+class ARAnchor {
+
+	[Export<ObjCBindings.Property> (""tracked"")]
+	nfloat IsTracked { get; set; }
+
+}
+";
+			
+			yield return [nfloatProperty, "nfloat_objc_msgSend", "void_objc_msgSend_nfloat", false, false];
+
+			const string nintProperty = @"
+using System;
+using ARKit;
+using Foundation;
+using CoreGraphics;
+using ObjCRuntime;
+using ObjCBindings;
+
+namepsace NS;
+
+[BindingType<ObjCBindings.Class>]
+class ARAnchor {
+
+	[Export<ObjCBindings.Property> (""tracked"")]
+	nint IsTracked { get; set; }
+
+}
+";
+			
+			yield return [nintProperty, "IntPtr_objc_msgSend", "void_objc_msgSend_IntPtr", false, false];
+			
+			const string nuintProperty = @"
+using System;
+using ARKit;
+using Foundation;
+using CoreGraphics;
+using ObjCRuntime;
+using ObjCBindings;
+
+namepsace NS;
+
+[BindingType<ObjCBindings.Class>]
+class ARAnchor {
+
+	[Export<ObjCBindings.Property> (""tracked"")]
+	nuint IsTracked { get; set; }
+
+}
+";
+			
+			yield return [nuintProperty, "UIntPtr_objc_msgSend", "void_objc_msgSend_UIntPtr", false, false];
+			
+			const string cgsizeProperty = @"
+using System;
+using ARKit;
+using Foundation;
+using CoreGraphics;
+using ObjCRuntime;
+using ObjCBindings;
+
+namepsace NS;
+
+[BindingType<ObjCBindings.Class>]
+class ARAnchor {
+
+	[Export<ObjCBindings.Property> (""tracked"")]
+	CGSize IsTracked { get; set; }
+
+}
+";
+			
+			yield return [cgsizeProperty, "CGSize_objc_msgSend", "void_objc_msgSend_CGSize", false, false];
+			
+			const string doubleProperty = @"
+using System;
+using ARKit;
+using Foundation;
+using CoreGraphics;
+using ObjCRuntime;
+using ObjCBindings;
+
+namepsace NS;
+
+[BindingType<ObjCBindings.Class>]
+class ARAnchor {
+
+	[Export<ObjCBindings.Property> (""tracked"")]
+	double IsTracked { get; set; }
+
+}
+";
+			
+			yield return [doubleProperty, "Double_objc_msgSend", "void_objc_msgSend_Double", false, false];
+		}
+		
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	class TestDataGetObjCMessageSendMethodNameSuper : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			var simple = new TestDataGetObjCMessageSendMethodName ();
+			foreach (var args in simple) {
+				// modify the first argument to be the correct msg send 
+				args [1] = ((string) args [1]).Replace ("objc_msgSend", "objc_msgSendSuper");
+				if (args[2] is not null)
+					args [2] = ((string) args [2]).Replace ("objc_msgSend", "objc_msgSendSuper");
+				args [3] = true;
+				yield return args;
+			}
+		}
+		
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	class TestDataGetObjCMessageSendMethodNameStret: IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			var simple = new TestDataGetObjCMessageSendMethodName ();
+			foreach (var args in simple) {
+				// modify the first argument to be the correct msg send 
+				args [1] = ((string) args [1]).Replace ("objc_msgSend", "objc_msgSend_stret");
+				if (args[2] is not null)
+					args [2] = ((string) args [2]).Replace ("objc_msgSend", "objc_msgSend_stret");
+				args [4] = true;
+				yield return args;
+			}
+		}
+		
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataGetObjCMessageSendMethodName>]
+	[AllSupportedPlatformsClassData<TestDataGetObjCMessageSendMethodNameSuper>]
+	[AllSupportedPlatformsClassData<TestDataGetObjCMessageSendMethodNameStret>]
+	void GetObjCMessageSendMethodNamePropertiesTests (ApplePlatform platform, string inputText, string expectedGetter, string expectedSetter, bool isSuper, bool isStret)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ().OfType<PropertyDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		Assert.True (Property.TryCreate (declaration, semanticModel, out var changes));
+		Assert.NotNull (changes);
+		var methods = GetObjCMessageSendMethods (changes.Value, isSuper: isSuper, isStret: isStret);
+		Assert.Equal (expectedGetter, methods.Getter);
+		Assert.Equal (expectedSetter, methods.Setter);
+	}
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/EnumExtensionTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/EnumExtensionTests.cs
@@ -18,10 +18,10 @@ public class EnumExtensionTests {
 	[InlineData (ObjCBindings.Method.CustomMarshalDirective, true)]
 	[InlineData (StringComparison.Ordinal, false)]
 	public void HasCustomMarshalDirective<T> (T enumValue, bool expected) where T : Enum
-		=> Assert.Equal(enumValue.HasCustomMarshalDirective (), expected);
-	
+		=> Assert.Equal (enumValue.HasCustomMarshalDirective (), expected);
+
 	[Theory]
 	[InlineData (ObjCBindings.Property.Notification, false)]
 	public void HasMarshalNativeExceptions<T> (T enumValue, bool expected) where T : Enum
-		=> Assert.Equal(enumValue.HasMarshalNativeExceptions (), expected);
+		=> Assert.Equal (enumValue.HasMarshalNativeExceptions (), expected);
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/EnumExtensionTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/EnumExtensionTests.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma warning disable APL0003
+
+using System;
+using Microsoft.Macios.Generator.Extensions;
+using Xunit;
+
+namespace Microsoft.Macios.Generator.Tests.Extensions;
+
+public class EnumExtensionTests {
+
+	[Theory]
+	[InlineData (ObjCBindings.Property.Notification, false)]
+	[InlineData (ObjCBindings.Property.CustomMarshalDirective, true)]
+	[InlineData (ObjCBindings.Method.Default, false)]
+	[InlineData (ObjCBindings.Method.CustomMarshalDirective, true)]
+	[InlineData (StringComparison.Ordinal, false)]
+	public void HasCustomMarshalDirective<T> (T enumValue, bool expected) where T : Enum
+		=> Assert.Equal(enumValue.HasCustomMarshalDirective (), expected);
+	
+	[Theory]
+	[InlineData (ObjCBindings.Property.Notification, false)]
+	public void HasMarshalNativeExceptions<T> (T enumValue, bool expected) where T : Enum
+		=> Assert.Equal(enumValue.HasMarshalNativeExceptions (), expected);
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
@@ -40,7 +40,8 @@ static class TestDataFactory {
 			name: "int",
 			specialType: SpecialType.System_Int32,
 			isBlittable: !isNullable,
-			isNullable: isNullable
+			isNullable: isNullable,
+			isStruct: true
 		) {
 			Parents = ["System.ValueType", "object"],
 			Interfaces = isNullable
@@ -86,7 +87,8 @@ static class TestDataFactory {
 			name: "nint",
 			specialType: SpecialType.System_IntPtr,
 			isBlittable: !isNullable,
-			isNullable: isNullable
+			isNullable: isNullable,
+			isStruct: true
 		) {
 			Parents = ["System.ValueType", "object"],
 			Interfaces = isNullable
@@ -132,7 +134,8 @@ static class TestDataFactory {
 		=> new (
 			name: "bool",
 			specialType: SpecialType.System_Boolean,
-			isBlittable: false
+			isBlittable: false,
+			isStruct: true
 		) {
 			Parents = ["System.ValueType", "object"],
 			Interfaces = [
@@ -147,7 +150,7 @@ static class TestDataFactory {
 		};
 
 	public static TypeInfo ReturnTypeForVoid ()
-		=> new ("void", SpecialType.System_Void) { Parents = ["System.ValueType", "object"], };
+		=> new ("void", SpecialType.System_Void, isStruct: true) { Parents = ["System.ValueType", "object"], };
 
 	public static TypeInfo ReturnTypeForClass (string className, bool isNullable = false)
 		=> new (
@@ -174,7 +177,8 @@ static class TestDataFactory {
 
 	public static TypeInfo ReturnTypeForStruct (string structName)
 		=> new (
-			name: structName
+			name: structName,
+			isStruct: true
 		) { Parents = ["System.ValueType", "object"] };
 
 	public static TypeInfo ReturnTypeForEnum (string enumName, bool isSmartEnum = false, bool isNativeEnum = false)


### PR DESCRIPTION
Add the code that will calculate the signature needed in the objc_msgSend which will be the method that calls the native objc message.

## Extra context

When we create a binding for a native type we need to be able to send 'messages' to the objc objects. From a C# developer perspective a message can be considered a method. So for example, the following objc code:
```objc
[object foo:bar];
```
Can be translated to: 
```c
objc_msgSend(object, sel_getUid("foo:"), bar);
```
We can say this process is similar to reflection and the[ Invoke method](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.methodbase.invoke?view=net-9.0). Our bindings provide methods around [objc_msgsend](https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend) which we use to send the messaged with the arguments needed by the message. For example, a property with a NSString backing fields defined as:
```csharp
[Export ("text")]
public string? Text { get; set; }
```
Results in the following generated code:
```csharp
[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
public virtual string? Text {
	[Export ("text")]
	get {
		global::UIKit.UIApplication.EnsureUIThread ();
		if (IsDirectBinding) {
			return CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, Selector.GetHandle ("text")), false)!;
		} else {
			return CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.SuperHandle, Selector.GetHandle ("text")), false)!;
		}
	}
	[Export ("setText:")]
	set {
		global::UIKit.UIApplication.EnsureUIThread ();
		var nsvalue = CFString.CreateNative (value);
		if (IsDirectBinding) {
			global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, Selector.GetHandle ("setText:"), nsvalue);
		} else {
			global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.SuperHandle, Selector.GetHandle ("setText:"), nsvalue);
		}
		CFString.ReleaseNative (nsvalue);
	}
}
```
Our objc_msgSend method signatures are calculated based on the method parameters and live in the runtime. These objc_msgSend calls are generated by https://github.com/xamarin/xamarin-macios/blob/main/runtime/bindings-generator.cs#L20 For example a objc_msgSend signature for a method that takes a string and returns a string would be:
```c
IntPtr_objc_msgSend_IntPtr
```
But this is a simplifications because there is a diff between sending a message to a super class (prefix super) or if it deals with a structure (stret). 

More info can be found in the Apple [documentation](https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend).
