### PR TITLE
[Rgen] Keep track if a type is a dictionary container.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
@@ -29,6 +29,7 @@ readonly partial struct TypeInfo {
 		symbol.GetInheritance (
 			isNSObject: out isNSObject,
 			isNativeObject: out isINativeObject,
+			isDictionaryContainer: out isDictionaryContainer,
 			parents: out parents,
 			interfaces: out interfaces);
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -123,7 +123,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		get => isINativeObject;
 		init => isINativeObject = value;
 	}
-	
+
 	readonly bool isDictionaryContainer = false;
 
 	public bool IsDictionaryContainer {

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -123,6 +123,13 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		get => isINativeObject;
 		init => isINativeObject = value;
 	}
+	
+	readonly bool isDictionaryContainer = false;
+
+	public bool IsDictionaryContainer {
+		get => isDictionaryContainer;
+		init => isDictionaryContainer = value;
+	}
 
 	readonly ImmutableArray<string> parents = [];
 	public ImmutableArray<string> Parents {
@@ -284,6 +291,7 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 		sb.Append ($"IsStruct: {IsStruct}, ");
 		sb.Append ($"IsVoid : {IsVoid}, ");
 		sb.Append ($"IsNSObject : {IsNSObject}, ");
+		sb.Append ($"IsDictionaryContainer: {IsDictionaryContainer}, ");
 		sb.Append ($"IsNativeObject: {IsINativeObject}, ");
 		sb.Append ($"IsInterface: {IsInterface}, ");
 		sb.Append ($"IsNativeIntegerType: {IsNativeIntegerType}, ");

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs
@@ -268,7 +268,7 @@ static partial class TypeSymbolExtensions {
 	/// <param name="interfaces">All implemented interfaces by the type and its parents.</param>
 	/// <param name="isNSObject">If the type inherits from NSObject.</param>
 	public static void GetInheritance (
-		this ITypeSymbol symbol, out bool isNSObject, out bool isNativeObject, out bool isDictionaryContainer, 
+		this ITypeSymbol symbol, out bool isNSObject, out bool isNativeObject, out bool isDictionaryContainer,
 		out ImmutableArray<string> parents,
 		out ImmutableArray<string> interfaces)
 	{

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs
@@ -263,18 +263,22 @@ static partial class TypeSymbolExtensions {
 	/// </summary>
 	/// <param name="symbol">The symbol whose inheritance we want to retrieve.</param>
 	/// <param name="isNativeObject">If the type implements the INativeObject interface.</param>
+	/// <param name="isDictionaryContainer">If the type inherits from Foundation.DictionaryContainer.</param>
 	/// <param name="parents">An immutable array of the parents in order from closest to furthest.</param>
 	/// <param name="interfaces">All implemented interfaces by the type and its parents.</param>
 	/// <param name="isNSObject">If the type inherits from NSObject.</param>
 	public static void GetInheritance (
-		this ITypeSymbol symbol, out bool isNSObject, out bool isNativeObject, out ImmutableArray<string> parents,
+		this ITypeSymbol symbol, out bool isNSObject, out bool isNativeObject, out bool isDictionaryContainer, 
+		out ImmutableArray<string> parents,
 		out ImmutableArray<string> interfaces)
 	{
 		const string nativeObjectInterface = "ObjCRuntime.INativeObject";
 		const string nsObjectClass = "Foundation.NSObject";
+		const string dictionaryContainerClass = "Foundation.DictionaryContainer";
 
 		isNSObject = false;
 		isNativeObject = false;
+		isDictionaryContainer = false;
 
 		// parents will be returned directly in a Immutable array via a builder since the order is important
 		// interfaces will use a hash set because we do not want duplicates.
@@ -287,6 +291,7 @@ static partial class TypeSymbolExtensions {
 			// check if we reach the NSObject as a parent
 			var parentName = currentType.ToDisplayString ().Trim ();
 			isNSObject |= parentName == nsObjectClass;
+			isDictionaryContainer |= parentName == dictionaryContainerClass;
 			parentsBuilder.Add (parentName);
 
 			// union with the current interfaces

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsInheritanceTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsInheritanceTests.cs
@@ -27,7 +27,13 @@ namespace NS;
 
 public class TestClass {}
 ";
-			yield return [simpleClass, false, false, new [] { "object" }, new string [] { }];
+			yield return [
+				simpleClass, 
+				false, 
+				false, 
+				false, 
+				new [] { "object" }, 
+				new string [] { }];
 
 			const string genericClass = @"
 using System;
@@ -36,7 +42,13 @@ namespace NS;
 
 public class TestClass<T> where T Enum {}
 ";
-			yield return [genericClass, false, false, new [] { "object" }, new string [] { }];
+			yield return [
+				genericClass, 
+				false, 
+				false, 
+				false, 
+				new [] { "object" }, 
+				new string [] { }];
 
 			const string singleParent = @"
 using System;
@@ -47,7 +59,13 @@ public class Parent {}
 public class TestClass : Parent {}
 ";
 
-			yield return [singleParent, false, false, new [] { "NS.Parent", "object" }, new string [] { }];
+			yield return [
+				singleParent, 
+				false, 
+				false, 
+				false, 
+				new [] { "NS.Parent", "object" }, 
+				new string [] { }];
 
 			const string genericParent = @"
 using System;
@@ -58,7 +76,13 @@ public class Parent<T> where T object {}
 public class TestClass : Parent<string> {}
 ";
 
-			yield return [genericParent, false, false, new [] { "NS.Parent<string>", "object" }, new string [] { }];
+			yield return [
+				genericParent, 
+				false, 
+				false, 
+				false, 
+				new [] { "NS.Parent<string>", "object" }, 
+				new string [] { }];
 
 			const string multiParent = @"
 using System;
@@ -70,7 +94,12 @@ public class Parent1 : Parent0 {}
 public class TestClass : Parent1 {}
 ";
 
-			yield return [multiParent, false, false, new [] { "NS.Parent1", "NS.Parent0", "object" }, new string [] { }];
+			yield return [multiParent, 
+				false, 
+				false, 
+				false, 
+				new [] { "NS.Parent1", "NS.Parent0", "object" }, 
+				new string [] { }];
 
 			const string singleInterface = @"
 using System;
@@ -81,7 +110,13 @@ public interface IInterface {}
 public class TestClass : IInterface {}
 ";
 
-			yield return [singleInterface, false, false, new [] { "object" }, new [] { "NS.IInterface" }];
+			yield return [
+				singleInterface, 
+				false, 
+				false, 
+				false, 
+				new [] { "object" }, 
+				new [] { "NS.IInterface" }];
 
 			const string genericInterface = @"
 using System;
@@ -92,7 +127,13 @@ public interface IInterface<T> where T : object {}
 public class TestClass : IInterface<string> {}
 ";
 
-			yield return [genericInterface, false, false, new [] { "object" }, new [] { "NS.IInterface<string>" }];
+			yield return [
+				genericInterface, 
+				false, 
+				false, 
+				false, 
+				new [] { "object" }, 
+				new [] { "NS.IInterface<string>" }];
 
 			const string severalInterfaces = @"
 using System;
@@ -104,7 +145,13 @@ public interface IInterface2 {}
 public class TestClass : IInterface1, IInterface2  {}
 ";
 
-			yield return [severalInterfaces, false, false, new [] { "object" }, new [] { "NS.IInterface1", "NS.IInterface2" }];
+			yield return [
+				severalInterfaces, 
+				false, 
+				false, 
+				false, 
+				new [] { "object" }, 
+				new [] { "NS.IInterface1", "NS.IInterface2" }];
 
 			const string severalGenericInterfaces = @"
 using System;
@@ -115,7 +162,12 @@ public interface IInterface1<T> where T : object {}
 public class TestClass : IInterface1<string>, IInterface1<int>  {}
 ";
 
-			yield return [severalGenericInterfaces, false, false, new [] { "object" }, new [] { "NS.IInterface1<string>", "NS.IInterface1<int>" }];
+			yield return [severalGenericInterfaces, 
+				false, 
+				false, 
+				false, 
+				new [] { "object" }, 
+				new [] { "NS.IInterface1<string>", "NS.IInterface1<int>" }];
 
 			const string parentSingleInterface = @"
 using System;
@@ -127,7 +179,13 @@ public class Parent : IInterface {}
 public class TestClass : Parent {}
 ";
 
-			yield return [parentSingleInterface, false, false, new [] { "NS.Parent", "object" }, new [] { "NS.IInterface" }];
+			yield return [
+				parentSingleInterface, 
+				false, 
+				false, 
+				false, 
+				new [] { "NS.Parent", "object" }, 
+				new [] { "NS.IInterface" }];
 
 			const string nsObjectChild = @"
 using System;
@@ -149,6 +207,7 @@ public partial class AVCaptureDataOutputSynchronizer : NSObject
 			yield return [nsObjectChild,
 				true,
 				true,
+				false, 
 				new [] { "Foundation.NSObject", "object" },
 				new [] {
 				"ObjCRuntime.INativeObject",
@@ -180,6 +239,7 @@ public partial class Child : AVCaptureDataOutputSynchronizer {}
 			yield return [nsObjectNestedChild,
 				true,
 				true,
+				false, 
 				new [] { "NS.AVCaptureDataOutputSynchronizer", "Foundation.NSObject", "object" },
 				new [] {
 				"ObjCRuntime.INativeObject",
@@ -209,10 +269,27 @@ public partial class AVCaptureDataOutputSynchronizer : INativeObject
 			yield return [nativeObjectInterface,
 				false,
 				true,
+				false, 
 				new [] { "object" },
 				new [] {
 				"ObjCRuntime.INativeObject",
 			}];
+
+			const string dictionaryContainer = @"
+using System;
+using Foundation;
+using ObjCRuntime;
+
+namespace NS;
+public partial class SKCloudServiceSetupOptions : DictionaryContainer { }
+";
+			
+			yield return [dictionaryContainer,
+				false,
+				false,
+				true, 
+				new [] { "Foundation.DictionaryContainer", "object" },
+				new string [] { }];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
@@ -221,7 +298,8 @@ public partial class AVCaptureDataOutputSynchronizer : INativeObject
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataInheritanceClasses>]
 	void GetInheritance (ApplePlatform platform, string inputText,
-		bool expectedIsNSObject, bool expectedIsNativeObject, string [] expectedParents, string [] expectedInterfaces)
+		bool expectedIsNSObject, bool expectedIsNativeObject, bool expectedDictionaryContainer, 
+		string [] expectedParents, string [] expectedInterfaces)
 	{
 		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);
 		Assert.Single (syntaxTrees);
@@ -237,11 +315,13 @@ public partial class AVCaptureDataOutputSynchronizer : INativeObject
 		symbol.GetInheritance (
 			isNSObject: out var isNsObject,
 			isNativeObject: out var isNativeObject,
+			isDictionaryContainer: out var isDictionaryContainer,
 			parents: out var parents,
 			interfaces: out var interfaces);
 		Assert.Equal (expectedIsNSObject, isNsObject);
 		Assert.Equal (expectedIsNativeObject, isNativeObject);
 		Assert.Equal (expectedParents, parents);
 		Assert.Equal (expectedInterfaces, interfaces);
+		Assert.Equal (expectedDictionaryContainer, isDictionaryContainer);
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsInheritanceTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsInheritanceTests.cs
@@ -28,11 +28,11 @@ namespace NS;
 public class TestClass {}
 ";
 			yield return [
-				simpleClass, 
-				false, 
-				false, 
-				false, 
-				new [] { "object" }, 
+				simpleClass,
+				false,
+				false,
+				false,
+				new [] { "object" },
 				new string [] { }];
 
 			const string genericClass = @"
@@ -43,11 +43,11 @@ namespace NS;
 public class TestClass<T> where T Enum {}
 ";
 			yield return [
-				genericClass, 
-				false, 
-				false, 
-				false, 
-				new [] { "object" }, 
+				genericClass,
+				false,
+				false,
+				false,
+				new [] { "object" },
 				new string [] { }];
 
 			const string singleParent = @"
@@ -60,11 +60,11 @@ public class TestClass : Parent {}
 ";
 
 			yield return [
-				singleParent, 
-				false, 
-				false, 
-				false, 
-				new [] { "NS.Parent", "object" }, 
+				singleParent,
+				false,
+				false,
+				false,
+				new [] { "NS.Parent", "object" },
 				new string [] { }];
 
 			const string genericParent = @"
@@ -77,11 +77,11 @@ public class TestClass : Parent<string> {}
 ";
 
 			yield return [
-				genericParent, 
-				false, 
-				false, 
-				false, 
-				new [] { "NS.Parent<string>", "object" }, 
+				genericParent,
+				false,
+				false,
+				false,
+				new [] { "NS.Parent<string>", "object" },
 				new string [] { }];
 
 			const string multiParent = @"
@@ -94,11 +94,11 @@ public class Parent1 : Parent0 {}
 public class TestClass : Parent1 {}
 ";
 
-			yield return [multiParent, 
-				false, 
-				false, 
-				false, 
-				new [] { "NS.Parent1", "NS.Parent0", "object" }, 
+			yield return [multiParent,
+				false,
+				false,
+				false,
+				new [] { "NS.Parent1", "NS.Parent0", "object" },
 				new string [] { }];
 
 			const string singleInterface = @"
@@ -111,11 +111,11 @@ public class TestClass : IInterface {}
 ";
 
 			yield return [
-				singleInterface, 
-				false, 
-				false, 
-				false, 
-				new [] { "object" }, 
+				singleInterface,
+				false,
+				false,
+				false,
+				new [] { "object" },
 				new [] { "NS.IInterface" }];
 
 			const string genericInterface = @"
@@ -128,11 +128,11 @@ public class TestClass : IInterface<string> {}
 ";
 
 			yield return [
-				genericInterface, 
-				false, 
-				false, 
-				false, 
-				new [] { "object" }, 
+				genericInterface,
+				false,
+				false,
+				false,
+				new [] { "object" },
 				new [] { "NS.IInterface<string>" }];
 
 			const string severalInterfaces = @"
@@ -146,11 +146,11 @@ public class TestClass : IInterface1, IInterface2  {}
 ";
 
 			yield return [
-				severalInterfaces, 
-				false, 
-				false, 
-				false, 
-				new [] { "object" }, 
+				severalInterfaces,
+				false,
+				false,
+				false,
+				new [] { "object" },
 				new [] { "NS.IInterface1", "NS.IInterface2" }];
 
 			const string severalGenericInterfaces = @"
@@ -162,11 +162,11 @@ public interface IInterface1<T> where T : object {}
 public class TestClass : IInterface1<string>, IInterface1<int>  {}
 ";
 
-			yield return [severalGenericInterfaces, 
-				false, 
-				false, 
-				false, 
-				new [] { "object" }, 
+			yield return [severalGenericInterfaces,
+				false,
+				false,
+				false,
+				new [] { "object" },
 				new [] { "NS.IInterface1<string>", "NS.IInterface1<int>" }];
 
 			const string parentSingleInterface = @"
@@ -180,11 +180,11 @@ public class TestClass : Parent {}
 ";
 
 			yield return [
-				parentSingleInterface, 
-				false, 
-				false, 
-				false, 
-				new [] { "NS.Parent", "object" }, 
+				parentSingleInterface,
+				false,
+				false,
+				false,
+				new [] { "NS.Parent", "object" },
 				new [] { "NS.IInterface" }];
 
 			const string nsObjectChild = @"
@@ -207,7 +207,7 @@ public partial class AVCaptureDataOutputSynchronizer : NSObject
 			yield return [nsObjectChild,
 				true,
 				true,
-				false, 
+				false,
 				new [] { "Foundation.NSObject", "object" },
 				new [] {
 				"ObjCRuntime.INativeObject",
@@ -239,7 +239,7 @@ public partial class Child : AVCaptureDataOutputSynchronizer {}
 			yield return [nsObjectNestedChild,
 				true,
 				true,
-				false, 
+				false,
 				new [] { "NS.AVCaptureDataOutputSynchronizer", "Foundation.NSObject", "object" },
 				new [] {
 				"ObjCRuntime.INativeObject",
@@ -269,7 +269,7 @@ public partial class AVCaptureDataOutputSynchronizer : INativeObject
 			yield return [nativeObjectInterface,
 				false,
 				true,
-				false, 
+				false,
 				new [] { "object" },
 				new [] {
 				"ObjCRuntime.INativeObject",
@@ -283,11 +283,11 @@ using ObjCRuntime;
 namespace NS;
 public partial class SKCloudServiceSetupOptions : DictionaryContainer { }
 ";
-			
+
 			yield return [dictionaryContainer,
 				false,
 				false,
-				true, 
+				true,
 				new [] { "Foundation.DictionaryContainer", "object" },
 				new string [] { }];
 		}
@@ -298,7 +298,7 @@ public partial class SKCloudServiceSetupOptions : DictionaryContainer { }
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataInheritanceClasses>]
 	void GetInheritance (ApplePlatform platform, string inputText,
-		bool expectedIsNSObject, bool expectedIsNativeObject, bool expectedDictionaryContainer, 
+		bool expectedIsNSObject, bool expectedIsNativeObject, bool expectedDictionaryContainer,
 		string [] expectedParents, string [] expectedInterfaces)
 	{
 		var (compilation, syntaxTrees) = CreateCompilation (platform, sources: inputText);


### PR DESCRIPTION
Dictionary containers require a special marshaling when we use them in the msgSend functions. Keep track of that fact in the TypeInfo so that we can make sure that it is correctly dealt with.