### PR TITLE
[Rgen] Add properties in the Property data model to decide if a field is needed.

### DIFF
--- a/src/ObjCBindings/ExportTag.cs
+++ b/src/ObjCBindings/ExportTag.cs
@@ -127,6 +127,13 @@ namespace ObjCBindings {
 		/// </summary>
 		IsThreadSafe = 1 << 7,
 
+		/// <summary>
+		/// If this falgs is applied to a property, we do not generate a
+		/// backing field.   See bugzilla #3359 and Assistly 7032 for some
+		/// background information
+		/// </summary>
+		Transient = 1 << 8,
+
 	}
 }
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License.
 using System;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.Macios.Generator.Availability;
 
@@ -96,8 +94,7 @@ readonly partial struct Property : IEquatable<Property> {
 		Accessors = accessors;
 	}
 
-	/// <inheritdoc />
-	public bool Equals (Property other)
+	bool CoreEquals (Property other)
 	{
 		// this could be a large && but ifs are more readable
 		if (Name != other.Name)
@@ -151,17 +148,4 @@ readonly partial struct Property : IEquatable<Property> {
 		return !left.Equals (right);
 	}
 
-	/// <inheritdoc />
-	public override string ToString ()
-	{
-		var sb = new StringBuilder (
-			$"Name: '{Name}', Type: {ReturnType}, Supported Platforms: {SymbolAvailability}, ExportFieldData: '{ExportFieldData?.ToString () ?? "null"}', ExportPropertyData: '{ExportPropertyData?.ToString () ?? "null"}' Attributes: [");
-		sb.AppendJoin (",", Attributes);
-		sb.Append ("], Modifiers: [");
-		sb.AppendJoin (",", Modifiers.Select (x => x.Text));
-		sb.Append ("], Accessors: [");
-		sb.AppendJoin (",", Accessors);
-		sb.Append (']');
-		return sb.ToString ();
-	}
 }

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Property.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Property.Transformer.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections;
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using Microsoft.Macios.Transformer.Attributes;
 
 namespace Microsoft.Macios.Generator.DataModel;
@@ -36,4 +38,21 @@ readonly partial struct Property {
 	/// True if the method was exported with the MarshalNativeExceptions flag allowing it to support native exceptions.
 	/// </summary>
 	public bool MarshalNativeExceptions => throw new NotImplementedException ();
+
+	/// <inheritdoc />
+	public bool Equals (Property other) => Comparer.Equals (this, other);
+
+	/// <inheritdoc />
+	public override string ToString ()
+	{
+		var sb = new StringBuilder (
+			$"Name: '{Name}', Type: {ReturnType}, Supported Platforms: {SymbolAvailability}, ExportFieldData: '{ExportFieldData?.ToString () ?? "null"}', ExportPropertyData: '{ExportPropertyData?.ToString () ?? "null"}' Attributes: [");
+		sb.AppendJoin (",", Attributes);
+		sb.Append ("], Modifiers: [");
+		sb.AppendJoin (",", Modifiers.Select (x => x.Text));
+		sb.Append ("], Accessors: [");
+		sb.AppendJoin (",", Accessors);
+		sb.Append (']');
+		return sb.ToString ();
+	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
@@ -1248,6 +1248,88 @@ public class TestClass {
 						),
 					])
 			];
+
+			const string nsObjectProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace Test;
+
+public class TestClass {
+
+	[Export<Property>(""name"")]
+	public NSObject Name { get; }
+}
+";
+			yield return [
+				nsObjectProperty,
+				new Property (
+					name: "Name",
+					returnType: ReturnTypeForNSObject (),
+					symbolAvailability: new (),
+					attributes: [
+						new (name: "ObjCBindings.ExportAttribute<ObjCBindings.Property>", arguments: ["name"]),
+					],
+					modifiers: [
+						SyntaxFactory.Token (kind: SyntaxKind.PublicKeyword),
+					],
+					accessors: [
+						new (
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
+							modifiers: []
+						)
+					]
+				) {
+					NeedsBackingField = true,
+					RequiresDirtyCheck = true,
+					ExportPropertyData = new (selector: "name"),
+				}
+			];
+
+			const string nsObjectArrayProperty = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace Test;
+
+public class TestClass {
+
+	[Export<Property>(""name"")]
+	public NSObject[] Name { get; }
+}
+";
+			yield return [
+				nsObjectArrayProperty,
+				new Property (
+					name: "Name",
+					returnType: ReturnTypeForArray ("Foundation.NSObject"),
+					symbolAvailability: new (),
+					attributes: [
+						new (name: "ObjCBindings.ExportAttribute<ObjCBindings.Property>", arguments: ["name"]),
+					],
+					modifiers: [
+						SyntaxFactory.Token (kind: SyntaxKind.PublicKeyword),
+					],
+					accessors: [
+						new (
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
+							modifiers: []
+						)
+					]
+				) {
+					NeedsBackingField = true,
+					RequiresDirtyCheck = true,
+					ExportPropertyData = new (selector: "name"),
+				}
+			];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator ()

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
@@ -300,16 +300,23 @@ static class TestDataFactory {
 			]
 		};
 
-	public static TypeInfo ReturnTypeForNSObject (string nsObjectName, bool isNullable = false)
+	public static TypeInfo ReturnTypeForNSObject (string? nsObjectName = null, bool isNullable = false)
 		=> new (
-			name: nsObjectName,
+			name: nsObjectName ?? "Foundation.NSObject",
 			isNullable: isNullable,
-			isArray: false
+			isArray: false,
+			isReferenceType: true
 		) {
 			IsNSObject = true,
 			IsINativeObject = true,
-			Parents = ["Foundation.NSObject", "object"],
-			Interfaces = ["ObjCRuntime.INativeObject"]
+			Parents = nsObjectName is null ? ["object"] : ["Foundation.NSObject", "object"],
+			Interfaces = [
+				"ObjCRuntime.INativeObject",
+				$"System.IEquatable<{nsObjectName ?? "Foundation.NSObject"}>",
+				"System.IDisposable",
+				"Foundation.INSObjectFactory",
+				"Foundation.INSObjectProtocol"
+			]
 		};
 
 	public static TypeInfo ReturnTypeForINativeObject (string nativeObjectName, bool isNullable = false)


### PR DESCRIPTION
Add some new properties, to be only used by the generator, in the property data model to decide the inclusion of a backing field and if this field needs to be checked.

We have moved the ToString method to the .Generator and .Transformer files so that we can reflect the two new properties. The same has happened for the Equals method.