### PR TITLE
[Rgen] Add a method that will return a constructor data model from a method signature.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.cs
@@ -3,12 +3,14 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.Macios.Generator.Availability;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
+[StructLayout(LayoutKind.Auto)]
 readonly partial struct Constructor : IEquatable<Constructor> {
 	/// <summary>
 	/// Type name that owns the constructor.

--- a/src/rgen/Microsoft.Macios.Transformer.Generator/Microsoft.Macios.Transformer.Generator/XamarinBindingAPIGenerator.cs
+++ b/src/rgen/Microsoft.Macios.Transformer.Generator/Microsoft.Macios.Transformer.Generator/XamarinBindingAPIGenerator.cs
@@ -244,6 +244,7 @@ public class XamarinBindingAPIGenerator : IIncrementalGenerator {
 			("Parameter", [AttributeTargets.Parameter]),
 			("Accessor", [AttributeTargets.Property]),
 			("Property", [AttributeTargets.Property]),
+			("Constructor", [AttributeTargets.Constructor]),
 			("Method", [AttributeTargets.Method]),
 			("Binding", [AttributeTargets.Interface, AttributeTargets.Class, AttributeTargets.Enum, AttributeTargets.Struct]),
 			("TypeInfo", [AttributeTargets.Parameter])

--- a/src/rgen/Microsoft.Macios.Transformer/AttributesNames.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/AttributesNames.cs
@@ -13,7 +13,7 @@ static class AttributesNames {
 	/// The [Abstract] attribute can be applied to either methods or properties and causes the generator to flag the
 	/// generated member as abstract and the class to be an abstract class.
 	/// </summary>
-	[BindingFlag (AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Interface)]
+	[BindingFlag (AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Interface)]
 	public const string AbstractAttribute = "AbstractAttribute";
 
 	[BindingFlag] 
@@ -103,7 +103,7 @@ static class AttributesNames {
 	
 	public const string ExperimentalAttribute = "System.Diagnostics.CodeAnalysis.ExperimentalAttribute";
 	
-	[BindingAttribute(typeof(ExportData), AttributeTargets.Method | AttributeTargets.Property)]
+	[BindingAttribute(typeof(ExportData), AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property)]
 	public const string ExportAttribute = "Foundation.ExportAttribute";
 
 	[BindingFlag] 
@@ -126,7 +126,7 @@ static class AttributesNames {
 	/// The [Internal] attribute can be applied to methods or properties and it has the effect of flagging the
 	/// generated code with the internal C# keyword making the code only accessible to code in the generated assembly.
 	/// </summary>
-	[BindingFlag (AttributeTargets.Method | AttributeTargets.Property)]
+	[BindingFlag (AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property)]
 	public const string InternalAttribute = "InternalAttribute";
 
 	public const string IntroducedAttribute = "IntroducedAttribute";
@@ -273,7 +273,7 @@ static class AttributesNames {
 	/// Use this attribute to instruct the binding generator that the binding for this particular method should be
 	/// flagged with an protected keyword.
 	/// </summary>
-	[BindingFlag (AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Event)]
+	[BindingFlag (AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Event)]
 	public const string ProtectedAttribute = "ProtectedAttribute";
 
 	[BindingFlag (AttributeTargets.Interface | AttributeTargets.Class)]

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Constructor.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Constructor.Transformer.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Microsoft.Macios.Generator.DataModel;
+
+readonly partial struct Constructor {
+	
+	
+	/// <summary>
+	/// Create a constructor from a method signature.
+	/// </summary>
+	/// <param name="method">The method to be used to create the constructor.</param>
+	public Constructor (in Method method)
+	{
+		Type = method.Type;
+		SymbolAvailability = method.SymbolAvailability;
+		Attributes = method.Attributes;
+		Parameters = method.Parameters;
+		AttributesDictionary = method.AttributesDictionary;
+		
+		// modifiers cannot only be copied, we do not have a virtual/override constructor, it is either
+		// public, private or internal. 
+		var modifierBuilder = ImmutableArray.CreateBuilder<SyntaxToken> ();
+		SyntaxKind modifier = SyntaxKind.PublicKeyword;
+		foreach (var methodModifier in method.Modifiers) {
+			var modifierKind = methodModifier.Kind ();
+			if (modifierKind is 
+			    SyntaxKind.PublicKeyword or SyntaxKind.ProtectedKeyword or SyntaxKind.InternalKeyword or SyntaxKind.PrivateKeyword) {
+				modifier = modifierKind;
+			}
+		}
+		
+		modifierBuilder.Add (Token (modifier));
+		// We will be adding partial because is part of the new API
+		modifierBuilder.Add (Token (SyntaxKind.PartialKeyword));
+		Modifiers = modifierBuilder.ToImmutable ();
+		
+	}
+}

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Method.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Method.Transformer.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.Availability;
 using Microsoft.Macios.Generator.Extensions;
 using Microsoft.Macios.Transformer.Attributes;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace Microsoft.Macios.Generator.DataModel;
 
@@ -88,4 +87,12 @@ readonly partial struct Method {
 			parameters: parametersBucket.ToImmutableArray ());
 		return true;
 	}
+
+	/// <summary>
+	/// Return the constructor representation of the method if it is a constructor in the bindings.
+	/// </summary>
+	/// <returns>A constructor data model if the method is one in the bindings or null otherwise.</returns>
+	public Constructor? ToConstructor ()
+		=> IsConstructor ? new Constructor (this) : null;
+
 }

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/DataModel/MethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/DataModel/MethodTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.Attributes;
@@ -11,6 +12,7 @@ using Xamarin.Tests;
 using Xamarin.Utils;
 using static Microsoft.Macios.Generator.Tests.TestDataFactory;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using Token = System.CommandLine.Parsing.Token;
 
 namespace Microsoft.Macios.Transformer.Tests.DataModel;
 
@@ -341,7 +343,6 @@ interface AVPlayer {
 			];
 		}
 
-
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
 
@@ -365,4 +366,132 @@ interface AVPlayer {
 		Assert.True (Method.TryCreate (declaration, semanticModel, out var method));
 		Assert.Equal (expectedData, method);
 	}
+	
+	class TestDataToConstructor: IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			yield return [
+				new Method (
+					type: "MyType", 
+					name: "SomeMethodName", 
+					returnType: ReturnTypeForVoid (), 
+					symbolAvailability: new (), 
+					attributes: new (), 
+					parameters: ImmutableArray<Parameter>.Empty),
+				null!
+			];
+			
+			yield return [
+				new Method (
+					type: "MyType", 
+					name: "Constructor", 
+					returnType: ReturnTypeForVoid (), 
+					symbolAvailability: new (), 
+					attributes: new (), 
+					parameters: ImmutableArray<Parameter>.Empty),
+				new Constructor(
+					type: "MyType", 
+					symbolAvailability: new(), 
+					attributes: [], 
+					modifiers: [Token (SyntaxKind.PublicKeyword), Token (SyntaxKind.PartialKeyword)], 
+					parameters: [])
+			];
+			
+			yield return [
+				new Method (
+					type: "MyType", 
+					name: "Constructor", 
+					returnType: ReturnTypeForVoid (), 
+					symbolAvailability: new (), 
+					attributes: new (), 
+					parameters: []) 
+				{
+					Modifiers = [
+						Token (SyntaxKind.InternalKeyword), 
+						Token (SyntaxKind.VirtualKeyword), 
+						Token (SyntaxKind.PartialKeyword)
+					]
+				},
+				new Constructor(
+					type: "MyType", 
+					symbolAvailability: new(), 
+					attributes: [], 
+					modifiers: [Token (SyntaxKind.InternalKeyword), Token (SyntaxKind.PartialKeyword)], 
+					parameters: [])
+			];
+			
+			yield return [
+				new Method (
+					type: "MyType", 
+					name: "Constructor", 
+					returnType: ReturnTypeForVoid (), 
+					symbolAvailability: new (), 
+					attributes: new (), 
+					parameters: []) 
+				{
+					Modifiers = [
+						Token (SyntaxKind.ProtectedKeyword), 
+						Token (SyntaxKind.VirtualKeyword), 
+						Token (SyntaxKind.PartialKeyword)
+					]
+				},
+				new Constructor(
+					type: "MyType", 
+					symbolAvailability: new(), 
+					attributes: [], 
+					modifiers: [Token (SyntaxKind.ProtectedKeyword), Token (SyntaxKind.PartialKeyword)], 
+					parameters: [])
+			];
+			
+			yield return [
+				new Method (
+					type: "MyType", 
+					name: "Constructor", 
+					returnType: ReturnTypeForVoid (), 
+					symbolAvailability: new (), 
+					attributes: new (), 
+					parameters: [
+						new Parameter(0, ReturnTypeForString (), "name")
+					]),
+				new Constructor(
+					type: "MyType", 
+					symbolAvailability: new(), 
+					attributes: [], 
+					modifiers: [Token (SyntaxKind.PublicKeyword), Token (SyntaxKind.PartialKeyword)], 
+					parameters: [
+						new Parameter(0, ReturnTypeForString (), "name")
+					])
+			];
+			
+			yield return [
+				new Method (
+					type: "MyType", 
+					name: "Constructor", 
+					returnType: ReturnTypeForVoid (), 
+					symbolAvailability: new (), 
+					attributes: new (), 
+					parameters: [
+						new Parameter(0, ReturnTypeForString (), "name"),
+						new Parameter(1, ReturnTypeForString (isNullable: true), "surname")
+					]),
+				new Constructor(
+					type: "MyType", 
+					symbolAvailability: new(), 
+					attributes: [], 
+					modifiers: [Token (SyntaxKind.PublicKeyword), Token (SyntaxKind.PartialKeyword)], 
+					parameters: [
+						new Parameter(0, ReturnTypeForString (), "name"),
+						new Parameter(1, ReturnTypeForString (isNullable: true), "surname")
+					])
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[ClassData (typeof(TestDataToConstructor))]
+	void ToConstructorTests (Method method, Constructor? expectedConstructor)
+		=> Assert.Equal (expectedConstructor, method.ToConstructor ());
+
 }


### PR DESCRIPTION
In the old Xamarin API constructor were defined as methods with the special 'Constructor' name. We add a ToConstructor method in the Method data model to be used by the transformer to keep track of those methods.