### PR TITLE
[RGen] Bump the version of Roslyn and other nugets.

### DIFF
--- a/src/ObjCBindings/ExportAttribute.cs
+++ b/src/ObjCBindings/ExportAttribute.cs
@@ -54,7 +54,7 @@ namespace ObjCBindings {
 		/// <summary>
 		/// The type of the result for an async method.
 		/// </summary>
-		public TypeInfo? ResultType { get; set; } = null;
+		public Type? ResultType { get; set; } = null;
 
 		/// <summary>
 		/// The name of the generated async method.
@@ -70,6 +70,16 @@ namespace ObjCBindings {
 		/// A code snippet to be executed after the async method call.
 		/// </summary>
 		public string? PostNonResultSnippet { get; set; } = null;
+
+		/// <summary>
+		/// The type of the strong delegate for a weak delegate property.
+		/// </summary>
+		public Type? StrongDelegateType { get; set; } = null;
+
+		/// <summary>
+		/// The name of the strong delegate for a weak delegate property.
+		/// </summary>
+		public string? StrongDelegateName { get; set; } = null;
 
 		protected ExportAttribute () { }
 

--- a/src/arkit.cs
+++ b/src/arkit.cs
@@ -7,6 +7,8 @@
 // Copyright 2017 Microsoft Inc. All rights reserved.
 //
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using System.Numerics;
@@ -724,7 +726,7 @@ namespace ARKit {
 		[iOS (13, 0)]
 		[Async]
 		[Export ("validateWithCompletionHandler:")]
-		void Validate (Action<NSError> completionHandler);
+		void Validate (Action<NSError?> completionHandler);
 
 		/// <param name="image">To be added.</param>
 		/// <param name="orientation">To be added.</param>
@@ -1010,7 +1012,7 @@ namespace ARKit {
 			<remarks>To be added.</remarks>
 			""")]
 		[Export ("getCurrentWorldMapWithCompletionHandler:")]
-		void GetCurrentWorldMap (Action<ARWorldMap, NSError> completionHandler);
+		void GetCurrentWorldMap (Action<ARWorldMap?, NSError?> completionHandler);
 
 		[Async (XmlDocs = """
 			<param name="transform">The transform to the position and orientation of the region from which to create a reference object.</param>
@@ -1022,7 +1024,7 @@ namespace ARKit {
 			""")]
 		[MarshalDirective (NativePrefix = "xamarin_simd__", Library = "__Internal")]
 		[Export ("createReferenceObjectWithTransform:center:extent:completionHandler:")]
-		void CreateReferenceObject (Matrix4 transform, Vector3 center, Vector3 extent, Action<ARReferenceObject, NSError> completionHandler);
+		void CreateReferenceObject (Matrix4 transform, Vector3 center, Vector3 extent, Action<ARReferenceObject?, NSError?> completionHandler);
 
 		[iOS (13, 0)]
 		[Export ("raycast:")]
@@ -1047,7 +1049,7 @@ namespace ARKit {
 		[iOS (16, 0)]
 		[Async]
 		[Export ("captureHighResolutionFrameWithCompletion:")]
-		void CaptureHighResolutionFrame (Action<ARFrame, NSError> handler);
+		void CaptureHighResolutionFrame (Action<ARFrame?, NSError?> handler);
 	}
 
 	/// <summary>Interface defining methods that respond to events in an <see cref="ARKit.ARSession" />.</summary>
@@ -2696,12 +2698,12 @@ namespace ARKit {
 		[Async]
 		[Static]
 		[Export ("checkAvailabilityWithCompletionHandler:")]
-		void CheckAvailability (Action<bool, NSError> completionHandler);
+		void CheckAvailability (Action<bool, NSError?> completionHandler);
 
 		[Async]
 		[Static]
 		[Export ("checkAvailabilityAtCoordinate:completionHandler:")]
-		void CheckAvailability (CLLocationCoordinate2D coordinate, Action<bool, NSError> completionHandler);
+		void CheckAvailability (CLLocationCoordinate2D coordinate, Action<bool, NSError?> completionHandler);
 
 		[Static]
 		[Export ("new")]

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Microsoft.Macios.Bindings.Analyzer.csproj
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Microsoft.Macios.Bindings.Analyzer.csproj
@@ -18,12 +18,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11">
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.9.2" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/rgen/Microsoft.Macios.Bindings.CodeFixers/Microsoft.Macios.Bindings.CodeFixers.csproj
+++ b/src/rgen/Microsoft.Macios.Bindings.CodeFixers/Microsoft.Macios.Bindings.CodeFixers.csproj
@@ -15,12 +15,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/ExportData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/ExportData.cs
@@ -74,6 +74,16 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 	/// A code snippet to be executed after the async method call.
 	/// </summary>
 	public string? PostNonResultSnippet { get; init; }
+	
+	/// <summary>
+	/// The type of the strong delegate for a weak delegate property.
+	/// </summary>
+	public TypeInfo? StrongDelegateType { get; init; }
+	
+	/// <summary>
+	/// The name of the strong delegate for a weak delegate property.
+	/// </summary>
+	public string? StrongDelegateName{ get; init; }
 
 	public ExportData () { }
 
@@ -119,6 +129,9 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 		string? methodName = null;
 		string? resultTypeName = null;
 		string? postNonResultSnippet = null;
+		// weak delegate related data
+		TypeInfo? strongDelegateType = null;
+		string? strongDelegateName = null;
 
 		switch (count) {
 		case 1:
@@ -163,6 +176,7 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 
 		// from this point we have to check the name of the argument AND if the export method is an Async method.
 		var isAsync = typeof (T) == typeof (ObjCBindings.Method) && flags is not null && flags.HasFlag (ObjCBindings.Method.Async);
+		var isWeakDelegate = typeof (T) == typeof (ObjCBindings.Property) && flags is not null && flags.HasFlag (ObjCBindings.Property.WeakDelegate);
 
 		// loop over all the named arguments and set the data accordingly, ignore the Flags one since we already set it
 		foreach (var (name, value) in attrsDict) {
@@ -206,6 +220,17 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 					postNonResultSnippet = (string?) value;
 				}
 				break;
+			// weak delegate related data
+			case "StrongDelegateType":
+				if (isWeakDelegate) {
+					strongDelegateType = new ((INamedTypeSymbol) value!);
+				}
+				break;
+			case "StrongDelegateName":
+				if (isWeakDelegate) {
+					strongDelegateName = (string?) value!;
+				}
+				break;
 			default:
 				data = null;
 				return false;
@@ -221,7 +246,10 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 				ResultType = isAsync ? resultType : null,
 				MethodName = isAsync ? methodName : null,
 				ResultTypeName = isAsync ? resultTypeName : null,
-				PostNonResultSnippet = isAsync ? postNonResultSnippet : null
+				PostNonResultSnippet = isAsync ? postNonResultSnippet : null,
+				// we set the data for the weak delegate only if the flags are set
+				StrongDelegateType = isWeakDelegate ? strongDelegateType : null,
+				StrongDelegateName = isWeakDelegate ? strongDelegateName : null
 			};
 			return true;
 		}

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/ExportData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/ExportData.cs
@@ -74,16 +74,16 @@ readonly struct ExportData<T> : IEquatable<ExportData<T>> where T : Enum {
 	/// A code snippet to be executed after the async method call.
 	/// </summary>
 	public string? PostNonResultSnippet { get; init; }
-	
+
 	/// <summary>
 	/// The type of the strong delegate for a weak delegate property.
 	/// </summary>
 	public TypeInfo? StrongDelegateType { get; init; }
-	
+
 	/// <summary>
 	/// The name of the strong delegate for a weak delegate property.
 	/// </summary>
-	public string? StrongDelegateName{ get; init; }
+	public string? StrongDelegateName { get; init; }
 
 	public ExportData () { }
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.Generator.cs
@@ -266,6 +266,19 @@ readonly partial struct Property {
 		return RequiresDirtyCheck == other.RequiresDirtyCheck;
 	}
 
+	public Property ToStrongDelegate ()
+	{
+		// has to be a property, weak delegate and have its strong delegate type set
+		if (!IsProperty || !IsWeakDelegate || ExportPropertyData.Value.StrongDelegateType is null)
+			return this;
+
+		// update the return type, all the rest is the same
+		return this with {
+			Name = ExportPropertyData.Value.StrongDelegateName ?? Name.Remove (0, 4 /* "Weak".Length */),
+			ReturnType = ExportPropertyData.Value.StrongDelegateType.Value.WithNullable (true),
+		};
+	}
+
 	/// <inheritdoc />
 	public override string ToString ()
 	{

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/Property.cs
@@ -18,7 +18,7 @@ readonly partial struct Property : IEquatable<Property> {
 	/// <summary>
 	/// Name of the property.
 	/// </summary>
-	public string Name { get; } = string.Empty;
+	public string Name { get; init; } = string.Empty;
 
 	readonly string? backingField = null;
 

--- a/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
+++ b/src/rgen/Microsoft.Macios.Generator/DataModel/TypeInfo.cs
@@ -556,20 +556,19 @@ readonly partial struct TypeInfo : IEquatable<TypeInfo> {
 	}
 
 	/// <summary>
-	/// If the current <see cref="TypeInfo"/> is nullable, this method returns a new <see cref="TypeInfo"/>
-	/// representing the non-nullable version of the type. Otherwise, it returns the current instance.
+	/// Returns a new <see cref="TypeInfo"/> with the specified nullability.
 	/// </summary>
+	/// <param name="isNullable">A boolean value indicating whether the new type should be nullable.</param>
 	/// <returns>
-	/// A new <see cref="TypeInfo"/> instance with <see cref="IsNullable"/> set to false if the original <see cref="IsNullable"/> was true;
-	/// otherwise, returns the current <see cref="TypeInfo"/> instance.
+	/// A new <see cref="TypeInfo"/> instance with the specified nullability. If the current instance already has the
+	/// specified nullability, the current instance is returned.
 	/// </returns>
-	public TypeInfo ToNonNullable ()
+	public TypeInfo WithNullable (bool isNullable)
 	{
-		if (!IsNullable)
+		if (IsNullable == isNullable)
 			return this;
-		// copy all the elements from the current array type and set the array type to false
 		return this with {
-			IsNullable = false,
+			IsNullable = isNullable,
 		};
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.ObjCRuntime.cs
@@ -1229,12 +1229,12 @@ static partial class BindingSyntaxFactory {
 			
 			// NSObject[] => CFArray.ArrayFromHandle<Foundation.NSMetadataItem> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, Selector.GetHandle ("results")))!;
 			{ Type.IsArray: true, Type.ArrayElementTypeIsWrapped: true }
-				=> GetCFArrayFromHandle (info.Type.ToArrayElementType ().ToNonNullable ().GetIdentifierSyntax (), [
+				=> GetCFArrayFromHandle (info.Type.ToArrayElementType ().WithNullable (isNullable: false).GetIdentifierSyntax (), [
 					Argument (expression)
 				], suppressNullableWarning: !info.Type.IsNullable), 
 			
 			{ Type.IsArray: true, Type.ArrayElementIsINativeObject: true }
-				=> GetCFArrayFromHandle (info.Type.ToArrayElementType ().ToNonNullable ().GetIdentifierSyntax (), [
+				=> GetCFArrayFromHandle (info.Type.ToArrayElementType ().WithNullable (isNullable: false).GetIdentifierSyntax (), [
 					Argument (expression)
 				], suppressNullableWarning: !info.Type.IsNullable), 
 			
@@ -1244,7 +1244,7 @@ static partial class BindingSyntaxFactory {
 			// Runtime.GetINativeObject<NSString> (auxVariable, false)!;
 			{ Type.IsINativeObject: true, Type.IsNSObject: false, ReleaseHandle: not null}
 				=> GetINativeObject (
-					nsObjectType: info.Type.ToNonNullable ().GetIdentifierSyntax (), 
+					nsObjectType: info.Type.WithNullable (isNullable: false).GetIdentifierSyntax (), 
 					args: [
 						Argument (expression),
 						BoolArgument (info.ReleaseHandle.Value)
@@ -1253,7 +1253,7 @@ static partial class BindingSyntaxFactory {
 			
 			{ Type.IsINativeObject: true, Type.IsNSObject: false, ReleaseHandle: null}
 				=> GetINativeObject (
-					nsObjectType: info.Type.ToNonNullable ().GetIdentifierSyntax (), 
+					nsObjectType: info.Type.WithNullable (isNullable: false).GetIdentifierSyntax (), 
 					args: [
 						Argument (expression),
 					], 
@@ -1263,7 +1263,7 @@ static partial class BindingSyntaxFactory {
 			// Runtime.GetNSObject<NSString> (auxVariable, false)!;
 			{ Type.IsNSObject: true, ReleaseHandle: not null} 
 				=> GetNSObject (
-					nsObjectType: info.Type.ToNonNullable ().GetIdentifierSyntax (), 
+					nsObjectType: info.Type.WithNullable (isNullable: false).GetIdentifierSyntax (), 
 					args: [
 						Argument (expression),
 						BoolArgument (false)
@@ -1272,7 +1272,7 @@ static partial class BindingSyntaxFactory {
 			
 			{ Type.IsNSObject: true, ReleaseHandle: null} 
 				=> GetNSObject (
-					nsObjectType: info.Type.ToNonNullable ().GetIdentifierSyntax (), 
+					nsObjectType: info.Type.WithNullable (isNullable: false).GetIdentifierSyntax (), 
 					args: [
 						Argument (expression),
 					],

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Trampoline.cs
@@ -208,7 +208,7 @@ static partial class BindingSyntaxFactory {
 			// parameters that are passed by reference, depend on the type that is referenced
 			{ IsByRef: true, Type.IsReferenceType: false, Type.IsNullable: true} 
 				=> (parameterIdentifier, 
-					PointerType (GetLowLevelType (parameterType.ToNonNullable ()))),
+					PointerType (GetLowLevelType (parameterType.WithNullable (isNullable: false)))),
 			
 			{ IsByRef: true, Type.IsReferenceType: false, Type.IsNullable: false} 
 				=> (parameterIdentifier, 
@@ -333,7 +333,7 @@ static partial class BindingSyntaxFactory {
 			
 			// Runtime.GetNSObject<ParameterType> (ParameterName) 
 			{ Type.IsNSObject: true, Type.IsNullable: true} =>
-				GetNSObject (parameterType.ToNonNullable ().GetIdentifierSyntax (), [
+				GetNSObject (parameterType.WithNullable (isNullable: false).GetIdentifierSyntax (), [
 					Argument (parameterIdentifier)
 				], suppressNullableWarning: false),
 			
@@ -345,7 +345,7 @@ static partial class BindingSyntaxFactory {
 			
 			// Runtime.GetINativeObject<ParameterType> (ParameterName, false)!
 			{ Type.IsINativeObject: true, Type.IsNullable: true } =>
-				GetINativeObject (parameterType.ToNonNullable ().GetIdentifierSyntax (), [
+				GetINativeObject (parameterType.WithNullable (isNullable: false).GetIdentifierSyntax (), [
 					Argument (parameterIdentifier), 
 					BoolArgument (false)
 				], suppressNullableWarning: false),

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.cs
@@ -68,6 +68,37 @@ static partial class BindingSyntaxFactory {
 			: invocation;
 	}
 
+	/// <summary>
+	/// Creates an invocation expression for calling a method on an instance variable.
+	/// </summary>
+	/// <param name="instanceVariable">The name of the instance variable.</param>
+	/// <param name="methodName">The name of the method to call.</param>
+	/// <param name="arguments">The arguments to pass to the method.</param>
+	/// <returns>An invocation expression for the method call.</returns>
+	static InvocationExpressionSyntax MemberInvocationExpression (TypeSyntax instanceVariable, string methodName,
+		ImmutableArray<ArgumentSyntax> arguments)
+	{
+		var argumentList = ArgumentList (
+			SeparatedList<ArgumentSyntax> (arguments.ToSyntaxNodeOrTokenArray ()));
+		return InvocationExpression (
+				MemberAccessExpression (
+					SyntaxKind.SimpleMemberAccessExpression,
+					instanceVariable,
+					IdentifierName (methodName).WithTrailingTrivia (Space)))
+			.WithArgumentList (argumentList);
+	}
+
+	/// <summary>
+	/// Creates an invocation expression for calling a method on an instance variable.
+	/// </summary>
+	/// <param name="instanceVariable">The name of the instance variable.</param>
+	/// <param name="methodName">The name of the method to call.</param>
+	/// <param name="arguments">The arguments to pass to the method.</param>
+	/// <returns>An invocation expression for the method call.</returns>
+	static InvocationExpressionSyntax MemberInvocationExpression (string instanceVariable, string methodName,
+		ImmutableArray<ArgumentSyntax> arguments)
+		=> MemberInvocationExpression (IdentifierName (instanceVariable), methodName, arguments);
+
 	static ExpressionSyntax ThrowException (string type, string? message = null)
 	{
 		var throwExpression = ObjectCreationExpression (IdentifierName (type));
@@ -296,4 +327,25 @@ static partial class BindingSyntaxFactory {
 	/// <returns>An <see cref="ArgumentSyntax"/> representing the parameter.</returns>
 	internal static ArgumentSyntax ArgumentForParameter (in DelegateParameter parameter)
 		=> ArgumentForParameter (parameter.Name, parameter.ReferenceKind);
+
+	/// <summary>
+	/// Creates an invocation expression for the SetException method of a TaskCompletionSource.
+	/// </summary>
+	/// <param name="tcsVariableName">The name of the TaskCompletionSource variable.</param>
+	/// <param name="arguments">The arguments to pass to the SetException method.</param>
+	/// <returns>An invocation expression for the SetException method.</returns>
+	internal static InvocationExpressionSyntax TcsSetException (string tcsVariableName,
+		ImmutableArray<ArgumentSyntax> arguments)
+		=> MemberInvocationExpression (tcsVariableName, "SetException", arguments);
+
+	/// <summary>
+	/// Creates an invocation expression for the SetResult method of a TaskCompletionSource.
+	/// </summary>
+	/// <param name="tcsVariableName">The name of the TaskCompletionSource variable.</param>
+	/// <param name="arguments">The arguments to pass to the SetResult method.</param>
+	/// <returns>An invocation expression for the SetResult method.</returns>
+	internal static InvocationExpressionSyntax TcsSetResult (string tcsVariableName,
+		ImmutableArray<ArgumentSyntax> arguments)
+		=> MemberInvocationExpression (tcsVariableName, "SetResult", arguments);
+
 }

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
@@ -174,6 +174,7 @@ return {backingField};
 			// add backing variable for the property if it is needed
 			if (property.NeedsBackingField) {
 				classBlock.WriteLine ();
+				classBlock.AppendGeneratedCodeAttribute (optimizable: true);
 				classBlock.WriteLine ($"object? {property.BackingField} = null;");
 			}
 
@@ -205,10 +206,14 @@ if (IsDirectBinding) {{
 }}
 {ExpressionStatement (KeepAlive ("this"))}
 ");
-					if (property.RequiresDirtyCheck) {
+					if (property.RequiresDirtyCheck || property.IsWeakDelegate) {
 						getterBlock.WriteLine ("MarkDirty ();");
+					}
+
+					if (property.NeedsBackingField) {
 						getterBlock.WriteLine ($"{property.BackingField} = {tempVar};");
 					}
+					
 					getterBlock.WriteLine ($"return {tempVar};");
 				}
 
@@ -245,8 +250,11 @@ $@"if (IsDirectBinding) {{
 					// the native object alive
 					setterBlock.Write (invocations.Setter.Value.Argument.PostDelegateCallConversion, verifyTrivia: false);
 					// mark property as dirty if needed
-					if (property.RequiresDirtyCheck) {
+					if (property.RequiresDirtyCheck || property.IsWeakDelegate) {
 						setterBlock.WriteLine ("MarkDirty ();");
+					}
+
+					if (property.NeedsBackingField) {
 						setterBlock.WriteLine ($"{property.BackingField} = value;");
 					}
 				}

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
@@ -259,6 +259,33 @@ $@"if (IsDirectBinding) {{
 					}
 				}
 			}
+			
+			// if the property is a weak delegate and has the strong delegate type set, we need to emit the
+			// strong delegate property
+			if (property is { IsProperty: true, IsWeakDelegate: true } 
+			    && property.ExportPropertyData.Value.StrongDelegateType is not null) {
+				classBlock.WriteLine ();
+				var strongDelegate = property.ToStrongDelegate ();
+				using (var propertyBlock =
+				       classBlock.CreateBlock (strongDelegate.ToDeclaration ().ToString (), block: true)) {
+					using (var getterBlock = 
+					       propertyBlock.CreateBlock ("get", block: true)) {
+						getterBlock.WriteLine (
+							$"return {property.Name} as {strongDelegate.ReturnType.WithNullable (isNullable: false).GetIdentifierSyntax ()};");
+					}
+					
+					using (var setterBlock = 
+					       propertyBlock.CreateBlock ("set", block: true)) {
+						setterBlock.WriteRaw (
+$@"var rvalue = value as NSObject;
+if (!(value is null) && rvalue is null) {{
+	throw new ArgumentException ($""The object passed of type {{value.GetType ()}} does not derive from NSObject"");
+}}
+{property.Name} = rvalue;
+");
+					}
+				}
+			}
 		}
 	}
 

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/ClassEmitter.cs
@@ -213,7 +213,7 @@ if (IsDirectBinding) {{
 					if (property.NeedsBackingField) {
 						getterBlock.WriteLine ($"{property.BackingField} = {tempVar};");
 					}
-					
+
 					getterBlock.WriteLine ($"return {tempVar};");
 				}
 
@@ -259,23 +259,23 @@ $@"if (IsDirectBinding) {{
 					}
 				}
 			}
-			
+
 			// if the property is a weak delegate and has the strong delegate type set, we need to emit the
 			// strong delegate property
-			if (property is { IsProperty: true, IsWeakDelegate: true } 
-			    && property.ExportPropertyData.Value.StrongDelegateType is not null) {
+			if (property is { IsProperty: true, IsWeakDelegate: true }
+				&& property.ExportPropertyData.Value.StrongDelegateType is not null) {
 				classBlock.WriteLine ();
 				var strongDelegate = property.ToStrongDelegate ();
 				using (var propertyBlock =
-				       classBlock.CreateBlock (strongDelegate.ToDeclaration ().ToString (), block: true)) {
-					using (var getterBlock = 
-					       propertyBlock.CreateBlock ("get", block: true)) {
+					   classBlock.CreateBlock (strongDelegate.ToDeclaration ().ToString (), block: true)) {
+					using (var getterBlock =
+						   propertyBlock.CreateBlock ("get", block: true)) {
 						getterBlock.WriteLine (
 							$"return {property.Name} as {strongDelegate.ReturnType.WithNullable (isNullable: false).GetIdentifierSyntax ()};");
 					}
-					
-					using (var setterBlock = 
-					       propertyBlock.CreateBlock ("set", block: true)) {
+
+					using (var setterBlock =
+						   propertyBlock.CreateBlock ("set", block: true)) {
 						setterBlock.WriteRaw (
 $@"var rvalue = value as NSObject;
 if (!(value is null) && rvalue is null) {{

--- a/src/rgen/Microsoft.Macios.Generator/Microsoft.Macios.Generator.csproj
+++ b/src/rgen/Microsoft.Macios.Generator/Microsoft.Macios.Generator.csproj
@@ -18,11 +18,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11">
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/rgen/Microsoft.Macios.Transformer/Microsoft.Macios.Transformer.csproj
+++ b/src/rgen/Microsoft.Macios.Transformer/Microsoft.Macios.Transformer.csproj
@@ -14,14 +14,14 @@
 
     <ItemGroup>
         <PackageReference Include="Marille" Version="0.5.3"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.9.2"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2"/>
-        <PackageReference Include="Mono.Cecil" Version="0.11.5" />
-        <PackageReference Include="Serilog" Version="4.0.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+        <PackageReference Include="Mono.Cecil" Version="0.11.6" />
+        <PackageReference Include="Serilog" Version="4.2.0" />
         <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0"/>
         <PackageReference Include="Serilog.Expressions" Version="4.0.0"/>
-        <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1"/>
-        <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0"/>
+        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+        <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1"/>
     </ItemGroup>
 

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -445,7 +445,7 @@ namespace UIKit {
 	///     <summary>Completion handler used with <see cref="UIKit.UIPrinter.ContactPrinter(UIKit.UIPrinterContactPrinterHandler)" />.</summary>
 	delegate void UIPrinterContactPrinterHandler (bool available);
 	/// <summary>Completion handler used with various <see cref="UIKit.UIPrinterPickerController" /> presentation methods.</summary>
-	delegate void UIPrinterPickerCompletionHandler (UIPrinterPickerController printerPickerController, bool userDidSelect, NSError error);
+	delegate void UIPrinterPickerCompletionHandler ([NullAllowed] UIPrinterPickerController printerPickerController, bool userDidSelect, [NullAllowed] NSError error);
 
 	delegate UISplitViewControllerDisplayMode UISplitViewControllerFetchTargetForActionHandler (UISplitViewController svc);
 	delegate bool UISplitViewControllerDisplayEvent (UISplitViewController splitViewController, UIViewController vc, NSObject sender);
@@ -453,7 +453,7 @@ namespace UIKit {
 	delegate bool UISplitViewControllerCanCollapsePredicate (UISplitViewController splitViewController, UIViewController secondaryViewController, UIViewController primaryViewController);
 	delegate UIViewController UISplitViewControllerGetSecondaryViewController (UISplitViewController splitViewController, UIViewController primaryViewController);
 	/// <summary>The callback executed after a <see cref="UIKit.UIActivityViewController" /> is dismissed.</summary>
-	delegate void UIActivityViewControllerCompletion (NSString activityType, bool completed, NSExtensionItem [] returnedItems, NSError error);
+	delegate void UIActivityViewControllerCompletion ([NullAllowed] NSString activityType, bool completed, [NullAllowed] NSExtensionItem [] returnedItems, [NullAllowed] NSError error);
 
 	// In the hopes that the parameter is self document: this array  can contain either UIDocuments or UIResponders
 	/// <param name="uidocumentOrResponderObjects">To be added.</param>
@@ -1703,6 +1703,7 @@ namespace UIKit {
 		NSString CategoryEdit { get; }
 	}
 
+	[return: NullAllowed]
 	delegate UIAccessibilityCustomRotorItemResult UIAccessibilityCustomRotorSearch (UIAccessibilityCustomRotorSearchPredicate predicate);
 
 	[MacCatalyst (13, 1)]
@@ -4494,7 +4495,9 @@ namespace UIKit {
 		FullWord,
 	}
 
+	[return: NullAllowed]
 	delegate UIViewController UIContextMenuContentPreviewProvider ();
+	[return: NullAllowed]
 	delegate UIMenu UIContextMenuActionProvider (UIMenuElement [] suggestedActions);
 
 	[TV (17, 0), iOS (13, 0)]
@@ -12193,6 +12196,7 @@ namespace UIKit {
 
 	[NoTV, iOS (13, 4)]
 	[MacCatalyst (13, 1)]
+	[return: NullAllowed]
 	delegate UIPointerStyle UIButtonPointerStyleProvider (UIButton button, UIPointerEffect proposedEffect, UIPointerShape proposedShape);
 
 	[NoTV, iOS (15, 0), MacCatalyst (15, 0)]
@@ -25336,6 +25340,7 @@ namespace UIKit {
 
 	[iOS (13, 0), TV (13, 0)]
 	[MacCatalyst (13, 1)]
+	[return: NullAllowed]
 	delegate UIViewController UIStoryboardViewControllerCreator (NSCoder coder);
 
 	[MacCatalyst (13, 1)]
@@ -26270,7 +26275,7 @@ namespace UIKit {
 	}
 
 	/// <summary>A delegate executed after printing completes or after a printing error occurs.</summary>
-	delegate void UIPrintInteractionCompletionHandler (UIPrintInteractionController printInteractionController, bool completed, NSError error);
+	delegate void UIPrintInteractionCompletionHandler ([NullAllowed] UIPrintInteractionController printInteractionController, bool completed, [NullAllowed] NSError error);
 
 	/// <include file="../docs/api/UIKit/UIPrintInteractionController.xml" path="/Documentation/Docs[@DocId='T:UIKit.UIPrintInteractionController']/*" />
 	[NoTV]
@@ -31250,6 +31255,7 @@ namespace UIKit {
 
 	[TV (13, 0), iOS (13, 0)]
 	[MacCatalyst (13, 1)]
+	[return: NullAllowed]
 	delegate NSCollectionLayoutSection UICollectionViewCompositionalLayoutSectionProvider (nint section, INSCollectionLayoutEnvironment layoutEnvironment);
 
 	[TV (13, 0), iOS (13, 0)]
@@ -31665,7 +31671,7 @@ namespace UIKit {
 
 	[iOS (13, 0), TV (13, 0)]
 	[MacCatalyst (13, 1)]
-	delegate NSDictionary UIScreenshotServiceDelegatePdfHandler (NSData pdfData, nint indexOfCurrentPage, CGRect rectInCurrentPage);
+	delegate NSDictionary UIScreenshotServiceDelegatePdfHandler ([NullAllowed] NSData pdfData, nint indexOfCurrentPage, CGRect rectInCurrentPage);
 
 	interface IUIScreenshotServiceDelegate { }
 
@@ -32120,10 +32126,12 @@ namespace UIKit {
 
 	[TV (13, 0), iOS (13, 0)]
 	[MacCatalyst (13, 1)]
+	[return: NullAllowed]
 	delegate UICollectionViewCell UICollectionViewDiffableDataSourceCellProvider (UICollectionView collectionView, NSIndexPath indexPath, NSObject itemIdentifier);
 
 	[TV (13, 0), iOS (13, 0)]
 	[MacCatalyst (13, 1)]
+	[return: NullAllowed]
 	delegate UICollectionReusableView UICollectionViewDiffableDataSourceSupplementaryViewProvider (UICollectionView collectionView, string elementKind, NSIndexPath indexPath);
 
 	[TV (13, 0), iOS (13, 0)]
@@ -32204,6 +32212,7 @@ namespace UIKit {
 
 	[TV (13, 0), iOS (13, 0)]
 	[MacCatalyst (13, 1)]
+	[return: NullAllowed]
 	delegate UITableViewCell UITableViewDiffableDataSourceCellProvider (UITableView tableView, NSIndexPath indexPath, NSObject obj);
 
 	[TV (13, 0), iOS (13, 0)]
@@ -32280,8 +32289,11 @@ namespace UIKit {
 		NSString ShareRecipients { get; }
 	}
 
+	[return: NullAllowed]
 	delegate NSObject UIActivityItemsConfigurationMetadataProviderHandler (NSString activityItemsConfigurationMetadataKey);
+	[return: NullAllowed]
 	delegate NSObject UIActivityItemsConfigurationPerItemMetadataProviderHandler (nint index, NSString activityItemsConfigurationMetadataKey);
+	[return: NullAllowed]
 	delegate NSObject UIActivityItemsConfigurationPreviewProviderHandler (nint index, NSString activityItemsConfigurationPreviewIntent, CGSize suggestedSize);
 
 	[NoTV, iOS (13, 0)]
@@ -32986,6 +32998,7 @@ namespace UIKit {
 
 	[NoTV]
 	[MacCatalyst (13, 1)]
+	[return: NullAllowed]
 	delegate UISwipeActionsConfiguration UICollectionLayoutListSwipeActionsConfigurationProvider (NSIndexPath indexPath);
 
 	[NoTV]
@@ -34391,6 +34404,7 @@ namespace UIKit {
 	}
 
 	[NoTV, iOS (15, 0), MacCatalyst (15, 0)]
+	[return: NullAllowed]
 	delegate UIWindowSceneActivationConfiguration UIWindowSceneActivationActionConfigurationProvider (UIWindowSceneActivationAction action);
 
 	[NoTV, iOS (15, 0), MacCatalyst (15, 0)]
@@ -34426,6 +34440,7 @@ namespace UIKit {
 	}
 
 	[NoTV, iOS (15, 0), MacCatalyst (15, 0)]
+	[return: NullAllowed]
 	delegate UIWindowSceneActivationConfiguration UIWindowSceneActivationInteractionConfigurationProvider (UIWindowSceneActivationInteraction interaction, CGPoint location);
 
 	[NoTV, iOS (15, 0), MacCatalyst (15, 0)]
@@ -35016,6 +35031,7 @@ namespace UIKit {
 	}
 
 	[NoTV, iOS (16, 0), MacCatalyst (16, 0)]
+	[return: NullAllowed]
 	delegate UIMenu OptionsMenuProviderHandler (UIMenuElement [] elements);
 
 	[NoTV, iOS (16, 0), MacCatalyst (16, 0)]
@@ -37788,6 +37804,7 @@ namespace UIKit {
 	}
 
 	[NoMac, NoTV, iOS (18, 1), MacCatalyst (18, 1)]
+	[return: NullAllowed]
 	delegate IUITextInput UITextInputReturnHandler ();
 
 	[NoMac, NoTV, iOS (18, 1), MacCatalyst (18, 1)]

--- a/src/vision.cs
+++ b/src/vision.cs
@@ -1128,7 +1128,7 @@ namespace Vision {
 	///       </example>
 	///     </remarks>
 	[MacCatalyst (13, 1)]
-	delegate void VNRequestCompletionHandler (VNRequest request, NSError error);
+	delegate void VNRequestCompletionHandler (VNRequest request, [NullAllowed] NSError error);
 
 	/// <summary>A subclass of <see cref="Vision.VNImageBasedRequest" /> that uses a Core ML model for processing.</summary>
 	[MacCatalyst (13, 1)]

--- a/src/webkit.cs
+++ b/src/webkit.cs
@@ -7866,7 +7866,7 @@ namespace WebKit {
 		void Close (WKWebExtensionContext context, WKWebExtensionWindowCallback completionHandler);
 	}
 
-	delegate void WKWebExtensionControllerDataRecordCallback (WKWebExtensionDataRecord dataRecord);
+	delegate void WKWebExtensionControllerDataRecordCallback ([NullAllowed] WKWebExtensionDataRecord dataRecord);
 	delegate void WKWebExtensionControllerDataRecordsCallback (WKWebExtensionDataRecord [] dataRecords);
 
 	[Mac (15, 4), iOS (18, 4), MacCatalyst (18, 4), NoTV]

--- a/src/xkit.cs
+++ b/src/xkit.cs
@@ -3842,7 +3842,7 @@ namespace UIKit {
 	delegate bool NSTextLayoutManagerEnumerateRenderingAttributesDelegate (NSTextLayoutManager textLayoutManager, NSDictionary<NSString, NSObject> attributes, NSTextRange textRange);
 
 	[TV (15, 0), iOS (15, 0), MacCatalyst (15, 0)]
-	delegate bool NSTextLayoutManagerEnumerateTextSegmentsDelegate (NSTextRange textSegmentRange, CGRect textSegmentFrame, nfloat baselinePosition, NSTextContainer textContainer);
+	delegate bool NSTextLayoutManagerEnumerateTextSegmentsDelegate ([NullAllowed] NSTextRange textSegmentRange, CGRect textSegmentFrame, nfloat baselinePosition, NSTextContainer textContainer);
 
 	[TV (15, 0), iOS (15, 0), MacCatalyst (15, 0)]
 	[DesignatedDefaultCtor]
@@ -4409,7 +4409,7 @@ namespace UIKit {
 	}
 
 	[TV (15, 0), iOS (15, 0), MacCatalyst (15, 0)]
-	delegate void NSTextSelectionDataSourceEnumerateSubstringsDelegate (NSString substring, NSTextRange substringRange, NSTextRange enclodingRange, out bool stop);
+	delegate void NSTextSelectionDataSourceEnumerateSubstringsDelegate ([NullAllowed] NSString substring, NSTextRange substringRange, [NullAllowed] NSTextRange enclodingRange, out bool stop);
 
 	[TV (15, 0), iOS (15, 0), MacCatalyst (15, 0)]
 	delegate void NSTextSelectionDataSourceEnumerateCaretOffsetsDelegate (nfloat caretOffset, INSTextLocation location, bool leadingEdge, out bool stop);

--- a/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/Microsoft.Macios.Bindings.Analyzer.Tests.csproj
+++ b/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/Microsoft.Macios.Bindings.Analyzer.Tests.csproj
@@ -10,9 +10,9 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.3-beta1.24352.1"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/rgen/Microsoft.Macios.Bindings.CodeFixers.Tests/Microsoft.Macios.Bindings.CodeFixers.Tests.csproj
+++ b/tests/rgen/Microsoft.Macios.Bindings.CodeFixers.Tests/Microsoft.Macios.Bindings.CodeFixers.Tests.csproj
@@ -14,9 +14,9 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.3-beta1.24352.1"/>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.3-beta1.24352.1"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/BaseGeneratorTestClass.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/BaseGeneratorTestClass.cs
@@ -105,6 +105,8 @@ public class BaseGeneratorTestClass {
 
 			// Run generators and retrieve all results.
 			var runResult = RunGenerators (driver, compilation);
+			var errors = runResult.Diagnostics.Where (d => d.Severity == DiagnosticSeverity.Error);
+			Assert.Empty (errors);
 
 			// All generated files can be found in 'RunResults.GeneratedTrees'.
 			var generatedFileSyntax = runResult.GeneratedTrees.Where (t => t.FilePath.EndsWith ($"{testData.ClassName}.g.cs")).ToArray ();

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/ClassGenerationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/ClassGenerationTests.cs
@@ -46,7 +46,7 @@ public class ClassGenerationTests : BaseGeneratorTestClass {
 			new (ApplePlatform.MacCatalyst, "ThreadSafeUIKitPropertyTests", "ThreadSafeUIKitPropertyTests.cs", "ExpectedThreadSafeUIKitPropertyTests.cs"),
 			new (ApplePlatform.MacOSX, "AppKitPropertyTests", "AppKitPropertyTests.cs", "ExpectedAppKitPropertyTests.cs"),
 			new (ApplePlatform.MacOSX, "ThreadSafeAppKitPropertyTests", "ThreadSafeAppKitPropertyTests.cs", "ExpectedThreadSafeAppKitPropertyTests.cs"),
-
+			
 			new (ApplePlatform.iOS, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs"),
 			new (ApplePlatform.TVOS, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs"),
 			new (ApplePlatform.MacCatalyst, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs"),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/ClassGenerationTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/ClassGenerationTests.cs
@@ -46,7 +46,7 @@ public class ClassGenerationTests : BaseGeneratorTestClass {
 			new (ApplePlatform.MacCatalyst, "ThreadSafeUIKitPropertyTests", "ThreadSafeUIKitPropertyTests.cs", "ExpectedThreadSafeUIKitPropertyTests.cs"),
 			new (ApplePlatform.MacOSX, "AppKitPropertyTests", "AppKitPropertyTests.cs", "ExpectedAppKitPropertyTests.cs"),
 			new (ApplePlatform.MacOSX, "ThreadSafeAppKitPropertyTests", "ThreadSafeAppKitPropertyTests.cs", "ExpectedThreadSafeAppKitPropertyTests.cs"),
-			
+
 			new (ApplePlatform.iOS, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs"),
 			new (ApplePlatform.TVOS, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs"),
 			new (ApplePlatform.MacCatalyst, "NSUserDefaults", "NSUserDefaults.cs", "ExpectedNSUserDefaults.cs"),

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/AVAudioPcmBufferDefaultCtr.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/AVAudioPcmBufferDefaultCtr.cs
@@ -1,3 +1,4 @@
+#pragma warning disable APL0003
 using System;
 using Foundation;
 using ObjCBindings;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/AVAudioPcmBufferNoDefaultCtr.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/AVAudioPcmBufferNoDefaultCtr.cs
@@ -1,3 +1,4 @@
+#pragma warning disable APL0003
 using System;
 using Foundation;
 using ObjCBindings;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/AVAudioPcmBufferNoNativeName.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/AVAudioPcmBufferNoNativeName.cs
@@ -1,3 +1,4 @@
+#pragma warning disable APL0003
 using System;
 using Foundation;
 using ObjCBindings;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/AppKitPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/AppKitPropertyTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
 
 using System;
 using System.Runtime.Versioning;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/CIImage.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/CIImage.cs
@@ -1,3 +1,4 @@
+#pragma warning disable APL0003
 using System;
 using System.Runtime.Versioning;
 using Foundation;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/MethodTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
 
 using System;
 using System.Runtime.Versioning;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/NSUserDefaults.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/NSUserDefaults.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
 
 using System;
 using System.Runtime.Versioning;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/PropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/PropertyTests.cs
@@ -85,7 +85,7 @@ public partial class PropertyTests {
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
-	[Export<Property> ("delegate", ArgumentSemantic.Assign)]
+	[Export<Property> ("delegate", ArgumentSemantic.Weak, Flags = Property.WeakDelegate)]
 	public virtual partial NSObject? WeakDelegate { get; set; }
 
 	// array nsobject

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/PropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/PropertyTests.cs
@@ -86,9 +86,9 @@ public partial class PropertyTests {
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
-	[Export<Property> ("delegate", 
-		ArgumentSemantic.Weak, 
-		Flags = Property.WeakDelegate, 
+	[Export<Property> ("delegate",
+		ArgumentSemantic.Weak,
+		Flags = Property.WeakDelegate,
 		StrongDelegateType = typeof (INSUserActivityDelegate))]
 	public virtual partial NSObject? WeakDelegate { get; set; }
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/PropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/PropertyTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
 
 using System;
 using System.Runtime.Versioning;
@@ -12,7 +13,7 @@ using nfloat = System.Runtime.InteropServices.NFloat;
 
 namespace TestNamespace;
 
-[BindingType<Class>]
+[BindingType<ObjCBindings.Class>]
 public partial class PropertyTests {
 
 	// the following are a list of examples of all possible property definitions
@@ -62,7 +63,7 @@ public partial class PropertyTests {
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
-	public virtual partial string? Name { get; set; }
+	public virtual partial string? OtherName { get; set; }
 
 	// array of strings
 	[Export<Property> ("surnames")]
@@ -70,7 +71,7 @@ public partial class PropertyTests {
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
-	public virtual partial string [] Name { get; set; }
+	public virtual partial string [] Names { get; set; }
 
 	// simple NSObject
 	[SupportedOSPlatform ("ios")]
@@ -85,7 +86,10 @@ public partial class PropertyTests {
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
-	[Export<Property> ("delegate", ArgumentSemantic.Weak, Flags = Property.WeakDelegate)]
+	[Export<Property> ("delegate", 
+		ArgumentSemantic.Weak, 
+		Flags = Property.WeakDelegate, 
+		StrongDelegateType = typeof (INSUserActivityDelegate))]
 	public virtual partial NSObject? WeakDelegate { get; set; }
 
 	// array nsobject
@@ -142,16 +146,6 @@ public partial class PropertyTests {
 		get;
 		[Export<Property> ("setLenient:")]
 		set;
-	}
-
-	// wrapper property example
-	[SupportedOSPlatform ("ios")]
-	[SupportedOSPlatform ("tvos")]
-	[SupportedOSPlatform ("macos")]
-	[SupportedOSPlatform ("maccatalyst13.1")]
-	public virtual INSMetadataQueryDelegate? Delegate {
-		get => WeakDelegate as INSMetadataQueryDelegate;
-		set => WeakDelegate = value;
 	}
 
 	// bindfrom

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ThreadSafeAppKitPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ThreadSafeAppKitPropertyTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
 
 using System;
 using System.Runtime.Versioning;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ThreadSafeUIKitPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/ThreadSafeUIKitPropertyTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
 
 using System;
 using System.Runtime.Versioning;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/TrampolinePropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/TrampolinePropertyTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
 
 namespace Microsoft.Macios.Generator.Tests.Classes.Data;
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/UIKitPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/UIKitPropertyTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma warning disable APL0003
 
 using System;
 using System.Runtime.Versioning;

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
@@ -234,6 +234,7 @@ public partial class PropertyTests
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
 	protected internal PropertyTests (global::ObjCRuntime.NativeHandle handle) : base (handle) {}
 
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	object? __mt_Alphanumerics_var = null;
 
 	[SupportedOSPlatform ("macos")]
@@ -280,6 +281,7 @@ public partial class PropertyTests
 		}
 	}
 
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	object? __mt_AttributedStringByInflectingString_var = null;
 
 	[SupportedOSPlatform ("macos")]
@@ -595,6 +597,7 @@ public partial class PropertyTests
 		}
 	}
 
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	object? __mt_Locale_var = null;
 
 	[SupportedOSPlatform ("macos")]
@@ -849,6 +852,7 @@ public partial class PropertyTests
 		}
 	}
 
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	object? __mt_Results_var = null;
 
 	[SupportedOSPlatform ("macos")]
@@ -975,6 +979,7 @@ public partial class PropertyTests
 		}
 	}
 
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	object? __mt_WeakDelegate_var = null;
 
 	[SupportedOSPlatform ("macos")]
@@ -997,6 +1002,8 @@ public partial class PropertyTests
 				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("delegate")));
 			}
 			global::System.GC.KeepAlive (this);
+			MarkDirty ();
+			__mt_WeakDelegate_var = ret;
 			return ret;
 		}
 
@@ -1014,6 +1021,8 @@ public partial class PropertyTests
 			}
 			global::System.GC.KeepAlive (this);
 			global::System.GC.KeepAlive (value);
+			MarkDirty ();
+			__mt_WeakDelegate_var = value;
 		}
 	}
 	// TODO: add binding code here

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/iOSExpectedPropertyTests.cs
@@ -734,47 +734,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial string? Name
-	{
-		[SupportedOSPlatform ("macos")]
-		[SupportedOSPlatform ("ios")]
-		[SupportedOSPlatform ("tvos")]
-		[SupportedOSPlatform ("maccatalyst13.1")]
-		get
-		{
-			string? ret;
-			if (IsDirectBinding) {
-				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
-			} else {
-				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
-			}
-			global::System.GC.KeepAlive (this);
-			return ret;
-		}
-
-		[SupportedOSPlatform ("macos")]
-		[SupportedOSPlatform ("ios")]
-		[SupportedOSPlatform ("tvos")]
-		[SupportedOSPlatform ("maccatalyst13.1")]
-		set
-		{
-			var nsvalue = global::CoreFoundation.CFString.CreateNative (value);
-			if (IsDirectBinding) {
-				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
-			} else {
-				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
-			}
-			global::System.GC.KeepAlive (this);
-			global::CoreFoundation.CFString.ReleaseNative (nsvalue);
-		}
-	}
-
-	[SupportedOSPlatform ("macos")]
-	[SupportedOSPlatform ("ios")]
-	[SupportedOSPlatform ("tvos")]
-	[SupportedOSPlatform ("maccatalyst13.1")]
-	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial string[] Name
+	public virtual partial string[] Names
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -808,6 +768,46 @@ public partial class PropertyTests
 			}
 			global::System.GC.KeepAlive (this);
 			global::System.GC.KeepAlive (nsa_value);
+		}
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public virtual partial string? OtherName
+	{
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("maccatalyst13.1")]
+		get
+		{
+			string? ret;
+			if (IsDirectBinding) {
+				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
+			} else {
+				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
+			}
+			global::System.GC.KeepAlive (this);
+			return ret;
+		}
+
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("maccatalyst13.1")]
+		set
+		{
+			var nsvalue = global::CoreFoundation.CFString.CreateNative (value);
+			if (IsDirectBinding) {
+				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
+			} else {
+				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
+			}
+			global::System.GC.KeepAlive (this);
+			global::CoreFoundation.CFString.ReleaseNative (nsvalue);
 		}
 	}
 
@@ -1023,6 +1023,22 @@ public partial class PropertyTests
 			global::System.GC.KeepAlive (value);
 			MarkDirty ();
 			__mt_WeakDelegate_var = value;
+		}
+	}
+
+	public virtual partial global::Foundation.INSUserActivityDelegate? Delegate
+	{
+		get
+		{
+			return WeakDelegate as global::Foundation.INSUserActivityDelegate;
+		}
+		set
+		{
+			var rvalue = value as NSObject;
+			if (!(value is null) && rvalue is null) {
+				throw new ArgumentException ($"The object passed of type {value.GetType ()} does not derive from NSObject");
+			}
+			WeakDelegate = rvalue;
 		}
 	}
 	// TODO: add binding code here

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
@@ -234,6 +234,7 @@ public partial class PropertyTests
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
 	protected internal PropertyTests (global::ObjCRuntime.NativeHandle handle) : base (handle) {}
 
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	object? __mt_Alphanumerics_var = null;
 
 	[SupportedOSPlatform ("macos")]
@@ -280,6 +281,7 @@ public partial class PropertyTests
 		}
 	}
 
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	object? __mt_AttributedStringByInflectingString_var = null;
 
 	[SupportedOSPlatform ("macos")]
@@ -595,6 +597,7 @@ public partial class PropertyTests
 		}
 	}
 
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	object? __mt_Locale_var = null;
 
 	[SupportedOSPlatform ("macos")]
@@ -849,6 +852,7 @@ public partial class PropertyTests
 		}
 	}
 
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	object? __mt_Results_var = null;
 
 	[SupportedOSPlatform ("macos")]
@@ -975,6 +979,7 @@ public partial class PropertyTests
 		}
 	}
 
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	object? __mt_WeakDelegate_var = null;
 
 	[SupportedOSPlatform ("macos")]
@@ -997,6 +1002,8 @@ public partial class PropertyTests
 				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("delegate")));
 			}
 			global::System.GC.KeepAlive (this);
+			MarkDirty ();
+			__mt_WeakDelegate_var = ret;
 			return ret;
 		}
 
@@ -1014,6 +1021,8 @@ public partial class PropertyTests
 			}
 			global::System.GC.KeepAlive (this);
 			global::System.GC.KeepAlive (value);
+			MarkDirty ();
+			__mt_WeakDelegate_var = value;
 		}
 	}
 	// TODO: add binding code here

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/macOSExpectedPropertyTests.cs
@@ -734,47 +734,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial string? Name
-	{
-		[SupportedOSPlatform ("macos")]
-		[SupportedOSPlatform ("ios")]
-		[SupportedOSPlatform ("tvos")]
-		[SupportedOSPlatform ("maccatalyst13.1")]
-		get
-		{
-			string? ret;
-			if (IsDirectBinding) {
-				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
-			} else {
-				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
-			}
-			global::System.GC.KeepAlive (this);
-			return ret;
-		}
-
-		[SupportedOSPlatform ("macos")]
-		[SupportedOSPlatform ("ios")]
-		[SupportedOSPlatform ("tvos")]
-		[SupportedOSPlatform ("maccatalyst13.1")]
-		set
-		{
-			var nsvalue = global::CoreFoundation.CFString.CreateNative (value);
-			if (IsDirectBinding) {
-				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
-			} else {
-				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
-			}
-			global::System.GC.KeepAlive (this);
-			global::CoreFoundation.CFString.ReleaseNative (nsvalue);
-		}
-	}
-
-	[SupportedOSPlatform ("macos")]
-	[SupportedOSPlatform ("ios")]
-	[SupportedOSPlatform ("tvos")]
-	[SupportedOSPlatform ("maccatalyst13.1")]
-	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial string[] Name
+	public virtual partial string[] Names
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -808,6 +768,46 @@ public partial class PropertyTests
 			}
 			global::System.GC.KeepAlive (this);
 			global::System.GC.KeepAlive (nsa_value);
+		}
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public virtual partial string? OtherName
+	{
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("maccatalyst13.1")]
+		get
+		{
+			string? ret;
+			if (IsDirectBinding) {
+				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
+			} else {
+				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
+			}
+			global::System.GC.KeepAlive (this);
+			return ret;
+		}
+
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("maccatalyst13.1")]
+		set
+		{
+			var nsvalue = global::CoreFoundation.CFString.CreateNative (value);
+			if (IsDirectBinding) {
+				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
+			} else {
+				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
+			}
+			global::System.GC.KeepAlive (this);
+			global::CoreFoundation.CFString.ReleaseNative (nsvalue);
 		}
 	}
 
@@ -1023,6 +1023,22 @@ public partial class PropertyTests
 			global::System.GC.KeepAlive (value);
 			MarkDirty ();
 			__mt_WeakDelegate_var = value;
+		}
+	}
+
+	public virtual partial global::Foundation.INSUserActivityDelegate? Delegate
+	{
+		get
+		{
+			return WeakDelegate as global::Foundation.INSUserActivityDelegate;
+		}
+		set
+		{
+			var rvalue = value as NSObject;
+			if (!(value is null) && rvalue is null) {
+				throw new ArgumentException ($"The object passed of type {value.GetType ()} does not derive from NSObject");
+			}
+			WeakDelegate = rvalue;
 		}
 	}
 	// TODO: add binding code here

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
@@ -234,6 +234,7 @@ public partial class PropertyTests
 	[EditorBrowsable (EditorBrowsableState.Advanced)]
 	protected internal PropertyTests (global::ObjCRuntime.NativeHandle handle) : base (handle) {}
 
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	object? __mt_Alphanumerics_var = null;
 
 	[SupportedOSPlatform ("macos")]
@@ -280,6 +281,7 @@ public partial class PropertyTests
 		}
 	}
 
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	object? __mt_AttributedStringByInflectingString_var = null;
 
 	[SupportedOSPlatform ("macos")]
@@ -595,6 +597,7 @@ public partial class PropertyTests
 		}
 	}
 
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	object? __mt_Locale_var = null;
 
 	[SupportedOSPlatform ("macos")]
@@ -849,6 +852,7 @@ public partial class PropertyTests
 		}
 	}
 
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	object? __mt_Results_var = null;
 
 	[SupportedOSPlatform ("macos")]
@@ -975,6 +979,7 @@ public partial class PropertyTests
 		}
 	}
 
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
 	object? __mt_WeakDelegate_var = null;
 
 	[SupportedOSPlatform ("macos")]
@@ -997,6 +1002,8 @@ public partial class PropertyTests
 				ret = global::ObjCRuntime.Runtime.GetNSObject<global::Foundation.NSObject> (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("delegate")));
 			}
 			global::System.GC.KeepAlive (this);
+			MarkDirty ();
+			__mt_WeakDelegate_var = ret;
 			return ret;
 		}
 
@@ -1014,6 +1021,8 @@ public partial class PropertyTests
 			}
 			global::System.GC.KeepAlive (this);
 			global::System.GC.KeepAlive (value);
+			MarkDirty ();
+			__mt_WeakDelegate_var = value;
 		}
 	}
 	// TODO: add binding code here

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Classes/Data/tvOSExpectedPropertyTests.cs
@@ -734,47 +734,7 @@ public partial class PropertyTests
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst13.1")]
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial string? Name
-	{
-		[SupportedOSPlatform ("macos")]
-		[SupportedOSPlatform ("ios")]
-		[SupportedOSPlatform ("tvos")]
-		[SupportedOSPlatform ("maccatalyst13.1")]
-		get
-		{
-			string? ret;
-			if (IsDirectBinding) {
-				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
-			} else {
-				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
-			}
-			global::System.GC.KeepAlive (this);
-			return ret;
-		}
-
-		[SupportedOSPlatform ("macos")]
-		[SupportedOSPlatform ("ios")]
-		[SupportedOSPlatform ("tvos")]
-		[SupportedOSPlatform ("maccatalyst13.1")]
-		set
-		{
-			var nsvalue = global::CoreFoundation.CFString.CreateNative (value);
-			if (IsDirectBinding) {
-				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
-			} else {
-				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
-			}
-			global::System.GC.KeepAlive (this);
-			global::CoreFoundation.CFString.ReleaseNative (nsvalue);
-		}
-	}
-
-	[SupportedOSPlatform ("macos")]
-	[SupportedOSPlatform ("ios")]
-	[SupportedOSPlatform ("tvos")]
-	[SupportedOSPlatform ("maccatalyst13.1")]
-	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	public virtual partial string[] Name
+	public virtual partial string[] Names
 	{
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]
@@ -808,6 +768,46 @@ public partial class PropertyTests
 			}
 			global::System.GC.KeepAlive (this);
 			global::System.GC.KeepAlive (nsa_value);
+		}
+	}
+
+	[SupportedOSPlatform ("macos")]
+	[SupportedOSPlatform ("ios")]
+	[SupportedOSPlatform ("tvos")]
+	[SupportedOSPlatform ("maccatalyst13.1")]
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public virtual partial string? OtherName
+	{
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("maccatalyst13.1")]
+		get
+		{
+			string? ret;
+			if (IsDirectBinding) {
+				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSend (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
+			} else {
+				ret = global::CoreFoundation.CFString.FromHandle (global::ObjCRuntime.Messaging.NativeHandle_objc_msgSendSuper (this.Handle, global::ObjCRuntime.Selector.GetHandle ("name")), false);
+			}
+			global::System.GC.KeepAlive (this);
+			return ret;
+		}
+
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios")]
+		[SupportedOSPlatform ("tvos")]
+		[SupportedOSPlatform ("maccatalyst13.1")]
+		set
+		{
+			var nsvalue = global::CoreFoundation.CFString.CreateNative (value);
+			if (IsDirectBinding) {
+				global::ObjCRuntime.Messaging.void_objc_msgSend_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
+			} else {
+				global::ObjCRuntime.Messaging.void_objc_msgSendSuper_NativeHandle (this.Handle, global::ObjCRuntime.Selector.GetHandle ("setName:"), nsvalue);
+			}
+			global::System.GC.KeepAlive (this);
+			global::CoreFoundation.CFString.ReleaseNative (nsvalue);
 		}
 	}
 
@@ -1023,6 +1023,22 @@ public partial class PropertyTests
 			global::System.GC.KeepAlive (value);
 			MarkDirty ();
 			__mt_WeakDelegate_var = value;
+		}
+	}
+
+	public virtual partial global::Foundation.INSUserActivityDelegate? Delegate
+	{
+		get
+		{
+			return WeakDelegate as global::Foundation.INSUserActivityDelegate;
+		}
+		set
+		{
+			var rvalue = value as NSObject;
+			if (!(value is null) && rvalue is null) {
+				throw new ArgumentException ($"The object passed of type {value.GetType ()} does not derive from NSObject");
+			}
+			WeakDelegate = rvalue;
 		}
 	}
 	// TODO: add binding code here

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Emitters/BindingSyntaxFactoryRuntimeTests.cs
@@ -1005,4 +1005,64 @@ public class BindingSyntaxFactoryRuntimeTests {
 		Assert.Equal (expectedSyntax, argumentSyntax.ToFullString ());
 	}
 
+	class TestDataTcsSetExceptionTests : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			yield return [
+				"tcs",
+				ImmutableArray.Create (
+					Argument (IdentifierName ("ex"))),
+				"tcs.SetException (ex)"
+			];
+
+			yield return [
+				"myTcs",
+				ImmutableArray.Create (
+					Argument (IdentifierName ("exception")),
+					Argument (IdentifierName ("additionalArg"))),
+				"myTcs.SetException (exception, additionalArg)"
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[ClassData (typeof (TestDataTcsSetExceptionTests))]
+	void TcsSetExceptionTests (string tcsVariableName, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
+	{
+		var declaration = TcsSetException (tcsVariableName, arguments);
+		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
+	}
+
+	class TestDataTcsSetResultTests : IEnumerable<object []> {
+		public IEnumerator<object []> GetEnumerator ()
+		{
+			yield return [
+				"tcs",
+				ImmutableArray.Create (
+					Argument (IdentifierName ("result"))),
+				"tcs.SetResult (result)"
+			];
+
+			yield return [
+				"myTcs",
+				ImmutableArray.Create (
+					Argument (IdentifierName ("value")),
+					Argument (IdentifierName ("additionalArg"))),
+				"myTcs.SetResult (value, additionalArg)"
+			];
+		}
+
+		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();
+	}
+
+	[Theory]
+	[ClassData (typeof (TestDataTcsSetResultTests))]
+	void TcsSetResultTests (string tcsVariableName, ImmutableArray<ArgumentSyntax> arguments, string expectedDeclaration)
+	{
+		var declaration = TcsSetResult (tcsVariableName, arguments);
+		Assert.Equal (expectedDeclaration, declaration.ToFullString ());
+	}
+
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/TypeSymbolExtensionsTests.cs
@@ -204,7 +204,9 @@ public class ParentClass {
 		var semanticModel = compilation.GetSemanticModel (syntaxTrees [0]);
 		var declaration = getNode (syntaxTrees [0].GetRoot ());
 		Assert.NotNull (declaration);
+#pragma warning disable RS1039
 		var symbol = semanticModel.GetDeclaredSymbol (declaration);
+#pragma warning restore RS1039
 		Assert.NotNull (symbol);
 		var parents = symbol.GetParents ().Select (p => p.Name).ToArray ();
 		Assert.Equal (expectedParents, parents);

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Microsoft.Macios.Generator.Tests.csproj
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Microsoft.Macios.Generator.Tests.csproj
@@ -15,12 +15,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.9.2"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.14.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.3-beta1.24352.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/BindAsDataTests.cs
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Attributes/BindAsDataTests.cs
@@ -123,7 +123,9 @@ interface UIFeedbackGenerator {
 
 		Assert.NotNull (declaration);
 
+#pragma warning disable RS1039
 		var symbol = semanticModel.GetDeclaredSymbol (declaration);
+#pragma warning restore RS1039
 		Assert.NotNull (symbol);
 		var attribute = symbol.GetAttribute<BindAsData> (AttributesNames.BindAsAttribute, BindAsData.TryParse);
 		Assert.NotNull (attribute);

--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Microsoft.Macios.Transformer.Tests.csproj
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Microsoft.Macios.Transformer.Tests.csproj
@@ -20,11 +20,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.2"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0"/>
-        <PackageReference Include="Mono.Cecil" Version="0.11.5" />
-        <PackageReference Include="xunit" Version="2.9.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="Mono.Cecil" Version="0.11.6" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Bump the version of the Roslyn nugets which allows use to check if there are any compilation warnings/errors in the code used for the tests. This simplifies the debug process when we have a mistake in the test code.

Some warnings that are incorrect from the roslyn analyzers had to be ignored, tests show that the warning is a false positive.