### PR TITLE
[runtime/src] Expand NSObject.Flags to 32 bits (uint).

### DIFF
--- a/runtime/delegates.t4
+++ b/runtime/delegates.t4
@@ -316,14 +316,14 @@
 
 		new XDelegate ("void", "void", "xamarin_set_flags_for_nsobject",
 			"GCHandle", "IntPtr", "gchandle",
-			"uint8_t", "byte", "flags"
+			"uint32_t", "uint", "flags"
 		) {
 			WrappedManagedFunction = "SetFlagsForNSObject",
 			OnlyDynamicUsage = false,
 			OnlyCoreCLR = true,
 		},
 
-		new XDelegate ("uint8_t", "byte", "xamarin_get_flags_for_nsobject",
+		new XDelegate ("uint32_t", "uint", "xamarin_get_flags_for_nsobject",
 			"GCHandle", "IntPtr", "gchandle"
 		) {
 			WrappedManagedFunction = "GetFlagsForNSObject",

--- a/runtime/monovm-bridge.m
+++ b/runtime/monovm-bridge.m
@@ -413,7 +413,7 @@ static MonoToggleRefStatus
 gc_toggleref_callback (MonoObject *object)
 {
 	MonoToggleRefStatus res;
-	uint8_t flags = xamarin_get_nsobject_flags (object);
+	uint32_t flags = xamarin_get_nsobject_flags (object);
 
 	res = xamarin_gc_toggleref_callback (flags, NULL, xamarin_get_nsobject_handle, object);
 

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -205,7 +205,7 @@ xamarin_get_nsobject_handle (MonoObject *obj)
 #endif
 }
 
-uint8_t
+uint32_t
 xamarin_get_nsobject_flags (MonoObject *obj)
 {
 #if defined (CORECLR_RUNTIME)
@@ -217,7 +217,7 @@ xamarin_get_nsobject_flags (MonoObject *obj)
 }
 
 void
-xamarin_set_nsobject_flags (MonoObject *obj, uint8_t flags)
+xamarin_set_nsobject_flags (MonoObject *obj, uint32_t flags)
 {
 #if defined (CORECLR_RUNTIME)
 	xamarin_set_flags_for_nsobject (obj->gchandle, flags);
@@ -698,7 +698,7 @@ xamarin_type_get_full_name (MonoType *type, GCHandle *exception_gchandle)
 // #define DEBUG_TOGGLEREF 1
 
 MonoToggleRefStatus
-xamarin_gc_toggleref_callback (uint8_t flags, id handle, xamarin_get_handle_func get_handle, MonoObject *info)
+xamarin_gc_toggleref_callback (uint32_t flags, id handle, xamarin_get_handle_func get_handle, MonoObject *info)
 {
 	MonoToggleRefStatus res;
 

--- a/runtime/xamarin/monovm-bridge.h
+++ b/runtime/xamarin/monovm-bridge.h
@@ -31,7 +31,7 @@ struct Managed_NSObject {
 	MonoObject obj;
 	id handle;
 	void *class_handle;
-	uint8_t flags;
+	uint32_t flags;
 };
 
 typedef struct {

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -187,8 +187,8 @@ MonoObject *	xamarin_get_nsobject_with_type_for_ptr_created (id self, bool owns,
 MonoObject *	xamarin_get_delegate_for_block_parameter (MonoMethod *method, guint32 token_ref, int par, void *nativeBlock, GCHandle *exception_gchandle);
 id              xamarin_get_block_for_delegate (MonoMethod *method, MonoObject *delegate, const char *signature /* NULL allowed, but requires the dynamic registrar at runtime to compute */, guint32 token_ref /* INVALID_TOKEN_REF allowed, but requires the dynamic registrar at runtime */, GCHandle *exception_gchandle);
 id				xamarin_get_nsobject_handle (MonoObject *obj);
-uint8_t         xamarin_get_nsobject_flags (MonoObject *obj);
-void			xamarin_set_nsobject_flags (MonoObject *obj, uint8_t flags);
+uint32_t        xamarin_get_nsobject_flags (MonoObject *obj);
+void			xamarin_set_nsobject_flags (MonoObject *obj, uint32_t flags);
 void			xamarin_throw_nsexception (MonoException *exc);
 void			xamarin_rethrow_managed_exception (GCHandle original_gchandle, GCHandle *exception_gchandle);
 MonoException *	xamarin_create_exception (const char *msg);
@@ -322,7 +322,7 @@ void			xamarin_gchandle_free (GCHandle handle);
 MonoObject *	xamarin_gchandle_unwrap (GCHandle handle); // Will get the target and free the GCHandle
 
 typedef id (*xamarin_get_handle_func) (MonoObject *info);
-MonoToggleRefStatus	xamarin_gc_toggleref_callback (uint8_t flags, id handle, xamarin_get_handle_func get_handle, MonoObject *info);
+MonoToggleRefStatus	xamarin_gc_toggleref_callback (uint32_t flags, id handle, xamarin_get_handle_func get_handle, MonoObject *info);
 void				xamarin_gc_event (MonoGCEvent event);
 
 void			xamarin_bridge_log_monoobject (MonoObject *obj, const char *stacktrace);

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -124,7 +124,7 @@ namespace Foundation {
 
 		// This enum has a native counterpart in runtime.h
 		[Flags]
-		internal enum Flags : byte {
+		internal enum Flags : uint {
 			Disposed = 1,
 			NativeRef = 2,
 			IsDirectBinding = 4,

--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -558,16 +558,16 @@ namespace ObjCRuntime {
 			return Marshal.StringToHGlobalAuto (location);
 		}
 
-		static void SetFlagsForNSObject (IntPtr gchandle, byte flags)
+		static void SetFlagsForNSObject (IntPtr gchandle, uint flags)
 		{
 			var obj = (NSObject) GetGCHandleTarget (gchandle)!;
 			obj.FlagsInternal = (NSObject.Flags) flags;
 		}
 
-		static byte GetFlagsForNSObject (IntPtr gchandle)
+		static uint GetFlagsForNSObject (IntPtr gchandle)
 		{
 			var obj = (NSObject) GetGCHandleTarget (gchandle)!;
-			return (byte) obj.FlagsInternal;
+			return (uint) obj.FlagsInternal;
 		}
 
 		static unsafe MonoObject* GetMethodDeclaringType (MonoObject* mobj)

--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -1453,10 +1453,10 @@ partial class TestRuntime {
 #endif
 	}
 
-	public static byte GetFlags (NSObject obj)
+	public static uint GetFlags (NSObject obj)
 	{
 		const string fieldName = "actual_flags";
-		return (byte) typeof (NSObject).GetField (fieldName, BindingFlags.Instance | BindingFlags.GetField | BindingFlags.NonPublic)!.GetValue (obj)!;
+		return (uint) typeof (NSObject).GetField (fieldName, BindingFlags.Instance | BindingFlags.GetField | BindingFlags.NonPublic)!.GetValue (obj)!;
 	}
 
 	// Determine if linkall was enabled by checking if an unused class in this assembly is still here.

--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -213,7 +213,7 @@ namespace Introspection {
 
 		bool GetIsDirectBinding (NSObject obj)
 		{
-			int flags = TestRuntime.GetFlags (obj);
+			var flags = TestRuntime.GetFlags (obj);
 			return (flags & 4) == 4;
 		}
 


### PR DESCRIPTION
1. We've already run out of available bits in a byte, so we'll need more bits
   available if we want more flags (which is coming in a future change).
2. Due to padding/alignment, this won't use any additional memory.