### PR TITLE
[RGen] Keep track in the generator if a type needs a stret call.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Constructor.Generator.cs
@@ -25,7 +25,7 @@ readonly partial struct Constructor {
 		// loop over the parameters of the construct since changes on those implies a change in the generated code
 		foreach (var parameter in constructor.Parameters) {
 			var parameterDeclaration = declaration.ParameterList.Parameters [parameter.Ordinal];
-			if (!Parameter.TryCreate (parameter, parameterDeclaration, context.SemanticModel, out var parameterChange))
+			if (!Parameter.TryCreate (parameter, parameterDeclaration, context, out var parameterChange))
 				continue;
 			parametersBucket.Add (parameterChange.Value);
 		}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Method.Generator.cs
@@ -76,7 +76,7 @@ readonly partial struct Method {
 		// loop over the parameters of the construct since changes on those implies a change in the generated code
 		foreach (var parameter in method.Parameters) {
 			var parameterDeclaration = declaration.ParameterList.Parameters [parameter.Ordinal];
-			if (!Parameter.TryCreate (parameter, parameterDeclaration, context.SemanticModel, out var parameterChange))
+			if (!Parameter.TryCreate (parameter, parameterDeclaration, context, out var parameterChange))
 				continue;
 			parametersBucket.Add (parameterChange.Value);
 		}
@@ -90,7 +90,7 @@ readonly partial struct Method {
 		change = new (
 			type: method.ContainingSymbol.ToDisplayString ().Trim (), // we want the full name
 			name: method.Name,
-			returnType: new TypeInfo (method.ReturnType),
+			returnType: new TypeInfo (method.ReturnType, context.Compilation),
 			symbolAvailability: method.GetSupportedPlatforms (),
 			exportMethodData: exportData,
 			attributes: attributes,

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Parameter.Generator.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.Context;
 using Microsoft.Macios.Generator.Extensions;
 
 namespace Microsoft.Macios.Generator.DataModel;
@@ -40,7 +41,7 @@ readonly partial struct Parameter {
 		}
 	}
 
-	public static bool TryCreate (IParameterSymbol symbol, ParameterSyntax declaration, SemanticModel semanticModel,
+	public static bool TryCreate (IParameterSymbol symbol, ParameterSyntax declaration, RootContext context,
 		[NotNullWhen (true)] out Parameter? parameter)
 	{
 		DelegateInfo? delegateInfo = null;
@@ -49,7 +50,7 @@ readonly partial struct Parameter {
 			DelegateInfo.TryCreate (namedTypeSymbol.DelegateInvokeMethod, out delegateInfo);
 		}
 
-		parameter = new (symbol.Ordinal, new (symbol.Type), symbol.Name) {
+		parameter = new (symbol.Ordinal, new (symbol.Type, context.Compilation), symbol.Name) {
 			BindAs = symbol.GetBindFromData (),
 			IsOptional = symbol.IsOptional,
 			IsParams = symbol.IsParams,
@@ -57,7 +58,7 @@ readonly partial struct Parameter {
 			DefaultValue = (symbol.HasExplicitDefaultValue) ? symbol.ExplicitDefaultValue?.ToString () : null,
 			ReferenceKind = symbol.RefKind.ToReferenceKind (),
 			Delegate = delegateInfo,
-			Attributes = declaration.GetAttributeCodeChanges (semanticModel),
+			Attributes = declaration.GetAttributeCodeChanges (context.SemanticModel),
 		};
 		return true;
 	}

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
@@ -200,7 +200,7 @@ readonly partial struct Property {
 
 		change = new (
 			name: memberName,
-			returnType: new (propertySymbol.Type),
+			returnType: new (propertySymbol.Type, context.Compilation),
 			symbolAvailability: propertySupportedPlatforms,
 			attributes: attributes,
 			modifiers: [.. declaration.Modifiers],

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
@@ -12,7 +12,7 @@ readonly partial struct TypeInfo {
 	/// Return if the type represents a wrapped object from the objc world.
 	/// </summary>
 	public bool IsWrapped { get; init; }
-	
+
 	/// <summary>
 	/// True if the type needs to use a stret call.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
@@ -12,13 +12,18 @@ readonly partial struct TypeInfo {
 	/// Return if the type represents a wrapped object from the objc world.
 	/// </summary>
 	public bool IsWrapped { get; init; }
+	
+	/// <summary>
+	/// True if the type needs to use a stret call.
+	/// </summary>
+	public bool NeedsStret { get; init; }
 
 	/// <summary>
 	/// Returns, if the type is an array, if its elements are a wrapped object from the objc world.
 	/// </summary>
 	public bool ArrayElementTypeIsWrapped { get; init; }
 
-	internal TypeInfo (ITypeSymbol symbol) :
+	internal TypeInfo (ITypeSymbol symbol, Compilation compilation) :
 		this (
 			symbol is IArrayTypeSymbol arrayTypeSymbol
 				? arrayTypeSymbol.ElementType.ToDisplayString ()
@@ -33,6 +38,7 @@ readonly partial struct TypeInfo {
 		IsInterface = symbol.TypeKind == TypeKind.Interface;
 		IsNativeIntegerType = symbol.IsNativeIntegerType;
 		IsNativeEnum = symbol.HasAttribute (AttributesNames.NativeEnumAttribute);
+		NeedsStret = symbol.NeedsStret (compilation);
 
 		// data that we can get from the symbol without being INamedType
 		symbol.GetInheritance (


### PR DESCRIPTION
This changes a little the way we create parameters and types because we need the compilation target to know if a type needs a stret call.

We do not use the NeedsStret in the equlas method because that information has not value when we are deciding if a type needs to be regenerated or not by the roslyn code generator.