### PR TITLE
[Rgen] Fix a bug  in the ToMarshallType with arrays.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -252,6 +252,9 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 			// structs will use their name
 			{ IsStruct: true, SpecialType: SpecialType.System_Double } => "Double", 
 			{ IsStruct: true } => Name,
+			
+			// arrays
+			{ IsArray: true } => NativeHandle,
 
 			// enums:
 			// IsSmartEnum: We are using a nsstring, so it should be a native handle.

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/GetObjCMessageSendMethodNameTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/GetObjCMessageSendMethodNameTests.cs
@@ -335,7 +335,7 @@ class ARAnchor {
 		string [] IncludedKeys { get; set; }
 }
 ";
-			
+
 			yield return [stringArrayProperty, "NativeHandle_objc_msgSend", "void_objc_msgSend_NativeHandle", false, false];
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/GetObjCMessageSendMethodNameTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/GetObjCMessageSendMethodNameTests.cs
@@ -319,6 +319,24 @@ class ARAnchor {
 ";
 
 			yield return [doubleProperty, "Double_objc_msgSend", "void_objc_msgSend_Double", false, false];
+
+			const string stringArrayProperty = @"
+using System;
+using Foundation;
+using CoreGraphics;
+using ObjCRuntime;
+using ObjCBindings;
+
+namepsace NS;
+
+[BindingType<ObjCBindings.Class>]
+class ARAnchor {
+		[Export<ObjCBindings.Property> (""includedKeys"", ArgumentSemantic.Copy)]
+		string [] IncludedKeys { get; set; }
+}
+";
+			
+			yield return [stringArrayProperty, "NativeHandle_objc_msgSend", "void_objc_msgSend_NativeHandle", false, false];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();


### PR DESCRIPTION
Make sure that the ToMarshallType return a NativeHandle when we are marshalling an array.