### PR TITLE
[RGen] Add factory method needed to create a aux variable for a BindFrom(typeof(NSNumber)).

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.Generator.cs
@@ -19,6 +19,7 @@ readonly partial struct Parameter {
 		NSStringStruct,
 		PrimitivePointer,
 		StringPointer,
+		BindFrom,
 	}
 
 	/// <summary>
@@ -65,6 +66,7 @@ readonly partial struct Parameter {
 			VariableType.NSStringStruct => $"_s{cleanedName}",
 			VariableType.PrimitivePointer => $"converted_{cleanedName}",
 			VariableType.StringPointer => $"_p{cleanedName}",
+			VariableType.BindFrom => $"nsb_{cleanedName}",
 			_ => null
 		};
 	}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -193,7 +193,7 @@ static partial class BindingSyntaxFactory {
 							IdentifierName (parameter.Name)),
 						IdentifierName ("GetNonNullHandle").WithTrailingTrivia (Space)))
 				.WithArgumentList (ArgumentList (
-					SingletonSeparatedList<ArgumentSyntax> (Argument (
+					SingletonSeparatedList (Argument (
 						InvocationExpression (
 								IdentifierName (Identifier (TriviaList (Space), SyntaxKind.NameOfKeyword, "nameof",
 									"nameof",
@@ -250,11 +250,111 @@ static partial class BindingSyntaxFactory {
 				Argument (IdentifierName (parameter.Name)))));
 
 		// generates {var} = CFString.CreateNative ({parameter.Name});
-		var declarator = VariableDeclarator (Identifier (variableName).WithLeadingTrivia (Space).WithTrailingTrivia (Space))
-			.WithInitializer (EqualsValueClause (cfstringFactoryInvocation.WithLeadingTrivia (Space)));
+		var declarator =
+			VariableDeclarator (Identifier (variableName).WithLeadingTrivia (Space).WithTrailingTrivia (Space))
+				.WithInitializer (EqualsValueClause (cfstringFactoryInvocation.WithLeadingTrivia (Space)));
 
 
 		// put everythign together
+		var declaration = VariableDeclaration (IdentifierName (Identifier (
+				TriviaList (), SyntaxKind.VarKeyword, "var", "var", TriviaList ())))
+			.WithVariables (SingletonSeparatedList (declarator));
+
+		return LocalDeclarationStatement (declaration);
+	}
+
+	internal static LocalDeclarationStatementSyntax? GetNSNumberAuxVariable (in Parameter parameter)
+	{
+		// the BindFrom attribute with a nsnumber supports the following types:
+		// - bool
+		// - byte
+		// - double
+		// - float
+		// - short
+		// - int
+		// - long
+		// - sbyte
+		// - ushort
+		// - uint
+		// - ulong
+		// - nfloat
+		// - nint
+		// - nuint
+		// - Enums: this are simply casted to their backing representation
+		// if we do not match the expected type, return null
+
+		// make sure that the parameter type is valid and return the required method for the nsnumber variable
+#pragma warning disable format
+		var factoryMethod = parameter.Type switch {
+			{ Name: "nint" } => "FromNInt",
+			{ Name: "nuint" } => "FromNUInt",
+			{ Name: "nfloat" or "NFloat" } => "FromNFloat",
+			{
+				IsEnum: true, IsSmartEnum: true
+			} => null, // we do not support smart enums, there is a special case for them 
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_SByte } => "FromSByte",
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Byte } => "FromByte",
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int16 } => "FromInt16",
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt16 } => "FromUInt16",
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int32 } => "FromInt32",
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt32 } => "FromUInt32",
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int64 } => "FromInt64",
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt64 } => "FromUInt64",
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_IntPtr } => "FromNint",
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UIntPtr } => "FromNUint",
+			{ SpecialType: SpecialType.System_Boolean } => "FromBoolean",
+			{ SpecialType: SpecialType.System_Byte } => "FromByte",
+			{ SpecialType: SpecialType.System_Double } => "FromDouble",
+			{ SpecialType: SpecialType.System_Single } => "FromFloat",
+			{ SpecialType: SpecialType.System_Int16 } => "FromInt16",
+			{ SpecialType: SpecialType.System_Int32 } => "FromInt32",
+			{ SpecialType: SpecialType.System_Int64 } => "FromInt64",
+			{ SpecialType: SpecialType.System_SByte } => "FromSByte",
+			{ SpecialType: SpecialType.System_UInt16 } => "FromUInt16",
+			{ SpecialType: SpecialType.System_UInt32 } => "FromUInt32",
+			{ SpecialType: SpecialType.System_UInt64 } => "FromUInt64",
+			{ SpecialType: SpecialType.System_IntPtr } => "FromNint",
+			{ SpecialType: SpecialType.System_UIntPtr } => "FromNUint",
+			_ => null,
+		};
+#pragma warning restore format
+
+		if (factoryMethod is null)
+			return null;
+		
+		var variableName = parameter.GetNameForVariableType (Parameter.VariableType.BindFrom);
+		if (variableName is null)
+			return null;
+
+		// generates: NSNumber.FromDouble
+		var factoryInvocation = InvocationExpression (
+			MemberAccessExpression (
+				SyntaxKind.SimpleMemberAccessExpression,
+				IdentifierName ("NSNumber"),
+				IdentifierName (factoryMethod).WithTrailingTrivia (Space))
+		);
+
+		// the arguments of the factory information depends on if we are dealing with a enum, in which case we cast
+		// or not, in which case we just add the arguments
+		if (parameter.Type.IsEnum) {
+			// generates: NSNumber.FromDouble ((int)value);
+			factoryInvocation = factoryInvocation
+				.WithArgumentList (ArgumentList (SingletonSeparatedList (Argument (
+					CastExpression (
+						IdentifierName (parameter.Type.EnumUnderlyingType.GetKeyword () ?? ""),
+						IdentifierName (parameter.Name).WithLeadingTrivia (Space))))));
+		} else {
+			// generates: NSNumber.FromDouble (value);
+			factoryInvocation = factoryInvocation
+				.WithArgumentList (ArgumentList (SingletonSeparatedList (
+					Argument (IdentifierName (parameter.Name)))));
+		}
+
+		var declarator =
+			VariableDeclarator (Identifier (variableName).WithLeadingTrivia (Space).WithTrailingTrivia (Space))
+				.WithInitializer (EqualsValueClause (factoryInvocation.WithLeadingTrivia (Space)));
+		
+		// generats: var nba_variable = NSNumber.FromDouble(value);
 		var declaration = VariableDeclaration (IdentifierName (Identifier (
 				TriviaList (), SyntaxKind.VarKeyword, "var", "var", TriviaList ())))
 			.WithVariables (SingletonSeparatedList (declarator));

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -321,7 +321,7 @@ static partial class BindingSyntaxFactory {
 
 		if (factoryMethod is null)
 			return null;
-		
+
 		var variableName = parameter.GetNameForVariableType (Parameter.VariableType.BindFrom);
 		if (variableName is null)
 			return null;
@@ -353,7 +353,7 @@ static partial class BindingSyntaxFactory {
 		var declarator =
 			VariableDeclarator (Identifier (variableName).WithLeadingTrivia (Space).WithTrailingTrivia (Space))
 				.WithInitializer (EqualsValueClause (factoryInvocation.WithLeadingTrivia (Space)));
-		
+
 		// generats: var nba_variable = NSNumber.FromDouble(value);
 		var declaration = VariableDeclaration (IdentifierName (Identifier (
 				TriviaList (), SyntaxKind.VarKeyword, "var", "var", TriviaList ())))

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ParameterTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/ParameterTests.cs
@@ -21,6 +21,7 @@ public class ParameterTests {
 			yield return [exampleParameter, Parameter.VariableType.NSArray, $"nsa_{exampleParameter.Name}"];
 			yield return [exampleParameter, Parameter.VariableType.NSString, $"ns{exampleParameter.Name}"];
 			yield return [exampleParameter, Parameter.VariableType.NSStringStruct, $"_s{exampleParameter.Name}"];
+			yield return [exampleParameter, Parameter.VariableType.BindFrom, $"nsb_{exampleParameter.Name}"];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
@@ -277,4 +277,76 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			Assert.Equal (expectedDeclaration, declaration.ToString ());
 		}
 	}
+	
+	class TestDataGetNSNumberAuxVariableTest : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			yield return [
+				new Parameter (0, ReturnTypeForInt (), "myParam"),
+				"var nsb_myParam = NSNumber.FromInt32 (myParam);"
+			];
+			
+			yield return [
+				new Parameter (0, ReturnTypeForInt (isUnsigned: true), "myParam"),
+				"var nsb_myParam = NSNumber.FromUInt32 (myParam);"
+			];
+
+			yield return [
+				new Parameter (0, ReturnTypeForBool (), "myParam"),
+				"var nsb_myParam = NSNumber.FromBoolean (myParam);"
+			];
+			
+			yield return [
+				new Parameter (0, ReturnTypeForEnum ("MyEnum"), "myParam"),
+				"var nsb_myParam = NSNumber.FromInt32 ((int) myParam);",
+			];
+			
+			yield return [
+				new Parameter (0, ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_Byte), "myParam"),
+				"var nsb_myParam = NSNumber.FromByte ((byte) myParam);",
+			];
+			
+			yield return [
+				new Parameter (0, ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_SByte), "myParam"),
+				"var nsb_myParam = NSNumber.FromSByte ((sbyte) myParam);",
+			];
+			
+			yield return [
+				new Parameter (0, ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_Int16), "myParam"),
+				"var nsb_myParam = NSNumber.FromInt16 ((short) myParam);",
+			];
+			
+			yield return [
+				new Parameter (0, ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_UInt16), "myParam"),
+				"var nsb_myParam = NSNumber.FromUInt16 ((ushort) myParam);",
+			];
+			
+			yield return [
+				new Parameter (0, ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_Int64), "myParam"),
+				"var nsb_myParam = NSNumber.FromInt64 ((long) myParam);",
+			];
+			
+			yield return [
+				new Parameter (0, ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_UInt64), "myParam"),
+				"var nsb_myParam = NSNumber.FromUInt64 ((ulong) myParam);",
+			];
+			
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	[Theory]
+	[ClassData (typeof (TestDataGetNSNumberAuxVariableTest))]
+	void GetNSNumberAuxVariableTests (in Parameter parameter, string? expectedDeclaration)
+	{
+		var declaration = GetNSNumberAuxVariable (parameter);
+		var str = declaration!.ToString ();
+		if (expectedDeclaration is null) {
+			Assert.Null (declaration);
+		} else {
+			Assert.NotNull (declaration);
+			Assert.Equal (expectedDeclaration, declaration.ToString ());
+		}
+	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
@@ -277,7 +277,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			Assert.Equal (expectedDeclaration, declaration.ToString ());
 		}
 	}
-	
+
 	class TestDataGetNSNumberAuxVariableTest : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -285,7 +285,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				new Parameter (0, ReturnTypeForInt (), "myParam"),
 				"var nsb_myParam = NSNumber.FromInt32 (myParam);"
 			];
-			
+
 			yield return [
 				new Parameter (0, ReturnTypeForInt (isUnsigned: true), "myParam"),
 				"var nsb_myParam = NSNumber.FromUInt32 (myParam);"
@@ -295,47 +295,47 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				new Parameter (0, ReturnTypeForBool (), "myParam"),
 				"var nsb_myParam = NSNumber.FromBoolean (myParam);"
 			];
-			
+
 			yield return [
 				new Parameter (0, ReturnTypeForEnum ("MyEnum"), "myParam"),
 				"var nsb_myParam = NSNumber.FromInt32 ((int) myParam);",
 			];
-			
+
 			yield return [
 				new Parameter (0, ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_Byte), "myParam"),
 				"var nsb_myParam = NSNumber.FromByte ((byte) myParam);",
 			];
-			
+
 			yield return [
 				new Parameter (0, ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_SByte), "myParam"),
 				"var nsb_myParam = NSNumber.FromSByte ((sbyte) myParam);",
 			];
-			
+
 			yield return [
 				new Parameter (0, ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_Int16), "myParam"),
 				"var nsb_myParam = NSNumber.FromInt16 ((short) myParam);",
 			];
-			
+
 			yield return [
 				new Parameter (0, ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_UInt16), "myParam"),
 				"var nsb_myParam = NSNumber.FromUInt16 ((ushort) myParam);",
 			];
-			
+
 			yield return [
 				new Parameter (0, ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_Int64), "myParam"),
 				"var nsb_myParam = NSNumber.FromInt64 ((long) myParam);",
 			];
-			
+
 			yield return [
 				new Parameter (0, ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_UInt64), "myParam"),
 				"var nsb_myParam = NSNumber.FromUInt64 ((ulong) myParam);",
 			];
-			
+
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
-	
+
 	[Theory]
 	[ClassData (typeof (TestDataGetNSNumberAuxVariableTest))]
 	void GetNSNumberAuxVariableTests (in Parameter parameter, string? expectedDeclaration)

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
@@ -35,10 +35,14 @@ static class TestDataFactory {
 			IsINativeObject = false,
 		};
 
-	public static TypeInfo ReturnTypeForInt (bool isNullable = false, bool keepInterfaces = false)
-		=> new (
-			name: "int",
-			specialType: SpecialType.System_Int32,
+	public static TypeInfo ReturnTypeForInt (bool isNullable = false, bool keepInterfaces = false,
+		bool isUnsigned = false)
+	{
+		var typeName = isUnsigned ? "int" : "uint";
+		var metadataName = isUnsigned ? "Int32" : "UInt32";
+		var type = new TypeInfo (
+			name: typeName,
+			specialType: isUnsigned ? SpecialType.System_UInt32 : SpecialType.System_Int32,
 			isBlittable: !isNullable,
 			isNullable: isNullable,
 			isStruct: true
@@ -48,39 +52,41 @@ static class TestDataFactory {
 				? []
 				: [
 					"System.IComparable",
-					"System.IComparable<int>",
+					$"System.IComparable<{typeName}>",
 					"System.IConvertible",
-					"System.IEquatable<int>",
+					$"System.IEquatable<{typeName}>",
 					"System.IFormattable",
-					"System.IParsable<int>",
+					$"System.IParsable<{typeName}>",
 					"System.ISpanFormattable",
-					"System.ISpanParsable<int>",
+					$"System.ISpanParsable<{typeName}>",
 					"System.IUtf8SpanFormattable",
-					"System.IUtf8SpanParsable<int>",
-					"System.Numerics.IAdditionOperators<int, int, int>",
-					"System.Numerics.IAdditiveIdentity<int, int>",
-					"System.Numerics.IBinaryInteger<int>",
-					"System.Numerics.IBinaryNumber<int>",
-					"System.Numerics.IBitwiseOperators<int, int, int>",
-					"System.Numerics.IComparisonOperators<int, int, bool>",
-					"System.Numerics.IEqualityOperators<int, int, bool>",
-					"System.Numerics.IDecrementOperators<int>",
-					"System.Numerics.IDivisionOperators<int, int, int>",
-					"System.Numerics.IIncrementOperators<int>",
-					"System.Numerics.IModulusOperators<int, int, int>",
-					"System.Numerics.IMultiplicativeIdentity<int, int>",
-					"System.Numerics.IMultiplyOperators<int, int, int>",
-					"System.Numerics.INumber<int>",
-					"System.Numerics.INumberBase<int>",
-					"System.Numerics.ISubtractionOperators<int, int, int>",
-					"System.Numerics.IUnaryNegationOperators<int, int>",
-					"System.Numerics.IUnaryPlusOperators<int, int>",
-					"System.Numerics.IShiftOperators<int, int, int>",
-					"System.Numerics.IMinMaxValue<int>",
-					"System.Numerics.ISignedNumber<int>"
+					$"System.IUtf8SpanParsable<{typeName}>",
+					$"System.Numerics.IAdditionOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IAdditiveIdentity<{typeName}, {typeName}>",
+					$"System.Numerics.IBinaryInteger<{typeName}>",
+					$"System.Numerics.IBinaryNumber<{typeName}>",
+					$"System.Numerics.IBitwiseOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IComparisonOperators<{typeName}, {typeName}, bool>",
+					$"System.Numerics.IEqualityOperators<{typeName}, {typeName}, bool>",
+					$"System.Numerics.IDecrementOperators<{typeName}>",
+					$"System.Numerics.IDivisionOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IIncrementOperators<{typeName}>",
+					$"System.Numerics.IModulusOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IMultiplicativeIdentity<{typeName}, {typeName}>",
+					$"System.Numerics.IMultiplyOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.INumber<{typeName}>",
+					$"System.Numerics.INumberBase<{typeName}>",
+					$"System.Numerics.ISubtractionOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IUnaryNegationOperators<{typeName}, {typeName}>",
+					$"System.Numerics.IUnaryPlusOperators<{typeName}, {typeName}>",
+					$"System.Numerics.IShiftOperators<{typeName}, {typeName}, {typeName}>",
+					$"System.Numerics.IMinMaxValue<{typeName}>",
+					$"System.Numerics.ISignedNumber<{typeName}>"
 				],
 			MetadataName = "Int32",
 		};
+		return type;
+	}
 
 	public static TypeInfo ReturnTypeForIntPtr (bool isNullable = false)
 		=> new (

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
@@ -38,8 +38,8 @@ static class TestDataFactory {
 	public static TypeInfo ReturnTypeForInt (bool isNullable = false, bool keepInterfaces = false,
 		bool isUnsigned = false)
 	{
-		var typeName = isUnsigned ? "int" : "uint";
-		var metadataName = isUnsigned ? "Int32" : "UInt32";
+		var typeName = isUnsigned ? "uint" : "int";
+		var metadataName = isUnsigned ? "UInt32" : "Int32";
 		var type = new TypeInfo (
 			name: typeName,
 			specialType: isUnsigned ? SpecialType.System_UInt32 : SpecialType.System_Int32,


### PR DESCRIPTION
This change allows to be able to generate an aux variable that will be needed if a customer defined a export method in the following way:

```csharp

[Export<Method> ()]
public virtual partial void MyMethod ([BindFrom (typeof (NSNumber))] double myDouble);
```

The above binding API indicates that the native method in objc will take a NSNumber but we want to expose our users a double. In order to send a NSNumber to objc, we need to declare an aux variable that will be used for the native method invocation.