### PR TITLE
[Rgen] Do not allow to convert methods with out/in params to constructors.

### DIFF
--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Method.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Method.Transformer.cs
@@ -97,9 +97,9 @@ readonly partial struct Method {
 	{
 		if (!IsConstructor)
 			return null;
-		
+
 		// do not allow constructors to have ref parameters
-		if (Parameters.Any(p => p.ReferenceKind != ReferenceKind.None))
+		if (Parameters.Any (p => p.ReferenceKind != ReferenceKind.None))
 			return null;
 
 		return new Constructor (this);

--- a/src/rgen/Microsoft.Macios.Transformer/DataModel/Method.Transformer.cs
+++ b/src/rgen/Microsoft.Macios.Transformer/DataModel/Method.Transformer.cs
@@ -94,6 +94,15 @@ readonly partial struct Method {
 	/// </summary>
 	/// <returns>A constructor data model if the method is one in the bindings or null otherwise.</returns>
 	public Constructor? ToConstructor ()
-		=> IsConstructor ? new Constructor (this) : null;
+	{
+		if (!IsConstructor)
+			return null;
+		
+		// do not allow constructors to have ref parameters
+		if (Parameters.Any(p => p.ReferenceKind != ReferenceKind.None))
+			return null;
+
+		return new Constructor (this);
+	}
 
 }

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/DataModel/MethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/DataModel/MethodTests.cs
@@ -12,7 +12,6 @@ using Xamarin.Tests;
 using Xamarin.Utils;
 using static Microsoft.Macios.Generator.Tests.TestDataFactory;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
-using Token = System.CommandLine.Parsing.Token;
 
 namespace Microsoft.Macios.Transformer.Tests.DataModel;
 
@@ -481,6 +480,20 @@ interface AVPlayer {
 						new Parameter (0, ReturnTypeForString (), "name"),
 						new Parameter (1, ReturnTypeForString (isNullable: true), "surname")
 					])
+			];
+			
+			yield return [
+				new Method (
+					type: "MyType",
+					name: "Constructor",
+					returnType: ReturnTypeForVoid (),
+					symbolAvailability: new (),
+					attributes: new (),
+					parameters: [
+						new Parameter (0, ReturnTypeForString (), "name") {ReferenceKind = ReferenceKind.Out},
+						new Parameter (1, ReturnTypeForString (isNullable: true), "surname")
+					]),
+				null!
 			];
 		}
 

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/DataModel/MethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/DataModel/MethodTests.cs
@@ -481,7 +481,7 @@ interface AVPlayer {
 						new Parameter (1, ReturnTypeForString (isNullable: true), "surname")
 					])
 			];
-			
+
 			yield return [
 				new Method (
 					type: "MyType",
@@ -490,7 +490,7 @@ interface AVPlayer {
 					symbolAvailability: new (),
 					attributes: new (),
 					parameters: [
-						new Parameter (0, ReturnTypeForString (), "name") {ReferenceKind = ReferenceKind.Out},
+						new Parameter (0, ReturnTypeForString (), "name") { ReferenceKind = ReferenceKind.Out },
 						new Parameter (1, ReturnTypeForString (isNullable: true), "surname")
 					]),
 				null!


### PR DESCRIPTION

While C# allows to have in/out params for constructors, those are not allowed in the bindings. Do not convert a method to a constructor if it has any other RefKind but None.