### PR TITLE
[Bgen] Do not return null in BindAs arrays when we have IntPtr.Zero

### DIFF
--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -2955,7 +2955,7 @@ public partial class Generator : IMemberGatherer {
 				var suffix = string.Empty;
 				print ("{0} retvalarrtmp;", NativeHandleType);
 				cast_a = "((retvalarrtmp = ";
-				cast_b = ") == IntPtr.Zero ? null! : (";
+				cast_b = ") == IntPtr.Zero ? [] : (";
 				cast_b += $"NSArray.ArrayFromHandleFunc <{TypeManager.FormatType (bindAsT.DeclaringType, bindAsT)}> (retvalarrtmp, {GetFromBindAsWrapper (minfo, out suffix)}, {owns})" + suffix;
 				cast_b += $"))";
 			} else if (etype == TypeCache.System_String) {


### PR DESCRIPTION
Returning null! is a bad practice and might result in a null reference exception in our users code. Before this change, the generated code looked like this:
```csharp
NativeHandle retvalarrtmp;
ret = ((retvalarrtmp = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, Selector.GetHandle ("dilationRates"))) == IntPtr.Zero ? null! : (NSArray.ArrayFromHandleFunc <int> (retvalarrtmp, ptr => {
  using (var num = Runtime.GetNSObject<NSNumber> (ptr)!) {
    return (int) num.Int32Value;
  }
}, false)));
```
After the change it looks like:
```csharp
NativeHandle retvalarrtmp;
ret = ((retvalarrtmp = global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, Selector.GetHandle ("dilationRates"))) == IntPtr.Zero ? [] : (NSArray.ArrayFromHandleFunc <int> (retvalarrtmp, ptr => {
  using (var num = Runtime.GetNSObject<NSNumber> (ptr)!) {
    return (int) num.Int32Value;
  }
}, false)));
```
When roslyn sees "[]" it generates "Array.Empty<string>()" for arrays and in the case of collections, it uses the empty constructor. I opted to use [] to simplify the code generation since it delegates it to roslyn vs writting Array.Empty<T> in bgen.