### PR TITLE
[Rgen] Add the selector fields to the generated classes.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Context/BindingContext.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Context/BindingContext.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+using System.Collections.Generic;
 using Microsoft.Macios.Generator.DataModel;
 using Microsoft.Macios.Generator.IO;
 
@@ -16,6 +18,11 @@ readonly struct BindingContext {
 	/// Current code changes for the binding context.
 	/// </summary>
 	public Binding Changes { get; }
+
+	/// <summary>
+	/// Dictionary that contains the names of the selectors that are being used in the generated code.
+	/// </summary>
+	public Dictionary<string, string> SelectorNames { get; } = new ();
 
 	public BindingContext (TabbedStringBuilder builder, Binding changes)
 	{

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
@@ -10,11 +10,12 @@ using Microsoft.CodeAnalysis;
 using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Context;
 using Microsoft.Macios.Generator.DataModel;
+using Microsoft.Macios.Generator.Extensions;
 using Microsoft.Macios.Generator.Formatters;
 using Microsoft.Macios.Generator.IO;
 using ObjCBindings;
-using Property = Microsoft.Macios.Generator.DataModel.Property;
 using static Microsoft.Macios.Generator.Emitters.BindingSyntaxFactory;
+using Property = Microsoft.Macios.Generator.DataModel.Property;
 
 namespace Microsoft.Macios.Generator.Emitters;
 
@@ -206,6 +207,63 @@ return {tempVar};
 		// to be implemented, do not throw or tests will fail.
 	}
 
+	/// <summary>
+	/// Emit the selector fields for the current class. The method will add the fields to the binding context so that
+	/// they can be used later.
+	/// </summary>
+	/// <param name="bindingContext">The current binding context.</param>
+	/// <param name="classBlock">The current class block.</param>
+	void EmitSelectorFields (in BindingContext bindingContext, TabbedWriter<StringWriter> classBlock)
+	{
+		// we will use the binding context to store the name of the selectors so that later other methods can
+		// access them
+		foreach (var method in bindingContext.Changes.Methods) {
+			if (method.ExportMethodData.Selector is null)
+				continue;
+			var selectorName = method.ExportMethodData.GetSelectorFieldName ()!;
+			if (bindingContext.SelectorNames.TryAdd (method.ExportMethodData.Selector, selectorName)) {
+				EmitField (method.ExportMethodData.Selector, selectorName);
+			}
+		}
+
+		// Similar to methods, but with properties is hard because we have a selector for the different 
+		// accessors.
+		//
+		// The accessor.GetSelector method helps to simplify the logic by returning the 
+		// correct selector for the accessor taking the export data from the property into account
+		foreach (var property in bindingContext.Changes.Properties) {
+			if (!property.IsProperty)
+				// ignore fields
+				continue;
+			var getter = property.GetAccessor (AccessorKind.Getter);
+			if (getter is not null) {
+				var selector = getter.Value.GetSelector (property)!;
+				var selectorName = selector.GetSelectorFieldName ();
+				if (bindingContext.SelectorNames.TryAdd (selector, selectorName)) {
+					EmitField (selector, selectorName);
+				}
+			}
+
+			var setter = property.GetAccessor (AccessorKind.Setter);
+			if (setter is not null) {
+				var selector = setter.Value.GetSelector (property)!;
+				var selectorName = selector.GetSelectorFieldName ();
+				if (bindingContext.SelectorNames.TryAdd (selector, selectorName)) {
+					EmitField (selector, selectorName);
+				}
+			}
+		}
+		// helper function that simply writes the necessary fields to the class block.
+		void EmitField (string selector, string selectorName)
+		{
+			classBlock.AppendGeneratedCodeAttribute (optimizable: true);
+			classBlock.WriteLine (GetSelectorStringField (selector, selectorName).ToString ());
+			classBlock.WriteLine (GetSelectorHandleField (selector, selectorName).ToString ());
+			// reading generated code should not be painful, add a space
+			classBlock.WriteLine ();
+		}
+	}
+
 	public bool TryEmit (in BindingContext bindingContext, [NotNullWhen (false)] out ImmutableArray<Diagnostic>? diagnostics)
 	{
 		diagnostics = null;
@@ -234,6 +292,9 @@ return {tempVar};
 		}
 		var modifiers = $"{string.Join (' ', bindingContext.Changes.Modifiers)} ";
 		using (var classBlock = bindingContext.Builder.CreateBlock ($"{(string.IsNullOrWhiteSpace (modifiers) ? string.Empty : modifiers)}class {bindingContext.Changes.Name}", true)) {
+			// emit the fields for the selectors before we register the class or anything
+			EmitSelectorFields (bindingContext, classBlock);
+
 			if (!bindingContext.Changes.IsStatic) {
 				classBlock.AppendGeneratedCodeAttribute (optimizable: true);
 				classBlock.WriteLine ($"static readonly NativeHandle class_ptr = Class.GetHandle (\"{registrationName}\");");

--- a/src/rgen/Microsoft.Macios.Generator/Extensions/ExportDataExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/ExportDataExtensions.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Macios.Generator.Attributes;
+
+namespace Microsoft.Macios.Generator.Extensions;
+
+static class ExportDataExtensions {
+
+	/// <summary>
+	/// Return the selector field name for a given export data.
+	/// </summary>
+	/// <param name="self">The export data whose selector name we want to retrienve.</param>
+	/// <param name="inlineSelectors">Id the selectors are inlined</param>
+	/// <typeparam name="T">The type of export data.</typeparam>
+	/// <returns>The selector handle name or null if it could not be calculated.</returns>
+	public static string? GetSelectorFieldName<T> (this ExportData<T> self, bool inlineSelectors = false) where T : Enum
+		=> self.Selector?.GetSelectorFieldName (inlineSelectors);
+}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
@@ -21,6 +21,98 @@ namespace TestNamespace;
 public partial class PropertyTests
 {
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selCountX = "count";
+	static readonly NativeHandle selCountXHandle = Selector.GetHandle ("count");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selLineSpacingX = "lineSpacing";
+	static readonly NativeHandle selLineSpacingXHandle = Selector.GetHandle ("lineSpacing");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetLineSpacing_X = "setLineSpacing:";
+	static readonly NativeHandle selSetLineSpacing_XHandle = Selector.GetHandle ("setLineSpacing:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSizesX = "sizes";
+	static readonly NativeHandle selSizesXHandle = Selector.GetHandle ("sizes");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selContainsAttachmentsX = "containsAttachments";
+	static readonly NativeHandle selContainsAttachmentsXHandle = Selector.GetHandle ("containsAttachments");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selNameX = "name";
+	static readonly NativeHandle selNameXHandle = Selector.GetHandle ("name");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetName_X = "setName:";
+	static readonly NativeHandle selSetName_XHandle = Selector.GetHandle ("setName:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSurnamesX = "surnames";
+	static readonly NativeHandle selSurnamesXHandle = Selector.GetHandle ("surnames");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetSurnames_X = "setSurnames:";
+	static readonly NativeHandle selSetSurnames_XHandle = Selector.GetHandle ("setSurnames:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selAttributedStringByInflectingStringX = "attributedStringByInflectingString";
+	static readonly NativeHandle selAttributedStringByInflectingStringXHandle = Selector.GetHandle ("attributedStringByInflectingString");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selDelegateX = "delegate";
+	static readonly NativeHandle selDelegateXHandle = Selector.GetHandle ("delegate");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetDelegate_X = "setDelegate:";
+	static readonly NativeHandle selSetDelegate_XHandle = Selector.GetHandle ("setDelegate:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selResultsX = "results";
+	static readonly NativeHandle selResultsXHandle = Selector.GetHandle ("results");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSizeX = "size";
+	static readonly NativeHandle selSizeXHandle = Selector.GetHandle ("size");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selAlphanumericCharacterSetX = "alphanumericCharacterSet";
+	static readonly NativeHandle selAlphanumericCharacterSetXHandle = Selector.GetHandle ("alphanumericCharacterSet");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selLocaleX = "locale";
+	static readonly NativeHandle selLocaleXHandle = Selector.GetHandle ("locale");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetLocale_X = "setLocale:";
+	static readonly NativeHandle selSetLocale_XHandle = Selector.GetHandle ("setLocale:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selIsForPersonMassUseX = "isForPersonMassUse";
+	static readonly NativeHandle selIsForPersonMassUseXHandle = Selector.GetHandle ("isForPersonMassUse");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetForPersonMassUse_X = "setForPersonMassUse:";
+	static readonly NativeHandle selSetForPersonMassUse_XHandle = Selector.GetHandle ("setForPersonMassUse:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selIsLenientX = "isLenient";
+	static readonly NativeHandle selIsLenientXHandle = Selector.GetHandle ("isLenient");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetLenient_X = "setLenient:";
+	static readonly NativeHandle selSetLenient_XHandle = Selector.GetHandle ("setLenient:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selCanDrawX = "canDraw";
+	static readonly NativeHandle selCanDrawXHandle = Selector.GetHandle ("canDraw");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetCanDraw_X = "setCanDraw:";
+	static readonly NativeHandle selSetCanDraw_XHandle = Selector.GetHandle ("setCanDraw:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	static readonly NativeHandle class_ptr = Class.GetHandle ("PropertyTests");
 
 	public override NativeHandle ClassHandle => class_ptr;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
@@ -21,6 +21,98 @@ namespace TestNamespace;
 public partial class PropertyTests
 {
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selCountX = "count";
+	static readonly NativeHandle selCountXHandle = Selector.GetHandle ("count");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selLineSpacingX = "lineSpacing";
+	static readonly NativeHandle selLineSpacingXHandle = Selector.GetHandle ("lineSpacing");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetLineSpacing_X = "setLineSpacing:";
+	static readonly NativeHandle selSetLineSpacing_XHandle = Selector.GetHandle ("setLineSpacing:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSizesX = "sizes";
+	static readonly NativeHandle selSizesXHandle = Selector.GetHandle ("sizes");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selContainsAttachmentsX = "containsAttachments";
+	static readonly NativeHandle selContainsAttachmentsXHandle = Selector.GetHandle ("containsAttachments");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selNameX = "name";
+	static readonly NativeHandle selNameXHandle = Selector.GetHandle ("name");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetName_X = "setName:";
+	static readonly NativeHandle selSetName_XHandle = Selector.GetHandle ("setName:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSurnamesX = "surnames";
+	static readonly NativeHandle selSurnamesXHandle = Selector.GetHandle ("surnames");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetSurnames_X = "setSurnames:";
+	static readonly NativeHandle selSetSurnames_XHandle = Selector.GetHandle ("setSurnames:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selAttributedStringByInflectingStringX = "attributedStringByInflectingString";
+	static readonly NativeHandle selAttributedStringByInflectingStringXHandle = Selector.GetHandle ("attributedStringByInflectingString");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selDelegateX = "delegate";
+	static readonly NativeHandle selDelegateXHandle = Selector.GetHandle ("delegate");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetDelegate_X = "setDelegate:";
+	static readonly NativeHandle selSetDelegate_XHandle = Selector.GetHandle ("setDelegate:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selResultsX = "results";
+	static readonly NativeHandle selResultsXHandle = Selector.GetHandle ("results");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSizeX = "size";
+	static readonly NativeHandle selSizeXHandle = Selector.GetHandle ("size");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selAlphanumericCharacterSetX = "alphanumericCharacterSet";
+	static readonly NativeHandle selAlphanumericCharacterSetXHandle = Selector.GetHandle ("alphanumericCharacterSet");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selLocaleX = "locale";
+	static readonly NativeHandle selLocaleXHandle = Selector.GetHandle ("locale");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetLocale_X = "setLocale:";
+	static readonly NativeHandle selSetLocale_XHandle = Selector.GetHandle ("setLocale:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selIsForPersonMassUseX = "isForPersonMassUse";
+	static readonly NativeHandle selIsForPersonMassUseXHandle = Selector.GetHandle ("isForPersonMassUse");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetForPersonMassUse_X = "setForPersonMassUse:";
+	static readonly NativeHandle selSetForPersonMassUse_XHandle = Selector.GetHandle ("setForPersonMassUse:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selIsLenientX = "isLenient";
+	static readonly NativeHandle selIsLenientXHandle = Selector.GetHandle ("isLenient");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetLenient_X = "setLenient:";
+	static readonly NativeHandle selSetLenient_XHandle = Selector.GetHandle ("setLenient:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selCanDrawX = "canDraw";
+	static readonly NativeHandle selCanDrawXHandle = Selector.GetHandle ("canDraw");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetCanDraw_X = "setCanDraw:";
+	static readonly NativeHandle selSetCanDraw_XHandle = Selector.GetHandle ("setCanDraw:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	static readonly NativeHandle class_ptr = Class.GetHandle ("PropertyTests");
 
 	public override NativeHandle ClassHandle => class_ptr;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
@@ -21,6 +21,98 @@ namespace TestNamespace;
 public partial class PropertyTests
 {
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selCountX = "count";
+	static readonly NativeHandle selCountXHandle = Selector.GetHandle ("count");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selLineSpacingX = "lineSpacing";
+	static readonly NativeHandle selLineSpacingXHandle = Selector.GetHandle ("lineSpacing");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetLineSpacing_X = "setLineSpacing:";
+	static readonly NativeHandle selSetLineSpacing_XHandle = Selector.GetHandle ("setLineSpacing:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSizesX = "sizes";
+	static readonly NativeHandle selSizesXHandle = Selector.GetHandle ("sizes");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selContainsAttachmentsX = "containsAttachments";
+	static readonly NativeHandle selContainsAttachmentsXHandle = Selector.GetHandle ("containsAttachments");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selNameX = "name";
+	static readonly NativeHandle selNameXHandle = Selector.GetHandle ("name");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetName_X = "setName:";
+	static readonly NativeHandle selSetName_XHandle = Selector.GetHandle ("setName:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSurnamesX = "surnames";
+	static readonly NativeHandle selSurnamesXHandle = Selector.GetHandle ("surnames");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetSurnames_X = "setSurnames:";
+	static readonly NativeHandle selSetSurnames_XHandle = Selector.GetHandle ("setSurnames:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selAttributedStringByInflectingStringX = "attributedStringByInflectingString";
+	static readonly NativeHandle selAttributedStringByInflectingStringXHandle = Selector.GetHandle ("attributedStringByInflectingString");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selDelegateX = "delegate";
+	static readonly NativeHandle selDelegateXHandle = Selector.GetHandle ("delegate");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetDelegate_X = "setDelegate:";
+	static readonly NativeHandle selSetDelegate_XHandle = Selector.GetHandle ("setDelegate:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selResultsX = "results";
+	static readonly NativeHandle selResultsXHandle = Selector.GetHandle ("results");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSizeX = "size";
+	static readonly NativeHandle selSizeXHandle = Selector.GetHandle ("size");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selAlphanumericCharacterSetX = "alphanumericCharacterSet";
+	static readonly NativeHandle selAlphanumericCharacterSetXHandle = Selector.GetHandle ("alphanumericCharacterSet");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selLocaleX = "locale";
+	static readonly NativeHandle selLocaleXHandle = Selector.GetHandle ("locale");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetLocale_X = "setLocale:";
+	static readonly NativeHandle selSetLocale_XHandle = Selector.GetHandle ("setLocale:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selIsForPersonMassUseX = "isForPersonMassUse";
+	static readonly NativeHandle selIsForPersonMassUseXHandle = Selector.GetHandle ("isForPersonMassUse");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetForPersonMassUse_X = "setForPersonMassUse:";
+	static readonly NativeHandle selSetForPersonMassUse_XHandle = Selector.GetHandle ("setForPersonMassUse:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selIsLenientX = "isLenient";
+	static readonly NativeHandle selIsLenientXHandle = Selector.GetHandle ("isLenient");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetLenient_X = "setLenient:";
+	static readonly NativeHandle selSetLenient_XHandle = Selector.GetHandle ("setLenient:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selCanDrawX = "canDraw";
+	static readonly NativeHandle selCanDrawXHandle = Selector.GetHandle ("canDraw");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	const string selSetCanDraw_X = "setCanDraw:";
+	static readonly NativeHandle selSetCanDraw_XHandle = Selector.GetHandle ("setCanDraw:");
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	static readonly NativeHandle class_ptr = Class.GetHandle ("PropertyTests");
 
 	public override NativeHandle ClassHandle => class_ptr;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryObjCRuntimeTests.cs
@@ -802,4 +802,56 @@ public class BindingSyntaxFactoryObjCRuntimeTests {
 		Assert.Equal (expectedVariable, name);
 		Assert.Equal (expectedDeclaration, declaration.ToString ());
 	}
+
+	class TestDataGetSelectorStringField : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			// selection of example selectors
+			yield return [
+				"RTFDFileWrapperFromRange:documentAttributes:",
+				"selRTFDFileWrapperFromRange_DocumentAttributes_XHandle",
+				"const string selRTFDFileWrapperFromRange_DocumentAttributes_X = \"RTFDFileWrapperFromRange:documentAttributes:\";"
+			];
+
+			yield return [
+				"RTFDFromRange:documentAttributes:",
+				"selRTFDFromRange_DocumentAttributes_XHandle",
+				"const string selRTFDFromRange_DocumentAttributes_X = \"RTFDFromRange:documentAttributes:\";"
+			];
+
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[ClassData (typeof (TestDataGetSelectorStringField))]
+	void GetSelectorStringFieldTest (string selector, string selectorName, string expectedDeclaration)
+		=> Assert.Equal (expectedDeclaration, GetSelectorStringField (selector, selectorName).ToString ());
+
+	class TestDataGetSelectorHandleField : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			// selection of example selectors
+			yield return [
+				"RTFDFileWrapperFromRange:documentAttributes:",
+				"selRTFDFileWrapperFromRange_DocumentAttributes_XHandle",
+				"static readonly NativeHandle selRTFDFileWrapperFromRange_DocumentAttributes_XHandle = Selector.GetHandle (\"RTFDFileWrapperFromRange:documentAttributes:\");"
+			];
+
+			yield return [
+				"RTFDFromRange:documentAttributes:",
+				"selRTFDFromRange_DocumentAttributes_XHandle",
+				"static readonly NativeHandle selRTFDFromRange_DocumentAttributes_XHandle = Selector.GetHandle (\"RTFDFromRange:documentAttributes:\");"
+			];
+
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[ClassData (typeof (TestDataGetSelectorHandleField))]
+	void GetSelectorHandleFieldTest (string selector, string selectorName, string expectedDeclaration)
+		=> Assert.Equal (expectedDeclaration, GetSelectorHandleField (selector, selectorName).ToString ());
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/ExportDataExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/ExportDataExtensionsTests.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma warning disable APL0003
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Macios.Generator.Attributes;
+using Microsoft.Macios.Generator.Extensions;
+using Xunit;
+
+namespace Microsoft.Macios.Generator.Tests.Extensions;
+
+public class ExportDataExtensionsTests {
+	class TestDataGetSelectorName : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			// selection of example selectors
+			yield return [
+				new ExportData<ObjCBindings.Method> ("RTFDFileWrapperFromRange:documentAttributes:"),
+				"selRTFDFileWrapperFromRange_DocumentAttributes_XHandle",
+				false
+			];
+
+			yield return [
+				new ExportData<ObjCBindings.Method> ("RTFDFileWrapperFromRange:documentAttributes:"),
+				"selRTFDFileWrapperFromRange_DocumentAttributes_",
+				true
+			];
+
+			yield return [
+				new ExportData<ObjCBindings.Method> ("RTFDFromRange:documentAttributes:"),
+				"selRTFDFromRange_DocumentAttributes_XHandle",
+				false
+			];
+
+			yield return [
+				new ExportData<ObjCBindings.Method> ("RTFDFromRange:documentAttributes:"),
+				"selRTFDFromRange_DocumentAttributes_",
+				true
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[ClassData (typeof (TestDataGetSelectorName))]
+	void GetSelectorFieldName (ExportData<ObjCBindings.Method> exportData, string expectedFieldName, bool inline)
+		=> Assert.Equal (expectedFieldName, exportData.GetSelectorFieldName (inline));
+
+}


### PR DESCRIPTION
Ensure that rgen adds the static readonly fields needed for the selectors in a class. We do so by:

1. Keeping track if the selectors in the binding context.
2. Provide the same logic as used by bgen for the field names.
3. Add two new factory methods that will write the local declaration syntaxt for the fields.

We have added tests for:
1. The selector name calculation.
2. The factory methods.
3. Update the expected generated code for a class with propeties.