### PR TITLE
[CoreVideo/WebKit] Refactor code a bit to unify indentation.

### DIFF
--- a/src/WebKit/WKPreferences.cs
+++ b/src/WebKit/WKPreferences.cs
@@ -19,13 +19,10 @@ namespace WebKit {
 		public bool TextInteractionEnabled {
 			get {
 #if IOS || __MACCATALYST__
-				if (SystemVersion.CheckiOS (15, 0))
-#elif MONOMAC
-				if (SystemVersion.CheckmacOS (12, 0))
+				if (!SystemVersion.CheckiOS (15, 0))
+					return _OldTextInteractionEnabled;
 #endif
 				return _NewGetTextInteractionEnabled ();
-				else
-					return _OldTextInteractionEnabled;
 			}
 			set => _OldTextInteractionEnabled = value;
 		}


### PR DESCRIPTION
* Remove redundant OS version checks (if the OS checked for is earlier than
  the earliest we support).
* Bring CVBuffer.GetAttachment<T> to macOS to unify API across all platforms.
* Rearrange code so that the indentation is the same on all conditional code
  paths (that way code formatters don't fight depending on which conditional
  compilation symbols are defined).