### PR TITLE
[Rgen] Add flags to use plain strings during the marshalling.

### DIFF
--- a/src/ObjCBindings/ExportTag.cs
+++ b/src/ObjCBindings/ExportTag.cs
@@ -25,6 +25,12 @@ namespace ObjCBindings {
 		/// Flags the object as being thread safe.
 		/// </summary>
 		IsThreadSafe = 1 << 3,
+
+		/// <summary>
+		/// If this flag is applied to a property, we do not generate a NSString for
+		/// marshalling the property.
+		/// </summary>
+		PlainString = 1 << 4,
 	}
 
 	/// <summary>
@@ -69,6 +75,11 @@ namespace ObjCBindings {
 		/// </summary>
 		IsThreadSafe = 1 << 6,
 
+		/// <summary>
+		/// If this flag is applied to a property, we do not generate a NSString for
+		/// marshalling the property.
+		/// </summary>
+		PlainString = 1 << 7,
 	}
 
 	/// <summary>
@@ -134,6 +145,11 @@ namespace ObjCBindings {
 		/// </summary>
 		Transient = 1 << 8,
 
+		/// <summary>
+		/// If this flag is applied to a property, we do not generate a NSString for
+		/// marshalling the property.
+		/// </summary>
+		PlainString = 1 << 9,
 	}
 }
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
@@ -34,6 +34,12 @@ readonly partial struct Method {
 	/// True if the method was exported with the MarshalNativeExceptions flag allowing it to support native exceptions.
 	/// </summary>
 	public bool MarshalNativeExceptions => ExportMethodData.Flags.HasFlag (ObjCBindings.Method.MarshalNativeExceptions);
+	
+	/// <summary>
+	/// True if the generator should not use a NSString for marshalling.
+	/// </summary>
+	public bool UsePlainString
+		=> ExportMethodData.Flags.HasFlag (ObjCBindings.Method.PlainString);
 
 	public Method (string type, string name, TypeInfo returnType,
 		SymbolAvailability symbolAvailability,

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
@@ -66,6 +66,18 @@ readonly partial struct Property {
 	/// True if the property should be generated without a backing field.
 	/// </summary>
 	public bool IsTransient => IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.Transient);
+	
+	/// <summary>
+	/// True if the property was marked to DisableZeroCopy.
+	/// </summary>
+	public bool DisableZeroCopy
+		=> IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.DisableZeroCopy);
+	
+	/// <summary>
+	/// True if the generator should not use a NSString for marshalling.
+	/// </summary>
+	public bool UsePlainString
+		=> IsProperty && ExportPropertyData.Value.Flags.HasFlag (ObjCBindings.Property.PlainString);
 
 	readonly bool? needsBackingField = null;
 	/// <summary>


### PR DESCRIPTION
Allow to use plain string when marshalling. This is not a very commong scenarion but we need to be prepared in case our custoemrs do use it.