### PR TITLE
[ci] Move CodeQL init/finalize to build.yml

### DIFF
--- a/tools/devops/automation/run-nightly-codeql.yml
+++ b/tools/devops/automation/run-nightly-codeql.yml
@@ -53,10 +53,6 @@ stages:
       clean: true
       submodules: true
 
-    - task: CodeQL3000Init@0
-      displayName: CodeQL 3000 Init
-      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
-
     - template: /tools/devops/automation/templates/build/build.yml
       parameters:
         vsdropsPrefix: ${{ variables.vsdropsPrefix }}
@@ -76,7 +72,3 @@ stages:
           inputs:
             path: $(Build.SourcesDirectory)/package
             artifact: not-signed-package
-
-    - task: CodeQL3000Finalize@0
-      displayName: CodeQL 3000 Finalize
-      condition: and(succeededOrFailed(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))

--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -160,6 +160,10 @@ steps:
        rm -rf ~/Library/Caches/com.apple.dt.Xcode
     displayName: 'Clear Xcode cache'
 
+  - task: CodeQL3000Init@0
+    displayName: CodeQL 3000 Init
+    condition: and(succeeded(), ne('${{ parameters.disableCodeQL }}', 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+
   # Actual build of the project
   - bash: $(System.DefaultWorkingDirectory)/$(BUILD_REPOSITORY_TITLE)/tools/devops/automation/scripts/bash/build-macios.sh
     name: build
@@ -172,6 +176,10 @@ steps:
   - ${{ each step in parameters.buildSteps }}:
       - ${{ each pair in step }}:
           ${{ pair.key }}: ${{ pair.value }}
+
+  - task: CodeQL3000Finalize@0
+    displayName: CodeQL 3000 Finalize
+    condition: and(succeededOrFailed(), ne('${{ parameters.disableCodeQL }}', 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
   # clean the bot after we use it
   - template: ../common/teardown.yml


### PR DESCRIPTION
Xcode provisioning failed on the last nightly CodeQL build attempt with:

    Xcode Select 16.2.0: provisioning claims to have completed successfully, but its condition still fails.

I am not sure if this is related to CodeQL setup, but we can wait to run
that setup until after environment provisioning is complete.