### PR TITLE
[RGen] Provide async methods for the TabbedWriter.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/IO/TabbedWriter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/IO/TabbedWriter.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 namespace Microsoft.Macios.Generator.IO;
 
 abstract class TabbedWriter<T> : IDisposable where T : TextWriter {
-	readonly SemaphoreSlim indentationSemaphore = new SemaphoreSlim(1, 1);	
+	readonly SemaphoreSlim indentationSemaphore = new SemaphoreSlim (1, 1);
 	protected readonly IndentedTextWriter Writer;
 	protected readonly T InnerWriter;
 	protected bool IsBlock;
@@ -64,7 +64,7 @@ abstract class TabbedWriter<T> : IDisposable where T : TextWriter {
 		try {
 			var oldIndent = Writer.Indent;
 			Writer.Indent = 0;
-			await Writer.WriteLineAsync();
+			await Writer.WriteLineAsync ();
 			Writer.Indent = oldIndent;
 		} finally {
 			indentationSemaphore.Release ();
@@ -72,7 +72,7 @@ abstract class TabbedWriter<T> : IDisposable where T : TextWriter {
 
 		return this;
 	}
-	
+
 	/// <summary>
 	/// Append content, but do not add a \n
 	/// </summary>
@@ -130,7 +130,7 @@ abstract class TabbedWriter<T> : IDisposable where T : TextWriter {
 
 		return this;
 	}
-	
+
 	/// <summary>
 	/// Append a new tabbed line.
 	/// </summary>
@@ -225,7 +225,7 @@ abstract class TabbedWriter<T> : IDisposable where T : TextWriter {
 		return this;
 	}
 #endif
-	
+
 	/// <summary>
 	/// Append a new raw literal by prepending the correct indentation.
 	/// </summary>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/IO/TabbedStringBuilderTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/IO/TabbedStringBuilderTests.cs
@@ -65,7 +65,7 @@ public class TabbedStringBuilderTests {
 		// an empty line should have not tabs
 		Assert.Equal ("\n", result);
 	}
-	
+
 	[Theory]
 	[InlineData (0)]
 	[InlineData (1)]
@@ -96,7 +96,7 @@ public class TabbedStringBuilderTests {
 
 		Assert.Equal ($"{expectedTabs}{{\n{expectedTabs}\t{line}\n{expectedTabs}}}\n", result);
 	}
-	
+
 	[Theory]
 	[InlineData ("// test comment", 0, "")]
 	[InlineData ("var t = 1;", 1, "\t")]
@@ -163,7 +163,7 @@ Because we are using a raw string  we expected:
 
 		Assert.Equal (expected, result);
 	}
-	
+
 	[Theory]
 	[InlineData (0, "")]
 	[InlineData (1, "\t")]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/IO/TabbedStringBuilderTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/IO/TabbedStringBuilderTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Availability;
 using Microsoft.Macios.Generator.IO;
@@ -64,6 +65,22 @@ public class TabbedStringBuilderTests {
 		// an empty line should have not tabs
 		Assert.Equal ("\n", result);
 	}
+	
+	[Theory]
+	[InlineData (0)]
+	[InlineData (1)]
+	[InlineData (5)]
+	public async Task AppendLineTestAsync (int tabCount)
+	{
+		string result;
+		using (var block = new TabbedStringBuilder (sb, tabCount)) {
+			await block.WriteLineAsync ();
+			result = block.ToCode ();
+		}
+
+		// an empty line should have not tabs
+		Assert.Equal ("\n", result);
+	}
 
 	[Theory]
 	[InlineData ("// test comment", 0, "")]
@@ -74,6 +91,21 @@ public class TabbedStringBuilderTests {
 		string result;
 		using (var block = new TabbedStringBuilder (sb, tabCount, true)) {
 			block.WriteLine (line);
+			result = block.ToCode ();
+		}
+
+		Assert.Equal ($"{expectedTabs}{{\n{expectedTabs}\t{line}\n{expectedTabs}}}\n", result);
+	}
+	
+	[Theory]
+	[InlineData ("// test comment", 0, "")]
+	[InlineData ("var t = 1;", 1, "\t")]
+	[InlineData ("Console.WriteLine (\"1\");", 5, "\t\t\t\t\t")]
+	public async Task AppendLineStringTestAsync (string line, int tabCount, string expectedTabs)
+	{
+		string result;
+		using (var block = new TabbedStringBuilder (sb, tabCount, true)) {
+			await block.WriteLineAsync (line);
 			result = block.ToCode ();
 		}
 
@@ -126,6 +158,37 @@ Because we are using a raw string  we expected:
 		string result;
 		using (var block = new TabbedStringBuilder (sb, tabCount)) {
 			block.WriteRaw (input);
+			result = block.ToCode ();
+		}
+
+		Assert.Equal (expected, result);
+	}
+	
+	[Theory]
+	[InlineData (0, "")]
+	[InlineData (1, "\t")]
+	[InlineData (5, "\t\t\t\t\t")]
+	public async Task AppendRawTestAsync (int tabCount, string expectedTabs)
+	{
+		var input = @"
+## Raw string
+Because we are using a raw string  we expected:
+  1. The string to be split in lines
+  2. All lines should have the right indentation
+     - This means nested one
+  3. And all lines should have the correct tabs
+";
+		var expected = $@"
+{expectedTabs}## Raw string
+{expectedTabs}Because we are using a raw string  we expected:
+{expectedTabs}  1. The string to be split in lines
+{expectedTabs}  2. All lines should have the right indentation
+{expectedTabs}     - This means nested one
+{expectedTabs}  3. And all lines should have the correct tabs
+";
+		string result;
+		using (var block = new TabbedStringBuilder (sb, tabCount)) {
+			await block.WriteRawAsync (input);
 			result = block.ToCode ();
 		}
 


### PR DESCRIPTION
Add all the async methods than can be added to the class. Do remember the following about async methods during the review:

1. We cannot use 'ref' parameters for a async method.
2. We cannot use ref readonly structs parameters and Span is one.
3. We cannot use those same types inside the body of an asyc method. So WriteRaw has to do the string allocations.

The Async methods are meant for the transformer, which is a project in which we can use async IO and we do not need to worry about memory in the same way we do in the roslyn code generator.