### PR TITLE
[devops] Increase verbosity when running macOS tests to track down random test failure.

### DIFF
--- a/tools/devops/automation/scripts/run_mac_tests.ps1
+++ b/tools/devops/automation/scripts/run_mac_tests.ps1
@@ -40,7 +40,7 @@ $macTest = @("dontlink", "introspection", "linksdk", "linkall", "monotouch-test"
 foreach ($t in $macTest) {
   $testName = "exec-$t"
   Write-Host "Execution test $testName"
-  make -d -C $testsPath $testName -f packaged-macos-tests.mk
+  make -d -C $testsPath $testName -f packaged-macos-tests.mk V=1
   if ($LastExitCode -eq 0) {
     Write-Host "$t succeeded"
   } else {

--- a/tools/devops/automation/scripts/run_mac_tests.ps1
+++ b/tools/devops/automation/scripts/run_mac_tests.ps1
@@ -29,7 +29,10 @@ $testsPath = "$SourcesDirectory/artifacts/mac-test-package/tests"
 Write-Host "Tests path is $testsPath"
 
 # print enviroment
-dir env:
+env -0 | sort -z | tr '\0' '\n'
+which dotnet
+dotnet --version
+dotnet --info
 
 [System.Collections.Generic.List[string]]$failures = @()
 
@@ -40,6 +43,7 @@ $macTest = @("dontlink", "introspection", "linksdk", "linkall", "monotouch-test"
 foreach ($t in $macTest) {
   $testName = "exec-$t"
   Write-Host "Execution test $testName"
+  Write-Host "make -d -C '$testsPath' $testName -f packaged-macos-tests.mk V=1"
   make -d -C $testsPath $testName -f packaged-macos-tests.mk V=1
   if ($LastExitCode -eq 0) {
     Write-Host "$t succeeded"

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -173,7 +173,7 @@ steps:
 
 - task: UseDotNet@2
   inputs:
-    version: 8.x
+    version: 8.0.405
 
 - pwsh: >-
     $(System.DefaultWorkingDirectory)/$(BUILD_REPOSITORY_TITLE)/tools/devops/automation/scripts/run_mac_tests.ps1


### PR DESCRIPTION
Trying to track down this:

    [...]
    Considering target file `exec-mac-dotnet-x64-dontlink'.
     File `exec-mac-dotnet-x64-dontlink' does not exist.
      Considering target file `../scripts/run-with-timeout/bin/Debug/run-with-timeout.dll'.
       File `../scripts/run-with-timeout/bin/Debug/run-with-timeout.dll' does not exist.
        Considering target file `../scripts/run-with-timeout/run-with-timeout.cs'.
         Looking for an implicit rule for `../scripts/run-with-timeout/run-with-timeout.cs'.
         No implicit rule found for `../scripts/run-with-timeout/run-with-timeout.cs'.
         Finished prerequisites of target file `../scripts/run-with-timeout/run-with-timeout.cs'.
        No need to remake target `../scripts/run-with-timeout/run-with-timeout.cs'.
        Considering target file `../scripts/run-with-timeout/run-with-timeout.csproj'.
         Looking for an implicit rule for `../scripts/run-with-timeout/run-with-timeout.csproj'.
         No implicit rule found for `../scripts/run-with-timeout/run-with-timeout.csproj'.
         Finished prerequisites of target file `../scripts/run-with-timeout/run-with-timeout.csproj'.
        No need to remake target `../scripts/run-with-timeout/run-with-timeout.csproj'.
       Finished prerequisites of target file `../scripts/run-with-timeout/bin/Debug/run-with-timeout.dll'.
      Must remake target `../scripts/run-with-timeout/bin/Debug/run-with-timeout.dll'.
    Putting child 0x600002dd4230 (../scripts/run-with-timeout/bin/Debug/run-with-timeout.dll) PID 29478 on the chain.
    Live child 0x600002dd4230 (../scripts/run-with-timeout/bin/Debug/run-with-timeout.dll) PID 29478
    Reaping losing child 0x600002dd4230 PID 29478
    Removing child 0x600002dd4230 PID 29478 from chain.
    make[1]: *** [../scripts/run-with-timeout/bin/Debug/run-with-timeout.dll] Killed: 9