### PR TITLE
Generate IL offsets for code emitted directly to IL via Cecil

### DIFF
--- a/tools/dotnet-linker/CecilExtensions.cs
+++ b/tools/dotnet-linker/CecilExtensions.cs
@@ -52,6 +52,8 @@ namespace Xamarin.Linker {
 
 		public static void GenerateILOffsets(this MethodBody body)
 		{
+			// This does not compute precise offsets, it just assigns a unique number to each instruction
+			// The trimmer relies on unique offsets to identify instructions
 			int instructionOffset = 0;
 			foreach (var instruction in body.Instructions) {
 				instruction.Offset = instructionOffset++;

--- a/tools/dotnet-linker/CecilExtensions.cs
+++ b/tools/dotnet-linker/CecilExtensions.cs
@@ -50,6 +50,14 @@ namespace Xamarin.Linker {
 			return body;
 		}
 
+		public static void GenerateILOffsets(this MethodBody body)
+		{
+			int instructionOffset = 0;
+			foreach (var instruction in body.Instructions) {
+				instruction.Offset = instructionOffset++;
+			}
+		}
+
 		public static void AddRange<T> (this Mono.Collections.Generic.Collection<T> self, IEnumerable<T>? items)
 		{
 			if (items is null)
@@ -124,10 +132,11 @@ namespace Xamarin.Linker {
 		{
 			// Add default ctor that just calls the base ctor
 			var defaultCtor = type.AddMethod (".ctor", MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName, abr.System_Void);
-			defaultCtor.CreateBody (out var il);
+			var body = defaultCtor.CreateBody (out var il);
 			il.Emit (OpCodes.Ldarg_0);
 			il.Emit (OpCodes.Call, abr.System_Object__ctor);
 			il.Emit (OpCodes.Ret);
+			body.GenerateILOffsets();
 			return defaultCtor;
 		}
 

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -379,7 +379,7 @@ namespace Xamarin.Linker {
 
 		public void EmitCallToProxyMethod (MethodDefinition method, MethodDefinition callback, MethodDefinition proxyInterfaceMethod)
 		{
-			_ = callback.CreateBody (out var il);
+			var body = callback.CreateBody (out var il);
 
 			// We don't know the generic parameters of the type we're working with but we know it is a NSObject and it
 			// implements the proxy interface. The generic parameters will be resolved in the proxy method through the v-table.
@@ -396,6 +396,8 @@ namespace Xamarin.Linker {
 
 			il.Emit (OpCodes.Callvirt, proxyInterfaceMethod);
 			il.Emit (OpCodes.Ret);
+
+			body.GenerateILOffsets();		
 		}
 
 		public void EmitCallToExportedMethod (MethodDefinition method, MethodDefinition callback)
@@ -618,6 +620,8 @@ namespace Xamarin.Linker {
 			foreach (var instr in leaveTryInstructions)
 				instr.Operand = leaveTryInstructionOperand;
 			eh.HandlerEnd = (Instruction) leaveEHInstruction.Operand;
+
+			body.GenerateILOffsets();
 		}
 
 		void AddExceptionHandler (ILProcessor il, VariableDefinition? returnVariable, Instruction placeholderNextInstruction, bool isGeneric, out ExceptionHandler eh, out Instruction leaveEHInstruction)
@@ -1380,6 +1384,8 @@ namespace Xamarin.Linker {
 			il.Emit (OpCodes.Call, ctor);
 			il.Emit (OpCodes.Ret);
 
+			body.GenerateILOffsets();
+
 			return clonedCtor;
 		}
 
@@ -1396,8 +1402,9 @@ namespace Xamarin.Linker {
 				registerToggleRef!.IsPublic = false;
 				registerToggleRef!.IsInternalCall = false;
 
-				registerToggleRef!.CreateBody (out var il);
+				var body = registerToggleRef!.CreateBody (out var il);
 				il.Emit (OpCodes.Ret);
+				body.GenerateILOffsets ();
 			}
 		}
 	}


### PR DESCRIPTION
The trimmer has logic which relies on IL Offsets for each instruction to differentiate events from different instructions. If there are two instructions with the same offset it can lead to confusion and eventually failures.

There's more detailed discussion of the problem in https://github.com/dotnet/runtime/issues/110753

This change modifies all the places where the custom steps are generating IL instructions to also generate unique IL offsets for each instruction (the actual values don't matter really).

This should fix the problem in https://github.com/dotnet/runtime/issues/110714