### PR TITLE
[Rgen] Add needed factory methods to cast an enum to its primitive type.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -64,16 +64,16 @@ static partial class BindingSyntaxFactory {
 			// return the native casting
 			return CastToNative (parameter);
 		}
-		
+
 		// returns the enum primitive to be used
 		var marshalType = parameter.Type.ToMarshallType ();
 		if (marshalType is null)
 			return null;
-		
+
 		// (byte) parameter
 		var castExpression = CastExpression (
-			type: IdentifierName (marshalType), 
-			expression: IdentifierName(parameter.Name).WithLeadingTrivia (Space));
+			type: IdentifierName (marshalType),
+			expression: IdentifierName (parameter.Name).WithLeadingTrivia (Space));
 		return castExpression;
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -51,7 +51,7 @@ static partial class BindingSyntaxFactory {
 	/// <summary>
 	/// Returns the expression needed to cast an enum parameter to its primitive type to be used in marshaling.
 	/// </summary>
-	/// <param name="parameter">The parameter whose castin we need to generated. The type info has to be
+	/// <param name="parameter">The parameter for which we need to generate the casting. The type info has to be
 	/// an enumerator. If it is not, the method returns null.</param>
 	/// <returns>The cast C# expression.</returns>
 	internal static CastExpressionSyntax? CastToPrimitive (in Parameter parameter)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
@@ -62,49 +62,49 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			Assert.Equal (expectedCast, expression?.ToString ());
 		}
 	}
-	
-	class TestDataCastToPrimitive: IEnumerable<object []> {
+
+	class TestDataCastToPrimitive : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
 			// not enum parameter
 			var boolParam = new Parameter (
-				position: 0, 
+				position: 0,
 				type: ReturnTypeForBool (),
-				name: "myParam");	
+				name: "myParam");
 			yield return [boolParam, null!];
-			
+
 			var enumParam = new Parameter (
-				position: 0, 
+				position: 0,
 				type: ReturnTypeForEnum ("MyEnum", isNativeEnum: false),
-				name: "myParam");	
-			
+				name: "myParam");
+
 			yield return [enumParam, "(int) myParam"];
-			
+
 			var byteParam = new Parameter (
-				position: 0, 
+				position: 0,
 				type: ReturnTypeForEnum ("MyEnum", isNativeEnum: false, underlyingType: SpecialType.System_Byte),
-				name: "myParam");	
-			
+				name: "myParam");
+
 			yield return [byteParam, "(byte) myParam"];
-			
-			
+
+
 			var longParam = new Parameter (
-				position: 0, 
+				position: 0,
 				type: ReturnTypeForEnum ("MyEnum", isNativeEnum: false, underlyingType: SpecialType.System_Int64),
-				name: "myParam");	
-			
+				name: "myParam");
+
 			yield return [longParam, "(long) myParam"];
 		}
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
-	
+
 	[Theory]
-	[ClassData(typeof(TestDataCastToPrimitive))]
+	[ClassData (typeof (TestDataCastToPrimitive))]
 	void CastToPrimitiveTests (Parameter parameter, string? expectedCast)
 	{
 		var expression = CastToPrimitive (parameter);
 		if (expectedCast is null) {
-			Assert.Null (expression);	
+			Assert.Null (expression);
 		} else {
 			Assert.NotNull (expression);
 			Assert.Equal (expectedCast, expression?.ToString ());

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
@@ -62,6 +62,54 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			Assert.Equal (expectedCast, expression?.ToString ());
 		}
 	}
+	
+	class TestDataCastToPrimitive: IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			// not enum parameter
+			var boolParam = new Parameter (
+				position: 0, 
+				type: ReturnTypeForBool (),
+				name: "myParam");	
+			yield return [boolParam, null!];
+			
+			var enumParam = new Parameter (
+				position: 0, 
+				type: ReturnTypeForEnum ("MyEnum", isNativeEnum: false),
+				name: "myParam");	
+			
+			yield return [enumParam, "(int) myParam"];
+			
+			var byteParam = new Parameter (
+				position: 0, 
+				type: ReturnTypeForEnum ("MyEnum", isNativeEnum: false, underlyingType: SpecialType.System_Byte),
+				name: "myParam");	
+			
+			yield return [byteParam, "(byte) myParam"];
+			
+			
+			var longParam = new Parameter (
+				position: 0, 
+				type: ReturnTypeForEnum ("MyEnum", isNativeEnum: false, underlyingType: SpecialType.System_Int64),
+				name: "myParam");	
+			
+			yield return [longParam, "(long) myParam"];
+		}
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	[Theory]
+	[ClassData(typeof(TestDataCastToPrimitive))]
+	void CastToPrimitiveTests (Parameter parameter, string? expectedCast)
+	{
+		var expression = CastToPrimitive (parameter);
+		if (expectedCast is null) {
+			Assert.Null (expression);	
+		} else {
+			Assert.NotNull (expression);
+			Assert.Equal (expectedCast, expression?.ToString ());
+		}
+	}
 
 	[Fact]
 	void CastToByteTests ()


### PR DESCRIPTION
Case to the underlying type if it is not a smart enum, else use the CastToNative method.