### PR TITLE
[RGen] Add an implementation of Stret.IsBuiltInType with Roslyn.

### DIFF
--- a/src/ObjCRuntime/Stret.cs
+++ b/src/ObjCRuntime/Stret.cs
@@ -29,7 +29,9 @@ using Generator = System.Object;
 #endif
 using System.Runtime.InteropServices;
 
+#if !RGEN
 using Foundation;
+#endif
 
 // Disable until we get around to enable + fix any issues.
 #nullable disable
@@ -41,7 +43,7 @@ namespace ObjCRuntime {
 			// https://github.com/llvm-mirror/clang/blob/82f6d5c9ae84c04d6e7b402f72c33638d1fb6bc8/lib/CodeGen/TargetInfo.cpp#L5516-L5519
 			return members <= 4;
 		}
-
+#if !RGEN
 		static bool IsHomogeneousAggregateBaseType_Armv7k (Type t, Generator generator)
 		{
 			// https://github.com/llvm-mirror/clang/blob/82f6d5c9ae84c04d6e7b402f72c33638d1fb6bc8/lib/CodeGen/TargetInfo.cpp#L5500-L5514
@@ -77,6 +79,7 @@ namespace ObjCRuntime {
 
 			return true;
 		}
+#endif
 
 #if BGENERATOR
 		public static bool ArmNeedStret (Type returnType, Generator generator)
@@ -227,8 +230,8 @@ namespace ObjCRuntime {
 		{
 			return IsBuiltInType (type, true /* doesn't matter */, out var _);
 		}
-
-		static bool IsBuiltInType (Type type, bool is_64_bits, out int type_size)
+		
+		internal static bool IsBuiltInType (Type type, bool is_64_bits, out int type_size)
 		{
 			type_size = 0;
 

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
@@ -116,6 +117,26 @@ static partial class TypeSymbolExtensions {
 
 	internal static T? GetAttribute<T> (this ISymbol symbol, string attributeName, TryParse<T> tryParse) where T : struct
 		=> GetAttribute (symbol, () => attributeName, tryParse);
+	
+	/// <summary>
+	/// Return the layout kind used by the symbol.
+	/// </summary>
+	/// <param name="symbol">The struct symbol whose layout we need to retrieve.</param>
+	/// <returns>The layout kind used by the symbol.</returns>
+	public static LayoutKind GetStructLayout (this ITypeSymbol symbol)
+	{
+		// Check for StructLayout attribute with LayoutKind.Sequential
+		var layoutAttribute = symbol.GetAttributes ()
+			.FirstOrDefault (attr =>
+				attr.AttributeClass?.ToString () == typeof (StructLayoutAttribute).FullName);
+
+		if (layoutAttribute is not null) {
+			return (LayoutKind) layoutAttribute.ConstructorArguments [0].Value!;
+		}
+		
+		// the default is auto, another lyaout would have been set in the attr
+		return LayoutKind.Auto;
+	}
 
 	/// <summary>
 	/// Returns if a type is blittable or not.
@@ -164,16 +185,7 @@ static partial class TypeSymbolExtensions {
 			// if we are dealing with a structure, we have to check the layout type and all its children
 			if (symbol.TypeKind == TypeKind.Struct) {
 				// Check for StructLayout attribute with LayoutKind.Sequential
-				var layoutAttribute = symbol.GetAttributes ()
-					.FirstOrDefault (attr =>
-						attr.AttributeClass?.ToString () == typeof (StructLayoutAttribute).FullName);
-
-				if (layoutAttribute is not null) {
-					var layoutKind = (LayoutKind) layoutAttribute.ConstructorArguments [0].Value!;
-					if (layoutKind == LayoutKind.Auto) {
-						return false;
-					}
-				} else {
+				if (symbol.GetStructLayout () == LayoutKind.Auto) {
 					return false;
 				}
 
@@ -193,6 +205,64 @@ static partial class TypeSymbolExtensions {
 			// any other types are not blittable
 			return false;
 		}
+	}
+
+	/// <summary>
+	/// Return the offset of a field in a Explicitly layout struct.
+	/// </summary>
+	/// <param name="symbol">A Field symbol.</param>
+	/// <returns></returns>
+	public static int GetFieldOffset (this IFieldSymbol symbol)
+	{
+		
+		var offsetAttribute = symbol.GetAttributes ()
+			.FirstOrDefault (attr =>
+				attr.AttributeClass?.ToString () == typeof (FieldOffsetAttribute).FullName);
+
+		return offsetAttribute is not null
+				? (int) offsetAttribute.ConstructorArguments [0].Value! : 0;
+	}
+
+	/// <summary>
+	/// Indicate whether the current symbol represents a type whose definition is nested inside the definition of
+	/// another symbol.
+	/// </summary>
+	/// <param name="symbol">The symbol under test.</param>
+	/// <returns>True if the symbol is nested.</returns>
+	internal static bool IsNested (this ITypeSymbol symbol) => symbol.ContainingType != null;
+	
+	/// <summary>
+	/// Try to get the size of a built-in type.
+	/// </summary>
+	/// <param name="symbol">The symbol under test.</param>
+	/// <param name="is64bits">The platform target.</param>
+	/// <param name="size">The size of the native type.</param>
+	/// <returns>True if we could calculate the size.</returns>
+	internal static bool TryGetBuiltInTypeSize (this ITypeSymbol symbol, bool is64bits, out int size)
+	{
+		if (symbol.IsNested ()) {
+			size = 0;
+			return false;
+		}
+
+		var symbolInfo = (
+			ContainingNamespace: symbol.ContainingNamespace.ToDisplayString (), 
+			Name: symbol.Name, 
+			SpecialType: symbol.SpecialType
+		);
+		var (currentSize, result) = symbolInfo switch {
+			{ SpecialType: SpecialType.System_Void } => (0, true),
+			{ ContainingNamespace: "ObjCRuntime", Name: "NativeHandle" } => (is64bits ? 8 : 4, true),
+			{ ContainingNamespace: "System.Runtime.InteropServices", Name: "NFloat" } => (is64bits ? 8 : 4, true),
+			{ ContainingNamespace: "System", Name: "Char" or "Boolean" or "SByte" or "Byte" } => (1, true),	
+			{ ContainingNamespace: "System", Name: "Int16" or "UInt16" } => (2, true),
+			{ ContainingNamespace: "System", Name: "Single" or "Int32" or "UInt32" } => (4, true),
+			{ ContainingNamespace: "System", Name: "Double" or "Int64" or "UInt64" } => (8, true),
+			{ ContainingNamespace: "System", Name: "IntPtr" or "UIntPtr" or "nuint" or "nint" } => (is64bits? 8 : 4, true),
+			_ => (0, false)
+		};
+		size = currentSize;
+		return result;
 	}
 
 	/// <summary>
@@ -236,4 +306,5 @@ static partial class TypeSymbolExtensions {
 		parents = parentsBuilder.ToImmutable ();
 		interfaces = [.. interfacesSet];
 	}
+	
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsSizeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsSizeTests.cs
@@ -1,0 +1,261 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using ObjCRuntime;
+using Xamarin.Tests;
+using Xamarin.Utils;
+using Xunit;
+using Microsoft.Macios.Generator.Extensions;
+
+namespace Microsoft.Macios.Generator.Tests.Extensions;
+
+public class TypeSymbolExtensionsSizeTests : BaseGeneratorTestClass {
+
+
+	class TestDataTryGetBuiltInTypeSize : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			// create properties so that we can get the return symbol and use it to calculate the size, 
+			// we make sure that the result is the same as the one returned by the Stret.cs code.
+			const string nfloatProperty = @"
+using System;
+using System.Runtime.InteropServices;
+
+namespace NS;
+
+public class TestClass {
+	NFloat Test { get; set; }
+}
+";
+			yield return [nfloatProperty, typeof(NFloat)];
+			
+			const string charProperty = @"
+using System;
+using System.Runtime.InteropServices;
+
+namespace NS;
+
+public class TestClass {
+	char Test { get; set; }
+}
+";
+			yield return [charProperty, typeof(Char)];
+							
+			const string boolProperty = @"
+using System;
+using System.Runtime.InteropServices;
+
+namespace NS;
+
+public class TestClass {
+	bool Test { get; set; }
+}
+";
+			yield return [boolProperty, typeof(Boolean)];
+			
+			const string sbyteProperty = @"
+using System;
+using System.Runtime.InteropServices;
+
+namespace NS;
+
+public class TestClass {
+	sbyte Test { get; set; }
+}
+";
+			yield return [sbyteProperty, typeof(SByte)];
+			
+			const string byteProperty = @"
+using System;
+using System.Runtime.InteropServices;
+
+namespace NS;
+
+public class TestClass {
+	byte Test { get; set; }
+}
+";
+			yield return [byteProperty, typeof(Byte)];
+			
+			const string singleProperty = @"
+using System;
+using System.Runtime.InteropServices;
+
+namespace NS;
+
+public class TestClass {
+	Single Test { get; set; }
+}
+";
+			yield return [singleProperty, typeof(Single)];
+			
+			const string intProperty = @"
+using System;
+using System.Runtime.InteropServices;
+
+namespace NS;
+
+public class TestClass {
+	int Test { get; set; }
+}
+";
+			yield return [intProperty, typeof(Int32)];
+			
+			const string uintProperty = @"
+using System;
+using System.Runtime.InteropServices;
+
+namespace NS;
+
+public class TestClass {
+	uint Test { get; set; }
+}
+";
+			yield return [uintProperty, typeof(UInt32)];
+			
+			const string doubleProperty = @"
+using System;
+using System.Runtime.InteropServices;
+
+namespace NS;
+
+public class TestClass {
+	double Test { get; set; }
+}
+";
+			yield return [doubleProperty, typeof(Double)];
+			
+			const string int64Property = @"
+using System;
+using System.Runtime.InteropServices;
+
+namespace NS;
+
+public class TestClass {
+	long Test { get; set; }
+}
+";
+			yield return [int64Property, typeof(Int64)];
+			
+			const string uint64Property = @"
+using System;
+using System.Runtime.InteropServices;
+
+namespace NS;
+
+public class TestClass {
+	ulong Test { get; set; }
+}
+";
+			yield return [uint64Property, typeof(UInt64)];
+			
+			const string intPtrProperty = @"
+using System;
+using System.Runtime.InteropServices;
+
+namespace NS;
+
+public class TestClass {
+	IntPtr Test { get; set; }
+}
+";
+			yield return [intPtrProperty, typeof(IntPtr)];
+			
+			const string uIntPtrProperty = @"
+using System;
+using System.Runtime.InteropServices;
+
+namespace NS;
+
+public class TestClass {
+	UIntPtr Test { get; set; }
+}
+";
+			yield return [uIntPtrProperty, typeof(UIntPtr)];
+			
+			const string nintProperty = @"
+using System;
+using System.Runtime.InteropServices;
+
+namespace NS;
+
+public class TestClass {
+	nint Test { get; set; }
+}
+";
+			yield return [nintProperty, typeof(nint)];
+			
+			const string nuintProperty = @"
+using System;
+using System.Runtime.InteropServices;
+
+namespace NS;
+
+public class TestClass {
+	nuint Test { get; set; }
+}
+";
+			yield return [nuintProperty , typeof(nuint)];
+			
+			const string floatProperty = @"
+using System;
+using System.Runtime.InteropServices;
+
+namespace NS;
+
+public class TestClass {
+	float Test { get; set; }
+}
+";
+			yield return [floatProperty, typeof(float)];
+			
+			const string stringProperty = @"
+using System;
+using System.Runtime.InteropServices;
+
+namespace NS;
+
+public class TestClass {
+	string Test { get; set; }
+}
+";
+			yield return [stringProperty, typeof(string)];
+
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataTryGetBuiltInTypeSize>]
+	public void TryGetBuiltInTypeSizeTests (ApplePlatform platform, string inputText, Type type)
+	{
+		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
+		Assert.Single (syntaxTrees);
+		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
+		var declaration = syntaxTrees [0].GetRoot ()
+			.DescendantNodes ().OfType<PropertyDeclarationSyntax> ()
+			.FirstOrDefault ();
+		Assert.NotNull (declaration);
+		var symbol = semanticModel.GetDeclaredSymbol (declaration);
+		Assert.NotNull (symbol);
+		// 32bit
+		var expectedResult = Stret.IsBuiltInType (type, false, out var expectedTypeSize);
+		var result = symbol.Type.TryGetBuiltInTypeSize (false, out var returnTypeSize);
+		Assert.Equal(expectedResult, result);
+		Assert.Equal(expectedTypeSize, returnTypeSize);
+		
+		// 64bit
+		var expectedResult64 = Stret.IsBuiltInType (type, false, out var expectedTypeSize64);
+		var result64 = symbol.Type.TryGetBuiltInTypeSize (false, out var returnTypeSize64);
+		Assert.Equal(expectedResult64, result64);
+		Assert.Equal(expectedTypeSize64, returnTypeSize64);
+	} 
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Microsoft.Macios.Generator.Tests.csproj
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Microsoft.Macios.Generator.Tests.csproj
@@ -7,6 +7,7 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <NoWarn>NU1608</NoWarn>
         <RootNamespace>Microsoft.Macios.Generator.Tests</RootNamespace>
+        <DefineConstants>RGEN</DefineConstants>
     </PropertyGroup>
 
     <ItemGroup>
@@ -27,6 +28,9 @@
     </ItemGroup>
     
     <ItemGroup>
+        <Compile Include="..\..\..\src\ObjCRuntime\Stret.cs">
+          <Link>external\ObjCRuntime\Stret.cs</Link>
+        </Compile>
         <Compile Include="..\..\common\Configuration.cs" >
             <Link>external\Configuration.cs</Link>
         </Compile>


### PR DESCRIPTION
Roslyn has no access to reflection. Add an implementation of the IsBuiltInType method using the Roslyn APIs and test one method against the other. Tests show that the implementations return the same values for the same inputs.