### PR TITLE
[Rgen] Boolean properties do not need a temp variable.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
@@ -120,8 +120,7 @@ readonly partial struct Property {
 				{ ReturnType: { IsVoid: false, NeedsStret: true } } => true, 
 				{ ReturnType: { IsVoid: false, IsWrapped: true } } => true, 
 				{ ReturnType.IsNativeEnum: true } => true, 
-				{ ReturnType.SpecialType: SpecialType.System_Boolean 
-					or SpecialType.System_Char or SpecialType.System_Delegate } => true, 
+				{ ReturnType.SpecialType: SpecialType.System_Char or SpecialType.System_Delegate } => true, 
 				{ ReturnType.IsDelegate: true } => true,
 				{ ReturnType.IsWrapped: true } => true,
 				// default will be false

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Property.cs
@@ -88,6 +88,9 @@ static partial class BindingSyntaxFactory {
 				{ SpecialType: SpecialType.System_String, IsNullable: false } =>
 					ExpressionStatement (SuppressNullableWarning (StringFromHandle ([Argument (objMsgSend), BoolArgument (false)]))),
 
+				// bool => global::ObjCRuntime.Messaging.bool_objc_msgSend (this.Handle, Selector.GetHandle ("canDraw")) != 0;
+				{ SpecialType: SpecialType.System_Boolean } => ExpressionStatement ( ByteToBool (objMsgSend)),
+				
 				// general case, just return the result of the send message
 				_ => ExpressionStatement (objMsgSend),
 			}; 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
@@ -195,13 +195,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			bool ret;
 			if (IsDirectBinding) {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSend (this.Handle, Selector.GetHandle ("canDraw")) != 0;
 			} else {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSendSuper (this.Handle, Selector.GetHandle ("canDraw")) != 0;
 			}
-			return ret;
 		}
 
 		[SupportedOSPlatform ("macos")]
@@ -227,13 +225,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			bool ret;
 			if (IsDirectBinding) {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSend (this.Handle, Selector.GetHandle ("containsAttachments")) != 0;
 			} else {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSendSuper (this.Handle, Selector.GetHandle ("containsAttachments")) != 0;
 			}
-			return ret;
 		}
 	}
 
@@ -271,13 +267,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			bool ret;
 			if (IsDirectBinding) {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSend (this.Handle, Selector.GetHandle ("isForPersonMassUse")) != 0;
 			} else {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSendSuper (this.Handle, Selector.GetHandle ("isForPersonMassUse")) != 0;
 			}
-			return ret;
 		}
 
 		[SupportedOSPlatform ("macos")]
@@ -303,13 +297,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			bool ret;
 			if (IsDirectBinding) {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSend (this.Handle, Selector.GetHandle ("isLenient")) != 0;
 			} else {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSendSuper (this.Handle, Selector.GetHandle ("isLenient")) != 0;
 			}
-			return ret;
 		}
 
 		[SupportedOSPlatform ("macos")]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
@@ -195,13 +195,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			bool ret;
 			if (IsDirectBinding) {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSend (this.Handle, Selector.GetHandle ("canDraw")) != 0;
 			} else {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSendSuper (this.Handle, Selector.GetHandle ("canDraw")) != 0;
 			}
-			return ret;
 		}
 
 		[SupportedOSPlatform ("macos")]
@@ -227,13 +225,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			bool ret;
 			if (IsDirectBinding) {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSend (this.Handle, Selector.GetHandle ("containsAttachments")) != 0;
 			} else {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSendSuper (this.Handle, Selector.GetHandle ("containsAttachments")) != 0;
 			}
-			return ret;
 		}
 	}
 
@@ -271,13 +267,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			bool ret;
 			if (IsDirectBinding) {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSend (this.Handle, Selector.GetHandle ("isForPersonMassUse")) != 0;
 			} else {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSendSuper (this.Handle, Selector.GetHandle ("isForPersonMassUse")) != 0;
 			}
-			return ret;
 		}
 
 		[SupportedOSPlatform ("macos")]
@@ -303,13 +297,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			bool ret;
 			if (IsDirectBinding) {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSend (this.Handle, Selector.GetHandle ("isLenient")) != 0;
 			} else {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSendSuper (this.Handle, Selector.GetHandle ("isLenient")) != 0;
 			}
-			return ret;
 		}
 
 		[SupportedOSPlatform ("macos")]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
@@ -195,13 +195,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			bool ret;
 			if (IsDirectBinding) {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSend (this.Handle, Selector.GetHandle ("canDraw")) != 0;
 			} else {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSendSuper (this.Handle, Selector.GetHandle ("canDraw")) != 0;
 			}
-			return ret;
 		}
 
 		[SupportedOSPlatform ("macos")]
@@ -227,13 +225,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			bool ret;
 			if (IsDirectBinding) {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSend (this.Handle, Selector.GetHandle ("containsAttachments")) != 0;
 			} else {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSendSuper (this.Handle, Selector.GetHandle ("containsAttachments")) != 0;
 			}
-			return ret;
 		}
 	}
 
@@ -271,13 +267,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			bool ret;
 			if (IsDirectBinding) {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSend (this.Handle, Selector.GetHandle ("isForPersonMassUse")) != 0;
 			} else {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSendSuper (this.Handle, Selector.GetHandle ("isForPersonMassUse")) != 0;
 			}
-			return ret;
 		}
 
 		[SupportedOSPlatform ("macos")]
@@ -303,13 +297,11 @@ public partial class PropertyTests
 		[SupportedOSPlatform ("maccatalyst13.1")]
 		get
 		{
-			bool ret;
 			if (IsDirectBinding) {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSend (this.Handle, Selector.GetHandle ("isLenient")) != 0;
 			} else {
-				ret = throw new NotImplementedException();
+				return global::ObjCRuntime.Messaging.bool_objc_msgSendSuper (this.Handle, Selector.GetHandle ("isLenient")) != 0;
 			}
-			return ret;
 		}
 
 		[SupportedOSPlatform ("macos")]

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/NeedsTempReturnTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/DataModel/PropertyTests/NeedsTempReturnTests.cs
@@ -61,7 +61,7 @@ public class TestClass {
 ";
 			yield return [
 				boolProperty,
-				true
+				false
 			];
 
 			const string charProperty = @"

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryPropertyTests.cs
@@ -63,7 +63,6 @@ public class BindingSyntaxFactoryPropertyTests {
 				ExportPropertyData = new ("myProperty", ArgumentSemantic.None, ObjCBindings.Property.IsThreadSafe)
 			};
 
-
 			yield return [
 				property,
 				"CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, Selector.GetHandle (\"myProperty\")), false);",
@@ -168,6 +167,31 @@ public class BindingSyntaxFactoryPropertyTests {
 				property,
 				"global::ObjCRuntime.Messaging.uint_objc_msgSend (this.Handle, Selector.GetHandle (\"myProperty\"));",
 				"global::ObjCRuntime.Messaging.uint_objc_msgSendSuper (this.Handle, Selector.GetHandle (\"myProperty\"));"
+			];
+
+			property = new Property (
+				name: "MyProperty",
+				returnType: ReturnTypeForBool (),
+				symbolAvailability: new (),
+				attributes: [],
+				modifiers: [],
+				accessors: [
+					new (
+						accessorKind: AccessorKind.Getter,
+						symbolAvailability: new (),
+						exportPropertyData: null,
+						attributes: [],
+						modifiers: []
+					)
+				]
+			) {
+				ExportPropertyData = new ("myProperty", ArgumentSemantic.None, ObjCBindings.Property.IsThreadSafe)
+			};
+
+			yield return [
+				property,
+				"global::ObjCRuntime.Messaging.bool_objc_msgSend (this.Handle, Selector.GetHandle (\"myProperty\")) != 0;",
+				"global::ObjCRuntime.Messaging.bool_objc_msgSendSuper (this.Handle, Selector.GetHandle (\"myProperty\")) != 0;"
 			];
 		}
 


### PR DESCRIPTION
The use of a temp variable in boolean properties was due to a limitation of how bgen wrote the code. We copied the behaviour to make sure we were compatible, yet that was not needed.

This change adds supports to boolean getters in properties without the need of a temp var.