### PR TITLE
[Rgen] Add the needed code to parse a BindAsAttriubte.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs
@@ -44,6 +44,23 @@ static partial class TypeSymbolExtensions {
 
 			attributeDataList.Add (attributeData);
 		}
+		
+		// if we are dealing with a method, we want to also return the attributes used for the return type
+		if (symbol is not IMethodSymbol methodSymbol) 
+			return attributes;
+		
+		var returnAttributes = methodSymbol.GetReturnTypeAttributes ();
+		foreach (var attributeData in returnAttributes) {
+			var attrName = attributeData.AttributeClass?.ToDisplayString ();
+			if (string.IsNullOrEmpty (attrName))
+				continue;
+			if (!attributes.TryGetValue (attrName, out var attributeDataList)) {
+				attributeDataList = new List<AttributeData> ();
+				attributes.Add (attrName, attributeDataList);
+			}
+
+			attributeDataList.Add (attributeData);
+		}
 
 		return attributes;
 	}

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs
@@ -44,11 +44,11 @@ static partial class TypeSymbolExtensions {
 
 			attributeDataList.Add (attributeData);
 		}
-		
+
 		// if we are dealing with a method, we want to also return the attributes used for the return type
-		if (symbol is not IMethodSymbol methodSymbol) 
+		if (symbol is not IMethodSymbol methodSymbol)
 			return attributes;
-		
+
 		var returnAttributes = methodSymbol.GetReturnTypeAttributes ();
 		foreach (var attributeData in returnAttributes) {
 			var attrName = attributeData.AttributeClass?.ToDisplayString ();

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/BindAsData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/BindAsData.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis;
 namespace Microsoft.Macios.Transformer.Attributes;
 
 readonly record struct BindAsData {
-	
+
 	public string Type { get; init; }
 	public string? OriginalType { get; init; }
 
@@ -20,7 +20,7 @@ readonly record struct BindAsData {
 	{
 		Type = type;
 		OriginalType = originalType;
-		
+
 	}
 
 	public static bool TryParse (AttributeData attributeData,
@@ -30,7 +30,7 @@ readonly record struct BindAsData {
 		var count = attributeData.ConstructorArguments.Length;
 		string type;
 		string? originalType = null;
-		
+
 		switch (count) {
 		case 1:
 			type = ((ITypeSymbol) attributeData.ConstructorArguments [0].Value!).ToDisplayString ();
@@ -39,12 +39,12 @@ readonly record struct BindAsData {
 			// 0 should not be an option..
 			return false;
 		}
-		
+
 		if (attributeData.NamedArguments.Length == 0) {
 			data = new (type);
 			return true;
 		}
-		
+
 		foreach (var (argumentName, value) in attributeData.NamedArguments) {
 			switch (argumentName) {
 			case "Type":
@@ -58,7 +58,7 @@ readonly record struct BindAsData {
 				return false;
 			}
 		}
-		
+
 		data = new (type, originalType);
 		return true;
 	}

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/BindAsData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/BindAsData.cs
@@ -48,10 +48,10 @@ readonly record struct BindAsData {
 		foreach (var (argumentName, value) in attributeData.NamedArguments) {
 			switch (argumentName) {
 			case "Type":
-				type = ((INamedTypeSymbol) value.Value!).ToDisplayString ();
+				type = ((ITypeSymbol) value.Value!).ToDisplayString ();
 				break;
 			case "OriginalType":
-				originalType = ((INamedTypeSymbol) value.Value!).ToDisplayString ();
+				originalType = ((ITypeSymbol) value.Value!).ToDisplayString ();
 				break;
 			default:
 				data = null;

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/BindAsData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/BindAsData.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Macios.Transformer.Attributes;
+
+readonly record struct BindAsData {
+	
+	public string Type { get; init; }
+	public string? OriginalType { get; init; }
+
+	public BindAsData (string type)
+	{
+		Type = type;
+	}
+
+	public BindAsData (string type, string? originalType)
+	{
+		Type = type;
+		OriginalType = originalType;
+		
+	}
+
+	public static bool TryParse (AttributeData attributeData,
+		[NotNullWhen (true)] out BindAsData? data)
+	{
+		data = null;
+		var count = attributeData.ConstructorArguments.Length;
+		string type;
+		string? originalType = null;
+		
+		switch (count) {
+		case 1:
+			type = ((ITypeSymbol) attributeData.ConstructorArguments [0].Value!).ToDisplayString ();
+			break;
+		default:
+			// 0 should not be an option..
+			return false;
+		}
+		
+		if (attributeData.NamedArguments.Length == 0) {
+			data = new (type);
+			return true;
+		}
+		
+		foreach (var (argumentName, value) in attributeData.NamedArguments) {
+			switch (argumentName) {
+			case "Type":
+				type = ((INamedTypeSymbol) value.Value!).ToDisplayString ();
+				break;
+			case "OriginalType":
+				originalType = ((INamedTypeSymbol) value.Value!).ToDisplayString ();
+				break;
+			default:
+				data = null;
+				return false;
+			}
+		}
+		
+		data = new (type, originalType);
+		return true;
+	}
+
+}

--- a/src/rgen/Microsoft.Macios.Transformer/AttributesNames.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/AttributesNames.cs
@@ -43,6 +43,9 @@ static class AttributesNames {
 	[BindingAttribute(typeof(BindData), AttributeTargets.Method )]
 	public const string BindAttribute = "BindAttribute";
 
+	[BindingAttribute(typeof(BindAsData), AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Parameter)]
+	public const string BindAsAttribute = "ObjCRuntime.BindAsAttribute";
+
 	/// <summary>
 	/// Use this attribute on a type definition to bind Objective-C categories and to expose those as C# extension
 	/// methods to mirror the way Objective-C exposes the functionality.

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/BindAsDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/BindAsDataTests.cs
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Extensions;
+using Microsoft.Macios.Transformer.Attributes;
+using Xamarin.Tests;
+using Xamarin.Utils;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Microsoft.Macios.Transformer.Tests.Attributes;
+
+public class BindAsDataTests : BaseTransformerTestClass {
+	
+	class TestDataTryCreate : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			var path = "/some/random/path.cs";
+
+			const string bindAsProperty = @"
+using System;
+using Foundation;
+using ObjCRuntime;
+using CoreMedia;
+
+namespace Test;
+
+[NoTV]
+[MacCatalyst (13, 1)]
+[DisableDefaultCtor]
+[Abstract]
+[BaseType (typeof (NSObject))]
+interface UIFeedbackGenerator {
+	[BindAs (typeof (CMVideoDimensions []))]
+	[Export (""supportedMaxPhotoDimensions"")]
+	NSValue [] SupportedMaxPhotoDimensions { get; }
+}
+";
+			
+			yield return [
+				PropertyDeclaration (IdentifierName ("string"), Identifier ("Hello")), 
+				(Source: bindAsProperty, Path: path), 
+				new BindAsData("CoreMedia.CMVideoDimensions[]")];
+				
+			
+			const string bindAsReturnMethod = @"
+using System;
+using Foundation;
+using ObjCRuntime;
+using CoreMedia;
+
+namespace Test;
+
+[NoTV]
+[MacCatalyst (13, 1)]
+[DisableDefaultCtor]
+[Abstract]
+[BaseType (typeof (NSObject))]
+interface UIFeedbackGenerator {
+	[return: BindAs (typeof (NSLinguisticTag []))]
+	[Export (""linguisticTagsInRange:scheme:options:orthography:tokenRanges:"")]
+	NSString [] GetLinguisticTags (NSRange range, NSString scheme, NSLinguisticTaggerOptions options, [NullAllowed] NSOrthography orthography, [NullAllowed] out NSValue [] tokenRanges);
+}
+";
+			
+			yield return [
+				MethodDeclaration (PredefinedType(Token(SyntaxKind.StringKeyword)), Identifier ("Hello")),
+				(Source: bindAsReturnMethod, Path: path), 
+				new BindAsData("Foundation.NSLinguisticTag[]")];
+
+
+			const string parameterBindAs = @"
+using System;
+using Foundation;
+using ObjCRuntime;
+using CoreMedia;
+
+namespace Test;
+
+[NoTV]
+[MacCatalyst (13, 1)]
+[DisableDefaultCtor]
+[Abstract]
+[BaseType (typeof (NSObject))]
+interface UIFeedbackGenerator {
+	[Export (""linguisticTagsInRange:scheme:options:orthography:tokenRanges:"")]
+	NSString [] GetLinguisticTags ([BindAs (typeof (ushort?))] NSString scheme);
+}
+";
+			var parameter = Parameter (Identifier ("variable"))
+					.WithType (PredefinedType (Token (SyntaxKind.StringKeyword)));
+			yield return [
+				parameter,
+				(Source: parameterBindAs, Path: path), 
+				new BindAsData("ushort?")];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataTryCreate>]
+	void TryCreateTests<T> (ApplePlatform platform, T _, (string Source, string Path) source, BindAsData expectedData)
+		where T : CSharpSyntaxNode 
+	{
+		// create a compilation used to create the transformer
+		var compilation = CreateCompilation (platform, sources: source);
+		var syntaxTree = compilation.SyntaxTrees.ForSource (source);
+		var trees = compilation.SyntaxTrees.Where (s => s.FilePath == source.Path).ToArray ();
+		Assert.Single (trees);
+		Assert.NotNull (syntaxTree);
+
+		var semanticModel = compilation.GetSemanticModel (syntaxTree);
+		Assert.NotNull (semanticModel);
+
+		var declaration = syntaxTree.GetRoot ()
+			.DescendantNodes ().OfType<T> ()
+			.LastOrDefault ();
+
+		Assert.NotNull (declaration);
+
+		var symbol = semanticModel.GetDeclaredSymbol (declaration);
+		Assert.NotNull (symbol);
+		var attribute = symbol.GetAttribute<BindAsData> (AttributesNames.BindAsAttribute, BindAsData.TryParse);
+		Assert.NotNull (attribute);
+		Assert.Equal (expectedData, attribute.Value);
+	}
+}

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/BindAsDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/BindAsDataTests.cs
@@ -14,7 +14,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 namespace Microsoft.Macios.Transformer.Tests.Attributes;
 
 public class BindAsDataTests : BaseTransformerTestClass {
-	
+
 	class TestDataTryCreate : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -39,13 +39,13 @@ interface UIFeedbackGenerator {
 	NSValue [] SupportedMaxPhotoDimensions { get; }
 }
 ";
-			
+
 			yield return [
-				PropertyDeclaration (IdentifierName ("string"), Identifier ("Hello")), 
-				(Source: bindAsProperty, Path: path), 
-				new BindAsData("CoreMedia.CMVideoDimensions[]")];
-				
-			
+				PropertyDeclaration (IdentifierName ("string"), Identifier ("Hello")),
+				(Source: bindAsProperty, Path: path),
+				new BindAsData ("CoreMedia.CMVideoDimensions[]")];
+
+
 			const string bindAsReturnMethod = @"
 using System;
 using Foundation;
@@ -65,11 +65,11 @@ interface UIFeedbackGenerator {
 	NSString [] GetLinguisticTags (NSRange range, NSString scheme, NSLinguisticTaggerOptions options, [NullAllowed] NSOrthography orthography, [NullAllowed] out NSValue [] tokenRanges);
 }
 ";
-			
+
 			yield return [
-				MethodDeclaration (PredefinedType(Token(SyntaxKind.StringKeyword)), Identifier ("Hello")),
-				(Source: bindAsReturnMethod, Path: path), 
-				new BindAsData("Foundation.NSLinguisticTag[]")];
+				MethodDeclaration (PredefinedType (Token (SyntaxKind.StringKeyword)), Identifier ("Hello")),
+				(Source: bindAsReturnMethod, Path: path),
+				new BindAsData ("Foundation.NSLinguisticTag[]")];
 
 
 			const string parameterBindAs = @"
@@ -94,8 +94,8 @@ interface UIFeedbackGenerator {
 					.WithType (PredefinedType (Token (SyntaxKind.StringKeyword)));
 			yield return [
 				parameter,
-				(Source: parameterBindAs, Path: path), 
-				new BindAsData("ushort?")];
+				(Source: parameterBindAs, Path: path),
+				new BindAsData ("ushort?")];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
@@ -104,7 +104,7 @@ interface UIFeedbackGenerator {
 	[Theory]
 	[AllSupportedPlatformsClassData<TestDataTryCreate>]
 	void TryCreateTests<T> (ApplePlatform platform, T _, (string Source, string Path) source, BindAsData expectedData)
-		where T : CSharpSyntaxNode 
+		where T : CSharpSyntaxNode
 	{
 		// create a compilation used to create the transformer
 		var compilation = CreateCompilation (platform, sources: source);


### PR DESCRIPTION
This change is a little more interesting than the others because I had to update the way we retrieve the attributes. Return attrbutes are only present on a special collection for IMethodSymbols, this meant that we had to add an extra pass for those attributes in the generic method in pur extensions.