### PR TITLE
[net10.0] Set the release branch name for .NET 10.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -122,7 +122,7 @@ endif
 
 ## If this branch is a release branch, set NUGET_RELEASE_BRANCH to the exact branch name (so that any other branches won't become release branches just by branching off from a release branch).
 ## Example: release/6.0.3xx
-# NUGET_RELEASE_BRANCH=
+NUGET_RELEASE_BRANCH=release/10.0.1xx
 
 ## If this is a pre-release (alpha, beta, rc, xcode, etc.) branch, set NUGET_HARDCODED_PRERELASE_BRANCH to the exact branch name. Also set NUGET_HARDCODED_PRELEASE_IDENTIFIER to the prerelease identifier to use.
 ## Example:


### PR DESCRIPTION
See equivalent change for .NET 9/main: cc88b23d5614ce66412832cce23f681427e6a80f