### PR TITLE
[RGen] Add a new flag to determine if a type is a core image filter.

### DIFF
--- a/src/ObjCBindings/BindingTypeAttribute.cs
+++ b/src/ObjCBindings/BindingTypeAttribute.cs
@@ -37,5 +37,50 @@ namespace ObjCBindings {
 		/// Get/Set the export configuration flags.
 		/// </summary >
 		public T? Flags { get; set; } = default (T);
+
+		/// <summary>
+		/// Get/set the visibility of the default constructor for a core image filter.
+		/// </summary >
+		public MethodAttributes DefaultCtorVisibility { get; set; }
+
+		/// <summary>
+		/// Get/set the visibility of the IntPtr constructor for a core image filter.
+		/// </summary >
+		public MethodAttributes IntPtrCtorVisibility { get; set; }
+
+		/// <summary>
+		///Get/set the visibility of the string constructor for a core image filter.
+		/// </summary >
+		public MethodAttributes StringCtorVisibility { get; set; }
+
+		/// <summary>
+		/// Creates a binding type attribute with the default flag value;
+		/// </summary>
+		public BindingTypeAttribute () {}
+
+		/// <summary>
+		/// Creates a binding type attribute with the specified flags.
+		/// </summary>
+		public BindingTypeAttribute (T flags)
+		{
+			Flags = flags;
+		}
+
+		/// <summary>
+		/// Creates a binding type attribute with the specified flags.
+		/// </summary>
+		public BindingTypeAttribute (string name)
+		{
+			Name = name;
+		}
+
+		/// <summary>
+		/// Creates a binding type attribute with the specified flags.
+		/// </summary>
+		public BindingTypeAttribute (string name, T flags)
+		{
+			Name = name;
+			Flags = flags;
+		}
 	}
 }

--- a/src/ObjCBindings/BindingTypeTag.cs
+++ b/src/ObjCBindings/BindingTypeTag.cs
@@ -72,4 +72,16 @@ namespace ObjCBindings {
 		/// </summary>
 		Default = 0,
 	}
+
+	/// <summary>
+	/// Flags to be used on core image filter bindings.
+	/// </summary>
+	[Flags]
+	[Experimental ("APL0003")]
+	public enum CoreImageFilter : Int64 {
+		/// <summary>
+		/// Use the default values.
+		/// </summary>
+		Default = 0,
+	}
 }

--- a/src/ObjCBindings/ExportAttribute.cs
+++ b/src/ObjCBindings/ExportAttribute.cs
@@ -51,6 +51,21 @@ namespace ObjCBindings {
 		/// </summary >
 		public string? Library { get; set; } = null;
 
+		/// <summary>
+		///
+		/// </summary >
+		public MethodAttributes DefaultCtorVisibility { get; set; }
+
+		/// <summary>
+		///
+		/// </summary >
+		public MethodAttributes IntPtrCtorVisibility { get; set; }
+
+		/// <summary>
+		///
+		/// </summary >
+		public MethodAttributes StringCtorVisibility { get; set; }
+
 		protected ExportAttribute () { }
 
 		/// <summary>

--- a/src/ObjCBindings/ExportTag.cs
+++ b/src/ObjCBindings/ExportTag.cs
@@ -134,6 +134,12 @@ namespace ObjCBindings {
 		/// </summary>
 		Transient = 1 << 8,
 
+		/// <summary>
+		/// If this flag is applied to a property, the generator will consider the property to be
+		/// part of a CoreImage filter and will generate the property as a CoreImage filter property.
+		/// </summary>
+		CoreImageFilterProperty = 1 << 9,
+
 	}
 }
 

--- a/src/rgen/Microsoft.Macios.Generator/AttributesNames.cs
+++ b/src/rgen/Microsoft.Macios.Generator/AttributesNames.cs
@@ -12,6 +12,7 @@ static class AttributesNames {
 	public const string BindingAttribute = "ObjCBindings.BindingTypeAttribute";
 	public const string BindingCategoryAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.Category>";
 	public const string BindingClassAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.Class>";
+	public const string BindingCoreImageFilterAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.CoreImageFilter>";
 	public const string BindFromAttribute = "ObjCBindings.BindFromAttribute";
 	public const string BindingProtocolAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.Protocol>";
 	public const string BindingStrongDictionaryAttribute = "ObjCBindings.BindingTypeAttribute<ObjCBindings.StrongDictionary>";
@@ -31,6 +32,7 @@ static class AttributesNames {
 		BindingClassAttribute,
 		BindingProtocolAttribute,
 		BindingStrongDictionaryAttribute,
+		BindingCoreImageFilterAttribute, 
 	];
 
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/AttributeCodeChange.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/AttributeCodeChange.cs
@@ -93,6 +93,7 @@ readonly struct AttributeCodeChange : IEquatable<AttributeCodeChange> {
 		var bucket = ImmutableArray.CreateBuilder<AttributeCodeChange> ();
 		foreach (AttributeListSyntax attributeListSyntax in attributes) {
 			foreach (AttributeSyntax attributeSyntax in attributeListSyntax.Attributes) {
+				var x = semanticModel.GetSymbolInfo (attributeSyntax);
 				if (semanticModel.GetSymbolInfo (attributeSyntax).Symbol is not IMethodSymbol attributeSymbol)
 					continue; // if we can't get the symbol, ignore it
 				var name = attributeSymbol.ContainingType.ToDisplayString ();

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/BindingType.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/BindingType.cs
@@ -27,5 +27,9 @@ enum BindingType : ulong {
 	/// Binding type for a enum with backing fields.
 	/// </summary>
 	SmartEnum,
+	/// <summary>
+	/// Binding type for a core image filter.
+	/// </summary>
+	CoreImageFilter,
 }
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CoreImageFilterTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/CoreImageFilterTests.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Macios.Generator.Tests.DataModel;
+
+public class CoreImageFilterTests {
+	
+}

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -904,6 +904,12 @@ function Get-GitHubPRsForHash {
     # loop over the result and remove all the extra noise we are not interested in
     $prs = [System.Collections.ArrayList]@()
     foreach ($prInfo in $request) {
+        $state = $prInfo.state
+        if ($state -ne "open") {
+            Write-Host "Skipping PR #$($prInfo.number) because it is not open"
+            continue
+        }
+        # only returns those PRS whose status is open
         $number = $prInfo.number
         Write-Host "Found PR #$number for commit $hash"
         $prs.Add($number) > $null


### PR DESCRIPTION
In the new binding API we want to be able to differentiate between a Class and a CoreImageFilter. This PR adds a new flag that can be used by the generator to identify the binding type and route the code generation to the correct emitter. This change allows the API to look as follows:

```csharp

// the following binding represents a class
[BindingType<Class> (Name="MyNSObject")
public partial class MyNSObjectClass : NSObject {
    // export methods, properties, events etc..
}

// the following binding represents a core Image filter
[BindingType<CoreImageFilter> (Name="MyNSObject")
public partial class MyNSObjectClass : NSObject {
    // export methods, properties, events etc..
}
```
The change also allows to customize the visibility of the core image filters like the following example:
```csharp
[BindingType<CoreImageFilter> (Name="MyNSObject", DefaultCtorVisibility=MethodAttributes.PrivateScope)
public partial class MyNSObjectClass : NSObject {
    // export methods, properties, events etc..
}
```

The analyzer will ensure (in a future PR) that a user cannot customize the visibility of the core Image filter constructors if the binding is not using the correct flag.