### PR TITLE
[Rgen] Provide a StreamWriter indent writer for the transformer.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/IO/TabbedWriter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/IO/TabbedWriter.cs
@@ -131,7 +131,7 @@ abstract class TabbedWriter<T> : IDisposable, IAsyncDisposable where T : TextWri
 
 		return this;
 	}
-	
+
 	/// <summary>
 	/// Append a new tabbed line.
 	/// </summary>
@@ -242,7 +242,7 @@ abstract class TabbedWriter<T> : IDisposable, IAsyncDisposable where T : TextWri
 		return this;
 	}
 #endif
-	
+
 	/// <summary>
 	/// Append a new raw literal by prepending the correct indentation.
 	/// </summary>
@@ -327,7 +327,7 @@ abstract class TabbedWriter<T> : IDisposable, IAsyncDisposable where T : TextWri
 		}
 		return CreateBlock (array [^1], block);
 	}
-	
+
 	public virtual void Close ()
 	{
 		// if we are closing, and it is a block, we need to close the block
@@ -338,7 +338,7 @@ abstract class TabbedWriter<T> : IDisposable, IAsyncDisposable where T : TextWri
 		}
 		Writer.Flush ();
 	}
-	
+
 	public virtual async Task CloseAsync ()
 	{
 		// if we are closing, and it is a block, we need to close the block
@@ -365,7 +365,7 @@ abstract class TabbedWriter<T> : IDisposable, IAsyncDisposable where T : TextWri
 		GC.SuppressFinalize (this);
 	}
 
-	public async ValueTask DisposeAsync()
+	public async ValueTask DisposeAsync ()
 	{
 		if (indentationSemaphore is IAsyncDisposable indentationSemaphoreAsyncDisposable)
 			await indentationSemaphoreAsyncDisposable.DisposeAsync ();

--- a/src/rgen/Microsoft.Macios.Transformer/IO/TabbedStreamWriter.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/IO/TabbedStreamWriter.cs
@@ -7,14 +7,14 @@ class TabbedStreamWriter : TabbedWriter<StreamWriter> {
 	readonly string path;
 	TabbedStreamWriter? parent;
 
-	TabbedStreamWriter (string filePath, FileMode mode, FileAccess access, FileShare share, 
+	TabbedStreamWriter (string filePath, FileMode mode, FileAccess access, FileShare share,
 		int currentCount = 0, bool block = false)
 		: base (new StreamWriter (new FileStream (filePath, mode, access, share)), currentCount, block)
 	{
 		// keep track of the path we are writing to
 		path = filePath;
 	}
-	
+
 	public TabbedStreamWriter (string filePath, int currentCount = 0, bool block = false)
 		: this (filePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite, currentCount, block) { }
 
@@ -54,17 +54,17 @@ class TabbedStreamWriter : TabbedWriter<StreamWriter> {
 		parent?.InnerWriter.BaseStream.Seek (0, SeekOrigin.End);
 		parent = null;
 	}
-	
+
 	public override void Close ()
 	{
-		base.Close();
+		base.Close ();
 		// if we have a parent, move the stream to the end
 		SyncParent ();
 	}
 
 	public override async Task CloseAsync ()
 	{
-		await base.CloseAsync();
+		await base.CloseAsync ();
 		SyncParent ();
 	}
 }

--- a/src/rgen/Microsoft.Macios.Transformer/IO/TabbedStreamWriter.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/IO/TabbedStreamWriter.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Macios.Generator.IO;
+
+class TabbedStreamWriter : TabbedWriter<StreamWriter> {
+	readonly string path;
+	TabbedStreamWriter? parent;
+
+	TabbedStreamWriter (string filePath, FileMode mode, FileAccess access, FileShare share, 
+		int currentCount = 0, bool block = false)
+		: base (new StreamWriter (new FileStream (filePath, mode, access, share)), currentCount, block)
+	{
+		// keep track of the path we are writing to
+		path = filePath;
+	}
+	
+	public TabbedStreamWriter (string filePath, int currentCount = 0, bool block = false)
+		: this (filePath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite, currentCount, block) { }
+
+	public override TabbedWriter<StreamWriter> CreateBlock (string line, bool block)
+	{
+		// when we create a new block, the first thing we want to do is make sure that
+		// we flush the current writer, so we do not mix the current block with the new one
+		if (!string.IsNullOrEmpty (line)) {
+			Writer.WriteLine (line);
+		}
+		Writer.Flush ();
+
+		// the issue now is that on the dispose method we are going to close and flush the writer, which means that
+		// we cannot use the writer of the parent, else we will have problems because the parent object will be closed.
+		// This means that in this method, it is safe to assume that we are create the tile stream as a read/write stream
+		// in append mode. If the file does not exist, we are ok with an exception.
+		var newBlock = new TabbedStreamWriter (path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite, Writer.Indent,
+			block);
+		// set the parent to point to this stream, this way when we are closed, we can tell it to move fwd
+		newBlock.parent = this;
+		return newBlock;
+	}
+
+	public void Flush ()
+	{
+		Writer.Flush ();
+	}
+
+	public async Task FlushAsync ()
+	{
+		await Writer.FlushAsync ();
+	}
+
+	void SyncParent ()
+	{
+		// if we have a parent, move the stream to the end
+		parent?.InnerWriter.BaseStream.Seek (0, SeekOrigin.End);
+		parent = null;
+	}
+	
+	public override void Close ()
+	{
+		base.Close();
+		// if we have a parent, move the stream to the end
+		SyncParent ();
+	}
+
+	public override async Task CloseAsync ()
+	{
+		await base.CloseAsync();
+		SyncParent ();
+	}
+}

--- a/src/rgen/Microsoft.Macios.Transformer/Microsoft.Macios.Transformer.csproj
+++ b/src/rgen/Microsoft.Macios.Transformer/Microsoft.Macios.Transformer.csproj
@@ -39,10 +39,10 @@
             <Link>CollectionComparer.cs</Link>
         </Compile>
         <Compile Include="../Microsoft.Macios.Generator/IO/TabbedWriter.cs">
-            <Link>TabbedWriter.cs</Link>
+            <Link>IO/TabbedWriter.cs</Link>
         </Compile>
         <Compile Include="../Microsoft.Macios.Generator/IO/TabbedStringBuilder.cs">
-            <Link>TabbedStringBuilder.cs</Link>
+            <Link>IO/TabbedStringBuilder.cs</Link>
         </Compile>
         <Compile Include="../Microsoft.Macios.Generator/Attributes/ObsoletedOSPlatformData.cs">
             <Link>Attributes/ObsoletedOSPlatformData.cs</Link>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/IO/TabbedStringBuilderTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/IO/TabbedStringBuilderTests.cs
@@ -65,7 +65,7 @@ public class TabbedStringBuilderTests {
 		// an empty line should have not tabs
 		Assert.Equal ("\n", result);
 	}
-	
+
 	[Theory]
 	[InlineData (0)]
 	[InlineData (1)]
@@ -112,7 +112,7 @@ public class TabbedStringBuilderTests {
 
 		Assert.Equal ($"{expectedTabs}{{\n{expectedTabs}\t{line}\n{expectedTabs}}}\n", result);
 	}
-	
+
 	[Theory]
 	[InlineData ("// test comment", 0, "")]
 	[InlineData ("var t = 1;", 1, "\t")]
@@ -194,7 +194,7 @@ Because we are using a raw string  we expected:
 
 		Assert.Equal (expected, result);
 	}
-	
+
 	[Theory]
 	[InlineData (0, "")]
 	[InlineData (1, "\t")]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/IO/TabbedStringBuilderTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/IO/TabbedStringBuilderTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Availability;
 using Microsoft.Macios.Generator.IO;
@@ -64,6 +65,22 @@ public class TabbedStringBuilderTests {
 		// an empty line should have not tabs
 		Assert.Equal ("\n", result);
 	}
+	
+	[Theory]
+	[InlineData (0)]
+	[InlineData (1)]
+	[InlineData (5)]
+	public async Task AppendLineTestAsync (int tabCount)
+	{
+		string result;
+		using (var block = new TabbedStringBuilder (sb, tabCount)) {
+			await block.WriteLineAsync ();
+			result = block.ToCode ();
+		}
+
+		// an empty line should have not tabs
+		Assert.Equal ("\n", result);
+	}
 
 	[Theory]
 	[InlineData ("// test comment", 0, "")]
@@ -74,6 +91,21 @@ public class TabbedStringBuilderTests {
 		string result;
 		using (var block = new TabbedStringBuilder (sb, tabCount, true)) {
 			block.WriteLine (line);
+			result = block.ToCode ();
+		}
+
+		Assert.Equal ($"{expectedTabs}{{\n{expectedTabs}\t{line}\n{expectedTabs}}}\n", result);
+	}
+	
+	[Theory]
+	[InlineData ("// test comment", 0, "")]
+	[InlineData ("var t = 1;", 1, "\t")]
+	[InlineData ("Console.WriteLine (\"1\");", 5, "\t\t\t\t\t")]
+	public async Task AppendLineStringTestAsync (string line, int tabCount, string expectedTabs)
+	{
+		string result;
+		using (var block = new TabbedStringBuilder (sb, tabCount, true)) {
+			await block.WriteLineAsync (line);
 			result = block.ToCode ();
 		}
 
@@ -126,6 +158,37 @@ Because we are using a raw string  we expected:
 		string result;
 		using (var block = new TabbedStringBuilder (sb, tabCount)) {
 			block.WriteRaw (input);
+			result = block.ToCode ();
+		}
+
+		Assert.Equal (expected, result);
+	}
+	
+	[Theory]
+	[InlineData (0, "")]
+	[InlineData (1, "\t")]
+	[InlineData (5, "\t\t\t\t\t")]
+	public async Task AppendRawTestAsync (int tabCount, string expectedTabs)
+	{
+		var input = @"
+## Raw string
+Because we are using a raw string  we expected:
+  1. The string to be split in lines
+  2. All lines should have the right indentation
+     - This means nested one
+  3. And all lines should have the correct tabs
+";
+		var expected = $@"
+{expectedTabs}## Raw string
+{expectedTabs}Because we are using a raw string  we expected:
+{expectedTabs}  1. The string to be split in lines
+{expectedTabs}  2. All lines should have the right indentation
+{expectedTabs}     - This means nested one
+{expectedTabs}  3. And all lines should have the correct tabs
+";
+		string result;
+		using (var block = new TabbedStringBuilder (sb, tabCount)) {
+			await block.WriteRawAsync (input);
 			result = block.ToCode ();
 		}
 

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/IO/TabbedStreamWriterTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/IO/TabbedStreamWriterTests.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Macios.Transformer.Tests.IO;
 
 public class TabbedStreamWriterTests : IDisposable {
 	readonly string tempFile = Path.GetTempFileName ();
-	
+
 	public void Dispose ()
 	{
 		if (File.Exists (tempFile))
@@ -31,7 +31,7 @@ public class TabbedStreamWriterTests : IDisposable {
 		}
 		Assert.Equal ($"{expectedTabs}Test\n", ReadFile ());
 	}
-	
+
 	[Theory]
 	[InlineData (0, "")]
 	[InlineData (1, "\t")]
@@ -44,7 +44,7 @@ public class TabbedStreamWriterTests : IDisposable {
 
 		Assert.Equal ($"{expectedTabs}{{\n{expectedTabs}\tTest\n{expectedTabs}}}\n", ReadFile ());
 	}
-	
+
 	[Fact]
 	public void ConstructorBlockNestedTest ()
 	{
@@ -81,7 +81,7 @@ using (var test2 = new Test ())
 ";
 		Assert.Equal (expectedResult, ReadFile ());
 	}
-	
+
 	[Fact]
 	public async Task ConstructorBlockNestedAsyncTest ()
 	{

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/IO/TabbedStreamWriterTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/IO/TabbedStreamWriterTests.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Macios.Generator.IO;
+
+namespace Microsoft.Macios.Transformer.Tests.IO;
+
+public class TabbedStreamWriterTests : IDisposable {
+	readonly string tempFile = Path.GetTempFileName ();
+	
+	public void Dispose ()
+	{
+		if (File.Exists (tempFile))
+			File.Delete (tempFile);
+	}
+
+	string ReadFile ()
+	{
+		using var reader = new StreamReader (tempFile);
+		return reader.ReadToEnd ();
+	}
+
+	[Theory]
+	[InlineData (0, "")]
+	[InlineData (1, "\t")]
+	[InlineData (5, "\t\t\t\t\t")]
+	public void ConstructorNotBlockTest (int tabCount, string expectedTabs)
+	{
+		using (var block = new TabbedStreamWriter (tempFile, tabCount)) {
+			block.WriteLine ("Test");
+		}
+		Assert.Equal ($"{expectedTabs}Test\n", ReadFile ());
+	}
+	
+	[Theory]
+	[InlineData (0, "")]
+	[InlineData (1, "\t")]
+	[InlineData (5, "\t\t\t\t\t")]
+	public void ConstructorBlockTest (int tabCount, string expectedTabs)
+	{
+		using (var block = new TabbedStreamWriter (tempFile, tabCount, true)) {
+			block.WriteLine ("Test");
+		}
+
+		Assert.Equal ($"{expectedTabs}{{\n{expectedTabs}\tTest\n{expectedTabs}}}\n", ReadFile ());
+	}
+	
+	[Fact]
+	public void ConstructorBlockNestedTest ()
+	{
+		using (var block = new TabbedStreamWriter (tempFile, 0, false)) {
+			block.WriteLine ("// create the first block");
+			using (var block2 = block.CreateBlock ("using (var test1 = new Test ())", true)) {
+				block2.WriteLine ("// call in first block");
+			}
+			block.WriteLine ();
+			block.WriteLine ("// create second block");
+			using (var block3 = block.CreateBlock ("using (var test2 = new Test ())", true)) {
+				block3.WriteLine ("// create nested block");
+				using (var block4 = block3.CreateBlock ("using (var test3 = new Test ())", true)) {
+					block4.WriteLine ("// code inside test2.test3");
+				}
+			}
+		}
+
+		const string expectedResult = @"// create the first block
+using (var test1 = new Test ())
+{
+	// call in first block
+}
+
+// create second block
+using (var test2 = new Test ())
+{
+	// create nested block
+	using (var test3 = new Test ())
+	{
+		// code inside test2.test3
+	}
+}
+";
+		Assert.Equal (expectedResult, ReadFile ());
+	}
+	
+	[Fact]
+	public async Task ConstructorBlockNestedAsyncTest ()
+	{
+		await using (var block = new TabbedStreamWriter (tempFile, 0, false)) {
+			await block.WriteLineAsync ("// create the first block");
+			await using (var block2 = block.CreateBlock ("using (var test1 = new Test ())", true)) {
+				await block2.WriteLineAsync ("// call in first block");
+			}
+			await block.WriteLineAsync ();
+			await block.WriteLineAsync ("// create second block");
+			await using (var block3 = block.CreateBlock ("using (var test2 = new Test ())", true)) {
+				await block3.WriteLineAsync ("// create nested block");
+				await using (var block4 = block3.CreateBlock ("using (var test3 = new Test ())", true)) {
+					await block4.WriteLineAsync ("// code inside test2.test3");
+				}
+			}
+		}
+
+		const string expectedResult = @"// create the first block
+using (var test1 = new Test ())
+{
+	// call in first block
+}
+
+// create second block
+using (var test2 = new Test ())
+{
+	// create nested block
+	using (var test3 = new Test ())
+	{
+		// code inside test2.test3
+	}
+}
+";
+		Assert.Equal (expectedResult, ReadFile ());
+	}
+}


### PR DESCRIPTION
The transformer can and will write to disk as opposed to the generator which needs to write to a string builder. We implement a file based stream writer that provides the same API plus it allows to perform the async IO for the transformer.