### PR TITLE
[Rgen] Move all the attributes to be readonly record struct.

### DIFF
--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/AsyncData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/AsyncData.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Macios.Transformer.Attributes;
 
-readonly struct AsyncData : IEquatable<AsyncData> {
+readonly record struct AsyncData {
 	/// <summary>
 	/// Diff the constructor used in the bindings.
 	/// </summary>
@@ -118,38 +118,4 @@ readonly struct AsyncData : IEquatable<AsyncData> {
 
 		return false;
 	}
-	
-	public bool Equals (AsyncData other)
-	{
-		if (ResultType != other.ResultType)
-			return false;
-		if (MethodName != other.MethodName)
-			return false;
-		if (ResultTypeName != other.ResultTypeName)
-			return false;
-		return PostNonResultSnippet == other.PostNonResultSnippet;
-	}
-
-	/// <inheritdoc />
-	public override bool Equals (object? obj)
-	{
-		return obj is AsyncData other && Equals (other);
-	}
-
-	/// <inheritdoc />
-	public override int GetHashCode ()
-		=> HashCode.Combine (ResultType, MethodName, ResultTypeName, PostNonResultSnippet);
-
-	public static bool operator == (AsyncData x, AsyncData y)
-	{
-		return x.Equals (y);
-	}
-
-	public static bool operator != (AsyncData x, AsyncData y)
-	{
-		return !(x == y);
-	}
-
-	public override string ToString ()
-		=> $"{{ ResultType: '{ResultType ?? "null"}', MethodName: '{MethodName ?? "null"}', ResultTypeName: '{ResultTypeName ?? "null"}', PostNonResultSnippet: '{PostNonResultSnippet ?? "null"}' }}";
 }

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/BackingFieldTypeData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/BackingFieldTypeData.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Macios.Transformer.Attributes;
 
-readonly struct BackingFieldTypeData : IEquatable<BackingFieldTypeData> {
+readonly record struct BackingFieldTypeData {
 
 	public string TypeName { get; }
 
@@ -50,37 +50,5 @@ readonly struct BackingFieldTypeData : IEquatable<BackingFieldTypeData> {
 
 		data = new (backingField);
 		return true;
-	}
-
-	public bool Equals (BackingFieldTypeData other)
-	{
-		return TypeName == other.TypeName;
-	}
-
-	/// <inheritdoc />
-	public override bool Equals (object? obj)
-	{
-		return obj is BackingFieldTypeData other && Equals (other);
-	}
-
-	/// <inheritdoc />
-	public override int GetHashCode ()
-		=> TypeName.GetHashCode ();
-
-
-	public static bool operator == (BackingFieldTypeData x, BackingFieldTypeData y)
-	{
-		return x.Equals (y);
-	}
-
-	public static bool operator != (BackingFieldTypeData x, BackingFieldTypeData y)
-	{
-		return !(x == y);
-	}
-
-	/// <inheritdoc />
-	public override string ToString ()
-	{
-		return $"{{ BackingFieldType: '{TypeName}' }}";
 	}
 }

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/BaseTypeData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/BaseTypeData.cs
@@ -8,7 +8,7 @@ using Microsoft.Macios.Generator;
 
 namespace Microsoft.Macios.Transformer.Attributes;
 
-readonly struct BaseTypeData : IEquatable<BaseTypeData> {
+readonly record struct BaseTypeData {
 
 	public string BaseType { get; } // is a type in the attribute, but we do not care for the transformation
 	public string? Name { get; init; } = null;
@@ -113,12 +113,6 @@ readonly struct BaseTypeData : IEquatable<BaseTypeData> {
 	}
 
 	/// <inheritdoc />
-	public override bool Equals (object? obj)
-	{
-		return obj is BaseTypeData other && Equals (other);
-	}
-
-	/// <inheritdoc />
 	public override int GetHashCode ()
 	{
 		var hash = new HashCode ();
@@ -133,26 +127,5 @@ readonly struct BaseTypeData : IEquatable<BaseTypeData> {
 		hash.Add (Singleton);
 		hash.Add (KeepRefUntil);
 		return hash.ToHashCode ();
-	}
-
-	public static bool operator == (BaseTypeData x, BaseTypeData y)
-	{
-		return x.Equals (y);
-	}
-
-	public static bool operator != (BaseTypeData x, BaseTypeData y)
-	{
-		return !(x == y);
-	}
-
-	public override string ToString ()
-	{
-		var sb = new StringBuilder ($"{{ BaseType: {BaseType}, Name: {Name ?? "null"}, ");
-		sb.Append ("Events: [");
-		sb.AppendJoin (", ", Events);
-		sb.Append ("], Delegates: [");
-		sb.AppendJoin (", ", Delegates);
-		sb.Append ($"], Singleton: {Singleton}, KeepRefUntil: {KeepRefUntil ?? "null"}, IsStubClass: {IsStubClass} }}");
-		return sb.ToString ();
 	}
 }

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/BindData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/BindData.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Macios.Transformer.Attributes;
 
-readonly struct BindData : IEquatable<BindData> {
+readonly record struct BindData {
 
 	public string Selector { get; }
 	public bool Virtual { get; init; }
@@ -55,39 +55,5 @@ readonly struct BindData : IEquatable<BindData> {
 
 		data = new (selector) { Virtual = @virtual, };
 		return true;
-	}
-
-	public bool Equals (BindData other)
-	{
-		if (Selector != other.Selector)
-			return false;
-		return Virtual == other.Virtual;
-	}
-
-	/// <inheritdoc />
-	public override bool Equals (object? obj)
-	{
-		return obj is BindData other && Equals (other);
-	}
-
-	/// <inheritdoc />
-	public override int GetHashCode ()
-		=> HashCode.Combine (Selector, Virtual);
-
-
-	public static bool operator == (BindData x, BindData y)
-	{
-		return x.Equals (y);
-	}
-
-	public static bool operator != (BindData x, BindData y)
-	{
-		return !(x == y);
-	}
-
-	/// <inheritdoc />
-	public override string ToString ()
-	{
-		return $"{{ BindSelector: '{Selector}', Virtual: {Virtual} }}";
 	}
 }

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/CoreImageFilterData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/CoreImageFilterData.cs
@@ -7,7 +7,7 @@ using MethodAttributes = Mono.Cecil.MethodAttributes;
 
 namespace Microsoft.Macios.Transformer.Attributes;
 
-readonly struct CoreImageFilterData : IEquatable<CoreImageFilterData> {
+readonly record struct CoreImageFilterData {
 
 	public MethodAttributes DefaultCtorVisibility { get; init; }
 
@@ -55,40 +55,5 @@ readonly struct CoreImageFilterData : IEquatable<CoreImageFilterData> {
 			StringCtorVisibility = stringVisibility,
 		};
 		return true;
-	}
-
-	public bool Equals (CoreImageFilterData other)
-	{
-		if (DefaultCtorVisibility != other.DefaultCtorVisibility)
-			return false;
-		if (IntPtrCtorVisibility != other.IntPtrCtorVisibility)
-			return false;
-		return StringCtorVisibility == other.StringCtorVisibility;
-	}
-
-	/// <inheritdoc />
-	public override bool Equals (object? obj)
-	{
-		return obj is CoreImageFilterData other && Equals (other);
-	}
-
-	/// <inheritdoc />
-	public override int GetHashCode ()
-		=> HashCode.Combine (DefaultCtorVisibility, IntPtrCtorVisibility, StringCtorVisibility);
-
-	public static bool operator == (CoreImageFilterData x, CoreImageFilterData y)
-	{
-		return x.Equals (y);
-	}
-
-	public static bool operator != (CoreImageFilterData x, CoreImageFilterData y)
-	{
-		return !(x == y);
-	}
-
-	/// <inheritdoc />
-	public override string ToString ()
-	{
-		return $"{{ DefaultCtorVisibility: {DefaultCtorVisibility}, IntPtrCtorVisibility: {IntPtrCtorVisibility}, StringCtorVisibility: {StringCtorVisibility} }}";
 	}
 }

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/CoreImageFilterPropertyData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/CoreImageFilterPropertyData.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Macios.Transformer.Attributes;
 
-readonly struct CoreImageFilterPropertyData : IEquatable<CoreImageFilterPropertyData> {
+readonly record struct CoreImageFilterPropertyData {
 
 	public string Name { get; }
 
@@ -49,35 +49,5 @@ readonly struct CoreImageFilterPropertyData : IEquatable<CoreImageFilterProperty
 
 		data = new (name);
 		return true;
-	}
-
-	public bool Equals (CoreImageFilterPropertyData other)
-		=> Name == other.Name;
-
-	/// <inheritdoc />
-	public override bool Equals (object? obj)
-	{
-		return obj is CoreImageFilterPropertyData other && Equals (other);
-	}
-
-	/// <inheritdoc />
-	public override int GetHashCode ()
-		=> HashCode.Combine (Name);
-
-
-	public static bool operator == (CoreImageFilterPropertyData x, CoreImageFilterPropertyData y)
-	{
-		return x.Equals (y);
-	}
-
-	public static bool operator != (CoreImageFilterPropertyData x, CoreImageFilterPropertyData y)
-	{
-		return !(x == y);
-	}
-
-	/// <inheritdoc />
-	public override string ToString ()
-	{
-		return $"{{ Name: '{Name}' }}";
 	}
 }

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/ErrorDomainData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/ErrorDomainData.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Macios.Transformer.Attributes;
 
-readonly struct ErrorDomainData : IEquatable<ErrorDomainData> {
+readonly record struct ErrorDomainData {
 
 	public string ErrorDomain { get; }
 	public string? LibraryName { get; }
@@ -65,38 +65,5 @@ readonly struct ErrorDomainData : IEquatable<ErrorDomainData> {
 
 		data = new (errorDomain, libraryName);
 		return true;
-	}
-
-	public bool Equals (ErrorDomainData other)
-	{
-		if (ErrorDomain != other.ErrorDomain)
-			return false;
-		return LibraryName == other.LibraryName;
-	}
-
-	/// <inheritdoc />
-	public override bool Equals (object? obj)
-	{
-		return obj is ErrorDomainData other && Equals (other);
-	}
-
-	/// <inheritdoc />
-	public override int GetHashCode ()
-		=> HashCode.Combine (ErrorDomain, LibraryName);
-
-	public static bool operator == (ErrorDomainData x, ErrorDomainData y)
-	{
-		return x.Equals (y);
-	}
-
-	public static bool operator != (ErrorDomainData x, ErrorDomainData y)
-	{
-		return !(x == y);
-	}
-
-	/// <inheritdoc />
-	public override string ToString ()
-	{
-		return $"{{ ErrorDomain: '{ErrorDomain}', LibraryName: '{LibraryName}' }}";
 	}
 }

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/ExportData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/ExportData.cs
@@ -7,7 +7,7 @@ using ObjCRuntime;
 
 namespace Microsoft.Macios.Transformer.Attributes;
 
-struct ExportData : IEquatable<ExportData> {
+readonly record struct ExportData {
 
 	/// <summary>
 	/// The exported native selector.
@@ -80,40 +80,5 @@ struct ExportData : IEquatable<ExportData> {
 
 		data = new (selector, argumentSemantic);
 		return true;
-	}
-
-	public bool Equals (ExportData other)
-	{
-		if (Selector != other.Selector)
-			return false;
-		return ArgumentSemantic == other.ArgumentSemantic;
-	}
-
-	/// <inheritdoc />
-	public override bool Equals (object? obj)
-	{
-		return obj is ExportData other && Equals (other);
-	}
-
-	/// <inheritdoc />
-	public override int GetHashCode ()
-	{
-		return HashCode.Combine (Selector, ArgumentSemantic);
-	}
-
-	public static bool operator == (ExportData x, ExportData y)
-	{
-		return x.Equals (y);
-	}
-
-	public static bool operator != (ExportData x, ExportData y)
-	{
-		return !(x == y);
-	}
-
-	/// <inheritdoc />
-	public override string ToString ()
-	{
-		return $"{{ Selector: '{Selector ?? "null"}', ArgumentSemantic: {ArgumentSemantic} }}";
 	}
 }

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/FieldData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/FieldData.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Macios.Transformer.Attributes;
 
-struct FieldData : IEquatable<FieldData> {
+readonly record struct FieldData {
 
 	public string SymbolName { get; }
 	public string? LibraryName { get; }
@@ -22,7 +22,7 @@ struct FieldData : IEquatable<FieldData> {
 	public static bool TryParse (AttributeData attributeData,
 		[NotNullWhen (true)] out FieldData? data)
 	{
-		data = default;
+		data = null;
 
 		var count = attributeData.ConstructorArguments.Length;
 		string? symbolName;
@@ -58,39 +58,5 @@ struct FieldData : IEquatable<FieldData> {
 		}
 		data = new (symbolName, libraryName);
 		return true;
-	}
-
-	public bool Equals (FieldData other)
-	{
-		if (SymbolName != other.SymbolName)
-			return false;
-		return LibraryName == other.LibraryName;
-	}
-
-	/// <inheritdoc />
-	public override bool Equals (object? obj)
-	{
-		return obj is FieldData other && Equals (other);
-	}
-
-	/// <inheritdoc />
-	public override int GetHashCode ()
-	{
-		return HashCode.Combine (SymbolName, LibraryName);
-	}
-
-	public static bool operator == (FieldData x, FieldData y)
-	{
-		return x.Equals (y);
-	}
-
-	public static bool operator != (FieldData x, FieldData y)
-	{
-		return !(x == y);
-	}
-
-	public override string ToString ()
-	{
-		return $"{{ SymbolName: '{SymbolName}' LibraryName: '{LibraryName ?? "null"}' }}";
 	}
 }

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/NativeData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/NativeData.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Macios.Transformer.Attributes;
 
-readonly struct NativeData : IEquatable<NativeData> {
+readonly record struct NativeData {
 
 	public string? NativeName { get; }
 
@@ -55,35 +55,5 @@ readonly struct NativeData : IEquatable<NativeData> {
 
 		data = new (nativeName);
 		return true;
-	}
-
-	public bool Equals (NativeData other)
-		=> NativeName == other.NativeName;
-
-	/// <inheritdoc />
-	public override bool Equals (object? obj)
-	{
-		return obj is NativeData other && Equals (other);
-	}
-
-	/// <inheritdoc />
-	public override int GetHashCode ()
-		=> HashCode.Combine (NativeName);
-
-
-	public static bool operator == (NativeData x, NativeData y)
-	{
-		return x.Equals (y);
-	}
-
-	public static bool operator != (NativeData x, NativeData y)
-	{
-		return !(x == y);
-	}
-
-	/// <inheritdoc />
-	public override string ToString ()
-	{
-		return $"{{ NativeName: '{NativeName}' }}";
 	}
 }

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/SnippetData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/SnippetData.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Macios.Transformer.Attributes;
 
-readonly struct SnippetData : IEquatable<SnippetData> {
+readonly record struct SnippetData {
 
 	public string Code { get; }
 
@@ -64,34 +64,4 @@ readonly struct SnippetData : IEquatable<SnippetData> {
 		data = new (code, optimizable);
 		return true;
 	}
-
-	public bool Equals (SnippetData other)
-	{
-		if (Code != other.Code)
-			return false;
-		return Optimizable == other.Optimizable;
-	}
-
-	/// <inheritdoc />
-	public override bool Equals (object? obj)
-	{
-		return obj is SnippetData other && Equals (other);
-	}
-
-	/// <inheritdoc />
-	public override int GetHashCode ()
-		=> HashCode.Combine (Code, Optimizable);
-
-	public static bool operator == (SnippetData x, SnippetData y)
-	{
-		return x.Equals (y);
-	}
-
-	public static bool operator != (SnippetData x, SnippetData y)
-	{
-		return !(x == y);
-	}
-
-	public override string ToString ()
-		=> $"{{ Code: '{Code}' Optimizable: {Optimizable} }}";
 }

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/StrongDictionaryData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/StrongDictionaryData.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Macios.Transformer.Attributes;
 
-readonly struct StrongDictionaryData : IEquatable<StrongDictionaryData> {
+readonly record struct StrongDictionaryData {
 
 	public string TypeWithKeys { get; }
 	public string? Suffix { get; }
@@ -60,34 +60,4 @@ readonly struct StrongDictionaryData : IEquatable<StrongDictionaryData> {
 		data = new (typeWithKeys, suffix);
 		return true;
 	}
-
-	public bool Equals (StrongDictionaryData other)
-	{
-		if (TypeWithKeys != other.TypeWithKeys)
-			return false;
-		return Suffix == other.Suffix;
-	}
-
-	/// <inheritdoc />
-	public override bool Equals (object? obj)
-	{
-		return obj is StrongDictionaryData other && Equals (other);
-	}
-
-	/// <inheritdoc />
-	public override int GetHashCode ()
-		=> HashCode.Combine (TypeWithKeys, Suffix);
-
-	public static bool operator == (StrongDictionaryData x, StrongDictionaryData y)
-	{
-		return x.Equals (y);
-	}
-
-	public static bool operator != (StrongDictionaryData x, StrongDictionaryData y)
-	{
-		return !(x == y);
-	}
-
-	public override string ToString ()
-		=> $"{{ TypeWithKeys: '{TypeWithKeys}' Suffix: '{Suffix}' }}";
 }

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/ThreadSafeData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/ThreadSafeData.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.Macios.Transformer.Attributes;
 
-readonly struct ThreadSafeData : IEquatable<ThreadSafeData> {
+readonly record struct ThreadSafeData {
 
 	public bool Safe { get; } = true;
 
@@ -40,29 +40,4 @@ readonly struct ThreadSafeData : IEquatable<ThreadSafeData> {
 		return true;
 	}
 
-	public bool Equals (ThreadSafeData other)
-		=> Safe == other.Safe;
-
-	/// <inheritdoc />
-	public override bool Equals (object? obj)
-	{
-		return obj is ThreadSafeData other && Equals (other);
-	}
-
-	/// <inheritdoc />
-	public override int GetHashCode ()
-		=> HashCode.Combine (Safe);
-
-	public static bool operator == (ThreadSafeData x, ThreadSafeData y)
-	{
-		return x.Equals (y);
-	}
-
-	public static bool operator != (ThreadSafeData x, ThreadSafeData y)
-	{
-		return !(x == y);
-	}
-
-	public override string ToString ()
-		=> $"{{ ThreadSafe: {Safe} }}";
 }


### PR DESCRIPTION
There is a reason we landed the code first as a struct, later as a readonly record struct. In the first pass, we added the manual code, had full control and were sure the method did what we exepcted. In the second pass we remove all the manual code EXCEPT that code that should be manual. We knew what to change becuase the tests failed with the code generated by the compiler.

The only method that the compiler generates that is not quite correct is the Equals for the BaseTypeAttribute that has to be written by hand.

Tests verify that the behaviour is the same as that one of the manual code.