### PR TITLE
[Rgen] Add a new CreateBlock method for several concatenated blocks.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/TabbedStringBuilder.cs
+++ b/src/rgen/Microsoft.Macios.Generator/TabbedStringBuilder.cs
@@ -281,14 +281,14 @@ partial class TabbedStringBuilder : IDisposable {
 	/// <returns></returns>
 	public TabbedStringBuilder CreateBlock (IEnumerable<string> lines, bool block)
 	{
-		var array = lines as string[] ?? lines.ToArray();
+		var array = lines as string [] ?? lines.ToArray ();
 		if (array.Length == 0) {
 			return CreateBlock (isBlock);
 		}
-		
+
 		// append all the lines, then create a block
 		for (var i = 0; i < array.Length - 1; i++) {
-			WriteTabs ().AppendLine (array[i]);
+			WriteTabs ().AppendLine (array [i]);
 		}
 		return CreateBlock (array [^1], block);
 	}

--- a/src/rgen/Microsoft.Macios.Generator/TabbedStringBuilder.cs
+++ b/src/rgen/Microsoft.Macios.Generator/TabbedStringBuilder.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -261,6 +263,34 @@ partial class TabbedStringBuilder : IDisposable {
 		}
 
 		return new TabbedStringBuilder (sb, tabCount, block);
+	}
+
+	/// <summary>
+	/// Concatenate an array of lines as a single block. The generated code is similar to the following
+	///
+	/// <code>
+	/// using (var nsobject = Create ())
+	/// using (var nsstring = Create ())
+	/// using (var x = new NSString ()) {
+	///    // your code goes here.
+	/// }
+	/// </code>
+	/// </summary>
+	/// <param name="lines">The lines to concatenate.</param>
+	/// <param name="block">True if the block should use braces, false otherwise.</param>
+	/// <returns></returns>
+	public TabbedStringBuilder CreateBlock (IEnumerable<string> lines, bool block)
+	{
+		var array = lines as string[] ?? lines.ToArray();
+		if (array.Length == 0) {
+			return CreateBlock (isBlock);
+		}
+		
+		// append all the lines, then create a block
+		for (var i = 0; i < array.Length - 1; i++) {
+			WriteTabs ().AppendLine (array[i]);
+		}
+		return CreateBlock (array [^1], block);
 	}
 
 	/// <summary>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TabbedStringBuilderTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TabbedStringBuilderTests.cs
@@ -346,4 +346,28 @@ Because we are using a raw string  we expected:
 		block.Clear ();
 		Assert.Equal (string.Empty, block.ToString ());
 	}
+
+	[Fact]
+	public void CreateBlockStringArray ()
+	{
+		var expecteString = 
+@"using (var m1 = new MemoryStream())
+using (var m2 = new MemoryStream())
+using (var m3 = new MemoryStream())
+{
+	// this is an example with several usings
+}
+";
+		var baseBlock = new TabbedStringBuilder (sb);
+		// create a list of lines to get the new block
+		var usingStatements = new [] {
+			"using (var m1 = new MemoryStream())",
+			"using (var m2 = new MemoryStream())",
+			"using (var m3 = new MemoryStream())",
+		};
+		using (var usingBlock = baseBlock.CreateBlock (usingStatements, true)) {
+			usingBlock.AppendLine ("// this is an example with several usings");
+		}
+		Assert.Equal (expecteString, baseBlock.ToString ());	
+	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TabbedStringBuilderTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TabbedStringBuilderTests.cs
@@ -350,7 +350,7 @@ Because we are using a raw string  we expected:
 	[Fact]
 	public void CreateBlockStringArray ()
 	{
-		var expecteString = 
+		var expecteString =
 @"using (var m1 = new MemoryStream())
 using (var m2 = new MemoryStream())
 using (var m3 = new MemoryStream())
@@ -368,6 +368,6 @@ using (var m3 = new MemoryStream())
 		using (var usingBlock = baseBlock.CreateBlock (usingStatements, true)) {
 			usingBlock.AppendLine ("// this is an example with several usings");
 		}
-		Assert.Equal (expecteString, baseBlock.ToString ());	
+		Assert.Equal (expecteString, baseBlock.ToString ());
 	}
 }


### PR DESCRIPTION
There are ocassions in which in we want to be able to concatenate several blocks one after the other. The most common scenario is when we are using fixed or using blocks. To make the code cleaner we do not want to create a collection of nested calls like:
```csharp
using (var m1 = new MemoryStream())
{
  using (var m2 = new MemoryStream())
  {
    using (var m3 = new MemoryStream())
    {
      // this is an example with several usings
    }
  }
}
```
instead we want the generator to write:
```csharp
using (var m1 = new MemoryStream())
using (var m2 = new MemoryStream())
using (var m3 = new MemoryStream())
{
  // this is an example with several usings
}
```

This new CreateBlock method takes an collection of lines and writes a single block similar to the one in the above example.