### PR TITLE
[Rgen]Remove duplicated methods after bad merge.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/IO/TabbedWriter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/IO/TabbedWriter.cs
@@ -149,22 +149,6 @@ abstract class TabbedWriter<T> : IDisposable, IAsyncDisposable where T : TextWri
 	}
 
 	/// <summary>
-	/// Append a new tabbed line.
-	/// </summary>
-	/// <param name="line">The line to append.</param>
-	/// <returns>The current builder.</returns>
-	public async Task<TabbedWriter<T>> WriteLineAsync (string line)
-	{
-		if (string.IsNullOrWhiteSpace (line)) {
-			await WriteLineAsync ();
-		} else {
-			await Writer.WriteLineAsync (line);
-		}
-
-		return this;
-	}
-
-	/// <summary>
 	/// Append a new tabbed lien from the span.
 	/// </summary>
 	/// <param name="span">The line to append.</param>
@@ -242,27 +226,6 @@ abstract class TabbedWriter<T> : IDisposable, IAsyncDisposable where T : TextWri
 		return this;
 	}
 #endif
-
-	/// <summary>
-	/// Append a new raw literal by prepending the correct indentation.
-	/// </summary>
-	/// <param name="rawString">The raw string to append.</param>
-	/// <returns>The current builder.</returns>
-	public async Task<TabbedWriter<T>> WriteRawAsync (string rawString)
-	{
-		// we will split the raw string in lines and then append them so that the
-		// tabbing is correct
-		var lines = rawString.Split (['\n'], StringSplitOptions.None);
-		for (var index = 0; index < lines.Length; index++) {
-			var line = lines [index];
-			if (index == lines.Length - 1) {
-				await WriteAsync (line);
-			} else {
-				await WriteLineAsync (line);
-			}
-		}
-		return this;
-	}
 
 	/// <summary>
 	/// Append a new raw literal by prepending the correct indentation.

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/IO/TabbedStringBuilderTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/IO/TabbedStringBuilderTests.cs
@@ -83,22 +83,6 @@ public class TabbedStringBuilderTests {
 	}
 
 	[Theory]
-	[InlineData (0)]
-	[InlineData (1)]
-	[InlineData (5)]
-	public async Task AppendLineTestAsync (int tabCount)
-	{
-		string result;
-		using (var block = new TabbedStringBuilder (sb, tabCount)) {
-			await block.WriteLineAsync ();
-			result = block.ToCode ();
-		}
-
-		// an empty line should have not tabs
-		Assert.Equal ("\n", result);
-	}
-
-	[Theory]
 	[InlineData ("// test comment", 0, "")]
 	[InlineData ("var t = 1;", 1, "\t")]
 	[InlineData ("Console.WriteLine (\"1\");", 5, "\t\t\t\t\t")]
@@ -107,21 +91,6 @@ public class TabbedStringBuilderTests {
 		string result;
 		using (var block = new TabbedStringBuilder (sb, tabCount, true)) {
 			block.WriteLine (line);
-			result = block.ToCode ();
-		}
-
-		Assert.Equal ($"{expectedTabs}{{\n{expectedTabs}\t{line}\n{expectedTabs}}}\n", result);
-	}
-
-	[Theory]
-	[InlineData ("// test comment", 0, "")]
-	[InlineData ("var t = 1;", 1, "\t")]
-	[InlineData ("Console.WriteLine (\"1\");", 5, "\t\t\t\t\t")]
-	public async Task AppendLineStringTestAsync (string line, int tabCount, string expectedTabs)
-	{
-		string result;
-		using (var block = new TabbedStringBuilder (sb, tabCount, true)) {
-			await block.WriteLineAsync (line);
 			result = block.ToCode ();
 		}
 
@@ -189,37 +158,6 @@ Because we are using a raw string  we expected:
 		string result;
 		using (var block = new TabbedStringBuilder (sb, tabCount)) {
 			block.WriteRaw (input);
-			result = block.ToCode ();
-		}
-
-		Assert.Equal (expected, result);
-	}
-
-	[Theory]
-	[InlineData (0, "")]
-	[InlineData (1, "\t")]
-	[InlineData (5, "\t\t\t\t\t")]
-	public async Task AppendRawTestAsync (int tabCount, string expectedTabs)
-	{
-		var input = @"
-## Raw string
-Because we are using a raw string  we expected:
-  1. The string to be split in lines
-  2. All lines should have the right indentation
-     - This means nested one
-  3. And all lines should have the correct tabs
-";
-		var expected = $@"
-{expectedTabs}## Raw string
-{expectedTabs}Because we are using a raw string  we expected:
-{expectedTabs}  1. The string to be split in lines
-{expectedTabs}  2. All lines should have the right indentation
-{expectedTabs}     - This means nested one
-{expectedTabs}  3. And all lines should have the correct tabs
-";
-		string result;
-		using (var block = new TabbedStringBuilder (sb, tabCount)) {
-			await block.WriteRawAsync (input);
 			result = block.ToCode ();
 		}
 


### PR DESCRIPTION
GitHub should have stopped this, it allowed a merge that should have had a clash. Remove the duplicated methods.