### PR TITLE
[Rgen] Start implementing the missing parts of the data model for the transformer.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
@@ -47,7 +47,6 @@ readonly partial struct TypeInfo {
 			IsArray = true;
 			ArrayElementTypeIsWrapped = arraySymbol.ElementType.IsWrapped ();
 		}
-		IsArray = symbol is IArrayTypeSymbol;
 
 		// try to get the named type symbol to have more educated decisions
 		var namedTypeSymbol = symbol as INamedTypeSymbol;

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Parameter.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Parameter.Transformer.cs
@@ -2,6 +2,10 @@
 // Licensed under the MIT License.
 
 using Microsoft.Macios.Transformer.Attributes;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.Extensions;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
@@ -11,4 +15,29 @@ readonly partial struct Parameter {
 	/// Returns the bind from data if present in the binding.
 	/// </summary>
 	public BindAsData? BindAs => BindAsAttribute;
+
+	public static bool TryCreate (IParameterSymbol symbol, ParameterSyntax declaration, SemanticModel semanticModel,
+		[NotNullWhen (true)] out Parameter? parameter)
+	{
+		DelegateInfo? delegateInfo = null;
+		if (symbol.Type is INamedTypeSymbol namedTypeSymbol
+			&& namedTypeSymbol.DelegateInvokeMethod is not null) {
+			DelegateInfo.TryCreate (namedTypeSymbol.DelegateInvokeMethod, out delegateInfo);
+		}
+
+		// retrieve the parameter attributes because those might affect the parameter type, for example, the 
+		// NullAllowed attribute can change the parameter type to be nullable.
+		var parameterAttrs = symbol.GetAttributeData ();
+		parameter = new (symbol.Ordinal, new (symbol.Type, parameterAttrs), symbol.Name) {
+			IsOptional = symbol.IsOptional,
+			IsParams = symbol.IsParams,
+			IsThis = symbol.IsThis,
+			DefaultValue = (symbol.HasExplicitDefaultValue) ? symbol.ExplicitDefaultValue?.ToString () : null,
+			ReferenceKind = symbol.RefKind.ToReferenceKind (),
+			Delegate = delegateInfo,
+			Attributes = declaration.GetAttributeCodeChanges (semanticModel),
+			AttributesDictionary = parameterAttrs,
+		};
+		return true;
+	}
 }

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/TypeInfo.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/TypeInfo.Transformer.cs
@@ -2,18 +2,46 @@
 // Licensed under the MIT License.
 
 using Microsoft.CodeAnalysis;
+using Microsoft.Macios.Generator.Extensions;
+using Microsoft.Macios.Transformer;
+using Microsoft.Macios.Transformer.Extensions;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
 readonly partial struct TypeInfo {
 
-	internal TypeInfo (ITypeSymbol symbol) :
+	internal TypeInfo (ITypeSymbol symbol, Dictionary<string, List<AttributeData>> attributes) :
 		this (
 			symbol is IArrayTypeSymbol arrayTypeSymbol
 				? arrayTypeSymbol.ElementType.ToDisplayString ()
 				: symbol.ToDisplayString ().Trim ('?', '[', ']'),
 			symbol.SpecialType)
 	{
-		throw new NotImplementedException ();
+		IsNullable = attributes.HasNullAllowedFlag ();
+		// special case, the old bindings might not have the ? operator but will have the attr 
+		IsBlittable = symbol.IsBlittable () && !IsNullable;
+		IsSmartEnum = symbol.IsSmartEnum ();
+		IsReferenceType = symbol.IsReferenceType;
+		IsStruct = symbol.TypeKind == TypeKind.Struct;
+		IsInterface = symbol.TypeKind == TypeKind.Interface;
+		IsNativeIntegerType = symbol.IsNativeIntegerType;
+		IsNativeEnum = symbol.HasAttribute (AttributesNames.NativeAttribute);
+
+		// data that we can get from the symbol without being INamedType
+		symbol.GetInheritance (
+			isNSObject: out isNSObject,
+			isNativeObject: out isINativeObject,
+			isDictionaryContainer: out isDictionaryContainer,
+			parents: out parents,
+			interfaces: out interfaces);
+		IsArray = symbol is IArrayTypeSymbol;
+
+		// try to get the named type symbol to have more educated decisions
+		var namedTypeSymbol = symbol as INamedTypeSymbol;
+
+		// store the enum special type, useful when generate code that needs to cast
+		EnumUnderlyingType = namedTypeSymbol?.EnumUnderlyingType?.SpecialType;
+		MetadataName = SpecialType is SpecialType.None or SpecialType.System_Void
+			? null : symbol.MetadataName;
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
@@ -35,7 +35,7 @@ static class TestDataFactory {
 			IsINativeObject = false,
 		};
 
-	public static TypeInfo ReturnTypeForInt (bool isNullable = false)
+	public static TypeInfo ReturnTypeForInt (bool isNullable = false, bool keepInterfaces = false)
 		=> new (
 			name: "int",
 			specialType: SpecialType.System_Int32,
@@ -44,7 +44,7 @@ static class TestDataFactory {
 			isStruct: true
 		) {
 			Parents = ["System.ValueType", "object"],
-			Interfaces = isNullable
+			Interfaces = isNullable && !keepInterfaces
 				? []
 				: [
 					"System.IComparable",
@@ -175,17 +175,19 @@ static class TestDataFactory {
 			IsInterface = true,
 		};
 
-	public static TypeInfo ReturnTypeForStruct (string structName)
+	public static TypeInfo ReturnTypeForStruct (string structName, bool isBlittable = false)
 		=> new (
 			name: structName,
+			isBlittable: isBlittable,
 			isStruct: true
 		) { Parents = ["System.ValueType", "object"] };
 
 	public static TypeInfo ReturnTypeForEnum (string enumName, bool isSmartEnum = false, bool isNativeEnum = false,
-		SpecialType underlyingType = SpecialType.System_Int32)
+		bool isNullable = false, bool isBlittable = true, SpecialType underlyingType = SpecialType.System_Int32)
 		=> new (
 			name: enumName,
-			isBlittable: true,
+			isNullable: isNullable,
+			isBlittable: isBlittable,
 			isSmartEnum: isSmartEnum
 		) {
 			Parents = [
@@ -300,7 +302,7 @@ static class TestDataFactory {
 			]
 		};
 
-	public static TypeInfo ReturnTypeForNSObject (string? nsObjectName = null, bool isNullable = false)
+	public static TypeInfo ReturnTypeForNSObject (string? nsObjectName = null, bool isNullable = false, bool isApiDefinition = false)
 		=> new (
 			name: nsObjectName ?? "Foundation.NSObject",
 			isNullable: isNullable,
@@ -310,13 +312,18 @@ static class TestDataFactory {
 			IsNSObject = true,
 			IsINativeObject = true,
 			Parents = nsObjectName is null ? ["object"] : ["Foundation.NSObject", "object"],
-			Interfaces = [
-				"ObjCRuntime.INativeObject",
-				$"System.IEquatable<{nsObjectName ?? "Foundation.NSObject"}>",
-				"System.IDisposable",
-				"Foundation.INSObjectFactory",
-				"Foundation.INSObjectProtocol"
-			]
+			Interfaces = isApiDefinition
+				? [
+					"ObjCRuntime.INativeObject",
+					"Foundation.INSObjectFactory",
+				]
+				: [
+					"ObjCRuntime.INativeObject",
+					$"System.IEquatable<{nsObjectName ?? "Foundation.NSObject"}>",
+					"System.IDisposable",
+					"Foundation.INSObjectFactory",
+					"Foundation.INSObjectProtocol"
+				]
 		};
 
 	public static TypeInfo ReturnTypeForINativeObject (string nativeObjectName, bool isNullable = false)

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/DataModel/ParameterTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/DataModel/ParameterTests.cs
@@ -1,0 +1,339 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Macios.Generator.DataModel;
+using Xamarin.Tests;
+using Xamarin.Utils;
+using static Microsoft.Macios.Generator.Tests.TestDataFactory;
+
+namespace Microsoft.Macios.Transformer.Tests.DataModel;
+
+public class ParameterTests : BaseTransformerTestClass {
+
+	class TestDataTryCreate : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			var path = "/some/random/path.cs";
+
+			const string simpleValueParameter = @"
+using System;
+
+namespace Test;
+
+public class MyClass () {
+
+	public void Hello (int value) { }
+}
+";
+
+			yield return [
+				(Source: simpleValueParameter, Path: path),
+				new Parameter (0, ReturnTypeForInt (), "value")
+			];
+
+			const string nullableValueParameter = @"
+using System;
+using ObjCRuntime;
+
+namespace Test;
+
+public class MyClass () {
+
+	public void Hello ([NullAllowed] int value) { }
+}
+";
+
+			yield return [
+				(Source: nullableValueParameter, Path: path),
+				new Parameter (
+					position: 0,
+					type: ReturnTypeForInt (isNullable: true, keepInterfaces: true),
+					name: "value") {
+					Attributes = [
+						new (name: "NullAllowedAttribute"),
+					]
+				}
+			];
+
+			const string arrayValueParameter = @"
+using System;
+using ObjCRuntime;
+
+namespace Test;
+
+public class MyClass () {
+
+	public void Hello (int[] value) { }
+}
+";
+			yield return [
+				(Source: arrayValueParameter, Path: path),
+				new Parameter (
+					position: 0,
+					type: ReturnTypeForArray ("int", isBlittable: true),
+					name: "value")
+			];
+
+			const string nullableArrayValueParameter = @"
+using System;
+using ObjCRuntime;
+
+namespace Test;
+
+public class MyClass () {
+
+	public void Hello ([NullAllowed] int[] value) { }
+}
+";
+			yield return [
+				(Source: nullableArrayValueParameter, Path: path),
+				new Parameter (
+					position: 0,
+					type: ReturnTypeForArray ("int", isBlittable: false, isNullable: true),
+					name: "value") {
+					Attributes = [
+						new (name: "NullAllowedAttribute"),
+					],
+				}
+			];
+
+			const string referenceParameter = @"
+using System;
+using ObjCRuntime;
+
+namespace Test;
+
+public class MyClass () {
+
+	public void Hello (string value) { }
+}
+";
+			yield return [
+				(Source: referenceParameter, Path: path),
+				new Parameter (0, ReturnTypeForString (), "value")
+			];
+
+			const string nullableReferenceParameter = @"
+using System;
+using ObjCRuntime;
+
+namespace Test;
+
+public class MyClass () {
+
+	public void Hello ([NullAllowed] string value) { }
+}
+";
+			yield return [
+				(Source: nullableReferenceParameter, Path: path),
+				new Parameter (
+					position: 0,
+					type: ReturnTypeForString (isNullable: true),
+					name: "value") {
+					Attributes = [
+						new (name: "NullAllowedAttribute"),
+					]
+				}
+			];
+
+			const string nsobjectParameter = @"
+using System;
+using Foundation;
+using ObjCRuntime;
+
+namespace Test;
+
+public class MyClass () {
+
+	public void Hello (NSObject value) { }
+}
+";
+
+			yield return [
+				(Source: nsobjectParameter, Path: path),
+				new Parameter (
+					position: 0,
+					type: ReturnTypeForNSObject (isApiDefinition: true),
+					name: "value")
+			];
+
+
+			const string enumParameter = @"
+using System;
+using Foundation;
+using ObjCRuntime;
+
+namespace Test;
+
+public enum MyEnum {
+	One,
+	Two,
+	Three
+}
+
+public class MyClass () {
+
+	public void Hello (MyEnum value) { }
+}
+";
+			yield return [
+				(Source: enumParameter, Path: path),
+				new Parameter (
+					position: 0,
+					type: ReturnTypeForEnum ("Test.MyEnum", underlyingType: SpecialType.System_Int32),
+					name: "value")
+			];
+
+			const string nullableEnumParameter = @"
+using System;
+using Foundation;
+using ObjCRuntime;
+
+namespace Test;
+
+public enum MyEnum {
+	One,
+	Two,
+	Three
+}
+
+public class MyClass () {
+	public void Hello ([NullAllowed] MyEnum value) { }
+}
+";
+			yield return [
+				(Source: nullableEnumParameter, Path: path),
+				new Parameter (
+					position: 0,
+					type: ReturnTypeForEnum ("Test.MyEnum", isNullable: true, isBlittable: false, underlyingType: SpecialType.System_Int32),
+					name: "value") {
+					Attributes = [
+						new (name: "NullAllowedAttribute"),
+					]
+				}
+			];
+
+			const string nativeEnumParameter = @"
+using System;
+using Foundation;
+using ObjCRuntime;
+
+namespace Test;
+
+[Native]
+public enum MyEnum {
+	One,
+	Two,
+	Three
+}
+
+public class MyClass () {
+	public void Hello (MyEnum value) { }
+}
+";
+			yield return [
+				(Source: nativeEnumParameter, Path: path),
+				new Parameter (
+					position: 0,
+					type: ReturnTypeForEnum ("Test.MyEnum", isNativeEnum: true, underlyingType: SpecialType.System_Int32),
+					name: "value")
+			];
+
+			const string blittableStructParam = @"
+using System;
+using System.Runtime.InteropServices;
+using Foundation;
+using ObjCRuntime;
+
+namespace Test;
+
+[StructLayout(LayoutKind.Sequential)]
+public struct MyEnum {
+	public int First { get; }
+	public int Second { get; }
+}
+
+public class MyClass () {
+	public void Hello (MyEnum value) { }
+}
+";
+			yield return [
+				(Source: blittableStructParam, Path: path),
+				new Parameter (0, ReturnTypeForStruct ("Test.MyEnum", isBlittable: true), "value")
+			];
+
+
+			const string nonBlittableStructParam = @"
+using System;
+using System.Runtime.InteropServices;
+using Foundation;
+using ObjCRuntime;
+
+namespace Test;
+
+public struct MyEnum {
+	public int First { get; }
+	public int Second { get; }
+}
+
+public class MyClass () {
+	public void Hello (MyEnum value) { }
+}
+";
+			yield return [
+				(Source: nonBlittableStructParam, Path: path),
+				new Parameter (0, ReturnTypeForStruct ("Test.MyEnum"), "value")
+			];
+
+			const string interfaceParameter = @"
+using System;
+using System.Runtime.InteropServices;
+using Foundation;
+using ObjCRuntime;
+
+namespace Test;
+
+public interface IMyInterface { }
+
+public class MyClass () {
+	public void Hello (IMyInterface value) { }
+}
+";
+			yield return [
+				(Source: interfaceParameter, Path: path),
+				new Parameter (0, ReturnTypeForInterface ("Test.IMyInterface"), "value")
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[AllSupportedPlatformsClassData<TestDataTryCreate>]
+	void TryCreateTests (ApplePlatform platform, (string Source, string Path) source, Parameter expectedData)
+	{
+		var compilation = CreateCompilation (platform, sources: source);
+		var syntaxTree = compilation.SyntaxTrees.ForSource (source);
+		var trees = compilation.SyntaxTrees.Where (s => s.FilePath == source.Path).ToArray ();
+		Assert.Single (trees);
+		Assert.NotNull (syntaxTree);
+
+		var semanticModel = compilation.GetSemanticModel (syntaxTree);
+		Assert.NotNull (semanticModel);
+
+		var declaration = syntaxTree.GetRoot ()
+				.DescendantNodes ().OfType<ParameterSyntax> ()
+				.LastOrDefault ();
+
+		Assert.NotNull (declaration);
+
+		var symbol = semanticModel.GetDeclaredSymbol (declaration);
+		Assert.NotNull (symbol);
+		Assert.True (Parameter.TryCreate (symbol, declaration, semanticModel, out var parameter));
+		Assert.Equal (expectedData, parameter);
+	}
+}

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Microsoft.Macios.Transformer.Tests.csproj
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Microsoft.Macios.Transformer.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
@@ -57,6 +57,9 @@
         </Compile>
         <Compile Include="..\..\mtouch\Cache.cs">
             <Link>external\Cache.cs</Link>
+        </Compile>
+        <Compile Include="..\Microsoft.Macios.Generator.Tests\TestDataFactory.cs">
+            <Link>external\TestDataFactory.cs</Link>
         </Compile>
     </ItemGroup>
     


### PR DESCRIPTION
The transformer and the code generation share 90% of the data model, but we need a 10% that is used to fix the mismatch between two projects.

In this change we finish the implementation fo the TypeInfo struct in the transformer by providing the TryCreate method that will use the attribute data to decide if a type was marked as nullable or not.

Remember that in the old xamarin bindings we did not use the ? annotation but we use the NullAllowedAttribute.