### PR TITLE
[RGen] Add BindFrom factory method that will return the correct declaration.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -467,6 +467,26 @@ static partial class BindingSyntaxFactory {
 		return LocalDeclarationStatement (declaration);
 	}
 
+	/// <summary>
+	/// Returns the aux variable declaration needed when a parameter has the BindFrom attribute.
+	/// </summary>
+	/// <param name="parameter">The parameter whose aux variable we want to declare.</param>
+	/// <returns>The syntax declaration of the aux variable or null if it could not be generated.</returns>
+	internal static LocalDeclarationStatementSyntax? GetBindFromAuxVariable (in Parameter parameter)
+	{
+		if (parameter.BindAs is null)
+			return null;
+		
+		// based on the bindas type call one of the helper factory methods
+		return parameter.BindAs.Value.Type switch {
+			"Foundation.NSNumber" => GetNSNumberAuxVariable (parameter),
+			"Foundation.NSValue" => GetNSValueAuxVariable (parameter),
+			"Foundation.NSString" => GetNSStringSmartEnumAuxVariable(parameter),
+			_ => null,
+		};
+	}
+
+
 	static string? GetObjCMessageSendMethodName<T> (ExportData<T> exportData,
 		TypeInfo returnType, ImmutableArray<Parameter> parameters, bool isSuper = false, bool isStret = false)
 		where T : Enum

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -476,12 +476,12 @@ static partial class BindingSyntaxFactory {
 	{
 		if (parameter.BindAs is null)
 			return null;
-		
+
 		// based on the bindas type call one of the helper factory methods
 		return parameter.BindAs.Value.Type switch {
 			"Foundation.NSNumber" => GetNSNumberAuxVariable (parameter),
 			"Foundation.NSValue" => GetNSValueAuxVariable (parameter),
-			"Foundation.NSString" => GetNSStringSmartEnumAuxVariable(parameter),
+			"Foundation.NSString" => GetNSStringSmartEnumAuxVariable (parameter),
 			_ => null,
 		};
 	}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
@@ -481,5 +481,69 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			Assert.Equal (expectedDeclaration, declaration.ToString ());
 		}
 	}
+	
+	class TestDataGetBindFromAuxVariableTests : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			// nsnumber
+			yield return [
+				new Parameter (
+					position: 0, 
+					type: ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_UInt64), 
+					name: "myParam") 
+				{
+					BindAs = new ("Foundation.NSNumber"),
+				},
+				"var nsb_myParam = NSNumber.FromUInt64 ((ulong) myParam);",
+			];
+			// nsvalue	
+			yield return [
+				new Parameter (
+					position: 0, 
+					type: ReturnTypeForStruct ("CoreAnimation.CATransform3D"), 
+					name: "myParam")
+				{
+					BindAs = new ("Foundation.NSValue"),
+				},
+				"var nsb_myParam = NSValue.FromCATransform3D (myParam);",
+			];
+			
+			// smart enum
+			yield return [
+				new Parameter (
+					position: 0, 
+					type: ReturnTypeForEnum("CoreAnimation.CATransform3D", isSmartEnum: true), 
+					name: "myParam")
+				{
+					BindAs = new ("Foundation.NSString"),
+				},
+				"var nsb_myParam = myParam.GetConstant ();",
+			];
+			
+			//missing attr
+			yield return [
+				new Parameter (
+					position: 0, 
+					type: ReturnTypeForEnum("CoreAnimation.CATransform3D", isSmartEnum: true), 
+					name: "myParam"),
+				null!
+			];
+			
+		}
 
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	[Theory]
+	[ClassData (typeof (TestDataGetBindFromAuxVariableTests))]
+	void GetBindFromAuxVariableTests (in Parameter parameter, string? expectedDeclaration)
+	{
+		var declaration = GetBindFromAuxVariable (parameter);
+		if (expectedDeclaration is null) {
+			Assert.Null (declaration);
+		} else {
+			Assert.NotNull (declaration);
+			Assert.Equal (expectedDeclaration, declaration.ToString ());
+		}
+	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
@@ -481,17 +481,16 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			Assert.Equal (expectedDeclaration, declaration.ToString ());
 		}
 	}
-	
+
 	class TestDataGetBindFromAuxVariableTests : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
 			// nsnumber
 			yield return [
 				new Parameter (
-					position: 0, 
-					type: ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_UInt64), 
-					name: "myParam") 
-				{
+					position: 0,
+					type: ReturnTypeForEnum ("MyEnum", underlyingType: SpecialType.System_UInt64),
+					name: "myParam") {
 					BindAs = new ("Foundation.NSNumber"),
 				},
 				"var nsb_myParam = NSNumber.FromUInt64 ((ulong) myParam);",
@@ -499,41 +498,39 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			// nsvalue	
 			yield return [
 				new Parameter (
-					position: 0, 
-					type: ReturnTypeForStruct ("CoreAnimation.CATransform3D"), 
-					name: "myParam")
-				{
+					position: 0,
+					type: ReturnTypeForStruct ("CoreAnimation.CATransform3D"),
+					name: "myParam") {
 					BindAs = new ("Foundation.NSValue"),
 				},
 				"var nsb_myParam = NSValue.FromCATransform3D (myParam);",
 			];
-			
+
 			// smart enum
 			yield return [
 				new Parameter (
-					position: 0, 
-					type: ReturnTypeForEnum("CoreAnimation.CATransform3D", isSmartEnum: true), 
-					name: "myParam")
-				{
+					position: 0,
+					type: ReturnTypeForEnum ("CoreAnimation.CATransform3D", isSmartEnum: true),
+					name: "myParam") {
 					BindAs = new ("Foundation.NSString"),
 				},
 				"var nsb_myParam = myParam.GetConstant ();",
 			];
-			
+
 			//missing attr
 			yield return [
 				new Parameter (
-					position: 0, 
-					type: ReturnTypeForEnum("CoreAnimation.CATransform3D", isSmartEnum: true), 
+					position: 0,
+					type: ReturnTypeForEnum ("CoreAnimation.CATransform3D", isSmartEnum: true),
 					name: "myParam"),
 				null!
 			];
-			
+
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
-	
+
 	[Theory]
 	[ClassData (typeof (TestDataGetBindFromAuxVariableTests))]
 	void GetBindFromAuxVariableTests (in Parameter parameter, string? expectedDeclaration)


### PR DESCRIPTION
This method is the final step to be able to generate the aux variable for a BindFrom decorated parameter. We just need to perform a switch on the type of the BindFrom attribute to decide the final declaration needed.