### PR TITLE
[tools] Make the dead code removal optimizer correctly handle unconditional branches.

### DIFF
--- a/tools/linker/CoreOptimizeGeneratedCode.cs
+++ b/tools/linker/CoreOptimizeGeneratedCode.cs
@@ -330,7 +330,7 @@ namespace Xamarin.Linker {
 				case FlowControl.Branch:
 					// Unconditional branch, we continue marking from the instruction that we branch to.
 					var br_target = (Instruction) ins.Operand;
-					return MarkInstructions (method, instructions, reachable, instructions.IndexOf (br_target), end);
+					return MarkInstructions (method, instructions, reachable, instructions.IndexOf (br_target), instructions.Count);
 				case FlowControl.Cond_Branch:
 					// Conditional instruction, we need to check if we can calculate a constant value for the condition
 					var cond_target = ins.Operand as Instruction;


### PR DESCRIPTION
When handling an unconditional branch, we need to mark all the instructions
until the end of the method, not only until the end of block that is currently
being processed.

This fixes a problem where the dead code optimizer would optimize away code
after an unconditonal branch, ending up with invalid IL because code that
wasn't optimized away would have branches into the removed code.