### PR TITLE
[Rgen] Create a generic method that can be used to test all attr parsing.

### DIFF
--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/AsyncDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/AsyncDataTests.cs
@@ -2,16 +2,14 @@
 // Licensed under the MIT License.
 
 using System.Collections;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.Macios.Generator.Extensions;
 using Microsoft.Macios.Transformer.Attributes;
 using Xamarin.Tests;
 using Xamarin.Utils;
 
 namespace Microsoft.Macios.Transformer.Tests.Attributes;
 
-public class AsyncDataTests : BaseTransformerTestClass {
+public class AsyncDataTests : AttributeParsingTestClass {
 
 	class TestDataTryCreate : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
@@ -146,23 +144,6 @@ interface NSTableViewDiffableDataSource {
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataTryCreate>]
 	void TryCreateTests (ApplePlatform platform, (string Source, string Path) source, AsyncData expectedData)
-	{
-		// create a compilation used to create the transformer
-		var compilation = CreateCompilation (platform, sources: source);
-		var syntaxTree = compilation.SyntaxTrees.ForSource (source);
-		Assert.NotNull (syntaxTree);
-
-		var semanticModel = compilation.GetSemanticModel (syntaxTree);
-		Assert.NotNull (semanticModel);
-
-		var declaration = syntaxTree.GetRoot ()
-			.DescendantNodes ().OfType<MethodDeclarationSyntax> ()
-			.FirstOrDefault ();
-		Assert.NotNull (declaration);
-
-		var symbol = semanticModel.GetDeclaredSymbol (declaration);
-		Assert.NotNull (symbol);
-		var attribute = symbol.GetAttribute<AsyncData> (AttributesNames.AsyncAttribute, AsyncData.TryParse);
-		Assert.Equal (expectedData, attribute);
-	}
+		=> AssertTryCreate<AsyncData, MethodDeclarationSyntax> (platform, source, AttributesNames.AsyncAttribute,
+			expectedData, AsyncData.TryParse);
 }

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/AttributeParsingTestClass.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/AttributeParsingTestClass.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Extensions;
+using Xamarin.Utils;
+
+namespace Microsoft.Macios.Transformer.Tests.Attributes;
+
+public class AttributeParsingTestClass : BaseTransformerTestClass {
+
+	internal void AssertTryCreate<T, TR> (ApplePlatform platform, (string Source, string Path) source,
+		string attributeName, T expectedData, TypeSymbolExtensions.TryParse<T> tryParse, bool lastOrDefault = false)
+		where T : struct
+		where TR : MemberDeclarationSyntax
+	{
+		// create a compilation used to create the transformer
+		var compilation = CreateCompilation (platform, sources: source);
+		var syntaxTree = compilation.SyntaxTrees.ForSource (source);
+		var trees = compilation.SyntaxTrees.Where (s => s.FilePath == source.Path).ToArray ();
+		Assert.Single (trees);
+		Assert.NotNull (syntaxTree);
+
+		var semanticModel = compilation.GetSemanticModel (syntaxTree);
+		Assert.NotNull (semanticModel);
+
+		TR? declaration = null;
+		if (lastOrDefault) {
+			declaration = syntaxTree.GetRoot ()
+				.DescendantNodes ().OfType<TR> ()
+				.LastOrDefault ();
+		} else {
+			declaration = syntaxTree.GetRoot ()
+				.DescendantNodes ().OfType<TR> ()
+				.FirstOrDefault ();
+		}
+
+		Assert.NotNull (declaration);
+
+		var symbol = semanticModel.GetDeclaredSymbol (declaration);
+		Assert.NotNull (symbol);
+		var attribute = symbol.GetAttribute (attributeName, tryParse);
+		Assert.NotNull (attribute);
+		Assert.Equal (expectedData, attribute.Value);
+	}
+}

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/BackingFieldTypeDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/BackingFieldTypeDataTests.cs
@@ -11,7 +11,7 @@ using Xamarin.Utils;
 
 namespace Microsoft.Macios.Transformer.Tests.Attributes;
 
-public class BackingFieldTypeDataTests : BaseTransformerTestClass {
+public class BackingFieldTypeDataTests : AttributeParsingTestClass {
 
 	class TestDataTryCreate : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
@@ -71,24 +71,6 @@ public enum ASAuthorizationProviderExtensionEncryptionAlgorithm {
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataTryCreate>]
 	void TryCreateTests (ApplePlatform platform, (string Source, string Path) source, BackingFieldTypeData expectedData)
-	{
-		// create a compilation used to create the transformer
-		var compilation = CreateCompilation (platform, sources: source);
-		var syntaxTree = compilation.SyntaxTrees.ForSource (source);
-		Assert.NotNull (syntaxTree);
-
-		var semanticModel = compilation.GetSemanticModel (syntaxTree);
-		Assert.NotNull (semanticModel);
-
-		var declaration = syntaxTree.GetRoot ()
-			.DescendantNodes ().OfType<BaseTypeDeclarationSyntax> ()
-			.LastOrDefault ();
-		Assert.NotNull (declaration);
-
-		var symbol = semanticModel.GetDeclaredSymbol (declaration);
-		Assert.NotNull (symbol);
-		var exportData = symbol.GetAttribute<BackingFieldTypeData> (
-			AttributesNames.BackingFieldTypeAttribute, BackingFieldTypeData.TryParse);
-		Assert.Equal (expectedData, exportData);
-	}
+		=> AssertTryCreate<BackingFieldTypeData, BaseTypeDeclarationSyntax> (platform, source, AttributesNames.BackingFieldTypeAttribute,
+			expectedData, BackingFieldTypeData.TryParse, lastOrDefault: true);
 }

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/BaseTypeDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/BaseTypeDataTests.cs
@@ -11,7 +11,7 @@ using Xamarin.Utils;
 
 namespace Microsoft.Macios.Transformer.Tests.Attributes;
 
-public class BaseTypeDataTests : BaseTransformerTestClass {
+public class BaseTypeDataTests : AttributeParsingTestClass {
 
 	class TestDataTryCreate : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
@@ -172,23 +172,6 @@ interface UIFeedbackGenerator : UIInteraction {
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataTryCreate>]
 	void TryCreateTests (ApplePlatform platform, (string Source, string Path) source, BaseTypeData expectedData)
-	{
-		// create a compilation used to create the transformer
-		var compilation = CreateCompilation (platform, sources: source);
-		var syntaxTree = compilation.SyntaxTrees.ForSource (source);
-		Assert.NotNull (syntaxTree);
-
-		var semanticModel = compilation.GetSemanticModel (syntaxTree);
-		Assert.NotNull (semanticModel);
-
-		var declaration = syntaxTree.GetRoot ()
-			.DescendantNodes ().OfType<BaseTypeDeclarationSyntax> ()
-			.LastOrDefault ();
-		Assert.NotNull (declaration);
-
-		var symbol = semanticModel.GetDeclaredSymbol (declaration);
-		Assert.NotNull (symbol);
-		var exportData = symbol.GetAttribute<BaseTypeData> (AttributesNames.BaseTypeAttribute, BaseTypeData.TryParse);
-		Assert.Equal (expectedData, exportData);
-	}
+		=> AssertTryCreate<BaseTypeData, BaseTypeDeclarationSyntax> (platform, source, AttributesNames.BaseTypeAttribute,
+			expectedData, BaseTypeData.TryParse, lastOrDefault: true);
 }

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/BindDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/BindDataTests.cs
@@ -11,7 +11,7 @@ using Xamarin.Utils;
 
 namespace Microsoft.Macios.Transformer.Tests.Attributes;
 
-public class BindDataTests : BaseTransformerTestClass {
+public class BindDataTests : AttributeParsingTestClass {
 
 	class TestDataTryCreate : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
@@ -69,24 +69,6 @@ interface UIFeedbackGenerator : UIInteraction {
 	[AllSupportedPlatformsClassData<TestDataTryCreate>]
 	void TryCreateTests (ApplePlatform platform, (string Source, string Path) source,
 		BindData expectedData)
-	{
-		// create a compilation used to create the transformer
-		var compilation = CreateCompilation (platform, sources: source);
-		var syntaxTree = compilation.SyntaxTrees.ForSource (source);
-		Assert.NotNull (syntaxTree);
-
-		var semanticModel = compilation.GetSemanticModel (syntaxTree);
-		Assert.NotNull (semanticModel);
-
-		var declaration = syntaxTree.GetRoot ()
-			.DescendantNodes ().OfType<MethodDeclarationSyntax> ()
-			.LastOrDefault ();
-		Assert.NotNull (declaration);
-
-		var symbol = semanticModel.GetDeclaredSymbol (declaration);
-		Assert.NotNull (symbol);
-		var exportData = symbol.GetAttribute<BindData> (
-			AttributesNames.BindAttribute, BindData.TryParse);
-		Assert.Equal (expectedData, exportData);
-	}
+		=> AssertTryCreate<BindData, MethodDeclarationSyntax> (platform, source, AttributesNames.BindAttribute,
+			expectedData, BindData.TryParse, lastOrDefault: true);
 }

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/CoreImageFilterDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/CoreImageFilterDataTests.cs
@@ -12,7 +12,7 @@ using MethodAttributes = Mono.Cecil.MethodAttributes;
 
 namespace Microsoft.Macios.Transformer.Tests.Attributes;
 
-public class CoreImageFilterDataTests : BaseTransformerTestClass {
+public class CoreImageFilterDataTests : AttributeParsingTestClass {
 	class TestDataTryCreate : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -92,24 +92,6 @@ interface CICompositingFilter : CIAccordionFoldTransitionProtocol {
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataTryCreate>]
 	void TryCreateTests (ApplePlatform platform, (string Source, string Path) source, CoreImageFilterData expectedData)
-	{
-		// create a compilation used to create the transformer
-		var compilation = CreateCompilation (platform, sources: source);
-		var syntaxTree = compilation.SyntaxTrees.ForSource (source);
-		Assert.NotNull (syntaxTree);
-
-		var semanticModel = compilation.GetSemanticModel (syntaxTree);
-		Assert.NotNull (semanticModel);
-
-		var declaration = syntaxTree.GetRoot ()
-			.DescendantNodes ().OfType<BaseTypeDeclarationSyntax> ()
-			.LastOrDefault ();
-		Assert.NotNull (declaration);
-
-		var symbol = semanticModel.GetDeclaredSymbol (declaration);
-		Assert.NotNull (symbol);
-		var exportData = symbol.GetAttribute<CoreImageFilterData> (AttributesNames.CoreImageFilterAttribute,
-			CoreImageFilterData.TryParse);
-		Assert.Equal (expectedData, exportData);
-	}
+		=> AssertTryCreate<CoreImageFilterData, BaseTypeDeclarationSyntax> (platform, source, AttributesNames.CoreImageFilterAttribute,
+			expectedData, CoreImageFilterData.TryParse, lastOrDefault: true);
 }

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/CoreImageFilterPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/CoreImageFilterPropertyTests.cs
@@ -11,7 +11,7 @@ using Xamarin.Utils;
 
 namespace Microsoft.Macios.Transformer.Tests.Attributes;
 
-public class CoreImageFilterPropertyTests : BaseTransformerTestClass {
+public class CoreImageFilterPropertyTests : AttributeParsingTestClass {
 	class TestDataTryCreate : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -46,25 +46,6 @@ interface CICompositingFilter : CIAccordionFoldTransitionProtocol {
 	[AllSupportedPlatformsClassData<TestDataTryCreate>]
 	void TryCreateTests (ApplePlatform platform, (string Source, string Path) source,
 		CoreImageFilterPropertyData expectedData)
-	{
-		// create a compilation used to create the transformer
-		var compilation = CreateCompilation (platform, sources: source);
-		var syntaxTree = compilation.SyntaxTrees.ForSource (source);
-		Assert.NotNull (syntaxTree);
-
-		var semanticModel = compilation.GetSemanticModel (syntaxTree);
-		Assert.NotNull (semanticModel);
-
-		var declaration = syntaxTree.GetRoot ()
-			.DescendantNodes ().OfType<PropertyDeclarationSyntax> ()
-			.LastOrDefault ();
-		Assert.NotNull (declaration);
-
-		var symbol = semanticModel.GetDeclaredSymbol (declaration);
-		Assert.NotNull (symbol);
-		var exportData =
-			symbol.GetAttribute<CoreImageFilterPropertyData> (AttributesNames.CoreImageFilterPropertyAttribute,
-				CoreImageFilterPropertyData.TryParse);
-		Assert.Equal (expectedData, exportData);
-	}
+		=> AssertTryCreate<CoreImageFilterPropertyData, PropertyDeclarationSyntax> (platform, source, AttributesNames.CoreImageFilterPropertyAttribute,
+			expectedData, CoreImageFilterPropertyData.TryParse, lastOrDefault: true);
 }

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/ErrorDomainDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/ErrorDomainDataTests.cs
@@ -11,7 +11,7 @@ using Xamarin.Utils;
 
 namespace Microsoft.Macios.Transformer.Tests.Attributes;
 
-public class ErrorDomainDataTests : BaseTransformerTestClass {
+public class ErrorDomainDataTests : AttributeParsingTestClass {
 
 	class TestDataTryCreate : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
@@ -67,24 +67,6 @@ public enum AVKitError : long {
 	[AllSupportedPlatformsClassData<TestDataTryCreate>]
 	void TryCreateTests (ApplePlatform platform, (string Source, string Path) source,
 		ErrorDomainData expectedData)
-	{
-		// create a compilation used to create the transformer
-		var compilation = CreateCompilation (platform, sources: source);
-		var syntaxTree = compilation.SyntaxTrees.ForSource (source);
-		Assert.NotNull (syntaxTree);
-
-		var semanticModel = compilation.GetSemanticModel (syntaxTree);
-		Assert.NotNull (semanticModel);
-
-		var declaration = syntaxTree.GetRoot ()
-			.DescendantNodes ().OfType<EnumDeclarationSyntax> ()
-			.LastOrDefault ();
-		Assert.NotNull (declaration);
-
-		var symbol = semanticModel.GetDeclaredSymbol (declaration);
-		Assert.NotNull (symbol);
-		var exportData = symbol.GetAttribute<ErrorDomainData> (
-			AttributesNames.ErrorDomainAttribute, ErrorDomainData.TryParse);
-		Assert.Equal (expectedData, exportData);
-	}
+		=> AssertTryCreate<ErrorDomainData, EnumDeclarationSyntax> (platform, source, AttributesNames.ErrorDomainAttribute,
+			expectedData, ErrorDomainData.TryParse, lastOrDefault: true);
 }

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/ExportDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/ExportDataTests.cs
@@ -12,7 +12,7 @@ using Xamarin.Utils;
 
 namespace Microsoft.Macios.Transformer.Tests.Attributes;
 
-public class ExportDataTests : BaseTransformerTestClass {
+public class ExportDataTests : AttributeParsingTestClass {
 
 
 	class TestDataTryCreate : IEnumerable<object []> {
@@ -68,23 +68,6 @@ interface UIFeedbackGenerator : UIInteraction {
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataTryCreate>]
 	void TryCreateTests (ApplePlatform platform, (string Source, string Path) source, ExportData expectedData)
-	{
-		// create a compilation used to create the transformer
-		var compilation = CreateCompilation (platform, sources: source);
-		var syntaxTree = compilation.SyntaxTrees.ForSource (source);
-		Assert.NotNull (syntaxTree);
-
-		var semanticModel = compilation.GetSemanticModel (syntaxTree);
-		Assert.NotNull (semanticModel);
-
-		var declaration = syntaxTree.GetRoot ()
-			.DescendantNodes ().OfType<MethodDeclarationSyntax> ()
-			.FirstOrDefault ();
-		Assert.NotNull (declaration);
-
-		var symbol = semanticModel.GetDeclaredSymbol (declaration);
-		Assert.NotNull (symbol);
-		var exportData = symbol.GetAttribute<ExportData> (AttributesNames.ExportAttribute, ExportData.TryParse);
-		Assert.Equal (expectedData, exportData);
-	}
+		=> AssertTryCreate<ExportData, MethodDeclarationSyntax> (platform, source, AttributesNames.ExportAttribute,
+			expectedData, ExportData.TryParse, lastOrDefault: false);
 }

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/FieldDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/FieldDataTests.cs
@@ -11,7 +11,7 @@ using Xamarin.Utils;
 
 namespace Microsoft.Macios.Transformer.Tests.Attributes;
 
-public class FieldDataTests : BaseTransformerTestClass {
+public class FieldDataTests : AttributeParsingTestClass {
 
 	class TestDataTryCreate : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
@@ -86,23 +86,6 @@ interface UIFeedbackGenerator : UIInteraction {
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataTryCreate>]
 	void TryCreateTests (ApplePlatform platform, (string Source, string Path) source, FieldData expectedData)
-	{
-		// create a compilation used to create the transformer
-		var compilation = CreateCompilation (platform, sources: source);
-		var syntaxTree = compilation.SyntaxTrees.ForSource (source);
-		Assert.NotNull (syntaxTree);
-
-		var semanticModel = compilation.GetSemanticModel (syntaxTree);
-		Assert.NotNull (semanticModel);
-
-		var declaration = syntaxTree.GetRoot ()
-			.DescendantNodes ().OfType<PropertyDeclarationSyntax> ()
-			.FirstOrDefault ();
-		Assert.NotNull (declaration);
-
-		var symbol = semanticModel.GetDeclaredSymbol (declaration);
-		Assert.NotNull (symbol);
-		var fieldData = symbol.GetAttribute<FieldData> (AttributesNames.FieldAttribute, FieldData.TryParse);
-		Assert.Equal (expectedData, fieldData);
-	}
+		=> AssertTryCreate<FieldData, PropertyDeclarationSyntax> (platform, source, AttributesNames.FieldAttribute,
+			expectedData, FieldData.TryParse, lastOrDefault: false);
 }

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/NativeDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/NativeDataTests.cs
@@ -11,7 +11,7 @@ using Xamarin.Utils;
 
 namespace Microsoft.Macios.Transformer.Tests.Attributes;
 
-public class NativeDataTests : BaseTransformerTestClass {
+public class NativeDataTests : AttributeParsingTestClass {
 
 	class TestDataTryCreate : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
@@ -76,25 +76,7 @@ public enum AVAudioQuality : long {
 	[AllSupportedPlatformsClassData<TestDataTryCreate>]
 	void TryCreateTests (ApplePlatform platform, (string Source, string Path) source,
 		NativeData expectedData)
-	{
-		// create a compilation used to create the transformer
-		var compilation = CreateCompilation (platform, sources: source);
-		var syntaxTree = compilation.SyntaxTrees.ForSource (source);
-		Assert.NotNull (syntaxTree);
-
-		var semanticModel = compilation.GetSemanticModel (syntaxTree);
-		Assert.NotNull (semanticModel);
-
-		var declaration = syntaxTree.GetRoot ()
-			.DescendantNodes ().OfType<EnumDeclarationSyntax> ()
-			.LastOrDefault ();
-		Assert.NotNull (declaration);
-
-		var symbol = semanticModel.GetDeclaredSymbol (declaration);
-		Assert.NotNull (symbol);
-		var exportData = symbol.GetAttribute<NativeData> (
-			AttributesNames.NativeAttribute, NativeData.TryParse);
-		Assert.Equal (expectedData, exportData);
-	}
+		=> AssertTryCreate<NativeData, EnumDeclarationSyntax> (platform, source, AttributesNames.NativeAttribute,
+			expectedData, NativeData.TryParse, lastOrDefault: true);
 
 }

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/SnippetDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/SnippetDataTests.cs
@@ -11,7 +11,7 @@ using Xamarin.Utils;
 
 namespace Microsoft.Macios.Transformer.Tests.Attributes;
 
-public class SnippetDataTests : BaseTransformerTestClass {
+public class SnippetDataTests : AttributeParsingTestClass {
 	class TestDataTryCreate : IEnumerable<object []> {
 
 		public IEnumerator<object []> GetEnumerator ()
@@ -40,23 +40,6 @@ interface NSButton { }
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataTryCreate>]
 	void TryCreateTests (ApplePlatform platform, (string Source, string Path) source, SnippetData expectedData)
-	{
-		// create a compilation used to create the transformer
-		var compilation = CreateCompilation (platform, sources: source);
-		var syntaxTree = compilation.SyntaxTrees.ForSource (source);
-		Assert.NotNull (syntaxTree);
-
-		var semanticModel = compilation.GetSemanticModel (syntaxTree);
-		Assert.NotNull (semanticModel);
-
-		var declaration = syntaxTree.GetRoot ()
-			.DescendantNodes ().OfType<BaseTypeDeclarationSyntax> ()
-			.FirstOrDefault ();
-		Assert.NotNull (declaration);
-
-		var symbol = semanticModel.GetDeclaredSymbol (declaration);
-		Assert.NotNull (symbol);
-		var attribute = symbol.GetAttribute<SnippetData> (AttributesNames.DisposeAttribute, SnippetData.TryParse);
-		Assert.Equal (expectedData, attribute);
-	}
+		=> AssertTryCreate<SnippetData, BaseTypeDeclarationSyntax> (platform, source, AttributesNames.DisposeAttribute,
+			expectedData, SnippetData.TryParse, lastOrDefault: true);
 }

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/StrongDictionaryDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/StrongDictionaryDataTests.cs
@@ -11,7 +11,7 @@ using Xamarin.Utils;
 
 namespace Microsoft.Macios.Transformer.Tests.Attributes;
 
-public class StrongDictionaryDataTests : BaseTransformerTestClass {
+public class StrongDictionaryDataTests : AttributeParsingTestClass {
 
 	class TestDataTryCreate : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
@@ -43,23 +43,6 @@ interface AVCapturePhotoSettingsThumbnailFormat {
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataTryCreate>]
 	void TryCreateTests (ApplePlatform platform, (string Source, string Path) source, StrongDictionaryData expectedData)
-	{
-		// create a compilation used to create the transformer
-		var compilation = CreateCompilation (platform, sources: source);
-		var syntaxTree = compilation.SyntaxTrees.ForSource (source);
-		Assert.NotNull (syntaxTree);
-
-		var semanticModel = compilation.GetSemanticModel (syntaxTree);
-		Assert.NotNull (semanticModel);
-
-		var declaration = syntaxTree.GetRoot ()
-			.DescendantNodes ().OfType<BaseTypeDeclarationSyntax> ()
-			.FirstOrDefault ();
-		Assert.NotNull (declaration);
-
-		var symbol = semanticModel.GetDeclaredSymbol (declaration);
-		Assert.NotNull (symbol);
-		var attribute = symbol.GetAttribute<StrongDictionaryData> (AttributesNames.StrongDictionaryAttribute, StrongDictionaryData.TryParse);
-		Assert.Equal (expectedData, attribute);
-	}
+		=> AssertTryCreate<StrongDictionaryData, BaseTypeDeclarationSyntax> (platform, source, AttributesNames.StrongDictionaryAttribute,
+			expectedData, StrongDictionaryData.TryParse, lastOrDefault: true);
 }

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/ThreadSafeDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/ThreadSafeDataTests.cs
@@ -11,7 +11,7 @@ using Xamarin.Utils;
 
 namespace Microsoft.Macios.Transformer.Tests.Attributes;
 
-public class ThreadSafeDataTests : BaseTransformerTestClass {
+public class ThreadSafeDataTests : AttributeParsingTestClass {
 
 	class TestDataTryCreate : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
@@ -70,23 +70,6 @@ interface UIFeedbackGenerator : UIInteraction {
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataTryCreate>]
 	void TryCreateTests (ApplePlatform platform, (string Source, string Path) source, ThreadSafeData expectedData)
-	{
-		// create a compilation used to create the transformer
-		var compilation = CreateCompilation (platform, sources: source);
-		var syntaxTree = compilation.SyntaxTrees.ForSource (source);
-		Assert.NotNull (syntaxTree);
-
-		var semanticModel = compilation.GetSemanticModel (syntaxTree);
-		Assert.NotNull (semanticModel);
-
-		var declaration = syntaxTree.GetRoot ()
-			.DescendantNodes ().OfType<MethodDeclarationSyntax> ()
-			.FirstOrDefault ();
-		Assert.NotNull (declaration);
-
-		var symbol = semanticModel.GetDeclaredSymbol (declaration);
-		Assert.NotNull (symbol);
-		var attribute = symbol.GetAttribute<ThreadSafeData> (AttributesNames.ThreadSafeAttribute, ThreadSafeData.TryParse);
-		Assert.Equal (expectedData, attribute);
-	}
+		=> AssertTryCreate<ThreadSafeData, MethodDeclarationSyntax> (platform, source, AttributesNames.ThreadSafeAttribute,
+			expectedData, ThreadSafeData.TryParse, lastOrDefault: true);
 }


### PR DESCRIPTION
The tests for the attr parsing for all attrs are very similar, we can create a generic test that can be reused by all and that way mantain less code and be faster when adding a new test.