### PR TITLE
[Rgen] Fix flacky tests when doing several compilations in parallel.

### DIFF
--- a/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/BaseGeneratorWithAnalyzerTestClass.cs
+++ b/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/BaseGeneratorWithAnalyzerTestClass.cs
@@ -16,7 +16,7 @@ public class BaseGeneratorWithAnalyzerTestClass : BaseGeneratorTestClass {
 	protected Task<ImmutableArray<Diagnostic>> RunAnalyzer<T> (T analyzer, Compilation compilation)
 		where T : DiagnosticAnalyzer
 	{
-		
+
 		var driver = CSharpGeneratorDriver.Create (new BindingSourceGeneratorGenerator ());
 		var compilationWithAnalyzers =
 			// run generators on the compilation

--- a/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/BaseGeneratorWithAnalyzerTestClass.cs
+++ b/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/BaseGeneratorWithAnalyzerTestClass.cs
@@ -3,7 +3,9 @@
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.Macios.Generator;
 using Microsoft.Macios.Generator.Tests;
 using Xunit;
 
@@ -14,9 +16,11 @@ public class BaseGeneratorWithAnalyzerTestClass : BaseGeneratorTestClass {
 	protected Task<ImmutableArray<Diagnostic>> RunAnalyzer<T> (T analyzer, Compilation compilation)
 		where T : DiagnosticAnalyzer
 	{
+		
+		var driver = CSharpGeneratorDriver.Create (new BindingSourceGeneratorGenerator ());
 		var compilationWithAnalyzers =
 			// run generators on the compilation
-			RunGeneratorsAndUpdateCompilation (compilation, out _)
+			RunGeneratorsAndUpdateCompilation (driver, compilation, out _)
 				// attach analyzers
 				.WithAnalyzers (ImmutableArray.Create<DiagnosticAnalyzer> (analyzer));
 		return compilationWithAnalyzers.GetAllDiagnosticsAsync ();

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/BaseGeneratorTestClass.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/BaseGeneratorTestClass.cs
@@ -6,8 +6,10 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Macios.Generator.Extensions;
 using Xamarin.Tests;
 using Xamarin.Utils;
 using Xunit;
@@ -18,8 +20,6 @@ namespace Microsoft.Macios.Generator.Tests;
 /// Base class that allows to test the generator.
 /// </summary>
 public class BaseGeneratorTestClass {
-	protected BindingSourceGeneratorGenerator GeneratorGenerator;
-	protected CSharpGeneratorDriver Driver;
 
 	// list of the defines for each platform, this is passed to the parser to ensure that
 	// we are testing the platforms as if they were being compiled.
@@ -30,20 +30,14 @@ public class BaseGeneratorTestClass {
 		{ TargetFramework.DotNet_MacCatalyst, new [] { "__MACCATALYST__" } },
 	};
 
-	public BaseGeneratorTestClass ()
+	protected Compilation RunGeneratorsAndUpdateCompilation (CSharpGeneratorDriver driver, Compilation compilation, out ImmutableArray<Diagnostic> diagnostics)
 	{
-		GeneratorGenerator = new BindingSourceGeneratorGenerator ();
-		Driver = CSharpGeneratorDriver.Create (GeneratorGenerator);
-	}
-
-	protected Compilation RunGeneratorsAndUpdateCompilation (Compilation compilation, out ImmutableArray<Diagnostic> diagnostics)
-	{
-		Driver.RunGeneratorsAndUpdateCompilation (compilation, out var updatedCompilation, out diagnostics);
+		driver.RunGeneratorsAndUpdateCompilation (compilation, out var updatedCompilation, out diagnostics);
 		return updatedCompilation;
 	}
 
-	protected GeneratorDriverRunResult RunGenerators (Compilation compilation)
-		=> Driver.RunGenerators (compilation).GetRunResult ();
+	GeneratorDriverRunResult RunGenerators (CSharpGeneratorDriver driver, Compilation compilation)
+		=> driver.RunGenerators (compilation).GetRunResult ();
 
 	protected IEnumerable<string> GetPlatformDefines (TargetFramework targetFramework)
 	{
@@ -85,26 +79,34 @@ public class BaseGeneratorTestClass {
 
 		return new (CSharpCompilation.Create (name, trees, references, options), trees);
 	}
-
+	
+	readonly static Lock uiNamespaceLock = new ();
 	protected void CompareGeneratedCode (ApplePlatform platform, string className, string inputFileName, string inputText, string outputFileName, string expectedOutputText, string? expectedLibraryText)
 	{
-		// We need to create a compilation with the required source code.
-		var (compilation, _) = CreateCompilation (platform, sources: inputText);
+		lock (uiNamespaceLock) {
+			var driver = CSharpGeneratorDriver.Create (new BindingSourceGeneratorGenerator ());
+			// We need to create a compilation with the required source code.
+			var (compilation, _) = CreateCompilation (platform, sources: inputText);
+			// for the refresh of the namespaces, this is needed to make sure that the generator does not get confused
+			// when several compilations are running
+			compilation.GetUINamespaces (force: true);
 
-		// Run generators and retrieve all results.
-		var runResult = RunGenerators (compilation);
+			// Run generators and retrieve all results.
+			var runResult = RunGenerators (driver, compilation);
 
-		// All generated files can be found in 'RunResults.GeneratedTrees'.
-		var generatedFileSyntax = runResult.GeneratedTrees.Single (t => t.FilePath.EndsWith ($"{className}.g.cs"));
+			// All generated files can be found in 'RunResults.GeneratedTrees'.
+			var generatedFileSyntax = runResult.GeneratedTrees.Where(t => t.FilePath.EndsWith ($"{className}.g.cs")).ToArray ();
+			Assert.Single (generatedFileSyntax);
 
-		// Complex generators should be tested using text comparison.
-		Assert.Equal (expectedOutputText, generatedFileSyntax.GetText ().ToString (),
-			ignoreLineEndingDifferences: true);
+			// Complex generators should be tested using text comparison.
+			Assert.Equal (expectedOutputText, generatedFileSyntax[0].GetText ().ToString (),
+				ignoreLineEndingDifferences: true);
 
-		if (expectedLibraryText is not null) {
-			// validate that Library.g.cs was created by the LibraryEmitter and matches the expectation
-			var generatedLibSyntax = runResult.GeneratedTrees.Single (t => t.FilePath.EndsWith ("Libraries.g.cs"));
-			Assert.Equal (expectedLibraryText, generatedLibSyntax.GetText ().ToString ());
+			if (expectedLibraryText is not null) {
+				// validate that Library.g.cs was created by the LibraryEmitter and matches the expectation
+				var generatedLibSyntax = runResult.GeneratedTrees.Single (t => t.FilePath.EndsWith ("Libraries.g.cs"));
+				Assert.Equal (expectedLibraryText, generatedLibSyntax.GetText ().ToString ());
+			}
 		}
 
 	}

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/BaseGeneratorTestClass.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/BaseGeneratorTestClass.cs
@@ -79,7 +79,7 @@ public class BaseGeneratorTestClass {
 
 		return new (CSharpCompilation.Create (name, trees, references, options), trees);
 	}
-	
+
 	readonly static Lock uiNamespaceLock = new ();
 	protected void CompareGeneratedCode (ApplePlatform platform, string className, string inputFileName, string inputText, string outputFileName, string expectedOutputText, string? expectedLibraryText)
 	{
@@ -95,11 +95,11 @@ public class BaseGeneratorTestClass {
 			var runResult = RunGenerators (driver, compilation);
 
 			// All generated files can be found in 'RunResults.GeneratedTrees'.
-			var generatedFileSyntax = runResult.GeneratedTrees.Where(t => t.FilePath.EndsWith ($"{className}.g.cs")).ToArray ();
+			var generatedFileSyntax = runResult.GeneratedTrees.Where (t => t.FilePath.EndsWith ($"{className}.g.cs")).ToArray ();
 			Assert.Single (generatedFileSyntax);
 
 			// Complex generators should be tested using text comparison.
-			Assert.Equal (expectedOutputText, generatedFileSyntax[0].GetText ().ToString (),
+			Assert.Equal (expectedOutputText, generatedFileSyntax [0].GetText ().ToString (),
 				ignoreLineEndingDifferences: true);
 
 			if (expectedLibraryText is not null) {

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/BindingSourceGeneratorGeneratorTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/BindingSourceGeneratorGeneratorTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
 using Xamarin.Tests;
 using Xamarin.Utils;
 using Xunit;
@@ -67,7 +68,8 @@ public partial class AVAudioPcmBuffer
 		var (compilation, _) = CreateCompilation (platform, sources: input);
 
 		// Run generators and retrieve all results.
-		var runResult = Driver.RunGenerators (compilation).GetRunResult ();
+		var driver = CSharpGeneratorDriver.Create (new BindingSourceGeneratorGenerator ());
+		var runResult = driver.RunGenerators (compilation).GetRunResult ();
 		Assert.Empty (runResult.Diagnostics);
 
 		// ensure that we do have all the needed attributes present


### PR DESCRIPTION
The code generation will not run several compilations in memory at the same time, but that does happen in the tests.

We have some flacky tests that happen when we have 2 or more compilation at the same time that have different UI namespaces, for example, a MacOS and a iOS compilation. In the situation of having more than one compilation we have a race condition on the extension method that returns the UI namespaces, this is only a problem during the tests. To workaround it, we won't allow the code generation tests run in parallel.