### PR TITLE
[Rgen] Add factory method to generate the return variable.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
@@ -28,6 +28,11 @@ readonly partial struct TypeInfo {
 	/// </summary>
 	public bool ArrayElementTypeIsWrapped { get; init; }
 
+	/// <summary>
+	/// Get the name of the variable for the type when it is used as a return value.
+	/// </summary>
+	public string ReturnVariableName => "ret"; // nothing fancy for now
+	
 	internal TypeInfo (ITypeSymbol symbol, Compilation compilation) :
 		this (
 			symbol is IArrayTypeSymbol arrayTypeSymbol

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.Generator.cs
@@ -32,7 +32,7 @@ readonly partial struct TypeInfo {
 	/// Get the name of the variable for the type when it is used as a return value.
 	/// </summary>
 	public string ReturnVariableName => "ret"; // nothing fancy for now
-	
+
 	internal TypeInfo (ITypeSymbol symbol, Compilation compilation) :
 		this (
 			symbol is IArrayTypeSymbol arrayTypeSymbol

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.DataModel;
 using Microsoft.Macios.Generator.Extensions;
+using Microsoft.Macios.Generator.Formatters;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 using Parameter = Microsoft.Macios.Generator.DataModel.Parameter;
@@ -669,6 +670,17 @@ static partial class BindingSyntaxFactory {
 			.NormalizeWhitespace (); // no special mono style
 	}
 
+	internal static (string Name, LocalDeclarationStatementSyntax Declaration) GetReturnValueAuxVariable (in TypeInfo returnType)
+	{
+		var typeSyntax = returnType.GetIdentifierSyntax ();
+		var variableName = returnType.ReturnVariableName;
+		// generates Type ret; The GetIdentifierSyntax will ensure that the correct type and nullable annotation is used
+		var declaration = LocalDeclarationStatement (
+			VariableDeclaration (typeSyntax.WithTrailingTrivia (Space))
+				.WithVariables (SingletonSeparatedList (VariableDeclarator (Identifier (variableName)))));
+		return (Name: variableName, Declaration: declaration);
+	}
+
 	/// <summary>
 	/// Returns a using statement or block for a local declaration.
 	///
@@ -689,7 +701,7 @@ static partial class BindingSyntaxFactory {
 	{
 		return declaration.WithUsingKeyword (Token (SyntaxKind.UsingKeyword).WithTrailingTrivia (Space));
 	}
-
+	
 	static string? GetObjCMessageSendMethodName<T> (ExportData<T> exportData,
 		TypeInfo returnType, ImmutableArray<Parameter> parameters, bool isSuper = false, bool isStret = false)
 		where T : Enum

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -701,7 +701,7 @@ static partial class BindingSyntaxFactory {
 	{
 		return declaration.WithUsingKeyword (Token (SyntaxKind.UsingKeyword).WithTrailingTrivia (Space));
 	}
-	
+
 	static string? GetObjCMessageSendMethodName<T> (ExportData<T> exportData,
 		TypeInfo returnType, ImmutableArray<Parameter> parameters, bool isSuper = false, bool isStret = false)
 		where T : Enum

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
@@ -10,6 +9,7 @@ using Microsoft.Macios.Generator.DataModel;
 using Xunit;
 using static Microsoft.Macios.Generator.Emitters.BindingSyntaxFactory;
 using static Microsoft.Macios.Generator.Tests.TestDataFactory;
+using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 
 namespace Microsoft.Macios.Generator.Tests.Emitters;
 
@@ -731,4 +731,75 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 	[ClassData (typeof (TestDataUsingTests))]
 	void UsingTests (LocalDeclarationStatementSyntax declaration, string expectedDeclaration)
 		=> Assert.Equal (expectedDeclaration, Using (declaration).ToString ());
+	
+	class TestDataGetReturnValueAuxVariable : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			yield return [
+				ReturnTypeForBool (),
+				"ret",
+				"bool ret;"
+			];
+			
+			yield return [
+				ReturnTypeForString (),
+				"ret",
+				"string ret;"
+			];
+			
+			yield return [
+				ReturnTypeForString (isNullable: true),
+				"ret",
+				"string? ret;"
+			];
+			
+			yield return [
+				ReturnTypeForNSObject("NSLocale"),
+				"ret",
+				"NSLocale ret;"
+			];
+			
+			yield return [
+				ReturnTypeForNSObject("NSLocale", isNullable: true),
+				"ret",
+				"NSLocale? ret;"
+			];
+			
+			yield return [
+				ReturnTypeForStruct("MyStruct"),
+				"ret",
+				"MyStruct ret;"
+			];
+			
+			yield return [
+				ReturnTypeForArray ("int"),
+				"ret",
+				"int[] ret;"
+			];
+			
+			yield return [
+				ReturnTypeForArray ("int", isNullable: true),
+				"ret",
+				"int[]? ret;"
+			];
+			
+			yield return [
+				ReturnTypeForArray ("int?", isNullable: true),
+				"ret",
+				"int?[]? ret;"
+			];
+			
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[ClassData (typeof (TestDataGetReturnValueAuxVariable))]
+	void GetReturnValueAuxVariableTests (TypeInfo typeInfo, string expectedVariable, string expectedDeclaration)
+	{
+		var (name, declaration) = GetReturnValueAuxVariable (typeInfo);	
+		Assert.Equal (expectedVariable, name);
+		Assert.Equal (expectedDeclaration, declaration.ToString ());
+	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
@@ -731,7 +731,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 	[ClassData (typeof (TestDataUsingTests))]
 	void UsingTests (LocalDeclarationStatementSyntax declaration, string expectedDeclaration)
 		=> Assert.Equal (expectedDeclaration, Using (declaration).ToString ());
-	
+
 	class TestDataGetReturnValueAuxVariable : IEnumerable<object []> {
 		public IEnumerator<object []> GetEnumerator ()
 		{
@@ -740,55 +740,55 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 				"ret",
 				"bool ret;"
 			];
-			
+
 			yield return [
 				ReturnTypeForString (),
 				"ret",
 				"string ret;"
 			];
-			
+
 			yield return [
 				ReturnTypeForString (isNullable: true),
 				"ret",
 				"string? ret;"
 			];
-			
+
 			yield return [
-				ReturnTypeForNSObject("NSLocale"),
+				ReturnTypeForNSObject ("NSLocale"),
 				"ret",
 				"NSLocale ret;"
 			];
-			
+
 			yield return [
-				ReturnTypeForNSObject("NSLocale", isNullable: true),
+				ReturnTypeForNSObject ("NSLocale", isNullable: true),
 				"ret",
 				"NSLocale? ret;"
 			];
-			
+
 			yield return [
-				ReturnTypeForStruct("MyStruct"),
+				ReturnTypeForStruct ("MyStruct"),
 				"ret",
 				"MyStruct ret;"
 			];
-			
+
 			yield return [
 				ReturnTypeForArray ("int"),
 				"ret",
 				"int[] ret;"
 			];
-			
+
 			yield return [
 				ReturnTypeForArray ("int", isNullable: true),
 				"ret",
 				"int[]? ret;"
 			];
-			
+
 			yield return [
 				ReturnTypeForArray ("int?", isNullable: true),
 				"ret",
 				"int?[]? ret;"
 			];
-			
+
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
@@ -798,7 +798,7 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 	[ClassData (typeof (TestDataGetReturnValueAuxVariable))]
 	void GetReturnValueAuxVariableTests (TypeInfo typeInfo, string expectedVariable, string expectedDeclaration)
 	{
-		var (name, declaration) = GetReturnValueAuxVariable (typeInfo);	
+		var (name, declaration) = GetReturnValueAuxVariable (typeInfo);
 		Assert.Equal (expectedVariable, name);
 		Assert.Equal (expectedDeclaration, declaration.ToString ());
 	}


### PR DESCRIPTION
There are some cases in which we need to store the return type of a method/property in a variable before we return it. Create a factory that will return the name of the return variable and its declaration.