### PR TITLE
[monotouch-test] Skip NWBrowserTest.TestStateChangesHandler in CI.

### DIFF
--- a/tests/monotouch-test/Network/NWBrowserTest.cs
+++ b/tests/monotouch-test/Network/NWBrowserTest.cs
@@ -75,7 +75,7 @@ namespace MonoTouchFixtures.Network {
 			// This test may cause cause a dialog asking for access to the local network. The test will work if access is either granted or
 			// revoked, but it won't work _while the dialog is up_ (which can't be detected), which makes it rather annoying on the bots.
 			// So just skip it there.
-			Configuration.IgnoreInCI ("This test may pop up a dialog asking for access to the local network, which will cause the test to fail.");
+			TestRuntime.IgnoreInCI ("This test may pop up a dialog asking for access to the local network, which will cause the test to fail.");
 
 			// In the test we are doing the following:
 			//


### PR DESCRIPTION
It doesn't work very well on machines humans don't see.