### PR TITLE
[Rgen] Add factory method that creates a NSArray aux variable.

### DIFF
--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
@@ -75,4 +75,77 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 		conditionalExpr = CastToByte (intParameter);
 		Assert.Null (conditionalExpr);
 	}
+
+	class TestDataGetNSArrayAuxVariableTest : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			// not array 
+
+			yield return [
+				new Parameter (0, ReturnTypeForInt (isNullable: false), "myParam"),
+				null!,
+				false];
+
+			// not nullable string[]
+			yield return [
+				new Parameter (0, ReturnTypeForArray ("string", isNullable: false), "myParam"),
+				"var nsa_myParam = NSArray.FromStrings (myParam);",
+				false];
+
+			yield return [
+				new Parameter (0, ReturnTypeForArray ("string", isNullable: false), "myParam"),
+				"using var nsa_myParam = NSArray.FromStrings (myParam);",
+				true];
+
+			// nullable string []
+			yield return [
+				new Parameter (0, ReturnTypeForArray ("string", isNullable: true), "myParam"),
+				"var nsa_myParam = myParam is null ? null : NSArray.FromStrings (myParam);",
+				false];
+
+			yield return [
+				new Parameter (0, ReturnTypeForArray ("string", isNullable: true), "myParam"),
+				"using var nsa_myParam = myParam is null ? null : NSArray.FromStrings (myParam);",
+				true];
+
+			// nsstrings
+
+			yield return [
+				new Parameter (0, ReturnTypeForArray ("NSString", isNullable: false), "myParam"),
+				"var nsa_myParam = NSArray.FromNSObjects (myParam);",
+				false];
+
+			yield return [
+				new Parameter (0, ReturnTypeForArray ("NSString", isNullable: false), "myParam"),
+				"using var nsa_myParam = NSArray.FromNSObjects (myParam);",
+				true];
+
+			yield return [
+				new Parameter (0, ReturnTypeForArray ("NSString", isNullable: true), "myParam"),
+				"var nsa_myParam = myParam is null ? null : NSArray.FromNSObjects (myParam);",
+				false];
+
+			yield return [
+				new Parameter (0, ReturnTypeForArray ("NSString", isNullable: true), "myParam"),
+				"using var nsa_myParam = myParam is null ? null : NSArray.FromNSObjects (myParam);",
+				true];
+
+
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[ClassData (typeof (TestDataGetNSArrayAuxVariableTest))]
+	void GetNSArrayAuxVariableTests (in Parameter parameter, string? expectedDeclaration, bool withUsing)
+	{
+		var declaration = GetNSArrayAuxVariable (in parameter, withUsing: withUsing);
+		if (expectedDeclaration is null) {
+			Assert.Null (declaration);
+		} else {
+			Assert.NotNull (declaration);
+			Assert.Equal (expectedDeclaration, declaration.ToString ());
+		}
+	}
 }


### PR DESCRIPTION
To be able to send arrays to objc we need to convert them to a NSArray. This change adds a factory method that will create the aux variables for when we need that conversion.

The factory allows to prepend the declaration with a using caluse to simplify the memory management in the bindings.