### PR TITLE
[Rgen] Add a factory method that will create the aux variable for handles.

### DIFF
--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
@@ -299,4 +299,28 @@ static class TestDataFactory {
 				"System.Runtime.Serialization.ISerializable",
 			]
 		};
+
+	public static TypeInfo ReturnTypeForNSObject (string nsObjectName, bool isNullable = false)
+		=> new (
+			name: nsObjectName,
+			isNullable: isNullable,
+			isArray: false
+		) {
+			IsNSObject = true,
+			IsINativeObject = true,
+			Parents = ["Foundation.NSObject", "object"],
+			Interfaces = ["ObjCRuntime.INativeObject"]
+		};
+
+	public static TypeInfo ReturnTypeForINativeObject (string nativeObjectName, bool isNullable = false)
+		=> new (
+			name: nativeObjectName,
+			isNullable: isNullable,
+			isArray: false
+		) {
+			IsNSObject = true,
+			IsINativeObject = true,
+			Parents = ["object"],
+			Interfaces = ["ObjCRuntime.INativeObject"]
+		};
 }


### PR DESCRIPTION
When we interact with nstobjects we need to send the Hanldes as a parameter and not the managed object. This new method will generated the aux variable needed to store the handle and use it in the message send objc method.