### PR TITLE
[RGen] Implement the BindFrom attribute.

### DIFF
--- a/src/ObjCBindings/BindFromAttribute.cs
+++ b/src/ObjCBindings/BindFromAttribute.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Reflection;
+using System.Diagnostics.CodeAnalysis;
+using ObjCRuntime;
+
+#nullable enable
+
+namespace ObjCBindings {
+
+	/// <summary>
+	/// Attribute to bind from a specific type.
+	/// </summary>
+	[Experimental ("APL0003")]
+	[AttributeUsage (AttributeTargets.ReturnValue | AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false)]
+	public class BindFromAttribute : Attribute {
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="BindFromAttribute"/> class.
+		/// </summary>
+		public BindFromAttribute (Type type)
+		{
+			Type = type;
+		}
+
+		/// <summary>
+		/// The type to bind from.
+		/// </summary>
+		public Type Type { get; set; }
+
+		/// <summary>
+		/// The original type that was bound from.
+		/// </summary>
+		public Type? OriginalType { get; set; } = null;
+	}
+}

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1935,6 +1935,7 @@ SHARED_CORE_SOURCES = \
 	DotNetGlobals.cs \
 	MinimumVersions.cs \
 	MonoPInvokeCallbackAttribute.cs \
+	ObjCBindings/BindFromAttribute.cs \
 	ObjCBindings/BindingTypeAttribute.cs \
 	ObjCBindings/BindingTypeTag.cs \
 	ObjCBindings/ExportAttribute.cs \

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Microsoft.Macios.Bindings.Analyzer.csproj
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Microsoft.Macios.Bindings.Analyzer.csproj
@@ -39,6 +39,9 @@
         <Compile Include="../Microsoft.Macios.Generator/DictionaryComparer.cs" >
             <Link>Generator/DictionaryComparer.cs</Link>
         </Compile>
+        <Compile Include="../Microsoft.Macios.Generator/Attributes/BindFromData.cs" >
+            <Link>Generator/Attributes/BindFromData.cs</Link>
+        </Compile>
         <Compile Include="../Microsoft.Macios.Generator/Attributes/FieldData.cs" >
             <Link>Generator/Attributes/FieldData.cs</Link>
         </Compile>

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/BindFromData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/BindFromData.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis;
 namespace Microsoft.Macios.Generator.Attributes;
 
 readonly struct BindFromData : IEquatable<BindFromData> {
-	
+
 	public string Type { get; }
 	public string? OriginalType { get; }
 
@@ -31,7 +31,7 @@ readonly struct BindFromData : IEquatable<BindFromData> {
 		var count = attributeData.ConstructorArguments.Length;
 		string? type;
 		string? originalType = null;
-		
+
 		switch (count) {
 		case 1:
 			type = ((INamedTypeSymbol) attributeData.ConstructorArguments [0].Value!).ToDisplayString ();
@@ -40,12 +40,12 @@ readonly struct BindFromData : IEquatable<BindFromData> {
 			// no other constructors are available
 			return false;
 		}
-		
+
 		if (attributeData.NamedArguments.Length == 0) {
 			data = new (type);
 			return true;
 		}
-		
+
 		foreach (var (name, value) in attributeData.NamedArguments) {
 			switch (name) {
 			case "Type":
@@ -62,7 +62,7 @@ readonly struct BindFromData : IEquatable<BindFromData> {
 		data = new (type, originalType);
 		return true;
 	}
-	
+
 	/// <inheritdoc />
 	public bool Equals (BindFromData other)
 	{
@@ -92,7 +92,7 @@ readonly struct BindFromData : IEquatable<BindFromData> {
 	{
 		return !(x == y);
 	}
-	
+
 	public override string ToString ()
 	{
 		return $"{{ Type: '{Type}', OriginalType: '{OriginalType ?? "null"}' }}";

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/BindFromData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/BindFromData.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Macios.Generator.Attributes;
+
+readonly struct BindFromData : IEquatable<BindFromData> {
+	
+	public string Type { get; }
+	public string? OriginalType { get; }
+
+	public BindFromData (string type)
+	{
+		Type = type;
+	}
+
+	public BindFromData (string type, string? originalType)
+	{
+		Type = type;
+		OriginalType = originalType;
+	}
+
+
+	public static bool TryParse (AttributeData attributeData,
+		[NotNullWhen (true)] out BindFromData? data)
+	{
+		data = null;
+		var count = attributeData.ConstructorArguments.Length;
+		string? type;
+		string? originalType = null;
+		
+		switch (count) {
+		case 1:
+			type = ((INamedTypeSymbol) attributeData.ConstructorArguments [0].Value!).ToDisplayString ();
+			break;
+		default:
+			// no other constructors are available
+			return false;
+		}
+		
+		if (attributeData.NamedArguments.Length == 0) {
+			data = new (type);
+			return true;
+		}
+		
+		foreach (var (name, value) in attributeData.NamedArguments) {
+			switch (name) {
+			case "Type":
+				type = ((INamedTypeSymbol) value.Value!).ToDisplayString ();
+				break;
+			case "OriginalType":
+				originalType = ((INamedTypeSymbol) value.Value!).ToDisplayString ();
+				break;
+			default:
+				data = null;
+				return false;
+			}
+		}
+		data = new (type, originalType);
+		return true;
+	}
+	
+	/// <inheritdoc />
+	public bool Equals (BindFromData other)
+	{
+		if (Type != other.Type)
+			return false;
+		return OriginalType == other.OriginalType;
+	}
+
+	/// <inheritdoc />
+	public override bool Equals (object? obj)
+	{
+		return obj is BindFromData other && Equals (other);
+	}
+
+	/// <inheritdoc />
+	public override int GetHashCode ()
+	{
+		return HashCode.Combine (Type, OriginalType);
+	}
+
+	public static bool operator == (BindFromData x, BindFromData y)
+	{
+		return x.Equals (y);
+	}
+
+	public static bool operator != (BindFromData x, BindFromData y)
+	{
+		return !(x == y);
+	}
+	
+	public override string ToString ()
+	{
+		return $"{{ Type: '{Type}', OriginalType: '{OriginalType ?? "null"}' }}";
+	}
+}

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/BindFromData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/BindFromData.cs
@@ -66,9 +66,7 @@ readonly struct BindFromData : IEquatable<BindFromData> {
 	/// <inheritdoc />
 	public bool Equals (BindFromData other)
 	{
-		if (Type != other.Type)
-			return false;
-		return OriginalType == other.OriginalType;
+		return Type == other.Type && OriginalType == other.OriginalType;
 	}
 
 	/// <inheritdoc />

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/FieldData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/FieldData.cs
@@ -137,6 +137,6 @@ readonly struct FieldData<T> : IEquatable<FieldData<T>> where T : Enum {
 	/// <inheritdoc />
 	public override string ToString ()
 	{
-		return $"{{ SymbolName: '{SymbolName}' LibraryName: '{LibraryName ?? "null"}', Flags: '{Flags}' }}";
+		return $"{{ SymbolName: '{SymbolName}', LibraryName: '{LibraryName ?? "null"}', Flags: '{Flags}' }}";
 	}
 }

--- a/src/rgen/Microsoft.Macios.Generator/AttributesNames.cs
+++ b/src/rgen/Microsoft.Macios.Generator/AttributesNames.cs
@@ -12,6 +12,7 @@ static class AttributesNames {
 	public const string BindingAttribute = "ObjCBindings.BindingTypeAttribute";
 	public const string BindingCategoryAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.Category>";
 	public const string BindingClassAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.Class>";
+	public const string BindFromAttribute = "ObjCBindings.BindFromAttribute";
 	public const string BindingProtocolAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.Protocol>";
 	public const string BindingStrongDictionaryAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.StrongDictionary>";
 	public const string FieldAttribute = "ObjCBindings.FieldAttribute";

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
@@ -19,6 +19,11 @@ readonly partial struct Method {
 	/// The data of the export attribute used to mark the value as a property binding. 
 	/// </summary>
 	public ExportData<ObjCBindings.Method> ExportMethodData { get; }
+	
+	/// <summary>
+	/// Returns the bind from data if present in the binding.
+	/// </summary>
+	public BindFromData? BindAs { get; init; }
 
 	/// <summary>
 	/// Returns if the method was marked as thread safe.
@@ -79,7 +84,10 @@ readonly partial struct Method {
 			exportMethodData: exportData,
 			attributes: attributes,
 			modifiers: [.. declaration.Modifiers],
-			parameters: parametersBucket.ToImmutableArray ());
+			parameters: parametersBucket.ToImmutableArray ()) 
+		{
+			BindAs = method.GetBindFromData (),
+		};
 
 		return true;
 	}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
@@ -19,7 +19,7 @@ readonly partial struct Method {
 	/// The data of the export attribute used to mark the value as a property binding. 
 	/// </summary>
 	public ExportData<ObjCBindings.Method> ExportMethodData { get; }
-	
+
 	/// <summary>
 	/// Returns the bind from data if present in the binding.
 	/// </summary>
@@ -84,8 +84,7 @@ readonly partial struct Method {
 			exportMethodData: exportData,
 			attributes: attributes,
 			modifiers: [.. declaration.Modifiers],
-			parameters: parametersBucket.ToImmutableArray ()) 
-		{
+			parameters: parametersBucket.ToImmutableArray ()) {
 			BindAs = method.GetBindFromData (),
 		};
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.cs
@@ -61,6 +61,8 @@ readonly partial struct Method : IEquatable<Method> {
 			return false;
 		if (ExportMethodData != other.ExportMethodData)
 			return false;
+		if (BindAs != other.BindAs)
+			return false;
 
 		var attrsComparer = new AttributesEqualityComparer ();
 		if (!attrsComparer.Equals (Attributes, other.Attributes))
@@ -86,6 +88,7 @@ readonly partial struct Method : IEquatable<Method> {
 		hashCode.Add (Type);
 		hashCode.Add (Name);
 		hashCode.Add (ReturnType);
+		hashCode.Add (BindAs);
 		foreach (var modifier in Modifiers) {
 			hashCode.Add (modifier);
 		}
@@ -119,6 +122,7 @@ readonly partial struct Method : IEquatable<Method> {
 		sb.Append ($"ReturnType: {ReturnType}, ");
 		sb.Append ($"SymbolAvailability: {SymbolAvailability}, ");
 		sb.Append ($"ExportMethodData: {ExportMethodData}, ");
+		sb.Append ($"BindAs: {BindAs}, ");
 		sb.Append ("Attributes: [");
 		sb.AppendJoin (", ", Attributes);
 		sb.Append ("], Modifiers: [");

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.Generator.cs
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.Extensions;
+
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly partial struct Parameter {
@@ -13,6 +19,33 @@ readonly partial struct Parameter {
 		NSStringStruct,
 		PrimitivePointer,
 		StringPointer,
+	}
+	
+	/// <summary>
+	/// Returns the bind from data if present in the binding.
+	/// </summary>
+	public BindFromData? BindAs { get; init; }
+	
+	public static bool TryCreate (IParameterSymbol symbol, ParameterSyntax declaration, SemanticModel semanticModel,
+		[NotNullWhen (true)] out Parameter? parameter)
+	{
+		DelegateInfo? delegateInfo = null;
+		if (symbol.Type is INamedTypeSymbol namedTypeSymbol
+			&& namedTypeSymbol.DelegateInvokeMethod is not null) {
+			DelegateInfo.TryCreate (namedTypeSymbol.DelegateInvokeMethod, out delegateInfo);
+		}
+
+		parameter = new (symbol.Ordinal, new (symbol.Type), symbol.Name) {
+			BindAs = symbol.GetBindFromData (),
+			IsOptional = symbol.IsOptional,
+			IsParams = symbol.IsParams,
+			IsThis = symbol.IsThis,
+			DefaultValue = (symbol.HasExplicitDefaultValue) ? symbol.ExplicitDefaultValue?.ToString () : null,
+			ReferenceKind = symbol.RefKind.ToReferenceKind (),
+			Delegate = delegateInfo,
+			Attributes = declaration.GetAttributeCodeChanges (semanticModel),
+		};
+		return true;
 	}
 
 	/// <summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.Generator.cs
@@ -20,12 +20,12 @@ readonly partial struct Parameter {
 		PrimitivePointer,
 		StringPointer,
 	}
-	
+
 	/// <summary>
 	/// Returns the bind from data if present in the binding.
 	/// </summary>
 	public BindFromData? BindAs { get; init; }
-	
+
 	public static bool TryCreate (IParameterSymbol symbol, ParameterSyntax declaration, SemanticModel semanticModel,
 		[NotNullWhen (true)] out Parameter? parameter)
 	{

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.cs
@@ -78,28 +78,7 @@ readonly partial struct Parameter : IEquatable<Parameter> {
 		Type = type;
 		Name = name;
 	}
-
-	public static bool TryCreate (IParameterSymbol symbol, ParameterSyntax declaration, SemanticModel semanticModel,
-		[NotNullWhen (true)] out Parameter? parameter)
-	{
-		DelegateInfo? delegateInfo = null;
-		if (symbol.Type is INamedTypeSymbol namedTypeSymbol
-			&& namedTypeSymbol.DelegateInvokeMethod is not null) {
-			DelegateInfo.TryCreate (namedTypeSymbol.DelegateInvokeMethod, out delegateInfo);
-		}
-
-		parameter = new (symbol.Ordinal, new (symbol.Type), symbol.Name) {
-			IsOptional = symbol.IsOptional,
-			IsParams = symbol.IsParams,
-			IsThis = symbol.IsThis,
-			DefaultValue = (symbol.HasExplicitDefaultValue) ? symbol.ExplicitDefaultValue?.ToString () : null,
-			ReferenceKind = symbol.RefKind.ToReferenceKind (),
-			Delegate = delegateInfo,
-			Attributes = declaration.GetAttributeCodeChanges (semanticModel),
-		};
-		return true;
-	}
-
+	
 	/// <inheritdoc/>
 	public bool Equals (Parameter other)
 	{
@@ -118,6 +97,8 @@ readonly partial struct Parameter : IEquatable<Parameter> {
 		if (DefaultValue != other.DefaultValue)
 			return false;
 		if (ReferenceKind != other.ReferenceKind)
+			return false;
+		if (BindAs != other.BindAs)
 			return false;
 		if (Delegate != other.Delegate)
 			return false;
@@ -145,6 +126,7 @@ readonly partial struct Parameter : IEquatable<Parameter> {
 		hashCode.Add (DefaultValue);
 		hashCode.Add ((int) ReferenceKind);
 		hashCode.Add (Delegate);
+		hashCode.Add (BindAs);
 		return hashCode.ToHashCode ();
 	}
 
@@ -165,13 +147,14 @@ readonly partial struct Parameter : IEquatable<Parameter> {
 		sb.Append ($"Position: {Position}, ");
 		sb.Append ($"Type: {Type}, ");
 		sb.Append ($"Name: {Name}, ");
-		sb.Append ("Attributes: ");
+		sb.Append ("Attributes: [");
 		sb.AppendJoin (", ", Attributes);
-		sb.Append ($" IsOptional: {IsOptional}, ");
+		sb.Append ($"] IsOptional: {IsOptional}, ");
 		sb.Append ($"IsParams: {IsParams}, ");
 		sb.Append ($"IsThis: {IsThis}, ");
 		sb.Append ($"DefaultValue: {DefaultValue}, ");
 		sb.Append ($"ReferenceKind: {ReferenceKind}, ");
+		sb.Append ($"BindAs: {BindAs?.ToString () ?? "null"}, ");
 		sb.Append ($"Delegate: {Delegate?.ToString () ?? "null"} }}");
 		return sb.ToString ();
 	}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.cs
@@ -78,7 +78,7 @@ readonly partial struct Parameter : IEquatable<Parameter> {
 		Type = type;
 		Name = name;
 	}
-	
+
 	/// <inheritdoc/>
 	public bool Equals (Parameter other)
 	{

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
@@ -52,7 +52,7 @@ readonly partial struct Property {
 	/// </summary>
 	public bool MarshalNativeExceptions
 		=> IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.MarshalNativeExceptions);
-	
+
 	/// <summary>
 	/// Returns the bind from data if present in the binding.
 	/// </summary>
@@ -168,8 +168,7 @@ readonly partial struct Property {
 			symbolAvailability: propertySupportedPlatforms,
 			attributes: attributes,
 			modifiers: [.. declaration.Modifiers],
-			accessors: accessorCodeChanges) 
-		{
+			accessors: accessorCodeChanges) {
 			BindAs = propertySymbol.GetBindFromData (),
 			ExportFieldData = GetFieldInfo (context, propertySymbol),
 			ExportPropertyData = propertySymbol.GetExportData<ObjCBindings.Property> (),

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
@@ -52,6 +52,11 @@ readonly partial struct Property {
 	/// </summary>
 	public bool MarshalNativeExceptions
 		=> IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.MarshalNativeExceptions);
+	
+	/// <summary>
+	/// Returns the bind from data if present in the binding.
+	/// </summary>
+	public BindFromData? BindAs { get; init; }
 
 	/// <summary>
 	/// True if the property should be generated without a backing field.
@@ -163,7 +168,9 @@ readonly partial struct Property {
 			symbolAvailability: propertySupportedPlatforms,
 			attributes: attributes,
 			modifiers: [.. declaration.Modifiers],
-			accessors: accessorCodeChanges) {
+			accessors: accessorCodeChanges) 
+		{
+			BindAs = propertySymbol.GetBindFromData (),
 			ExportFieldData = GetFieldInfo (context, propertySymbol),
 			ExportPropertyData = propertySymbol.GetExportData<ObjCBindings.Property> (),
 		};
@@ -190,6 +197,7 @@ readonly partial struct Property {
 		sb.Append ($"IsTransient: '{IsTransient}', ");
 		sb.Append ($"NeedsBackingField: '{NeedsBackingField}', ");
 		sb.Append ($"RequiresDirtyCheck: '{RequiresDirtyCheck}', ");
+		sb.Append ($"BindAs: '{BindAs}', ");
 		sb.Append ("Attributes: [");
 		sb.AppendJoin (",", Attributes);
 		sb.Append ("], Modifiers: [");

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -113,6 +113,8 @@ readonly partial struct Property : IEquatable<Property> {
 			return false;
 		if (ExportPropertyData != other.ExportPropertyData)
 			return false;
+		if (BindAs != other.BindAs)
+			return false;
 
 		var attrsComparer = new AttributesEqualityComparer ();
 		if (!attrsComparer.Equals (Attributes, other.Attributes))

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Core.cs
@@ -27,11 +27,6 @@ static partial class TypeSymbolExtensions {
 	public static Dictionary<string, List<AttributeData>> GetAttributeData (this ISymbol symbol)
 	{
 		var boundAttributes = symbol.GetAttributes ();
-		if (boundAttributes.Length == 0) {
-			// return an empty dictionary if there are no attributes
-			return new ();
-		}
-
 		var attributes = new Dictionary<string, List<AttributeData>> ();
 		foreach (var attributeData in boundAttributes) {
 			var attrName = attributeData.AttributeClass?.ToDisplayString ();

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Generator.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Availability;
@@ -134,6 +133,9 @@ static partial class TypeSymbolExtensions {
 	public static FieldData<T>? GetFieldData<T> (this ISymbol symbol) where T : Enum
 		=> GetAttribute<FieldData<T>> (symbol, AttributesNames.GetFieldAttributeName<T>, FieldData<T>.TryParse);
 
+	public static BindFromData? GetBindFromData (this ISymbol symbol)
+		=> GetAttribute<BindFromData> (symbol, AttributesNames.BindFromAttribute, BindFromData.TryParse);
+	
 	public static bool X86NeedStret (ITypeSymbol returnType)
 	{
 		if (!returnType.IsValueType || returnType.SpecialType == SpecialType.System_Enum ||

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/TypeSymbolExtensions.Generator.cs
@@ -135,7 +135,7 @@ static partial class TypeSymbolExtensions {
 
 	public static BindFromData? GetBindFromData (this ISymbol symbol)
 		=> GetAttribute<BindFromData> (symbol, AttributesNames.BindFromAttribute, BindFromData.TryParse);
-	
+
 	public static bool X86NeedStret (ITypeSymbol returnType)
 	{
 		if (!returnType.IsValueType || returnType.SpecialType == SpecialType.System_Enum ||

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Method.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Method.Transformer.cs
@@ -16,6 +16,11 @@ readonly partial struct Method {
 	public ExportData ExportMethodData { get; }
 
 	/// <summary>
+	/// Returns the bind from data if present in the binding.
+	/// </summary>
+	public BindAsData? BindAs => BindAsAttribute;
+
+	/// <summary>
 	/// True if the method was exported with the MarshalNativeExceptions flag allowing it to support native exceptions.
 	/// </summary>
 	public bool MarshalNativeExceptions => throw new NotImplementedException ();

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Parameter.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Parameter.Transformer.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Macios.Transformer.Attributes;
+
+namespace Microsoft.Macios.Generator.DataModel;
+
+readonly partial struct Parameter {
+
+	/// <summary>
+	/// Returns the bind from data if present in the binding.
+	/// </summary>
+	public BindAsData? BindAs => BindAsAttribute;
+}

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Property.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Property.Transformer.cs
@@ -38,7 +38,7 @@ readonly partial struct Property {
 	/// True if the method was exported with the MarshalNativeExceptions flag allowing it to support native exceptions.
 	/// </summary>
 	public bool MarshalNativeExceptions => throw new NotImplementedException ();
-	
+
 	/// <summary>
 	/// Returns the bind from data if present in the binding.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Property.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Property.Transformer.cs
@@ -38,6 +38,11 @@ readonly partial struct Property {
 	/// True if the method was exported with the MarshalNativeExceptions flag allowing it to support native exceptions.
 	/// </summary>
 	public bool MarshalNativeExceptions => throw new NotImplementedException ();
+	
+	/// <summary>
+	/// Returns the bind from data if present in the binding.
+	/// </summary>
+	public BindAsData? BindAs => BindAsAttribute;
 
 	/// <inheritdoc />
 	public bool Equals (Property other) => Comparer.Equals (this, other);
@@ -45,8 +50,10 @@ readonly partial struct Property {
 	/// <inheritdoc />
 	public override string ToString ()
 	{
-		var sb = new StringBuilder (
-			$"Name: '{Name}', Type: {ReturnType}, Supported Platforms: {SymbolAvailability}, ExportFieldData: '{ExportFieldData?.ToString () ?? "null"}', ExportPropertyData: '{ExportPropertyData?.ToString () ?? "null"}' Attributes: [");
+		var sb = new StringBuilder ($"Name: '{Name}', Type: {ReturnType}, ");
+		sb.Append ($"Supported Platforms: {SymbolAvailability}, ");
+		sb.Append ($"ExportFieldData: '{ExportFieldData?.ToString () ?? "null"}', ");
+		sb.Append ($"ExportPropertyData: '{ExportPropertyData?.ToString () ?? "null"}' Attributes: [");
 		sb.AppendJoin (",", Attributes);
 		sb.Append ("], Modifiers: [");
 		sb.AppendJoin (",", Modifiers.Select (x => x.Text));

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Attributes/FieldDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Attributes/FieldDataTests.cs
@@ -63,11 +63,11 @@ public class FieldDataTests {
 		{
 			yield return [
 				new FieldData<EnumValue> ("symbol", null, EnumValue.Default),
-				"{ SymbolName: 'symbol' LibraryName: 'null', Flags: 'Default' }"
+				"{ SymbolName: 'symbol', LibraryName: 'null', Flags: 'Default' }"
 			];
 			yield return [
 				new FieldData<EnumValue> ("symbol", "lib", EnumValue.Default),
-				"{ SymbolName: 'symbol' LibraryName: 'lib', Flags: 'Default' }"
+				"{ SymbolName: 'symbol', LibraryName: 'lib', Flags: 'Default' }"
 			];
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumMemberCodeChangesTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/EnumMemberCodeChangesTests.cs
@@ -281,7 +281,7 @@ public class EnumMemberCodeChangesTests {
 				attributes: []);
 			yield return [
 				fieldDataEnum,
-				"{ Name: 'EnumValue' SymbolAvailability: [] FieldInfo: FieldData = { SymbolName: 'x' LibraryName: 'libName', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library Attributes: [] }"
+				"{ Name: 'EnumValue' SymbolAvailability: [] FieldInfo: FieldData = { SymbolName: 'x', LibraryName: 'libName', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library Attributes: [] }"
 			];
 
 			var builder = SymbolAvailability.CreateBuilder ();
@@ -296,7 +296,7 @@ public class EnumMemberCodeChangesTests {
 				attributes: []);
 			yield return [
 				availabilityEnum,
-				"{ Name: 'EnumValue' SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldInfo: FieldData = { SymbolName: 'x' LibraryName: 'libName', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library Attributes: [] }"
+				"{ Name: 'EnumValue' SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldInfo: FieldData = { SymbolName: 'x', LibraryName: 'libName', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library Attributes: [] }"
 			];
 
 			var attrsEnum = new EnumMember (
@@ -311,7 +311,7 @@ public class EnumMemberCodeChangesTests {
 				]);
 			yield return [
 				attrsEnum,
-				"{ Name: 'EnumValue' SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldInfo: FieldData = { SymbolName: 'x' LibraryName: 'libName', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library Attributes: [{ Name: Attribute1, Arguments: [] }, { Name: Attribute2, Arguments: [] }] }"
+				"{ Name: 'EnumValue' SymbolAvailability: [{ Platform: 'iOS', Supported: '0.0', Unsupported: [], Obsoleted: [] }] FieldInfo: FieldData = { SymbolName: 'x', LibraryName: 'libName', Flags: 'Default' }, LibraryName = Test, LibraryPath = /path/to/library Attributes: [{ Name: Attribute1, Arguments: [] }, { Name: Attribute2, Arguments: [] }] }"
 			];
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests.cs
@@ -573,6 +573,75 @@ namespace NS {
 					]
 				)
 			];
+			
+			const string returnTypeBindFromAttribute = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public class MyClass {
+		[return: BindFrom (typeof(NSNumber))]
+		public int MyMethod () {}
+	}
+}
+";
+
+			yield return [
+				returnTypeBindFromAttribute,
+				new Method (
+					type: "NS.MyClass",
+					name: "MyMethod",
+					returnType: ReturnTypeForInt (),
+					symbolAvailability: new (),
+					exportMethodData: new (),
+					attributes: [
+						new ("ObjCBindings.BindFromAttribute", ["Foundation.NSNumber"]),
+					],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					parameters: []
+				) {
+					BindAs = new ("Foundation.NSNumber"),
+				}
+			];
+			
+			const string parameterBindFromAttr = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace NS {
+	public class MyClass {
+		public void MyMethod ([BindFrom (typeof(NSNumber))] int value) {}
+	}
+}
+";
+
+			yield return [
+				parameterBindFromAttr,
+				new Method (
+					type: "NS.MyClass",
+					name: "MyMethod",
+					returnType: ReturnTypeForVoid(),
+					symbolAvailability: new (),
+					exportMethodData: new (),
+					attributes: [
+					],
+					modifiers: [
+						SyntaxFactory.Token (SyntaxKind.PublicKeyword),
+					],
+					parameters: [
+						new (0, ReturnTypeForInt (), "value") {
+							Attributes = [
+								new ("ObjCBindings.BindFromAttribute", ["Foundation.NSNumber"]),
+							],
+							BindAs = new BindFromData("Foundation.NSNumber"),
+						}
+					]
+				)
+			];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/MethodTests.cs
@@ -573,7 +573,7 @@ namespace NS {
 					]
 				)
 			];
-			
+
 			const string returnTypeBindFromAttribute = @"
 using System;
 using Foundation;
@@ -606,7 +606,7 @@ namespace NS {
 					BindAs = new ("Foundation.NSNumber"),
 				}
 			];
-			
+
 			const string parameterBindFromAttr = @"
 using System;
 using Foundation;
@@ -624,7 +624,7 @@ namespace NS {
 				new Method (
 					type: "NS.MyClass",
 					name: "MyMethod",
-					returnType: ReturnTypeForVoid(),
+					returnType: ReturnTypeForVoid (),
 					symbolAvailability: new (),
 					exportMethodData: new (),
 					attributes: [
@@ -637,7 +637,7 @@ namespace NS {
 							Attributes = [
 								new ("ObjCBindings.BindFromAttribute", ["Foundation.NSNumber"]),
 							],
-							BindAs = new BindFromData("Foundation.NSNumber"),
+							BindAs = new BindFromData ("Foundation.NSNumber"),
 						}
 					]
 				)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
@@ -1330,6 +1330,47 @@ public class TestClass {
 					ExportPropertyData = new (selector: "name"),
 				}
 			];
+			
+			const string bindFromAttribute = @"
+using System;
+using Foundation;
+using ObjCBindings;
+
+namespace Test;
+
+public class TestClass {
+
+	[Export<Property>(""name""), BindFrom (typeof(NSNumber))]
+	public int Name { get; }
+}
+";
+			yield return [
+				bindFromAttribute,
+				new Property (
+					name: "Name",
+					returnType: ReturnTypeForInt (),
+					symbolAvailability: new (),
+					attributes: [
+						new (name: "ObjCBindings.ExportAttribute<ObjCBindings.Property>", arguments: ["name"]),
+						new (name: "ObjCBindings.BindFromAttribute", arguments: ["Foundation.NSNumber"]),
+					],
+					modifiers: [
+						SyntaxFactory.Token (kind: SyntaxKind.PublicKeyword),
+					],
+					accessors: [
+						new (
+							accessorKind: AccessorKind.Getter,
+							symbolAvailability: new (),
+							exportPropertyData: null,
+							attributes: [],
+							modifiers: []
+						)
+					]
+				) {
+					ExportPropertyData = new (selector: "name"),
+					BindAs = new ("Foundation.NSNumber"),
+				}
+			];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator ()

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests.cs
@@ -1330,7 +1330,7 @@ public class TestClass {
 					ExportPropertyData = new (selector: "name"),
 				}
 			];
-			
+
 			const string bindFromAttribute = @"
 using System;
 using Foundation;


### PR DESCRIPTION
The BindFromAttribute is similar to the BindAsAttribute but in the opossite direction. This allows the bindings to be cleaner since we can specify in the partial method the return type we really want and the NSNumber/NSString transformation will be done in the generated code.