### PR TITLE
[Rgen] Use ITypeSymbol over INamedTypeSymbol since they interface is more general and will give less problems.

### DIFF
--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/AsyncData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/AsyncData.cs
@@ -51,7 +51,7 @@ readonly record struct AsyncData {
 				methodName = methodNameValue;
 			} else {
 				constructorType = ConstructorType.ResultType;
-				resultType = ((INamedTypeSymbol) attributeData.ConstructorArguments [0].Value!).ToDisplayString ();
+				resultType = ((ITypeSymbol) attributeData.ConstructorArguments [0].Value!).ToDisplayString ();
 			}
 			break;
 		default:
@@ -70,7 +70,7 @@ readonly record struct AsyncData {
 		foreach (var (argumentName, value) in attributeData.NamedArguments) {
 			switch (argumentName) {
 			case "ResultType":
-				resultType = ((INamedTypeSymbol) value.Value!).ToDisplayString ();
+				resultType = ((ITypeSymbol) value.Value!).ToDisplayString ();
 				break;
 			case "MethodName":
 				methodName = (string) value.Value!;

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/BackingFieldTypeData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/BackingFieldTypeData.cs
@@ -25,7 +25,7 @@ readonly record struct BackingFieldTypeData {
 
 		switch (count) {
 		case 1:
-			backingField = ((INamedTypeSymbol) attributeData.ConstructorArguments [0].Value!).ToDisplayString ();
+			backingField = ((ITypeSymbol) attributeData.ConstructorArguments [0].Value!).ToDisplayString ();
 			break;
 		default:
 			// 0 should not be an option..
@@ -40,7 +40,7 @@ readonly record struct BackingFieldTypeData {
 		foreach (var (argumentName, value) in attributeData.NamedArguments) {
 			switch (argumentName) {
 			case "BackingFieldType":
-				backingField = ((INamedTypeSymbol) value.Value!).ToDisplayString ();
+				backingField = ((ITypeSymbol) value.Value!).ToDisplayString ();
 				break;
 			default:
 				data = null;

--- a/src/rgen/Microsoft.Macios.Transformer/Attributes/BaseTypeData.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/Attributes/BaseTypeData.cs
@@ -42,7 +42,7 @@ readonly record struct BaseTypeData {
 
 		switch (count) {
 		case 1:
-			baseType = ((INamedTypeSymbol) attributeData.ConstructorArguments [0].Value!).ToDisplayString ();
+			baseType = ((ITypeSymbol) attributeData.ConstructorArguments [0].Value!).ToDisplayString ();
 			break;
 		default:
 			// 0 should not be an option..
@@ -61,7 +61,7 @@ readonly record struct BaseTypeData {
 				break;
 			case "Events":
 				events = value.Values.Select (
-					v => ((INamedTypeSymbol) v.Value!).ToDisplayString ())
+					v => ((ITypeSymbol) v.Value!).ToDisplayString ())
 					.ToArray ();
 				break;
 			case "Delegates":


### PR DESCRIPTION
No need to add more tests because they all ready cover all valid uses.