### PR TITLE
[ci] Add nightly codeql pipeline

### DIFF
--- a/tools/devops/automation/run-nightly-codeql.yml
+++ b/tools/devops/automation/run-nightly-codeql.yml
@@ -45,7 +45,7 @@ stages:
       displayName: CodeQL 3000 Init
       condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
-    - template: build.yml
+    - template: /tools/devops/automation/templates/build/build.yml
       parameters:
         isPR: false
         repositoryAlias: self

--- a/tools/devops/automation/run-nightly-codeql.yml
+++ b/tools/devops/automation/run-nightly-codeql.yml
@@ -59,6 +59,7 @@ stages:
         keyringPass: $(pass--lab--mac--builder--keychain)
         gitHubToken: $(Github.Token)
         xqaCertPass: $(xqa--certificates--password)
+        use1ES: false
         buildSteps:
           - bash: $(Build.SourcesDirectory)/$(BUILD_REPOSITORY_TITLE)/tools/devops/automation/scripts/bash/build-nugets.sh
             displayName: 'Build Nugets'

--- a/tools/devops/automation/run-nightly-codeql.yml
+++ b/tools/devops/automation/run-nightly-codeql.yml
@@ -11,9 +11,10 @@ schedules:
     - main
 
 parameters:
-- name: commit
+- name: macOSName  # comes from the build agent demand named macOS.Name
+  displayName: Name of the version of macOS to use
   type: string
-  default: HEAD
+  default: 'Sequoia'
 
 resources:
   repositories:
@@ -34,6 +35,13 @@ stages:
   - job: build_nightly_codeql
     displayName: CodeQL
     timeoutInMinutes: 480
+    pool:
+      os: macOS
+      name: $(CIBuildPool)
+      demands:
+        - Agent.OS -equals Darwin
+        - macOS.Name -equals ${{ parameters.macOSName }}
+        - XcodeChannel -equals Stable
     workspace:
       clean: all
     steps:
@@ -47,9 +55,7 @@ stages:
 
     - template: /tools/devops/automation/templates/build/build.yml
       parameters:
-        isPR: false
-        repositoryAlias: self
-        commit: ${{ parameters.commit }}
+        vsdropsPrefix: ${{ variables.vsdropsPrefix }}
         keyringPass: $(pass--lab--mac--builder--keychain)
         gitHubToken: $(Github.Token)
         xqaCertPass: $(xqa--certificates--password)

--- a/tools/devops/automation/run-nightly-codeql.yml
+++ b/tools/devops/automation/run-nightly-codeql.yml
@@ -60,7 +60,7 @@ stages:
 
     - task: CodeQL3000Init@0
       displayName: CodeQL 3000 Init
-      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+      #condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
     - template: /tools/devops/automation/templates/build/build.yml
       parameters:
@@ -69,6 +69,7 @@ stages:
         gitHubToken: $(Github.Token)
         xqaCertPass: $(xqa--certificates--password)
         use1ES: false
+        disableCodeQL: false
         buildSteps:
           - bash: $(Build.SourcesDirectory)/$(BUILD_REPOSITORY_TITLE)/tools/devops/automation/scripts/bash/build-nugets.sh
             displayName: 'Build Nugets'
@@ -83,4 +84,4 @@ stages:
 
     - task: CodeQL3000Finalize@0
       displayName: CodeQL 3000 Finalize
-      condition: and(succeededOrFailed(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+      #condition: and(succeededOrFailed(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))

--- a/tools/devops/automation/run-nightly-codeql.yml
+++ b/tools/devops/automation/run-nightly-codeql.yml
@@ -1,0 +1,70 @@
+# xamarin-macios-nightly-codeql
+
+trigger: none
+pr: none
+
+schedules:
+- cron: "0 5 * * *"
+  displayName: Run daily at 5:00 UTC
+  branches:
+    include:
+    - main
+
+parameters:
+- name: commit
+  type: string
+  default: HEAD
+
+resources:
+  repositories:
+  - repository: yaml-templates
+    type: github
+    name: xamarin/yaml-templates
+    ref: refs/heads/main
+    endpoint: xamarin
+
+variables:
+- template: /tools/devops/automation/templates/variables/common.yml
+
+stages:
+- stage: build_nightly
+  displayName: Build Nightly
+  dependsOn: []
+  jobs:
+  - job: build_nightly_codeql
+    displayName: CodeQL
+    timeoutInMinutes: 480
+    workspace:
+      clean: all
+    steps:
+    - checkout: self
+      clean: true
+      submodules: true
+
+    - task: CodeQL3000Init@0
+      displayName: CodeQL 3000 Init
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+
+    - template: build.yml
+      parameters:
+        isPR: false
+        repositoryAlias: self
+        commit: ${{ parameters.commit }}
+        keyringPass: $(pass--lab--mac--builder--keychain)
+        gitHubToken: $(Github.Token)
+        xqaCertPass: $(xqa--certificates--password)
+        buildSteps:
+          - bash: $(Build.SourcesDirectory)/$(BUILD_REPOSITORY_TITLE)/tools/devops/automation/scripts/bash/build-nugets.sh
+            displayName: 'Build Nugets'
+            condition: and(succeeded(), contains(variables['configuration.BuildNugets'], 'True'))
+            timeoutInMinutes: 360
+
+          - task: PublishPipelineArtifact@1
+            displayName: Publish Build Artifacts
+            inputs:
+              path: $(Build.SourcesDirectory)/package
+              artifact: not-signed-package
+
+    - task: CodeQL3000Finalize@0
+      displayName: CodeQL 3000 Finalize
+      condition: and(succeededOrFailed(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))

--- a/tools/devops/automation/run-nightly-codeql.yml
+++ b/tools/devops/automation/run-nightly-codeql.yml
@@ -23,6 +23,15 @@ resources:
     name: xamarin/yaml-templates
     ref: refs/heads/main
     endpoint: xamarin
+  - repository: maccore
+    type: github
+    name: xamarin/maccore
+    ref: refs/heads/main
+    endpoint: xamarin
+  - repository: macios-adr
+    type: git
+    name: macios-adr
+    ref: refs/heads/main
 
 variables:
 - template: /tools/devops/automation/templates/variables/common.yml

--- a/tools/devops/automation/run-nightly-codeql.yml
+++ b/tools/devops/automation/run-nightly-codeql.yml
@@ -46,7 +46,7 @@ stages:
     timeoutInMinutes: 480
     pool:
       os: macOS
-      name: $(CIBuildPool)
+      name: $(PRBuildPool)
       demands:
         - Agent.OS -equals Darwin
         - macOS.Name -equals ${{ parameters.macOSName }}

--- a/tools/devops/automation/run-nightly-codeql.yml
+++ b/tools/devops/automation/run-nightly-codeql.yml
@@ -48,9 +48,9 @@ stages:
       os: macOS
       name: $(PRBuildPool)
       demands:
-        - Agent.OS -equals Darwin
-        - macOS.Name -equals ${{ parameters.macOSName }}
-        - XcodeChannel -equals Stable
+      - Agent.OS -equals Darwin
+      - macOS.Name -equals ${{ parameters.macOSName }}
+      - XcodeChannel -equals Stable
     workspace:
       clean: all
     steps:
@@ -60,7 +60,7 @@ stages:
 
     - task: CodeQL3000Init@0
       displayName: CodeQL 3000 Init
-      #condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+      # condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
     - template: /tools/devops/automation/templates/build/build.yml
       parameters:
@@ -71,17 +71,17 @@ stages:
         use1ES: false
         disableCodeQL: false
         buildSteps:
-          - bash: $(Build.SourcesDirectory)/$(BUILD_REPOSITORY_TITLE)/tools/devops/automation/scripts/bash/build-nugets.sh
-            displayName: 'Build Nugets'
-            condition: and(succeeded(), contains(variables['configuration.BuildNugets'], 'True'))
-            timeoutInMinutes: 360
+        - bash: $(Build.SourcesDirectory)/$(BUILD_REPOSITORY_TITLE)/tools/devops/automation/scripts/bash/build-nugets.sh
+          displayName: 'Build Nugets'
+          condition: and(succeeded(), contains(variables['configuration.BuildNugets'], 'True'))
+          timeoutInMinutes: 360
 
-          - task: PublishPipelineArtifact@1
-            displayName: Publish Build Artifacts
-            inputs:
-              path: $(Build.SourcesDirectory)/package
-              artifact: not-signed-package
+        - task: PublishPipelineArtifact@1
+          displayName: Publish Build Artifacts
+          inputs:
+            path: $(Build.SourcesDirectory)/package
+            artifact: not-signed-package
 
     - task: CodeQL3000Finalize@0
       displayName: CodeQL 3000 Finalize
-      #condition: and(succeededOrFailed(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+      # condition: and(succeededOrFailed(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -44,6 +44,10 @@ parameters:
     type: boolean
     default: true
 
+- name: disableCodeQL
+  type: boolean
+  default: true
+
 steps:
 
   - template: ../common/checkout.yml
@@ -54,6 +58,7 @@ steps:
 
   - template: ../common/setup.yml
     parameters:
+      disableCodeQL: ${{ parameters.disableCodeQL }}
       keyringPass: ${{ parameters.keyringPass }}
 
   - template: install-certificates.yml@yaml-templates

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -44,9 +44,9 @@ parameters:
     type: boolean
     default: true
 
-- name: disableCodeQL
-  type: boolean
-  default: true
+  - name: disableCodeQL
+    type: boolean
+    default: true
 
 steps:
 

--- a/tools/devops/automation/templates/common/setup.yml
+++ b/tools/devops/automation/templates/common/setup.yml
@@ -1,7 +1,9 @@
 # Template that does all the boiler plate needed to build and execute tests on macOS bots
 
 parameters:
-
+- name: disableCodeQL
+  type: boolean
+  default: true
 - name: keyringPass
   type: string
 
@@ -13,6 +15,7 @@ steps:
 - bash: $(Build.SourcesDirectory)/$(BUILD_REPOSITORY_TITLE)/tools/devops/automation/scripts/disable-codeql-arm64.sh
   displayName: 'Disable CodeQL on arm64'
   name: disableCodeQLOnArm64
+  condition: and(succeeded(), eq('${{ parameters.disableCodeQL }}', 'true'))
 
 - bash: $(Build.SourcesDirectory)/$(BUILD_REPOSITORY_TITLE)/tools/devops/automation/scripts/bash/fix-github-ssh-key.sh
   displayName: 'Fix GitHub SSH host key'


### PR DESCRIPTION
Pipeline: https://dev.azure.com/devdiv/DevDiv/_build?definitionId=25491&_a=summary

A new scheduled pipeline has been added to run CodeQL against scoped build steps.