### PR TITLE
[Rgen] Add the needed factory method to generate NSArrays for the BindFrom attr.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -470,19 +470,19 @@ static partial class BindingSyntaxFactory {
 		// we can only work with parameters that are an array
 		if (!parameter.Type.IsArray)
 			return null;
-		
+
 		var variableName = parameter.GetNameForVariableType (Parameter.VariableType.BindFrom);
 		if (variableName is null)
 			return null;
-		
+
 		// use a switch to decide which of the constructors we are going to use to build the array.
 		var lambdaFunctionVariable = "obj";
 		var nsNumberExpr = ObjectCreationExpression (
 				IdentifierName ("NSNumber").WithLeadingTrivia (Space).WithTrailingTrivia (Space))
 			.WithArgumentList (ArgumentList (SingletonSeparatedList (
 				Argument (IdentifierName (lambdaFunctionVariable)))));
-		var nsValueExpr= ObjectCreationExpression (
-				IdentifierName ("NSValue").WithLeadingTrivia (Space).WithTrailingTrivia(Space))
+		var nsValueExpr = ObjectCreationExpression (
+				IdentifierName ("NSValue").WithLeadingTrivia (Space).WithTrailingTrivia (Space))
 			.WithArgumentList (ArgumentList (SingletonSeparatedList (
 				Argument (IdentifierName (lambdaFunctionVariable)))));
 		var smartEnumExpr = InvocationExpression (MemberAccessExpression (
@@ -549,8 +549,8 @@ static partial class BindingSyntaxFactory {
 		// obj => new NSNumber (obj);
 		// obj => new NSValue (obj);
 		// obj => obj.GetValue ();
-		var lambdaExpression = SimpleLambdaExpression(Parameter(Identifier(lambdaFunctionVariable).WithTrailingTrivia (Space)))
-			.WithExpressionBody(constructor.WithLeadingTrivia (Space));
+		var lambdaExpression = SimpleLambdaExpression (Parameter (Identifier (lambdaFunctionVariable).WithTrailingTrivia (Space)))
+			.WithExpressionBody (constructor.WithLeadingTrivia (Space));
 
 		// generate: NSArray.FromNSObjects (o => new NSNumber (o), shape);
 		var factoryInvocation = InvocationExpression (MemberAccessExpression (
@@ -560,11 +560,11 @@ static partial class BindingSyntaxFactory {
 			ArgumentList (
 				SeparatedList<ArgumentSyntax> (
 					new SyntaxNodeOrToken [] {
-						Argument (lambdaExpression), 
-						Token (SyntaxKind.CommaToken), 
+						Argument (lambdaExpression),
+						Token (SyntaxKind.CommaToken),
 						Argument (IdentifierName (parameter.Name).WithLeadingTrivia (Space))
 					})));
-		
+
 		var declarator =
 			VariableDeclarator (Identifier (variableName).WithLeadingTrivia (Space).WithTrailingTrivia (Space))
 				.WithInitializer (EqualsValueClause (factoryInvocation.WithLeadingTrivia (Space)));

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -289,9 +289,7 @@ static partial class BindingSyntaxFactory {
 			{ Name: "nint" } => "FromNInt",
 			{ Name: "nuint" } => "FromNUInt",
 			{ Name: "nfloat" or "NFloat" } => "FromNFloat",
-			{
-				IsEnum: true, IsSmartEnum: true
-			} => null, // we do not support smart enums, there is a special case for them 
+			{ IsEnum: true, IsSmartEnum: true } => null, // we do not support smart enums, there is a special case for them 
 			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_SByte } => "FromSByte",
 			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Byte } => "FromByte",
 			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int16 } => "FromInt16",
@@ -467,6 +465,117 @@ static partial class BindingSyntaxFactory {
 		return LocalDeclarationStatement (declaration);
 	}
 
+	internal static LocalDeclarationStatementSyntax? GetNSArrayBindFromAuxVariable (in Parameter parameter)
+	{
+		// we can only work with parameters that are an array
+		if (!parameter.Type.IsArray)
+			return null;
+		
+		var variableName = parameter.GetNameForVariableType (Parameter.VariableType.BindFrom);
+		if (variableName is null)
+			return null;
+		
+		// use a switch to decide which of the constructors we are going to use to build the array.
+		var lambdaFunctionVariable = "obj";
+		var nsNumberExpr = ObjectCreationExpression (
+				IdentifierName ("NSNumber").WithLeadingTrivia (Space).WithTrailingTrivia (Space))
+			.WithArgumentList (ArgumentList (SingletonSeparatedList (
+				Argument (IdentifierName (lambdaFunctionVariable)))));
+		var nsValueExpr= ObjectCreationExpression (
+				IdentifierName ("NSValue").WithLeadingTrivia (Space).WithTrailingTrivia(Space))
+			.WithArgumentList (ArgumentList (SingletonSeparatedList (
+				Argument (IdentifierName (lambdaFunctionVariable)))));
+		var smartEnumExpr = InvocationExpression (MemberAccessExpression (
+			SyntaxKind.SimpleMemberAccessExpression,
+			IdentifierName (lambdaFunctionVariable).WithLeadingTrivia (Space),
+			IdentifierName ("GetConstant")));
+			
+#pragma warning disable format
+		ExpressionSyntax? constructor = parameter.Type switch {
+			// smart enums
+			{ IsEnum: true, IsSmartEnum: true } => smartEnumExpr,
+			// NSNumber types:
+			{ Name: "nint" } => nsNumberExpr,
+			{ Name: "nuint" } => nsNumberExpr,
+			{ Name: "nfloat" or "NFloat" } => nsNumberExpr,
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_SByte } => nsNumberExpr,
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Byte } => nsNumberExpr,
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int16 } => nsNumberExpr,
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt16 } => nsNumberExpr,
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int32 } => nsNumberExpr,
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt32 } => nsNumberExpr,
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_Int64 } => nsNumberExpr,
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UInt64 } => nsNumberExpr,
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_IntPtr } => nsNumberExpr,
+			{ IsEnum: true, EnumUnderlyingType: SpecialType.System_UIntPtr } => nsNumberExpr,
+			{ SpecialType: SpecialType.System_Boolean } => nsNumberExpr,
+			{ SpecialType: SpecialType.System_Byte } => nsNumberExpr,
+			{ SpecialType: SpecialType.System_Double } => nsNumberExpr,
+			{ SpecialType: SpecialType.System_Single } => nsNumberExpr,
+			{ SpecialType: SpecialType.System_Int16 } => nsNumberExpr,
+			{ SpecialType: SpecialType.System_Int32 } => nsNumberExpr,
+			{ SpecialType: SpecialType.System_Int64 } => nsNumberExpr,
+			{ SpecialType: SpecialType.System_SByte } => nsNumberExpr,
+			{ SpecialType: SpecialType.System_UInt16 } => nsNumberExpr,
+			{ SpecialType: SpecialType.System_UInt32 } => nsNumberExpr,
+			{ SpecialType: SpecialType.System_UInt64 } => nsNumberExpr,
+			{ SpecialType: SpecialType.System_IntPtr } => nsNumberExpr,
+			{ SpecialType: SpecialType.System_UIntPtr } => nsNumberExpr,
+			// NSValue related types:
+			{ FullyQualifiedName: "CoreGraphics.CGAffineTransform" } => nsValueExpr, 
+			{ FullyQualifiedName: "Foundation.NSRange" } =>  nsValueExpr, 
+			{ FullyQualifiedName: "CoreGraphics.CGVector" } =>  nsValueExpr, 
+			{ FullyQualifiedName: "SceneKit.SCNMatrix4" } => nsValueExpr, 
+			{ FullyQualifiedName: "CoreLocation.CLLocationCoordinate2D" } => nsValueExpr, 
+			{ FullyQualifiedName: "SceneKit.SCNVector3" } => nsValueExpr,
+			{ FullyQualifiedName: "SceneKit.SCNVector4" } => nsValueExpr,
+			{ FullyQualifiedName: "CoreGraphics.CGPoint" } => nsValueExpr,
+			{ FullyQualifiedName: "CoreGraphics.CGRect" } => nsValueExpr,
+			{ FullyQualifiedName: "CoreGraphics.CGSize" } => nsValueExpr,
+			{ FullyQualifiedName: "UIKit.UIEdgeInsets" } => nsValueExpr,
+			{ FullyQualifiedName: "UIKit.UIOffset" } => nsValueExpr,
+			{ FullyQualifiedName: "MapKit.MKCoordinateSpan" } => nsNumberExpr,
+			{ FullyQualifiedName: "CoreMedia.CMTimeRange" } => nsNumberExpr,
+			{ FullyQualifiedName: "CoreMedia.CMTime" } => nsValueExpr, 
+			{ FullyQualifiedName: "CoreMedia.CMTimeMapping" } => nsValueExpr, 
+			{ FullyQualifiedName: "CoreAnimation.CATransform3D" } => nsValueExpr, 
+			_ => null
+		};
+#pragma warning restore format
+		
+		if (constructor is null)
+			return null;
+		// generates:
+		// obj => new NSNumber (obj);
+		// obj => new NSValue (obj);
+		// obj => obj.GetValue ();
+		var lambdaExpression = SimpleLambdaExpression(Parameter(Identifier(lambdaFunctionVariable).WithTrailingTrivia (Space)))
+			.WithExpressionBody(constructor.WithLeadingTrivia (Space));
+
+		// generate: NSArray.FromNSObjects (o => new NSNumber (o), shape);
+		var factoryInvocation = InvocationExpression (MemberAccessExpression (
+			SyntaxKind.SimpleMemberAccessExpression,
+			IdentifierName ("NSArray"),
+			IdentifierName ("FromNSObjects").WithTrailingTrivia (Space))).WithArgumentList (
+			ArgumentList (
+				SeparatedList<ArgumentSyntax> (
+					new SyntaxNodeOrToken [] {
+						Argument (lambdaExpression), 
+						Token (SyntaxKind.CommaToken), 
+						Argument (IdentifierName (parameter.Name).WithLeadingTrivia (Space))
+					})));
+		
+		var declarator =
+			VariableDeclarator (Identifier (variableName).WithLeadingTrivia (Space).WithTrailingTrivia (Space))
+				.WithInitializer (EqualsValueClause (factoryInvocation.WithLeadingTrivia (Space)));
+
+		var declaration = VariableDeclaration (IdentifierName (Identifier (
+				TriviaList (), SyntaxKind.VarKeyword, "var", "var", TriviaList ())))
+			.WithVariables (SingletonSeparatedList (declarator));
+
+		return LocalDeclarationStatement (declaration);
+	}
+
 	/// <summary>
 	/// Returns the aux variable declaration needed when a parameter has the BindFrom attribute.
 	/// </summary>
@@ -477,13 +586,16 @@ static partial class BindingSyntaxFactory {
 		if (parameter.BindAs is null)
 			return null;
 
+#pragma warning disable format
 		// based on the bindas type call one of the helper factory methods
-		return parameter.BindAs.Value.Type switch {
-			"Foundation.NSNumber" => GetNSNumberAuxVariable (parameter),
-			"Foundation.NSValue" => GetNSValueAuxVariable (parameter),
-			"Foundation.NSString" => GetNSStringSmartEnumAuxVariable (parameter),
+		return (Type: parameter.BindAs.Value.Type, IsArray: parameter.Type.IsArray) switch {
+			{ IsArray: true } => GetNSArrayBindFromAuxVariable (parameter),
+			{ Type: "Foundation.NSNumber" } => GetNSNumberAuxVariable (parameter),
+			{ Type: "Foundation.NSValue" } => GetNSValueAuxVariable (parameter),
+			{ Type: "Foundation.NSString" } => GetNSStringSmartEnumAuxVariable(parameter),
 			_ => null,
 		};
+#pragma warning restore format
 	}
 
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
@@ -481,7 +481,63 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			Assert.Equal (expectedDeclaration, declaration.ToString ());
 		}
 	}
+	
+	class TestDataGetNSArrayBindFromAuxVariableTests : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			// nsnumber
+			yield return [
+				new Parameter (
+					position: 0, 
+					type: ReturnTypeForArray ("nint"),
+					name: "myParam") 
+				{
+					BindAs = new ("Foundation.NSNumber"),
+				},
+				"var nsb_myParam = NSArray.FromNSObjects (obj => new NSNumber (obj), myParam);"
+			];
+			
+			// nsvalue
+			yield return [
+				new Parameter (
+					position: 0, 
+					type: ReturnTypeForArray ("CoreGraphics.CGAffineTransform", isStruct: true),
+					name: "myParam") 
+				{
+					BindAs = new ("Foundation.NSValue"),
+				},
+				"var nsb_myParam = NSArray.FromNSObjects (obj => new NSValue (obj), myParam);"
+			];
+			
+			// smart enum
+			yield return [
+				new Parameter (
+					position: 0, 
+					type: ReturnTypeForArray ("MySmartEnum", isEnum: true, isSmartEnum: true),
+					name: "myParam") 
+				{
+					BindAs = new ("Foundation.NSString"),
+				},
+				"var nsb_myParam = NSArray.FromNSObjects (obj => obj.GetConstant(), myParam);"
+			];
+		}
 
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+	
+	[Theory]
+	[ClassData (typeof (TestDataGetNSArrayBindFromAuxVariableTests))]
+	void GetNSArrayBindFromAuxVariableTests (in Parameter parameter, string? expectedDeclaration)
+	{
+		var declaration = GetNSArrayBindFromAuxVariable (parameter);
+		if (expectedDeclaration is null) {
+			Assert.Null (declaration);
+		} else {
+			Assert.NotNull (declaration);
+			Assert.Equal (expectedDeclaration, declaration.ToString ());
+		}
+	}
+	
 	class TestDataGetBindFromAuxVariableTests : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -495,6 +551,18 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				},
 				"var nsb_myParam = NSNumber.FromUInt64 ((ulong) myParam);",
 			];
+			
+			yield return [
+				new Parameter (
+					position: 0, 
+					type: ReturnTypeForArray ("nint"),
+					name: "myParam") 
+				{
+					BindAs = new ("Foundation.NSNumber"),
+				},
+				"var nsb_myParam = NSArray.FromNSObjects (obj => new NSNumber (obj), myParam);"
+			];
+			
 			// nsvalue	
 			yield return [
 				new Parameter (
@@ -505,7 +573,18 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				},
 				"var nsb_myParam = NSValue.FromCATransform3D (myParam);",
 			];
-
+			
+			yield return [
+				new Parameter (
+					position: 0, 
+					type: ReturnTypeForArray ("CoreGraphics.CGAffineTransform", isStruct: true),
+					name: "myParam") 
+				{
+					BindAs = new ("Foundation.NSValue"),
+				},
+				"var nsb_myParam = NSArray.FromNSObjects (obj => new NSValue (obj), myParam);"
+			];
+			
 			// smart enum
 			yield return [
 				new Parameter (
@@ -516,7 +595,18 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				},
 				"var nsb_myParam = myParam.GetConstant ();",
 			];
-
+			
+			yield return [
+				new Parameter (
+					position: 0, 
+					type: ReturnTypeForArray ("MySmartEnum", isEnum: true, isSmartEnum: true),
+					name: "myParam") 
+				{
+					BindAs = new ("Foundation.NSString"),
+				},
+				"var nsb_myParam = NSArray.FromNSObjects (obj => obj.GetConstant(), myParam);"
+			];
+			
 			//missing attr
 			yield return [
 				new Parameter (

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
@@ -481,41 +481,38 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			Assert.Equal (expectedDeclaration, declaration.ToString ());
 		}
 	}
-	
+
 	class TestDataGetNSArrayBindFromAuxVariableTests : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
 			// nsnumber
 			yield return [
 				new Parameter (
-					position: 0, 
+					position: 0,
 					type: ReturnTypeForArray ("nint"),
-					name: "myParam") 
-				{
+					name: "myParam") {
 					BindAs = new ("Foundation.NSNumber"),
 				},
 				"var nsb_myParam = NSArray.FromNSObjects (obj => new NSNumber (obj), myParam);"
 			];
-			
+
 			// nsvalue
 			yield return [
 				new Parameter (
-					position: 0, 
+					position: 0,
 					type: ReturnTypeForArray ("CoreGraphics.CGAffineTransform", isStruct: true),
-					name: "myParam") 
-				{
+					name: "myParam") {
 					BindAs = new ("Foundation.NSValue"),
 				},
 				"var nsb_myParam = NSArray.FromNSObjects (obj => new NSValue (obj), myParam);"
 			];
-			
+
 			// smart enum
 			yield return [
 				new Parameter (
-					position: 0, 
+					position: 0,
 					type: ReturnTypeForArray ("MySmartEnum", isEnum: true, isSmartEnum: true),
-					name: "myParam") 
-				{
+					name: "myParam") {
 					BindAs = new ("Foundation.NSString"),
 				},
 				"var nsb_myParam = NSArray.FromNSObjects (obj => obj.GetConstant(), myParam);"
@@ -524,7 +521,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
 	}
-	
+
 	[Theory]
 	[ClassData (typeof (TestDataGetNSArrayBindFromAuxVariableTests))]
 	void GetNSArrayBindFromAuxVariableTests (in Parameter parameter, string? expectedDeclaration)
@@ -537,7 +534,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 			Assert.Equal (expectedDeclaration, declaration.ToString ());
 		}
 	}
-	
+
 	class TestDataGetBindFromAuxVariableTests : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -551,18 +548,17 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				},
 				"var nsb_myParam = NSNumber.FromUInt64 ((ulong) myParam);",
 			];
-			
+
 			yield return [
 				new Parameter (
-					position: 0, 
+					position: 0,
 					type: ReturnTypeForArray ("nint"),
-					name: "myParam") 
-				{
+					name: "myParam") {
 					BindAs = new ("Foundation.NSNumber"),
 				},
 				"var nsb_myParam = NSArray.FromNSObjects (obj => new NSNumber (obj), myParam);"
 			];
-			
+
 			// nsvalue	
 			yield return [
 				new Parameter (
@@ -573,18 +569,17 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				},
 				"var nsb_myParam = NSValue.FromCATransform3D (myParam);",
 			];
-			
+
 			yield return [
 				new Parameter (
-					position: 0, 
+					position: 0,
 					type: ReturnTypeForArray ("CoreGraphics.CGAffineTransform", isStruct: true),
-					name: "myParam") 
-				{
+					name: "myParam") {
 					BindAs = new ("Foundation.NSValue"),
 				},
 				"var nsb_myParam = NSArray.FromNSObjects (obj => new NSValue (obj), myParam);"
 			];
-			
+
 			// smart enum
 			yield return [
 				new Parameter (
@@ -595,18 +590,17 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				},
 				"var nsb_myParam = myParam.GetConstant ();",
 			];
-			
+
 			yield return [
 				new Parameter (
-					position: 0, 
+					position: 0,
 					type: ReturnTypeForArray ("MySmartEnum", isEnum: true, isSmartEnum: true),
-					name: "myParam") 
-				{
+					name: "myParam") {
 					BindAs = new ("Foundation.NSString"),
 				},
 				"var nsb_myParam = NSArray.FromNSObjects (obj => obj.GetConstant(), myParam);"
 			];
-			
+
 			//missing attr
 			yield return [
 				new Parameter (

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
@@ -211,14 +211,22 @@ static class TestDataFactory {
 			EnumUnderlyingType = underlyingType,
 		};
 
-	public static TypeInfo ReturnTypeForArray (string type, bool isNullable = false, bool isBlittable = false)
+	public static TypeInfo ReturnTypeForArray (string type, 
+		bool isNullable = false, 
+		bool isBlittable = false, 
+		bool isEnum = false, 
+		bool isSmartEnum = false, 
+		bool isStruct = false)
 		=> new (
 			name: type,
 			isNullable: isNullable,
 			isBlittable: isBlittable,
 			isArray: true,
-			isReferenceType: true
+			isReferenceType: true,
+			isSmartEnum: isSmartEnum,
+			isStruct: isStruct
 		) {
+			EnumUnderlyingType = isEnum ? SpecialType.System_Int32 : null, 
 			Parents = ["System.Array", "object"],
 			Interfaces = [
 				$"System.Collections.Generic.IList<{type}>",

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/TestDataFactory.cs
@@ -211,11 +211,11 @@ static class TestDataFactory {
 			EnumUnderlyingType = underlyingType,
 		};
 
-	public static TypeInfo ReturnTypeForArray (string type, 
-		bool isNullable = false, 
-		bool isBlittable = false, 
-		bool isEnum = false, 
-		bool isSmartEnum = false, 
+	public static TypeInfo ReturnTypeForArray (string type,
+		bool isNullable = false,
+		bool isBlittable = false,
+		bool isEnum = false,
+		bool isSmartEnum = false,
 		bool isStruct = false)
 		=> new (
 			name: type,
@@ -226,7 +226,7 @@ static class TestDataFactory {
 			isSmartEnum: isSmartEnum,
 			isStruct: isStruct
 		) {
-			EnumUnderlyingType = isEnum ? SpecialType.System_Int32 : null, 
+			EnumUnderlyingType = isEnum ? SpecialType.System_Int32 : null,
 			Parents = ["System.Array", "object"],
 			Interfaces = [
 				$"System.Collections.Generic.IList<{type}>",


### PR DESCRIPTION
We forgot to add support for an array of value. We allow suers to do [BindFrom (NSNumer)] on a method that returns an array. This means that we need to generate an NSArray that we will use to call the native code.

There are 3 possible cases:

1. Array of enums (it people ever choose to do it).
2. Array of NSNumber.
3. Array of NSValue.

The above 3 create the following aux variables accordingly:

```csharp
// enum
var nsb_myParam = NSArray.FromNSObjects (obj => obj.GetConstant(), myParam)

// nsnumber
var nsb_myParam = NSArray.FromNSObjects (obj => new NSNumber (obj), myParam)

// nsValue
var nsb_myParam = NSArray.FromNSObjects (obj => new NSValue (obj), myParam)

```