### PR TITLE
[Rgen] Renamed CodeChanges to Binding to be more clear.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Context/BindingContext.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Context/BindingContext.cs
@@ -14,9 +14,9 @@ readonly struct BindingContext {
 	/// <summary>
 	/// Current code changes for the binding context.
 	/// </summary>
-	public CodeChanges Changes { get; }
+	public Binding Changes { get; }
 
-	public BindingContext (TabbedStringBuilder builder, CodeChanges changes)
+	public BindingContext (TabbedStringBuilder builder, Binding changes)
 	{
 		Builder = builder;
 		Changes = changes;

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Binding.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Binding.Generator.cs
@@ -14,7 +14,7 @@ using Microsoft.Macios.Generator.Extensions;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
-readonly partial struct CodeChanges {
+readonly partial struct Binding {
 
 	/// <summary>
 	/// Represents the type of binding that the code changes are for.
@@ -146,7 +146,7 @@ readonly partial struct CodeChanges {
 	/// <param name="namespace">The namespace that contains the named type.</param>
 	/// <param name="fullyQualifiedSymbol">The fully qualified name of the symbol.</param>
 	/// <param name="symbolAvailability">The platform availability of the named symbol.</param>
-	internal CodeChanges (BindingInfo bindingInfo, string name, ImmutableArray<string> @namespace,
+	internal Binding (BindingInfo bindingInfo, string name, ImmutableArray<string> @namespace,
 		string fullyQualifiedSymbol, SymbolAvailability symbolAvailability)
 	{
 		this.bindingInfo = bindingInfo;
@@ -157,11 +157,11 @@ readonly partial struct CodeChanges {
 	}
 
 	/// <summary>
-	/// Creates a new instance of the <see cref="CodeChanges"/> struct for a given enum declaration.
+	/// Creates a new instance of the <see cref="Binding"/> struct for a given enum declaration.
 	/// </summary>
 	/// <param name="enumDeclaration">The enum declaration that triggered the change.</param>
 	/// <param name="context">The root binding context of the current compilation.</param>
-	CodeChanges (EnumDeclarationSyntax enumDeclaration, RootBindingContext context)
+	Binding (EnumDeclarationSyntax enumDeclaration, RootBindingContext context)
 	{
 		context.SemanticModel.GetSymbolData (
 			declaration: enumDeclaration,
@@ -207,11 +207,11 @@ readonly partial struct CodeChanges {
 	}
 
 	/// <summary>
-	/// Creates a new instance of the <see cref="CodeChanges"/> struct for a given class declaration.
+	/// Creates a new instance of the <see cref="Binding"/> struct for a given class declaration.
 	/// </summary>
 	/// <param name="classDeclaration">The class declaration that triggered the change.</param>
 	/// <param name="context">The root binding context of the current compilation.</param>
-	CodeChanges (ClassDeclarationSyntax classDeclaration, RootBindingContext context)
+	Binding (ClassDeclarationSyntax classDeclaration, RootBindingContext context)
 	{
 		context.SemanticModel.GetSymbolData (
 			declaration: classDeclaration,
@@ -239,11 +239,11 @@ readonly partial struct CodeChanges {
 	}
 
 	/// <summary>
-	/// Creates a new instance of the <see cref="CodeChanges"/> struct for a given interface declaration.
+	/// Creates a new instance of the <see cref="Binding"/> struct for a given interface declaration.
 	/// </summary>
 	/// <param name="interfaceDeclaration">The interface declaration that triggered the change.</param>
 	/// <param name="context">The root binding context of the current compilation.</param>
-	CodeChanges (InterfaceDeclarationSyntax interfaceDeclaration, RootBindingContext context)
+	Binding (InterfaceDeclarationSyntax interfaceDeclaration, RootBindingContext context)
 	{
 		context.SemanticModel.GetSymbolData (
 			declaration: interfaceDeclaration,
@@ -275,13 +275,13 @@ readonly partial struct CodeChanges {
 	/// <param name="baseTypeDeclarationSyntax">The declaration syntax whose change we want to calculate.</param>
 	/// <param name="context">The root binding context of the current compilation.</param>
 	/// <returns>A code change or null if it could not be calculated.</returns>
-	public static CodeChanges? FromDeclaration (BaseTypeDeclarationSyntax baseTypeDeclarationSyntax,
+	public static Binding? FromDeclaration (BaseTypeDeclarationSyntax baseTypeDeclarationSyntax,
 		RootBindingContext context)
 		=> baseTypeDeclarationSyntax switch {
-			EnumDeclarationSyntax enumDeclarationSyntax => new CodeChanges (enumDeclarationSyntax, context),
-			InterfaceDeclarationSyntax interfaceDeclarationSyntax => new CodeChanges (interfaceDeclarationSyntax,
+			EnumDeclarationSyntax enumDeclarationSyntax => new Binding (enumDeclarationSyntax, context),
+			InterfaceDeclarationSyntax interfaceDeclarationSyntax => new Binding (interfaceDeclarationSyntax,
 				context),
-			ClassDeclarationSyntax classDeclarationSyntax => new CodeChanges (classDeclarationSyntax, context),
+			ClassDeclarationSyntax classDeclarationSyntax => new Binding (classDeclarationSyntax, context),
 			_ => null
 		};
 }

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Binding.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Binding.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Macios.Generator.DataModel;
 /// generated code.
 /// </summary>
 [StructLayout (LayoutKind.Auto)]
-readonly partial struct CodeChanges {
+readonly partial struct Binding {
 
 	readonly string name = string.Empty;
 	/// <summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/BindingEqualityComparer.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/BindingEqualityComparer.cs
@@ -8,9 +8,9 @@ namespace Microsoft.Macios.Generator.DataModel;
 /// <summary>
 /// Custom code changes comparer used for the Roslyn code generation to invalidate caching.
 /// </summary>
-class CodeChangesEqualityComparer : EqualityComparer<CodeChanges> {
+class BindingEqualityComparer : EqualityComparer<Binding> {
 	/// <inheritdoc />
-	public override bool Equals (CodeChanges x, CodeChanges y)
+	public override bool Equals (Binding x, Binding y)
 	{
 
 		// order does not matter in the using directives, use a comparer that sorts them
@@ -82,7 +82,7 @@ class CodeChangesEqualityComparer : EqualityComparer<CodeChanges> {
 	}
 
 	/// <inheritdoc />
-	public override int GetHashCode (CodeChanges obj)
+	public override int GetHashCode (Binding obj)
 	{
 		return HashCode.Combine (obj.FullyQualifiedSymbol, obj.EnumMembers);
 	}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/CategoryEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/CategoryEmitter.cs
@@ -10,7 +10,7 @@ using Microsoft.Macios.Generator.DataModel;
 namespace Microsoft.Macios.Generator.Emitters;
 
 class CategoryEmitter : ICodeEmitter {
-	public string GetSymbolName (in CodeChanges codeChanges) => string.Empty;
+	public string GetSymbolName (in Binding binding) => string.Empty;
 	public IEnumerable<string> UsingStatements => [];
 	public bool TryEmit (in BindingContext bindingContext, [NotNullWhen (false)] out ImmutableArray<Diagnostic>? diagnostics)
 	{

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
@@ -17,7 +17,7 @@ using static Microsoft.Macios.Generator.Emitters.BindingSyntaxFactory;
 namespace Microsoft.Macios.Generator.Emitters;
 
 class ClassEmitter : ICodeEmitter {
-	public string GetSymbolName (in CodeChanges codeChanges) => codeChanges.Name;
+	public string GetSymbolName (in Binding binding) => binding.Name;
 
 	public IEnumerable<string> UsingStatements => [
 		"System",

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/EmitterFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/EmitterFactory.cs
@@ -17,6 +17,6 @@ static class EmitterFactory {
 		{ BindingType.Protocol, new InterfaceEmitter () },
 		{ BindingType.Category, new CategoryEmitter () },
 	};
-	public static bool TryCreate (CodeChanges changes, [NotNullWhen (true)] out ICodeEmitter? emitter)
+	public static bool TryCreate (Binding changes, [NotNullWhen (true)] out ICodeEmitter? emitter)
 		=> emitters.TryGetValue (changes.BindingType, out emitter);
 }

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ICodeEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ICodeEmitter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Macios.Generator.Emitters;
 /// Interface to be implemented by all those classes that know how to emit code for a binding.
 /// </summary>
 interface ICodeEmitter {
-	string GetSymbolName (in CodeChanges codeChanges);
+	string GetSymbolName (in Binding binding);
 	bool TryEmit (in BindingContext bindingContext, [NotNullWhen (false)] out ImmutableArray<Diagnostic>? diagnostics);
 	IEnumerable<string> UsingStatements { get; }
 }

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/InterfaceEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/InterfaceEmitter.cs
@@ -10,7 +10,7 @@ using Microsoft.Macios.Generator.DataModel;
 namespace Microsoft.Macios.Generator.Emitters;
 
 class InterfaceEmitter : ICodeEmitter {
-	public string GetSymbolName (in CodeChanges codeChanges) => string.Empty;
+	public string GetSymbolName (in Binding binding) => string.Empty;
 	public IEnumerable<string> UsingStatements => [];
 	public bool TryEmit (in BindingContext bindingContext, [NotNullWhen (false)] out ImmutableArray<Diagnostic>? diagnostics)
 	{

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/TrampolineEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/TrampolineEmitter.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Macios.Generator.Emitters;
 
 class TrampolineEmitter : ICodeEmitter {
 	public string SymbolNamespace => string.Empty;
-	public string GetSymbolName (in CodeChanges codeChanges) => string.Empty;
+	public string GetSymbolName (in Binding binding) => string.Empty;
 	public IEnumerable<string> UsingStatements { get; } = [];
 	public bool TryEmit (in BindingContext bindingContext, [NotNullWhen (false)] out ImmutableArray<Diagnostic>? diagnostics)
 	{

--- a/src/rgen/Microsoft.Macios.Generator/Formatters/SmartEnumFormatter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Formatters/SmartEnumFormatter.cs
@@ -16,7 +16,7 @@ static class SmartEnumFormatter {
 	/// <param name="smartEnumChange">The smart enum code change.</param>
 	/// <param name="extensionClassName">The name to use for the extension class.</param>
 	/// <returns>The class declaration for the extension class for a smart enum change.</returns>
-	public static CompilationUnitSyntax ToSmartEnumExtensionDeclaration (this in CodeChanges smartEnumChange,
+	public static CompilationUnitSyntax ToSmartEnumExtensionDeclaration (this in Binding smartEnumChange,
 		string extensionClassName)
 	{
 		// add to a set to make sure we do no duplicate them and make sure static and partial are present 
@@ -40,7 +40,7 @@ static class SmartEnumFormatter {
 	/// <param name="smartEnumChange">The smart enum code change.</param>
 	/// <param name="extensionClassName">The name to use for the extension class.</param>
 	/// <returns>The class declaration for the extension class for a smart enum change.</returns>
-	public static CompilationUnitSyntax? ToSmartEnumExtensionDeclaration (this in CodeChanges? smartEnumChange,
+	public static CompilationUnitSyntax? ToSmartEnumExtensionDeclaration (this in Binding? smartEnumChange,
 		string extensionClassName)
 		=> smartEnumChange is null ? null : ToSmartEnumExtensionDeclaration (smartEnumChange.Value, extensionClassName);
 }

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/CodeChanges.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/CodeChanges.Transformer.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Macios.Generator.DataModel;
 
-readonly partial struct CodeChanges {
+readonly partial struct Binding {
 
 	/// <summary>
 	/// Represents the type of binding that the code changes are for.
@@ -12,7 +12,7 @@ readonly partial struct CodeChanges {
 
 	public BindingInfo BindingInfo => throw new NotImplementedException ();
 
-	public CodeChanges ()
+	public Binding ()
 	{
 		FullyQualifiedSymbol = "";
 		IsStatic = false;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingComparerTests.cs
@@ -9,19 +9,19 @@ using static Microsoft.Macios.Generator.Tests.TestDataFactory;
 
 namespace Microsoft.Macios.Generator.Tests.DataModel;
 
-public class CodeChangesComparerTests : BaseGeneratorTestClass {
-	readonly CodeChangesEqualityComparer comparer = new ();
+public class BindingComparerTests : BaseGeneratorTestClass {
+	readonly BindingEqualityComparer comparer = new ();
 
 	[Fact]
 	public void CompareDifferentFullyQualifiedSymbol ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name1",
 			@namespace: ["NS"],
 			fullyQualifiedSymbol: "NS.name1",
 			symbolAvailability: new ());
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name1",
 			@namespace: ["NS"],
@@ -33,7 +33,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentBase ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name1",
 			@namespace: ["NS"],
@@ -41,7 +41,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 			symbolAvailability: new ()) {
 			Base = "Base1"
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name1",
 			@namespace: ["NS"],
@@ -55,7 +55,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentInterface ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name1",
 			@namespace: ["NS"],
@@ -63,7 +63,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 			symbolAvailability: new ()) {
 			Interfaces = ["IBase1"]
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name1",
 			@namespace: ["NS"],
@@ -77,13 +77,13 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentNameSymbol ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name1",
 			@namespace: ["NS"],
 			fullyQualifiedSymbol: "NS.name1",
 			symbolAvailability: new ());
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name2",
 			@namespace: ["NS"],
@@ -95,13 +95,13 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentNamespaceSymbol ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name1",
 			@namespace: ["NS1"],
 			fullyQualifiedSymbol: "NS.name1",
 			symbolAvailability: new ());
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name1",
 			@namespace: ["NS2"],
@@ -113,13 +113,13 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentBindingType ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
 			fullyQualifiedSymbol: "NS.name",
 			symbolAvailability: new ());
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -131,13 +131,13 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentAttributesLength ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
 			fullyQualifiedSymbol: "NS.name",
 			symbolAvailability: new ());
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -153,7 +153,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentAttributes ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -163,7 +163,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				new AttributeCodeChange (name: "name", arguments: ["arg1", "arg2"])
 			],
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -179,13 +179,13 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentMembersLength ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
 			fullyQualifiedSymbol: "NS.name",
 			symbolAvailability: new ());
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -207,7 +207,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentMembers ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -223,7 +223,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					attributes: [])
 			],
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -245,7 +245,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentPropertyLength ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -254,7 +254,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 			EnumMembers = [],
 			Properties = []
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -301,7 +301,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareSamePropertiesDiffOrder ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"], fullyQualifiedSymbol: "NS.name", symbolAvailability: new ()) {
@@ -367,7 +367,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					]),
 			]
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -441,7 +441,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentProperties ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -509,7 +509,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					]),
 			]
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -582,7 +582,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentEventsLength ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -666,7 +666,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					]),
 			]
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -740,7 +740,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareSameEventsDiffOrder ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -846,7 +846,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					]),
 			]
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -960,7 +960,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentEvents ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -1044,7 +1044,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 					]),
 			]
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -1137,7 +1137,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentMethodsLength ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -1283,7 +1283,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				)
 			]
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -1420,7 +1420,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareSameMethodsDiffOrder ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -1566,7 +1566,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				)
 			]
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -1719,7 +1719,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentMethods ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -1842,7 +1842,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				),
 			]
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -1984,7 +1984,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 		var builder = SymbolAvailability.CreateBuilder ();
 		builder.Add (new SupportedOSPlatformData ("ios"));
 		builder.Add (new SupportedOSPlatformData ("tvos"));
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -2130,7 +2130,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				)
 			]
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -2278,7 +2278,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 		var builder = SymbolAvailability.CreateBuilder ();
 		builder.Add (new SupportedOSPlatformData ("ios"));
 		builder.Add (new SupportedOSPlatformData ("tvos"));
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -2424,7 +2424,7 @@ public class CodeChangesComparerTests : BaseGeneratorTestClass {
 				)
 			]
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingEqualityComparerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingEqualityComparerTests.cs
@@ -7,19 +7,19 @@ using static Microsoft.Macios.Generator.Tests.TestDataFactory;
 
 namespace Microsoft.Macios.Generator.Tests.DataModel;
 
-public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
-	readonly CodeChangesEqualityComparer equalityComparer = new ();
+public class BindingEqualityComparerTests : BaseGeneratorTestClass {
+	readonly BindingEqualityComparer equalityComparer = new ();
 
 	[Fact]
 	public void CompareDifferentFullyQualifiedSymbol ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name1",
 			@namespace: ["NS"],
 			fullyQualifiedSymbol: "NS.name1",
 			symbolAvailability: new ());
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name2",
 			@namespace: ["NS"],
@@ -31,13 +31,13 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentBindingType ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.SmartEnum, new ()),
 			name: "name",
 			@namespace: ["NS"],
 			fullyQualifiedSymbol: "NS.name",
 			symbolAvailability: new ());
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -49,13 +49,13 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentAttributesLength ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
 			fullyQualifiedSymbol: "NS.name",
 			symbolAvailability: new ());
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -71,7 +71,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentAttributes ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -81,7 +81,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 				new AttributeCodeChange (name: "name", arguments: ["arg1", "arg2"])
 			],
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -97,13 +97,13 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentMembersLength ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
 			fullyQualifiedSymbol: "NS.name",
 			symbolAvailability: new ());
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -125,7 +125,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentMembers ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -141,7 +141,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					attributes: [])
 			],
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -163,7 +163,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentPropertyLength ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -172,7 +172,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 			EnumMembers = [],
 			Properties = []
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -219,7 +219,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareSamePropertiesDiffOrder ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -287,7 +287,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					]),
 			]
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -361,7 +361,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentProperties ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -429,7 +429,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					]),
 			]
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -503,7 +503,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentConstructorLength ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -572,7 +572,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 			],
 			Constructors = [],
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -649,7 +649,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareDifferentConstructors ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -720,7 +720,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 				new (type: "MyClass", symbolAvailability: new (), attributes: [], modifiers: [], parameters: [])
 			],
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -803,7 +803,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareSameConstructors ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -881,7 +881,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 					])
 			],
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -965,7 +965,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareSameConstructorsDiffOrder ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -1043,7 +1043,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 				new (type: "MyClass", symbolAvailability: new (), attributes: [], modifiers: [], parameters: []),
 			],
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -1126,7 +1126,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 	[Fact]
 	public void CompareSameDiffModifiers ()
 	{
-		var changes1 = new CodeChanges (
+		var changes1 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],
@@ -1208,7 +1208,7 @@ public class CodeChangesEqualityComparerTests : BaseGeneratorTestClass {
 				new (type: "MyClass", symbolAvailability: new (), attributes: [], modifiers: [], parameters: []),
 			],
 		};
-		var changes2 = new CodeChanges (
+		var changes2 = new Binding (
 			bindingInfo: new (BindingType.Protocol, new ()),
 			name: "name",
 			@namespace: ["NS"],

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/BindingTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Microsoft.Macios.Generator.Tests.DataModel;
 
-public class CodeChangesTests : BaseGeneratorTestClass {
+public class BindingTests : BaseGeneratorTestClass {
 	class TestDataSkipEnumValueDeclaration : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -74,7 +74,7 @@ enum AVMediaCharacteristics {
 			.FirstOrDefault ();
 		Assert.NotNull (node);
 		var semanticModel = compilation.GetSemanticModel (sourceTrees [0]);
-		Assert.Equal (expected, CodeChanges.Skip (node, semanticModel));
+		Assert.Equal (expected, Binding.Skip (node, semanticModel));
 	}
 
 
@@ -183,7 +183,7 @@ public class TestClass {
 			.FirstOrDefault ();
 		Assert.NotNull (node);
 		var semanticModel = compilation.GetSemanticModel (sourceTrees [0]);
-		Assert.Equal (expected, CodeChanges.Skip (node, semanticModel));
+		Assert.Equal (expected, Binding.Skip (node, semanticModel));
 	}
 
 	class TestDataSkipMethodDeclaration : IEnumerable<object []> {
@@ -249,6 +249,6 @@ public class TestClass {
 			.FirstOrDefault ();
 		Assert.NotNull (node);
 		var semanticModel = compilation.GetSemanticModel (sourceTrees [0]);
-		Assert.Equal (expected, CodeChanges.Skip (node, semanticModel));
+		Assert.Equal (expected, Binding.Skip (node, semanticModel));
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassBindingTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ClassBindingTests.cs
@@ -20,8 +20,8 @@ using static Microsoft.Macios.Generator.Tests.TestDataFactory;
 
 namespace Microsoft.Macios.Generator.Tests.DataModel;
 
-public class ClassCodeChangesTests : BaseGeneratorTestClass {
-	readonly CodeChangesEqualityComparer comparer = new ();
+public class ClassBindingTests : BaseGeneratorTestClass {
+	readonly BindingEqualityComparer comparer = new ();
 
 	class TestDataCodeChangesFromClassDeclaration : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
@@ -45,7 +45,7 @@ public partial class MyClass {
 
 			yield return [
 				emptyClass,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Class> ()),
 					name: "MyClass",
 					@namespace: ["NS"],
@@ -79,7 +79,7 @@ public partial class MyClass : NSObject {
 
 			yield return [
 				emptyClassWithBase,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Class> ()),
 					name: "MyClass",
 					@namespace: ["NS"],
@@ -115,7 +115,7 @@ public partial class MyClass : NSObject, IMyInterface {
 
 			yield return [
 				emptyClassWithBaseWithInterface,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Class> ()),
 					name: "MyClass",
 					@namespace: ["NS"],
@@ -149,7 +149,7 @@ internal partial class MyClass {
 
 			yield return [
 				internalClass,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Class> ()),
 					name: "MyClass",
 					@namespace: ["NS"],
@@ -187,7 +187,7 @@ public partial class MyClass {
 
 			yield return [
 				emptyClassAvailability,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Class> ()),
 					name: "MyClass",
 					@namespace: ["NS"],
@@ -225,7 +225,7 @@ public partial class MyClass {
 
 			yield return [
 				singleConstructorClass,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Class> ()),
 					name: "MyClass",
 					@namespace: ["NS"],
@@ -275,7 +275,7 @@ public partial class MyClass {
 
 			yield return [
 				multiConstructorClass,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Class> ()),
 					name: "MyClass",
 					@namespace: ["NS"],
@@ -335,7 +335,7 @@ public partial class MyClass {
 
 			yield return [
 				singlePropertyClass,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Class> ()),
 					name: "MyClass",
 					@namespace: ["NS"],
@@ -406,7 +406,7 @@ public partial class MyClass {
 
 			yield return [
 				singlePropertySmartEnumClass,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Class> ()),
 					name: "MyClass",
 					@namespace: ["NS"],
@@ -476,7 +476,7 @@ public partial class MyClass {
 
 			yield return [
 				singlePropertyEnumClass,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Class> ()),
 					name: "MyClass",
 					@namespace: ["NS"],
@@ -542,7 +542,7 @@ public partial class MyClass {
 
 			yield return [
 				notificationPropertyClass,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Class> ()),
 					name: "MyClass",
 					@namespace: ["NS"],
@@ -611,7 +611,7 @@ public partial class MyClass {
 
 			yield return [
 				fieldPropertyClass,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Class> ()),
 					name: "MyClass",
 					@namespace: ["NS"],
@@ -683,7 +683,7 @@ public partial class MyClass {
 
 			yield return [
 				multiPropertyClassMissingExport,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Class> ()),
 					name: "MyClass",
 					@namespace: ["NS"],
@@ -749,7 +749,7 @@ public partial class MyClass {
 
 			yield return [
 				customMarshallingProperty,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Class> ()),
 					name: "MyClass",
 					@namespace: ["NS"],
@@ -824,7 +824,7 @@ public partial class MyClass {
 
 			yield return [
 				multiPropertyClass,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Class> ()),
 					name: "MyClass",
 					@namespace: ["NS"],
@@ -920,7 +920,7 @@ public partial class MyClass {
 
 			yield return [
 				singleMethodClass,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Class> ()),
 					name: "MyClass",
 					@namespace: ["NS"],
@@ -975,7 +975,7 @@ public partial class MyClass {
 
 			yield return [
 				multiMethodClassMissingExport,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Class> ()),
 					name: "MyClass",
 					@namespace: ["NS"],
@@ -1031,7 +1031,7 @@ public partial class MyClass {
 ";
 			yield return [
 				multiMethodClass,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Class> ()),
 					name: "MyClass",
 					@namespace: ["NS"],
@@ -1102,7 +1102,7 @@ public partial class MyClass {
 
 			yield return [
 				singleEventClass,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Class> ()),
 					name: "MyClass",
 					@namespace: ["NS"],
@@ -1165,7 +1165,7 @@ public partial class MyClass {
 
 			yield return [
 				multiEventClass,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Class> ()),
 					name: "MyClass",
 					@namespace: ["NS"],
@@ -1243,7 +1243,7 @@ public partial class MyClass {
 
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataCodeChangesFromClassDeclaration>]
-	void CodeChangesFromClassDeclaration (ApplePlatform platform, string inputText, CodeChanges expected)
+	void CodeChangesFromClassDeclaration (ApplePlatform platform, string inputText, Binding expected)
 	{
 		var (compilation, sourceTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (sourceTrees);
@@ -1254,7 +1254,7 @@ public partial class MyClass {
 			.FirstOrDefault ();
 		Assert.NotNull (node);
 		var semanticModel = compilation.GetSemanticModel (sourceTrees [0]);
-		var changes = CodeChanges.FromDeclaration (node, semanticModel);
+		var changes = Binding.FromDeclaration (node, semanticModel);
 		Assert.NotNull (changes);
 		Assert.Equal (expected, changes.Value, comparer);
 	}
@@ -1262,7 +1262,7 @@ public partial class MyClass {
 	[Fact]
 	public void IsStaticPropertyTest ()
 	{
-		var changes = new CodeChanges (
+		var changes = new Binding (
 			bindingInfo: new (new BindingTypeData<Class> ()),
 			name: "name1",
 			@namespace: ["NS"],
@@ -1271,7 +1271,7 @@ public partial class MyClass {
 
 		Assert.False (changes.IsStatic);
 
-		changes = new CodeChanges (
+		changes = new Binding (
 			bindingInfo: new (new BindingTypeData<Class> ()),
 			name: "name1",
 			@namespace: ["NS"],
@@ -1289,7 +1289,7 @@ public partial class MyClass {
 	[Fact]
 	public void IsPartialPropertyTest ()
 	{
-		var changes = new CodeChanges (
+		var changes = new Binding (
 			bindingInfo: new (new BindingTypeData<Class> ()),
 			name: "name1",
 			@namespace: ["NS"],
@@ -1298,7 +1298,7 @@ public partial class MyClass {
 
 		Assert.False (changes.IsPartial);
 
-		changes = new CodeChanges (
+		changes = new Binding (
 			bindingInfo: new (new BindingTypeData<Class> ()),
 			name: "name1",
 			@namespace: ["NS"],
@@ -1316,7 +1316,7 @@ public partial class MyClass {
 	[Fact]
 	public void IsAbstractPropertyTest ()
 	{
-		var changes = new CodeChanges (
+		var changes = new Binding (
 			bindingInfo: new (new BindingTypeData<Class> ()),
 			name: "name1",
 			@namespace: ["NS"],
@@ -1325,7 +1325,7 @@ public partial class MyClass {
 
 		Assert.False (changes.IsAbstract);
 
-		changes = new CodeChanges (
+		changes = new Binding (
 			bindingInfo: new (new BindingTypeData<Class> ()),
 			name: "name1",
 			@namespace: ["NS"],

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumDeclarationCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumDeclarationCodeChangesTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 namespace Microsoft.Macios.Generator.Tests.DataModel;
 
 public class EnumDeclarationCodeChangesTests : BaseGeneratorTestClass {
-	CodeChanges CreateCodeChanges (ApplePlatform platform, string name, string inputText)
+	Binding CreateCodeChanges (ApplePlatform platform, string name, string inputText)
 	{
 		var (compilation, sourceTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (sourceTrees);
@@ -20,7 +20,7 @@ public class EnumDeclarationCodeChangesTests : BaseGeneratorTestClass {
 			.FirstOrDefault ();
 		Assert.NotNull (enumDeclaration);
 		var semanticModel = compilation.GetSemanticModel (sourceTrees [0]);
-		var codeChange = CodeChanges.FromDeclaration (enumDeclaration, semanticModel);
+		var codeChange = Binding.FromDeclaration (enumDeclaration, semanticModel);
 		Assert.NotNull (codeChange);
 		return codeChange.Value;
 	}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/InterfaceCodeChangesTests.cs
@@ -19,7 +19,7 @@ using static Microsoft.Macios.Generator.Tests.TestDataFactory;
 namespace Microsoft.Macios.Generator.Tests.DataModel;
 
 public class InterfaceCodeChangesTests : BaseGeneratorTestClass {
-	readonly CodeChangesEqualityComparer comparer = new ();
+	readonly BindingEqualityComparer comparer = new ();
 
 	class TestDataCodeChangesFromClassDeclaration : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
@@ -38,7 +38,7 @@ public partial interface IProtocol {
 
 			yield return [
 				emptyInterface,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Protocol> ()),
 					name: "IProtocol",
 					@namespace: ["NS"],
@@ -70,7 +70,7 @@ internal partial interface IProtocol {
 
 			yield return [
 				internalInterface,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Protocol> ()),
 					name: "IProtocol",
 					@namespace: ["NS"],
@@ -102,7 +102,7 @@ public partial interface IProtocol {
 
 			yield return [
 				singlePropertyInterface,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Protocol> ()),
 					name: "IProtocol",
 					@namespace: ["NS"],
@@ -171,7 +171,7 @@ public partial interface IProtocol {
 
 			yield return [
 				singlePropertySmartEnumInterface,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Protocol> ()),
 					name: "IProtocol",
 					@namespace: ["NS"],
@@ -239,7 +239,7 @@ public partial interface IProtocol {
 
 			yield return [
 				singlePropertyEnumInterface,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Protocol> ()),
 					name: "IProtocol",
 					@namespace: ["NS"],
@@ -303,7 +303,7 @@ public partial interface IProtocol {
 
 			yield return [
 				notificationPropertyInterface,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Protocol> ()),
 					name: "IProtocol",
 					@namespace: ["NS"],
@@ -371,7 +371,7 @@ public partial interface IProtocol {
 
 			yield return [
 				multiPropertyInterfaceMissingExport,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Protocol> ()),
 					name: "IProtocol",
 					@namespace: ["NS"],
@@ -435,7 +435,7 @@ public partial interface MyClass {
 
 			yield return [
 				customMarshallingProperty,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Protocol> ()),
 					name: "MyClass",
 					@namespace: ["NS"],
@@ -510,7 +510,7 @@ public partial interface IProtocol {
 
 			yield return [
 				multiPropertyInterface,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Protocol> ()),
 					name: "IProtocol",
 					@namespace: ["NS"],
@@ -604,7 +604,7 @@ public partial interface IProtocol {
 
 			yield return [
 				singleMethodInterface,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Protocol> ()),
 					name: "IProtocol",
 					@namespace: ["NS"],
@@ -657,7 +657,7 @@ public partial interface IProtocol {
 
 			yield return [
 				multiMethodInterfaceMissingExport,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Protocol> ()),
 					name: "IProtocol",
 					@namespace: ["NS"],
@@ -711,7 +711,7 @@ public partial interface IProtocol {
 ";
 			yield return [
 				multiMethodInterface,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Protocol> ()),
 					name: "IProtocol",
 					@namespace: ["NS"],
@@ -780,7 +780,7 @@ public partial interface IProtocol {
 
 			yield return [
 				singleEventInterface,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Protocol> ()),
 					name: "IProtocol",
 					@namespace: ["NS"],
@@ -841,7 +841,7 @@ public partial interface IProtocol {
 
 			yield return [
 				multiEventInterface,
-				new CodeChanges (
+				new Binding (
 					bindingInfo: new (new BindingTypeData<Protocol> ()),
 					name: "IProtocol",
 					@namespace: ["NS"],
@@ -917,7 +917,7 @@ public partial interface IProtocol {
 
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataCodeChangesFromClassDeclaration>]
-	void CodeChangesFromInterfaceDeclaration (ApplePlatform platform, string inputText, CodeChanges expected)
+	void CodeChangesFromInterfaceDeclaration (ApplePlatform platform, string inputText, Binding expected)
 	{
 		var (compilation, sourceTrees) =
 			CreateCompilation (platform, sources: inputText);
@@ -929,7 +929,7 @@ public partial interface IProtocol {
 			.FirstOrDefault ();
 		Assert.NotNull (node);
 		var semanticModel = compilation.GetSemanticModel (sourceTrees [0]);
-		var changes = CodeChanges.FromDeclaration (node, semanticModel);
+		var changes = Binding.FromDeclaration (node, semanticModel);
 		Assert.NotNull (changes);
 		Assert.Equal (expected, changes.Value, comparer);
 	}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/EmitterFactoryTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/EmitterFactoryTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 namespace Microsoft.Macios.Generator.Tests.Emitters;
 
 public class EmitterFactoryTests : BaseGeneratorTestClass {
-	CodeChanges CreateSymbol<T> (ApplePlatform platform, string inputText) where T : BaseTypeDeclarationSyntax
+	Binding CreateSymbol<T> (ApplePlatform platform, string inputText) where T : BaseTypeDeclarationSyntax
 	{
 		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (syntaxTrees);
@@ -25,7 +25,7 @@ public class EmitterFactoryTests : BaseGeneratorTestClass {
 		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
 		var symbol = semanticModel.GetDeclaredSymbol (declaration);
 		Assert.NotNull (symbol);
-		var changes = CodeChanges.FromDeclaration (declaration, semanticModel);
+		var changes = Binding.FromDeclaration (declaration, semanticModel);
 		Assert.NotNull (changes);
 		return changes.Value;
 	}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Formatters/SmartEnumFormatterTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Formatters/SmartEnumFormatterTests.cs
@@ -73,7 +73,7 @@ internal enum AVCaptureDeviceType {
 		Assert.NotNull (declaration);
 		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
 		Assert.NotNull (semanticModel);
-		var changes = CodeChanges.FromDeclaration (declaration, semanticModel);
+		var changes = Binding.FromDeclaration (declaration, semanticModel);
 		Assert.NotNull (changes);
 		var classDeclaration = changes.ToSmartEnumExtensionDeclaration (className);
 		Assert.NotNull (classDeclaration);


### PR DESCRIPTION
Initially the structure was name to make it simpler to understand that it was a code change/update that was detected by the roslyn incremental generator. Now that the structure is shared with the transformer, it makes more sense to rename it to 'Binding'.

We have update all the helper classes too.