### PR TITLE
[src] Clean conditional NET code.

### DIFF
--- a/src/CoreVideo/CVBuffer.cs
+++ b/src/CoreVideo/CVBuffer.cs
@@ -35,21 +35,15 @@ using CoreFoundation;
 using ObjCRuntime;
 using Foundation;
 
-#if !NET
-using NativeHandle = System.IntPtr;
-#endif
-
 #nullable enable
 
 namespace CoreVideo {
 
 	// CVBuffer.h
-#if NET
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("tvos")]
-#endif
 	public partial class CVBuffer : NativeObject {
 #if !COREBUILD
 		[Preserve (Conditional = true)]
@@ -93,7 +87,6 @@ namespace CoreVideo {
 			CVBufferRemoveAttachment (Handle, key.Handle);
 		}
 
-#if NET
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
@@ -102,12 +95,6 @@ namespace CoreVideo {
 		[ObsoletedOSPlatform ("tvos15.0")]
 		[ObsoletedOSPlatform ("maccatalyst15.0")]
 		[ObsoletedOSPlatform ("ios15.0")]
-#else
-		[Deprecated (PlatformName.MacOSX, 12, 0)]
-		[Deprecated (PlatformName.iOS, 15, 0)]
-		[Deprecated (PlatformName.TvOS, 15, 0)]
-		[Deprecated (PlatformName.MacCatalyst, 15, 0)]
-#endif
 		[DllImport (Constants.CoreVideoLibrary)]
 		unsafe extern static /* CFTypeRef */ IntPtr CVBufferGetAttachment (/* CVBufferRef */ IntPtr buffer, /* CFStringRef */ IntPtr key, CVAttachmentMode* attachmentMode);
 
@@ -119,16 +106,10 @@ namespace CoreVideo {
 
 		// The new method is the same as the old one but changing the ownership from Get to Copy, so we will use the new version if possible since the
 		// older method has been deprecatd.
-#if NET
 		[SupportedOSPlatform ("tvos15.0")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios15.0")]
 		[SupportedOSPlatform ("maccatalyst")]
-#else
-		[TV (15, 0)]
-		[iOS (15, 0)]
-		[MacCatalyst (15, 0)]
-#endif
 		[DllImport (Constants.CoreVideoLibrary)]
 		unsafe extern static /* CFTypeRef */ IntPtr CVBufferCopyAttachment (/* CVBufferRef */ IntPtr buffer, /* CFStringRef */ IntPtr key, CVAttachmentMode* attachmentMode);
 
@@ -163,7 +144,6 @@ namespace CoreVideo {
 		}
 #endif
 
-#if NET
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
@@ -172,25 +152,13 @@ namespace CoreVideo {
 		[ObsoletedOSPlatform ("tvos15.0")]
 		[ObsoletedOSPlatform ("maccatalyst15.0")]
 		[ObsoletedOSPlatform ("ios15.0")]
-#else
-		[Deprecated (PlatformName.MacOSX, 12, 0)]
-		[Deprecated (PlatformName.iOS, 15, 0)]
-		[Deprecated (PlatformName.TvOS, 15, 0)]
-		[Deprecated (PlatformName.MacCatalyst, 15, 0)]
-#endif
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static /* CFDictionaryRef */ IntPtr CVBufferGetAttachments (/* CVBufferRef */ IntPtr buffer, CVAttachmentMode attachmentMode);
 
-#if NET
 		[SupportedOSPlatform ("tvos15.0")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios15.0")]
 		[SupportedOSPlatform ("maccatalyst")]
-#else
-		[TV (15, 0)]
-		[iOS (15, 0)]
-		[MacCatalyst (15, 0)]
-#endif
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static /* CFDictionaryRef */ IntPtr CVBufferCopyAttachments (/* CVBufferRef */ IntPtr buffer, CVAttachmentMode attachmentMode);
 
@@ -247,29 +215,17 @@ namespace CoreVideo {
 			CVBufferSetAttachments (Handle, theAttachments.Handle, attachmentMode);
 		}
 
-#if NET
 		[SupportedOSPlatform ("ios15.0")]
 		[SupportedOSPlatform ("tvos15.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
-#else
-		[iOS (15, 0)]
-		[TV (15, 0)]
-		[MacCatalyst (15, 0)]
-#endif
 		[DllImport (Constants.CoreVideoLibrary)]
 		static extern byte CVBufferHasAttachment (/* CVBufferRef */ IntPtr buffer, /* CFStringRef */ IntPtr key);
 
-#if NET
 		[SupportedOSPlatform ("ios15.0")]
 		[SupportedOSPlatform ("tvos15.0")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
-#else
-		[iOS (15, 0)]
-		[TV (15, 0)]
-		[MacCatalyst (15, 0)]
-#endif
 		public bool HasAttachment (NSString key)
 		{
 			if (key is null)

--- a/src/WebKit/WKPreferences.cs
+++ b/src/WebKit/WKPreferences.cs
@@ -12,15 +12,10 @@ namespace WebKit {
 
 #if !COREBUILD
 		// we use the attrs of the old property 
-#if NET
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios14.5")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[UnsupportedOSPlatform ("tvos")]
-#else
-		[iOS (14, 5)]
-		[MacCatalyst (14, 5)]
-#endif
 		public bool TextInteractionEnabled {
 			get {
 #if IOS || __MACCATALYST__

--- a/tests/common/MonoTouch.Dialog/Elements.cs
+++ b/tests/common/MonoTouch.Dialog/Elements.cs
@@ -966,8 +966,7 @@ namespace MonoTouch.Dialog {
 		static public CGSize StringSize (this string self, UIFont font)
 		{
 			using (var str = (NSString) self) {
-				return str.GetSizeUsingAttributes (new UIStringAttributes ()
-				{
+				return str.GetSizeUsingAttributes (new UIStringAttributes () {
 					Font = font,
 				});
 			}
@@ -982,11 +981,9 @@ namespace MonoTouch.Dialog {
 
 		static public CGSize StringSize (this NSString self, UIFont font, CGSize constrainedToSize, UILineBreakMode lineBreakMode)
 		{
-			return self.GetBoundingRect (constrainedToSize, NSStringDrawingOptions.UsesLineFragmentOrigin, new UIStringAttributes ()
-			{
+			return self.GetBoundingRect (constrainedToSize, NSStringDrawingOptions.UsesLineFragmentOrigin, new UIStringAttributes () {
 				Font = font,
-				ParagraphStyle = new NSMutableParagraphStyle ()
-				{
+				ParagraphStyle = new NSMutableParagraphStyle () {
 					LineBreakMode = lineBreakMode,
 				},
 			}, null).Size;
@@ -1000,8 +997,7 @@ namespace MonoTouch.Dialog {
 		static public void DrawString (this string self, CGRect rect, UIFont font)
 		{
 			using (var str = (NSString) self) {
-				NSStringDrawing.DrawString (str, rect, new UIStringAttributes ()
-				{
+				NSStringDrawing.DrawString (str, rect, new UIStringAttributes () {
 					Font = font,
 				});
 			}
@@ -1010,11 +1006,9 @@ namespace MonoTouch.Dialog {
 		static public void DrawString (this string self, CGPoint point, float width, UIFont font, UILineBreakMode lineBreakMode)
 		{
 			using (var str = (NSString) self) {
-				NSStringDrawing.DrawString (str, point, new UIStringAttributes ()
-				{
+				NSStringDrawing.DrawString (str, point, new UIStringAttributes () {
 					Font = font,
-					ParagraphStyle = new NSMutableParagraphStyle ()
-					{
+					ParagraphStyle = new NSMutableParagraphStyle () {
 						LineBreakMode = lineBreakMode,
 					},
 				});
@@ -1024,11 +1018,9 @@ namespace MonoTouch.Dialog {
 		static public void DrawString (this string self, CGRect rect, UIFont font, UILineBreakMode lineBreakMode, UITextAlignment alignment)
 		{
 			using (var str = (NSString) self) {
-				NSStringDrawing.DrawString (str, rect, new UIStringAttributes ()
-				{
+				NSStringDrawing.DrawString (str, rect, new UIStringAttributes () {
 					Font = font,
-					ParagraphStyle = new NSMutableParagraphStyle ()
-					{
+					ParagraphStyle = new NSMutableParagraphStyle () {
 						LineBreakMode = lineBreakMode,
 						Alignment = alignment,
 					},

--- a/tests/monotouch-test/DeviceDiscoveryExtension/DDDeviceTest.cs
+++ b/tests/monotouch-test/DeviceDiscoveryExtension/DDDeviceTest.cs
@@ -21,20 +21,20 @@ using UniformTypeIdentifiers;
 using NUnit.Framework;
 
 namespace MonoTouchFixtures.DeviceDiscoveryExtension {
-	
+
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class DDDeviceTest {
-		
+
 		[Test]
 		public void NetworkEndpointTest ()
 		{
-			TestRuntime.AssertXcodeVersion (14,0);
+			TestRuntime.AssertXcodeVersion (14, 0);
 
 			var uuid = Guid.NewGuid ();
 			var endpoint = NWEndpoint.Create ("www.microsoft.com", "https");
 			var device = new DDDevice ("MyDevice", DDDeviceCategory.LaptopComputer, UTType.CreateFromIdentifier ("com.adobe.pdf"), uuid.ToString ());
-			
+
 			device.NetworkEndpoint = endpoint;
 			var tmpEndpoint = device.NetworkEndpoint;
 

--- a/tests/monotouch-test/DeviceDiscoveryUI/DDDevicePickerViewControllerTest.cs
+++ b/tests/monotouch-test/DeviceDiscoveryUI/DDDevicePickerViewControllerTest.cs
@@ -18,11 +18,11 @@ using NUnit.Framework;
 using Xamarin.Utils;
 
 namespace MonoTouchFixtures.DeviceDiscoveryUI {
-	
+
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class DDDevicePickerViewControllerTest {
-		
+
 		const string serviceName = "MyAppService";
 
 		[OneTimeSetUp]
@@ -34,7 +34,7 @@ namespace MonoTouchFixtures.DeviceDiscoveryUI {
 			var browserDescriptor = NWBrowserDescriptor.CreateApplicationServiceName (serviceName);
 			var parameters = NWParameters.CreateApplicationService ();
 			var isSupported = DDDevicePickerViewController.IsSupported (browserDescriptor, parameters);
-			
+
 			// DDDevicePickerViewController seems to work only for devices
 			if (TestRuntime.IsSimulator)
 				Assert.IsFalse (isSupported, "IsSupported");
@@ -51,7 +51,7 @@ namespace MonoTouchFixtures.DeviceDiscoveryUI {
 			var browserDescriptor = NWBrowserDescriptor.CreateApplicationServiceName (serviceName);
 			var parameters = NWParameters.CreateApplicationService ();
 			var isSupported = DDDevicePickerViewController.IsSupported (browserDescriptor, parameters);
-			
+
 			// If this fails, please, double check that MyAppService is registered within the Info.plist
 			// https://developer.apple.com/documentation/bundleresources/information_property_list/nsapplicationservices
 			Assert.IsTrue (isSupported, $"The {serviceName} key might not be registered in the Info.plist.");
@@ -69,11 +69,11 @@ namespace MonoTouchFixtures.DeviceDiscoveryUI {
 			var browserDescriptor = NWBrowserDescriptor.CreateApplicationServiceName (serviceName);
 			var parameters = NWParameters.CreateApplicationService ();
 			var isSupported = DDDevicePickerViewController.IsSupported (browserDescriptor, parameters);
-			
+
 			// If this fails, please, double check that MyAppService is registered within the Info.plist
 			// https://developer.apple.com/documentation/bundleresources/information_property_list/nsapplicationservices
 			Assert.IsTrue (isSupported, $"The {serviceName} key might not be registered in the Info.plist.");
-			
+
 			Assert.DoesNotThrow (() => {
 				var devicePicker = new DDDevicePickerViewController (browserDescriptor, parameters);
 				devicePicker.SetDevicePicker ((endpoint, error) => { });


### PR DESCRIPTION
* Remove all !NET code from these files.
* Autoformat.

These changes focus on conditional NET code that causes formatting to differ
depending on whether NET is defined or not (thus removing any !NET code
unifies code formatting across conditional compilation symbols).

This PR might be easier to view with whitespace changes disabled.