### PR TITLE
[net10.0] [tests] Ignore NativeAOT tests that are failing due to a dotnet/sdk issue.

### DIFF
--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -2040,6 +2040,7 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.iOS, "iossimulator-x64")]
 		[TestCase (ApplePlatform.MacOSX, "osx-arm64")]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64")]
+		[Ignore ("https://github.com/dotnet/sdk/issues/46790")]
 		public void PublishAotDuringBuild (ApplePlatform platform, string runtimeIdentifiers)
 		{
 			var project = "MySimpleApp";
@@ -2057,6 +2058,7 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.iOS, "ios-arm64")]
 		[TestCase (ApplePlatform.iOS, "iossimulator-arm64")]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
+		[Ignore ("https://github.com/dotnet/sdk/issues/46790")]
 		public void BuildMyNativeAotAppWithTrimAnalysisWarning (ApplePlatform platform, string runtimeIdentifiers)
 		{
 			var project = "MyNativeAotAppWithTrimAnalysisWarning";


### PR DESCRIPTION
Ref: https://github.com/dotnet/sdk/issues/46790