### PR TITLE
[RGen] Make the transformer generator be netstandard2.1 to make editors happy.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/TabbedStringBuilder.cs
+++ b/src/rgen/Microsoft.Macios.Generator/TabbedStringBuilder.cs
@@ -122,6 +122,8 @@ partial class TabbedStringBuilder : IDisposable {
 		return this;
 	}
 
+#if NET9_0
+	
 	public TabbedStringBuilder Append (ref DefaultInterpolatedStringHandler handler)
 	{
 		WriteTabs ().Append (handler.ToStringAndClear ());
@@ -133,7 +135,7 @@ partial class TabbedStringBuilder : IDisposable {
 		WriteTabs ().Append (handler.ToStringAndClear ()).AppendLine ();
 		return this;
 	}
-
+	
 
 	/// <summary>
 	/// Append a new raw literal by prepending the correct indentation.
@@ -156,6 +158,8 @@ partial class TabbedStringBuilder : IDisposable {
 
 		return this;
 	}
+	
+#endif
 
 	/// <summary>
 	/// Append the generated code attribute to the current string builder. Added for convenience.

--- a/src/rgen/Microsoft.Macios.Transformer.Generator/Microsoft.Macios.Transformer.Generator/Microsoft.Macios.Transformer.Generator.csproj
+++ b/src/rgen/Microsoft.Macios.Transformer.Generator/Microsoft.Macios.Transformer.Generator/Microsoft.Macios.Transformer.Generator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>


### PR DESCRIPTION


In theory we can use net9.0 but some editors need netstandard2.1. We don't want yet to move Rgen, but we do want to move the transformer one beause it makes workign with the project easier.