### PR TITLE
[Rgen] Provide a method to return the current UI namespaces.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Extensions/CompilationExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/CompilationExtensions.cs
@@ -53,7 +53,7 @@ static class CompilationExtensions {
 	{
 		CSharpSyntaxTree? firstTree = (CSharpSyntaxTree?) self.SyntaxTrees.FirstOrDefault ();
 
-		return firstTree is null ? ImmutableArray<string>.Empty : [..firstTree.Options.PreprocessorSymbolNames];
+		return firstTree is null ? ImmutableArray<string>.Empty : [.. firstTree.Options.PreprocessorSymbolNames];
 	}
 
 
@@ -86,7 +86,7 @@ static class CompilationExtensions {
 	{
 		lock (uiNamespaceLock) {
 			if (force || uiNamespacesCache is null) {
-				uiNamespacesCache = new();
+				uiNamespacesCache = new ();
 				// build the hash set based on the current definitions used in the compilation
 				var preprocessorSymbols = self.GetPreprocessorSymbols ();
 				foreach (var ns in uiNamespaces) {

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/CompilationExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/CompilationExtensions.cs
@@ -1,11 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.Macios.Generator.Extensions;
 
 static class CompilationExtensions {
-
 	/// <summary>
 	/// Return the current platform that the compilation is targeting.
 	/// </summary>
@@ -41,5 +47,57 @@ static class CompilationExtensions {
 
 		// we cannot identify the platform we are working on
 		return PlatformName.None;
+	}
+
+	public static ImmutableArray<string> GetPreprocessorSymbols (this Compilation self)
+	{
+		CSharpSyntaxTree? firstTree = (CSharpSyntaxTree?) self.SyntaxTrees.FirstOrDefault ();
+
+		return firstTree is null ? ImmutableArray<string>.Empty : [..firstTree.Options.PreprocessorSymbolNames];
+	}
+
+
+	// list of known ui namespaces
+	static readonly HashSet<string> uiNamespaces = new HashSet<string> {
+		"AppKit",
+		"UIKit",
+		"Twitter",
+		"NewsstandKit",
+		"QuickLook",
+		"EventKitUI",
+		"AddressBookUI",
+		"MessageUI",
+		"PhotosUI",
+		"HealthKitUI",
+		"GameKit",
+		"MapKit"
+	};
+
+	readonly static Lock uiNamespaceLock = new Lock ();
+	static HashSet<string>? uiNamespacesCache = null;
+
+	/// <summary>
+	/// Calculates the UI namespaces for the current compilation.
+	/// </summary>
+	/// <param name="self">The compilation under qury.</param>
+	/// <param name="force">For the namespaces to be recalculated.</param>
+	/// <returns>The currently configured UI namespaces.</returns>
+	public static IReadOnlySet<string> GetUINamespaces (this Compilation self, bool force = false)
+	{
+		lock (uiNamespaceLock) {
+			if (force || uiNamespacesCache is null) {
+				uiNamespacesCache = new();
+				// build the hash set based on the current definitions used in the compilation
+				var preprocessorSymbols = self.GetPreprocessorSymbols ();
+				foreach (var ns in uiNamespaces) {
+					var define = $"HAS_{ns.ToUpper ()}";
+					if (preprocessorSymbols.Contains (define)) {
+						uiNamespacesCache.Add (ns);
+					}
+				}
+			}
+
+			return uiNamespacesCache;
+		}
 	}
 }

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -805,5 +805,22 @@ namespace Xamarin.Tests {
 			rspPath = Path.Combine (SourceRoot, "src", "build", "dotnet", platform, $"apidefinition-{platform}.rsp");
 			return true;
 		}
+
+		public static bool TryGetPlatformPreprocessorSymbolsRsp (TargetFramework framework,
+			[NotNullWhen (true)] out string rspPath)
+		{
+			rspPath = null;
+			var platform = framework.Platform switch {
+				ApplePlatform.iOS => "ios",
+				ApplePlatform.TVOS => "tvos",
+				ApplePlatform.MacOSX => "macos",
+				ApplePlatform.MacCatalyst => "maccatalyst",
+				_ => null,
+			};
+			if (platform is null)
+				return false;
+			rspPath = Path.Combine (SourceRoot, "src", "rsp", "dotnet", $"{platform}-defines-dotnet.rsp");
+			return true;
+		}
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/BaseGeneratorTestClass.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/BaseGeneratorTestClass.cs
@@ -54,7 +54,7 @@ public class BaseGeneratorTestClass {
 				args, null, null);
 			var frameworkDefines = parseResult.ParseOptions.PreprocessorSymbolNames.ToList ();
 			// add the platform ones that are not in this rsp
-			frameworkDefines.AddRange (platformDefines[targetFramework]);
+			frameworkDefines.AddRange (platformDefines [targetFramework]);
 			return frameworkDefines;
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/BaseGeneratorTestClass.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/BaseGeneratorTestClass.cs
@@ -23,11 +23,11 @@ public class BaseGeneratorTestClass {
 
 	// list of the defines for each platform, this is passed to the parser to ensure that
 	// we are testing the platforms as if they were being compiled.
-	readonly Dictionary<ApplePlatform, string []> platformDefines = new () {
-		{ ApplePlatform.iOS, new [] { "__IOS__" } },
-		{ ApplePlatform.TVOS, new [] { "__TVOS__" } },
-		{ ApplePlatform.MacOSX, new [] { "__MACOS__" } },
-		{ ApplePlatform.MacCatalyst, new [] { "__MACCATALYST__" } },
+	readonly Dictionary<TargetFramework, string []> platformDefines = new () {
+		{ TargetFramework.DotNet_iOS, new [] { "__IOS__" } },
+		{ TargetFramework.DotNet_tvOS, new [] { "__TVOS__" } },
+		{ TargetFramework.DotNet_macOS, new [] { "__MACOS__" } },
+		{ TargetFramework.DotNet_MacCatalyst, new [] { "__MACCATALYST__" } },
 	};
 
 	public BaseGeneratorTestClass ()
@@ -45,6 +45,22 @@ public class BaseGeneratorTestClass {
 	protected GeneratorDriverRunResult RunGenerators (Compilation compilation)
 		=> Driver.RunGenerators (compilation).GetRunResult ();
 
+	protected IEnumerable<string> GetPlatformDefines (TargetFramework targetFramework)
+	{
+		if (Configuration.TryGetPlatformPreprocessorSymbolsRsp (targetFramework, out var rspFile)) {
+			var args = new [] { $"@{rspFile}" };
+			var workingDirectory = Path.Combine (Configuration.SourceRoot, "src");
+			var parseResult = CSharpCommandLineParser.Default.Parse (
+				args, null, null);
+			var frameworkDefines = parseResult.ParseOptions.PreprocessorSymbolNames.ToList ();
+			// add the platform ones that are not in this rsp
+			frameworkDefines.AddRange (platformDefines[targetFramework]);
+			return frameworkDefines;
+		}
+
+		return [];
+	}
+
 	protected CompilationResult CreateCompilation (ApplePlatform platform, [CallerMemberName] string name = "", params string [] sources)
 	{
 		// get the dotnet bcl and fully load it for the test.
@@ -52,6 +68,8 @@ public class BaseGeneratorTestClass {
 			.Select (assembly => MetadataReference.CreateFromFile (assembly)).ToList ();
 		// get the dll for the current platform
 		var targetFramework = TargetFramework.GetTargetFramework (platform, isDotNet: true);
+		// get the platform definitions
+		var preprocessorSymbols = GetPlatformDefines (targetFramework);
 		var platformDll = Configuration.GetBaseLibrary (targetFramework);
 		if (!string.IsNullOrEmpty (platformDll)) {
 			references.Add (MetadataReference.CreateFromFile (platformDll));
@@ -59,7 +77,7 @@ public class BaseGeneratorTestClass {
 			throw new InvalidOperationException ($"Could not find platform dll for {platform}");
 		}
 
-		var parseOptions = new CSharpParseOptions (LanguageVersion.Latest, DocumentationMode.None, preprocessorSymbols: platformDefines [platform]);
+		var parseOptions = new CSharpParseOptions (LanguageVersion.Latest, DocumentationMode.None, preprocessorSymbols: preprocessorSymbols);
 		var trees = sources.Select (s => CSharpSyntaxTree.ParseText (s, parseOptions)).ToImmutableArray ();
 
 		var options = new CSharpCompilationOptions (OutputKind.NetModule)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/CompilationExtensionsTest.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/CompilationExtensionsTest.cs
@@ -1,5 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
 using Microsoft.Macios.Generator.Extensions;
 using Xamarin.Tests;
 using Xamarin.Utils;
@@ -20,5 +24,77 @@ public class CompilationExtensionsTest : BaseGeneratorTestClass {
 		// the compilation
 		var (compilation, _) = CreateCompilation (platform);
 		Assert.Equal (expectedPlatform, compilation.GetCurrentPlatform ());
+	}
+
+	class TestDataGetUINamespaces : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			yield return [
+				ApplePlatform.iOS, 
+				new [] {
+					"UIKit",
+					"Twitter",
+					"NewsstandKit",
+					"QuickLook",
+					"EventKitUI",
+					"AddressBookUI",
+					"MessageUI",
+					"PhotosUI",
+					"HealthKitUI",
+					"GameKit",
+					"MapKit"
+				}];
+			
+			yield return [
+				ApplePlatform.TVOS, 
+				new [] {
+					"UIKit", 
+					"PhotosUI", 
+					"GameKit", 
+					"MapKit",
+				}];
+			
+			yield return [
+				ApplePlatform.MacOSX, 
+				new [] {
+					"AppKit", 
+					"QuickLook",
+					"PhotosUI",
+					"GameKit",
+					"MapKit",
+				}];
+			
+			yield return [
+				ApplePlatform.MacCatalyst, 
+				new [] {
+					"AppKit", 
+					"UIKit", 
+					"QuickLook", 
+					"EventKitUI", 
+					"MessageUI", 
+					"PhotosUI", 
+					"HealthKitUI", 
+					"GameKit", 
+					"MapKit",
+				}];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	[Theory]
+	[ClassData (typeof(TestDataGetUINamespaces))]
+	public void GetUINamespacesTests (ApplePlatform platform, string [] expectedNamespaces)
+	{
+		var collectionComparer = new CollectionComparer<string> (StringComparer.Ordinal);
+		// we need a source to trigger the parsing. Otherwise the compilation will have no syntax
+		// trees and therefore no preprocessor symbols
+		const string dummyClass = @"
+using System;
+
+public class DummyClass {}
+";
+		var (compilation, _) = CreateCompilation (platform, sources: dummyClass);
+		Assert.True (collectionComparer.Equals (expectedNamespaces, compilation.GetUINamespaces (force: true)));
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/CompilationExtensionsTest.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/CompilationExtensionsTest.cs
@@ -30,7 +30,7 @@ public class CompilationExtensionsTest : BaseGeneratorTestClass {
 		public IEnumerator<object []> GetEnumerator ()
 		{
 			yield return [
-				ApplePlatform.iOS, 
+				ApplePlatform.iOS,
 				new [] {
 					"UIKit",
 					"Twitter",
@@ -44,46 +44,46 @@ public class CompilationExtensionsTest : BaseGeneratorTestClass {
 					"GameKit",
 					"MapKit"
 				}];
-			
+
 			yield return [
-				ApplePlatform.TVOS, 
+				ApplePlatform.TVOS,
 				new [] {
-					"UIKit", 
-					"PhotosUI", 
-					"GameKit", 
+					"UIKit",
+					"PhotosUI",
+					"GameKit",
 					"MapKit",
 				}];
-			
+
 			yield return [
-				ApplePlatform.MacOSX, 
+				ApplePlatform.MacOSX,
 				new [] {
-					"AppKit", 
+					"AppKit",
 					"QuickLook",
 					"PhotosUI",
 					"GameKit",
 					"MapKit",
 				}];
-			
+
 			yield return [
-				ApplePlatform.MacCatalyst, 
+				ApplePlatform.MacCatalyst,
 				new [] {
-					"AppKit", 
-					"UIKit", 
-					"QuickLook", 
-					"EventKitUI", 
-					"MessageUI", 
-					"PhotosUI", 
-					"HealthKitUI", 
-					"GameKit", 
+					"AppKit",
+					"UIKit",
+					"QuickLook",
+					"EventKitUI",
+					"MessageUI",
+					"PhotosUI",
+					"HealthKitUI",
+					"GameKit",
 					"MapKit",
 				}];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
-	
+
 	[Theory]
-	[ClassData (typeof(TestDataGetUINamespaces))]
+	[ClassData (typeof (TestDataGetUINamespaces))]
 	public void GetUINamespacesTests (ApplePlatform platform, string [] expectedNamespaces)
 	{
 		var collectionComparer = new CollectionComparer<string> (StringComparer.Ordinal);

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Microsoft.Macios.Generator.Tests.csproj
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Microsoft.Macios.Generator.Tests.csproj
@@ -8,6 +8,10 @@
         <NoWarn>NU1608</NoWarn>
         <RootNamespace>Microsoft.Macios.Generator.Tests</RootNamespace>
         <DefineConstants>RGEN</DefineConstants>
+
+        <!-- Ensure we do have the def rsp-->
+        <SourceDirectory>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\..\src'))</SourceDirectory>
+        <DotnetRspDirectory>rsp/dotnet</DotnetRspDirectory>
     </PropertyGroup>
 
     <ItemGroup>
@@ -62,5 +66,13 @@
         <None Include="Classes\Data\*.cs" />
     </ItemGroup>
 
+
+    <Target Name="BuildTestLibraries" BeforeTargets="BeforeBuild">
+        <Message Text="Processing platform: %(Platform.Identity)" />
+        <Exec Command="make -j8 -C $(SourceDirectory) $(DotnetRspDirectory)/ios-defines-dotnet.rsp"/>
+        <Exec Command="make -j8 -C $(SourceDirectory) $(DotnetRspDirectory)/tvos-defines-dotnet.rsp"/>
+        <Exec Command="make -j8 -C $(SourceDirectory) $(DotnetRspDirectory)/macos-defines-dotnet.rsp"/>
+        <Exec Command="make -j8 -C $(SourceDirectory) $(DotnetRspDirectory)/maccatalyst-defines-dotnet.rsp"/>
+    </Target>
 
 </Project>


### PR DESCRIPTION
Use the current compilation preprocessor symbols to determine which of the UI namespaces are present in the compilation.