### PR TITLE
[Bgen] Simplify the BindAs generated code.

### DIFF
--- a/src/Foundation/NSNumber2.cs
+++ b/src/Foundation/NSNumber2.cs
@@ -130,93 +130,143 @@ namespace Foundation {
 			return source.BoolValue;
 		}
 
+		/// <summary>
+		/// Convert a NativeHandle to a NSNumber and return its value as a boolean.
+		/// </summary>
+		/// <param name="handle">The NativeHandle to convert.</param>
 		public static bool ToBool (NativeHandle handle)
 		{
 			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.BoolValue;
 		}
 
+		/// <summary>
+		/// Convert a NativeHandle to a NSNumber and return its value as a byte.
+		/// </summary>
+		/// <param name="handle">The NativeHandle to convert.</param>
 		public static byte ToByte (NativeHandle handle)
 		{
 			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.ByteValue;
 		}
 
+		/// <summary>
+		/// Convert a NativeHandle to a NSNumber and return its value as a sbyte.
+		/// </summary>
+		/// <param name="handle">The NativeHandle to convert.</param>
 		public static sbyte ToSByte (NativeHandle handle)
 		{
 			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.SByteValue;
 		}
 
+		/// <summary>
+		/// Convert a NativeHandle to a NSNumber and return its value as a short.
+		/// </summary>
+		/// <param name="handle">The NativeHandle to convert.</param>
 		public static short ToInt16 (NativeHandle handle)
 		{
 			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.Int16Value;
 		}
 
+		/// <summary>
+		/// Convert a NativeHandle to a NSNumber and return its value as a ushort.
+		/// </summary>
+		/// <param name="handle">The NativeHandle to convert.</param>
 		public static ushort ToUInt16 (NativeHandle handle)
 		{
 			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.UInt16Value;
 		}
 
+		/// <summary>
+		/// Convert a NativeHandle to a NSNumber and return its value as an int.
+		/// </summary>
+		/// <param name="handle">The NativeHandle to convert.</param>
 		public static int ToInt32 (NativeHandle handle)
 		{
 			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.Int32Value;
 		}
 
+		/// <summary>
+		/// Convert a NativeHandle to a NSNumber and return its value as a uint.
+		/// </summary>
+		/// <param name="handle">The NativeHandle to convert.</param>
 		public static uint ToUInt32 (NativeHandle handle)
 		{
 			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.UInt32Value;
 		}
 
+		/// <summary>
+		/// Convert a NativeHandle to a NSNumber and return its value as a long.
+		/// </summary>
+		/// <param name="handle">The NativeHandle to convert.</param>
 		public static long ToInt64 (NativeHandle handle)
 		{
 			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.Int64Value;
 		}
 
+		/// <summary>
+		/// Convert a NativeHandle to a NSNumber and return its value as a ulong.
+		/// </summary>
+		/// <param name="handle">The NativeHandle to convert.</param>
 		public static ulong ToUInt64 (NativeHandle handle)
 		{
 			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.UInt64Value;
 		}
 
+		/// <summary>
+		/// Convert a NativeHandle to a NSNumber and return its value as a float.
+		/// </summary>
+		/// <param name="handle">The NativeHandle to convert.</param>
 		public static float ToFloat (NativeHandle handle)
 		{
 			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.FloatValue;
 		}
 
+		/// <summary>
+		/// Convert a NativeHandle to a NSNumber and return its value as a nfloat.
+		/// </summary>
+		/// <param name="handle">The NativeHandle to convert.</param>
 		public static nfloat ToNFloat (NativeHandle handle)
 		{
 			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.NFloatValue;
 		}
 
+		/// <summary>
+		/// Convert a NativeHandle to a NSNumber and return its value as a double.
+		/// </summary>
+		/// <param name="handle">The NativeHandle to convert.</param>
 		public static double ToDouble (NativeHandle handle)
 		{
 			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.DoubleValue;
 		}
 
+		/// <summary>
+		/// Convert a NativeHandle to a NSNumber and return its value as a nint.
+		/// </summary>
+		/// <param name="handle">The NativeHandle to convert.</param>
 		public static nint ToNInt (NativeHandle handle)
 		{
 			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.NIntValue;
 		}
 
+		/// <summary>
+		/// Convert a NativeHandle to a NSNumber and return its value as a nuint.
+		/// </summary>
 		public static nuint ToNUInt (NativeHandle handle)
 		{
 			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.NUIntValue;
-		}
-
-		public static T ToEnum<T> (NativeHandle handle) where T : Enum
-		{
-			return (T) (object) ToInt32 (handle);
 		}
 
 		public NSNumber (nfloat value) :

--- a/src/Foundation/NSNumber2.cs
+++ b/src/Foundation/NSNumber2.cs
@@ -130,6 +130,96 @@ namespace Foundation {
 			return source.BoolValue;
 		}
 
+		public static bool ToBool (NativeHandle handle)
+		{
+			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			return num.BoolValue;
+		}
+		
+		public static byte ToByte (NativeHandle handle)
+		{
+			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			return num.ByteValue;
+		}
+
+		public static sbyte ToSByte (NativeHandle handle)
+		{
+			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			return num.SByteValue;
+		}
+
+		public static short ToInt16 (NativeHandle handle)
+		{
+			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			return num.Int16Value;
+		}
+
+		public static ushort ToUInt16 (NativeHandle handle)
+		{
+			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			return num.UInt16Value;
+		}
+
+		public static int ToInt32 (NativeHandle handle)
+		{
+			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			return num.Int32Value;
+		}
+
+		public static uint ToUInt32 (NativeHandle handle)
+		{
+			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			return num.UInt32Value;
+		}
+
+		public static long ToInt64 (NativeHandle handle)
+		{
+			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			return num.Int64Value;
+		}
+
+		public static ulong ToUInt64 (NativeHandle handle)
+		{
+			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			return num.UInt64Value;
+		}
+
+		public static float ToFloat (NativeHandle handle)
+		{
+			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			return num.FloatValue;
+		}
+
+		public static nfloat ToNFloat (NativeHandle handle)
+		{
+			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			return num.NFloatValue;
+		}
+
+		public static double ToDouble (NativeHandle handle)
+		{
+			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			return num.DoubleValue;
+		}
+
+		public static nint ToNInt (NativeHandle handle)
+		{
+			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			return num.NIntValue;
+		}
+
+		public static nuint ToNUInt (NativeHandle handle)
+		{
+			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			return num.NUIntValue;
+		}
+
+		public static T ToEnum<T> (NativeHandle handle) where T : Enum
+		{
+			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			return (T) (object) num.Int32Value;
+		}
+
 		public NSNumber (nfloat value) :
 			this ((double) value)
 		{

--- a/src/Foundation/NSNumber2.cs
+++ b/src/Foundation/NSNumber2.cs
@@ -216,8 +216,7 @@ namespace Foundation {
 
 		public static T ToEnum<T> (NativeHandle handle) where T : Enum
 		{
-			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
-			return (T) (object) num.Int32Value;
+			return (T) (object) ToInt32 (handle);
 		}
 
 		public NSNumber (nfloat value) :

--- a/src/Foundation/NSNumber2.cs
+++ b/src/Foundation/NSNumber2.cs
@@ -132,91 +132,91 @@ namespace Foundation {
 
 		public static bool ToBool (NativeHandle handle)
 		{
-			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.BoolValue;
 		}
-		
+
 		public static byte ToByte (NativeHandle handle)
 		{
-			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.ByteValue;
 		}
 
 		public static sbyte ToSByte (NativeHandle handle)
 		{
-			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.SByteValue;
 		}
 
 		public static short ToInt16 (NativeHandle handle)
 		{
-			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.Int16Value;
 		}
 
 		public static ushort ToUInt16 (NativeHandle handle)
 		{
-			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.UInt16Value;
 		}
 
 		public static int ToInt32 (NativeHandle handle)
 		{
-			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.Int32Value;
 		}
 
 		public static uint ToUInt32 (NativeHandle handle)
 		{
-			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.UInt32Value;
 		}
 
 		public static long ToInt64 (NativeHandle handle)
 		{
-			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.Int64Value;
 		}
 
 		public static ulong ToUInt64 (NativeHandle handle)
 		{
-			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.UInt64Value;
 		}
 
 		public static float ToFloat (NativeHandle handle)
 		{
-			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.FloatValue;
 		}
 
 		public static nfloat ToNFloat (NativeHandle handle)
 		{
-			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.NFloatValue;
 		}
 
 		public static double ToDouble (NativeHandle handle)
 		{
-			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.DoubleValue;
 		}
 
 		public static nint ToNInt (NativeHandle handle)
 		{
-			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.NIntValue;
 		}
 
 		public static nuint ToNUInt (NativeHandle handle)
 		{
-			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return num.NUIntValue;
 		}
 
 		public static T ToEnum<T> (NativeHandle handle) where T : Enum
 		{
-			using var num = Runtime.GetNSObject<NSNumber>(handle)!;
+			using var num = Runtime.GetNSObject<NSNumber> (handle)!;
 			return (T) (object) num.Int32Value;
 		}
 

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -521,8 +521,7 @@ public partial class Generator : IMemberGatherer {
 			else if (arrType == TypeCache.NSNumber && !arrIsNullable) {
 				if (arrRetType.IsEnum) {
 					append = $"NSNumber.ToEnum<{TypeManager.FormatType (arrRetType.DeclaringType, arrRetType)}>";
-				}
-				else if (TypeManager.NSNumberToValueMap.TryGetValue (arrRetType, out valueFetcher) || arrRetType.IsEnum) {
+				} else if (TypeManager.NSNumberToValueMap.TryGetValue (arrRetType, out valueFetcher) || arrRetType.IsEnum) {
 					append = $"NSNumber.{valueFetcher}";
 				} else
 					throw GetBindAsException ("unbox", retType.Name, arrType.Name, "array", minfo.mi);

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -528,7 +528,7 @@ public partial class Generator : IMemberGatherer {
 						throw GetBindAsException ("unbox", retType.Name, arrType.Name, "array", minfo.mi);
 					}
 				} else if (TypeManager.NSNumberToValueMap.TryGetValue (arrRetType, out valueFetcher)) {
-						append = $"NSNumber.{valueFetcher}";
+					append = $"NSNumber.{valueFetcher}";
 				} else
 					throw GetBindAsException ("unbox", retType.Name, arrType.Name, "array", minfo.mi);
 			} else if (arrType == TypeCache.NSValue && !arrIsNullable) {

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -519,9 +519,11 @@ public partial class Generator : IMemberGatherer {
 			if (arrType == TypeCache.NSString && !arrIsNullable)
 				append = $"ptr => {{\n\tusing (var str = Runtime.GetNSObject<NSString> (ptr)!) {{\n\t\treturn {TypeManager.FormatType (arrRetType.DeclaringType, arrRetType)}Extensions.GetValue (str);\n\t}}\n}}";
 			else if (arrType == TypeCache.NSNumber && !arrIsNullable) {
-				if (TypeManager.NSNumberReturnMap.TryGetValue (arrRetType, out valueFetcher) || arrRetType.IsEnum) {
-					var getterStr = string.Format ("{0}{1}", arrIsNullable ? "?" : string.Empty, arrRetType.IsEnum ? ".Int32Value" : valueFetcher);
-					append = string.Format ("ptr => {{\n\tusing (var num = Runtime.GetNSObject<NSNumber> (ptr)!) {{\n\t\treturn ({1}) num{0};\n\t}}\n}}", getterStr, TypeManager.FormatType (arrRetType.DeclaringType, arrRetType));
+				if (arrRetType.IsEnum) {
+					append = $"NSNumber.ToEnum<{TypeManager.FormatType (arrRetType.DeclaringType, arrRetType)}>";
+				}
+				else if (TypeManager.NSNumberToValueMap.TryGetValue (arrRetType, out valueFetcher) || arrRetType.IsEnum) {
+					append = $"NSNumber.{valueFetcher}";
 				} else
 					throw GetBindAsException ("unbox", retType.Name, arrType.Name, "array", minfo.mi);
 			} else if (arrType == TypeCache.NSValue && !arrIsNullable) {

--- a/src/bgen/TypeManager.cs
+++ b/src/bgen/TypeManager.cs
@@ -14,6 +14,7 @@ public class TypeManager {
 	TypeCache TypeCache { get { return BindingTouch.TypeCache; } }
 
 	Dictionary<Type, string>? nsnumberReturnMap;
+	Dictionary<Type, string>? nsnumberToValueMap;
 	HashSet<string> typesThatMustAlwaysBeGloballyNamed = new ();
 
 	public void SetTypesThatMustAlwaysBeGloballyNamed (Type [] types)
@@ -57,6 +58,40 @@ public class TypeManager {
 					nsnumberReturnMap [tuple.Item1] = tuple.Item2;
 			}
 			return nsnumberReturnMap;
+		}
+	}
+	
+	/// <summary>
+	/// Maps the NSNumber types to the corresponding ToValue function. For example
+	/// int => "ToInt32"
+	/// </summary>
+	public Dictionary<Type, string> NSNumberToValueMap
+	{
+		get {
+			if (nsnumberToValueMap is not null)
+				return nsnumberToValueMap;
+			Tuple<Type?, string> [] typeMap = {
+				new (TypeCache.System_Boolean, "ToBool"),
+				new (TypeCache.System_Byte, "ToByte"),
+				new (TypeCache.System_Double, "ToDouble"),
+				new (TypeCache.System_Float, "ToFloat"),
+				new (TypeCache.System_Int16, "ToInt16"),
+				new (TypeCache.System_Int32, "ToInt32"),
+				new (TypeCache.System_Int64, "ToInt64"),
+				new (TypeCache.System_SByte, "ToSByte"),
+				new (TypeCache.System_UInt16, "ToUInt16"),
+				new (TypeCache.System_UInt32, "ToUInt32"),
+				new (TypeCache.System_UInt64, "ToUInt64"),
+				new (TypeCache.System_nfloat, "ToNFloat"),
+				new (TypeCache.System_nint, "ToNInt"),
+				new (TypeCache.System_nuint, "ToNUInt"),
+			};
+			nsnumberToValueMap = new ();
+			foreach (var tuple in typeMap) {
+				if (tuple.Item1 is not null)
+					nsnumberToValueMap [tuple.Item1] = tuple.Item2;
+			}
+			return nsnumberToValueMap;
 		}
 	}
 

--- a/src/bgen/TypeManager.cs
+++ b/src/bgen/TypeManager.cs
@@ -60,13 +60,12 @@ public class TypeManager {
 			return nsnumberReturnMap;
 		}
 	}
-	
+
 	/// <summary>
 	/// Maps the NSNumber types to the corresponding ToValue function. For example
 	/// int => "ToInt32"
 	/// </summary>
-	public Dictionary<Type, string> NSNumberToValueMap
-	{
+	public Dictionary<Type, string> NSNumberToValueMap {
 		get {
 			if (nsnumberToValueMap is not null)
 				return nsnumberToValueMap;


### PR DESCRIPTION
When a property that returns an NSNumber array is marked with the BindAs attribute, the bgen code generator uses the following pattern:

```csharp
NativeHandle retvalarrtmp;
ret = ((retvalarrtmp = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, Selector.GetHandle ("sourceSampleDataTrackIDs"))) == IntPtr.Zero ? null! : (NSArray.ArrayFromHandleFunc <int> (retvalarrtmp, ptr => {
  using (var num = Runtime.GetNSObject<NSNumber> (ptr)!) {
    return (int) num.Int32Value;
  }
}, false)));
```
This code can be simplified to use a static group method. So that it looks like:
```csharp
NativeHandle retvalarrtmp;
ret = ((retvalarrtmp = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, Selector.GetHandle ("sourceSampleDataTrackIDs"))) == IntPtr.Zero ? null! : (NSArray.ArrayFromHandleFunc <int> (retvalarrtmp, NSNumber.ToInt32, false)));
```
A seasoned C# developer would mention that in C# 10 and under using method groups (specially static ones) alocates more memory than using lambdas (lambdas were cached, static methods were not, see https://github.com/dotnet/roslyn/issues/5835). Alas, this is not longer the case after https://github.com/dotnet/roslyn/pull/58288 which means that the memory usage is the same allowing us to clean our generated code.

Using static group methods also opens the door to other possible improvements mentioned in the roslyn PR.

PS: This is some extra work we are doing to make the generated code simpler before we move to rgen.