### PR TITLE
[monotouch-test] Deduplicate code to create NWConnections.

### DIFF
--- a/tests/monotouch-test/Network/NWConnectionTest.cs
+++ b/tests/monotouch-test/Network/NWConnectionTest.cs
@@ -14,52 +14,18 @@ namespace MonoTouchFixtures.Network {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class NWConnectionTest {
-
-		AutoResetEvent connectedEvent;  // used to let us know when the connection was established so that we can access the Report
-		string host;
+		ConnectionManager manager;
 		NWConnection connection;
-
-		void ConnectionStateHandler (NWConnectionState state, NWError error)
-		{
-			switch (state) {
-			case NWConnectionState.Ready:
-				connectedEvent.Set ();
-				break;
-			case NWConnectionState.Invalid:
-			case NWConnectionState.Failed:
-				Assert.Inconclusive ("Network connection could not be performed.");
-				break;
-			}
-		}
-
-		[OneTimeSetUp]
-		public void Init () => TestRuntime.AssertXcodeVersion (10, 0);
 
 		[SetUp]
 		public void SetUp ()
 		{
-			// connect and once the connection is done, deal with the diff tests
-			connectedEvent = new AutoResetEvent (false);
-			host = NetworkResources.MicrosoftUri.Host;
-			// we create a connection which we are going to use to get the availabe
-			// interfaces, that way we can later test protperties of the NWParameters class.
-			using (var parameters = NWParameters.CreateUdp ())
-			using (var endpoint = NWEndpoint.Create (host, "80")) {
-				using (var protocolStack = parameters.ProtocolStack) {
-					var ipOptions = protocolStack.InternetProtocol;
-					ipOptions.SetVersion (NWIPVersion.Version4);
-				}
-				connection = new NWConnection (endpoint, parameters);
-				connection.SetQueue (DispatchQueue.DefaultGlobalQueue); // important, else we will get blocked
-				connection.SetStateChangeHandler (ConnectionStateHandler);
-				connection.Start ();
-				Assert.True (connectedEvent.WaitOne (20000), "Connection timed out.");
-			}
-
+			manager = new ConnectionManager ();
+			connection = manager.CreateConnection ();
 		}
 
 		[TearDown]
-		public void TearDown () => connection?.Dispose ();
+		public void TearDown () => manager?.Dispose ();
 
 		[Test]
 		public void TestEndpointProperty () => Assert.IsNotNull (connection.Endpoint);
@@ -107,6 +73,80 @@ namespace MonoTouchFixtures.Network {
 			connection.ForceCancel ();
 			// lib should ignore the second call
 			Assert.IsFalse (cancelled.WaitOne (3000));
+		}
+	}
+
+	class ConnectionManager : IDisposable {
+		string host = NetworkResources.MicrosoftUri.Host;
+		AutoResetEvent connectedEvent = new AutoResetEvent (false);  // used to let us know when the connection was established so that we can access the Report
+		NWConnection? connection;
+		NWParameters? parameters;
+		bool tcp;
+
+		public ConnectionManager (bool tcp = false, string? host = null)
+		{
+			this.tcp = tcp;
+			if (host is not null)
+				this.host = host;
+		}
+
+		public void Dispose ()
+		{
+			connection?.Dispose ();
+			connection = null;
+			parameters?.Dispose ();
+			parameters = null;
+		}
+
+		void ConnectionStateHandler (NWConnectionState state, NWError error)
+		{
+			switch (state) {
+			case NWConnectionState.Ready:
+				connectedEvent.Set ();
+				break;
+			case NWConnectionState.Cancelled:
+				break;
+			case NWConnectionState.Invalid:
+			case NWConnectionState.Failed:
+				Assert.Inconclusive ($"Network connection could not be performed: {error}");
+				break;
+			}
+		}
+
+		public NWConnection CreateConnection ()
+		{
+			return CreateConnection (out var _);
+		}
+
+		public NWConnection CreateConnection (out NWParameters parameters)
+		{
+			// connect and once the connection is done, deal with the diff tests
+			// we create a connection which we are going to use to get the availabe
+			// interfaces, that way we can later test protperties of the NWParameters class.
+
+			Exception? e = null;
+
+			parameters = (tcp ? NWParameters.CreateTcp () : NWParameters.CreateUdp ());
+
+			using (var endpoint = NWEndpoint.Create (host, "80")) {
+				using (var protocolStack = parameters.ProtocolStack) {
+					var ipOptions = protocolStack.InternetProtocol;
+					ipOptions.SetVersion (NWIPVersion.Version4);
+				}
+				var connection = new NWConnection (endpoint, parameters);
+				connection.SetQueue (DispatchQueue.DefaultGlobalQueue); // important, else we will get blocked
+				connection.SetStateChangeHandler ((state, error) => {
+					try {
+						ConnectionStateHandler (state, error);
+					} catch (Exception ex) {
+						e = ex;
+					}
+				});
+				connection.Start ();
+				Assert.True (connectedEvent.WaitOne (20000), "Connection timed out.");
+				Assert.That (e, Is.Null, "No exception");
+				return connection;
+			}
 		}
 	}
 }

--- a/tests/monotouch-test/Network/NWEstablishmentReportTest.cs
+++ b/tests/monotouch-test/Network/NWEstablishmentReportTest.cs
@@ -14,60 +14,33 @@ namespace MonoTouchFixtures.Network {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class NWEstablishmentReportTest {
-
-		AutoResetEvent connectedEvent;  // used to let us know when the connection was established so that we can access the Report
 		AutoResetEvent reportEvent;  // used to let us know when the connection was established and we got the report
-		string host;
+		ConnectionManager manager;
 		NWConnection connection;
 		NWEstablishmentReport report;
-
-		void ConnectionStateHandler (NWConnectionState state, NWError error)
-		{
-			switch (state) {
-			case NWConnectionState.Ready:
-				connectedEvent.Set ();
-				break;
-			case NWConnectionState.Invalid:
-			case NWConnectionState.Failed:
-				Assert.Inconclusive ("Network connection could not be performed.");
-				break;
-			}
-		}
 
 		[OneTimeSetUp]
 		public void Init ()
 		{
-			TestRuntime.AssertXcodeVersion (11, 0);
 			// connect so that we can later when the report and test with it
-			connectedEvent = new AutoResetEvent (false);
 			reportEvent = new AutoResetEvent (false);
-			host = NetworkResources.MicrosoftUri.Host;
-			// we create a connection which we are going to use to get the availabe
-			// interfaces, that way we can later test protperties of the NWParameters class.
-			using (var parameters = NWParameters.CreateUdp ())
-			using (var endpoint = NWEndpoint.Create (host, "80")) {
-				using (var protocolStack = parameters.ProtocolStack) {
-					var ipOptions = protocolStack.InternetProtocol;
-					ipOptions.SetVersion (NWIPVersion.Version4);
-				}
-				connection = new NWConnection (endpoint, parameters);
-				connection.SetQueue (DispatchQueue.DefaultGlobalQueue); // important, else we will get blocked
-				connection.SetStateChangeHandler (ConnectionStateHandler);
-				connection.Start ();
-				Assert.True (connectedEvent.WaitOne (20000), "Connection timed out.");
-				connection.GetEstablishmentReport (DispatchQueue.DefaultGlobalQueue, (r) => {
-					report = r;
-					reportEvent.Set ();
-				});
-				Assert.True (reportEvent.WaitOne (20000), "Connection timed out.");
-			}
+
+
+			manager = new ConnectionManager ();
+			connection = manager.CreateConnection ();
+
+			connection.GetEstablishmentReport (DispatchQueue.DefaultGlobalQueue, (r) => {
+				report = r;
+				reportEvent.Set ();
+			});
+			Assert.True (reportEvent.WaitOne (20000), "Connection timed out.");
 		}
 
 		[OneTimeTearDown]
 		public void Dispose ()
 		{
 			report?.Dispose ();
-			connection?.Dispose ();
+			manager?.Dispose ();
 		}
 
 		[Test]

--- a/tests/monotouch-test/Network/NWResolutionReportTest.cs
+++ b/tests/monotouch-test/Network/NWResolutionReportTest.cs
@@ -11,61 +11,34 @@ namespace MonoTouchFixtures.Network {
 	[TestFixture]
 	[Preserve (AllMembers = true)]
 	public class NWResolutionReportTest {
-		AutoResetEvent connectedEvent;  // used to let us know when the connection was established so that we can access the Report
 		AutoResetEvent reportEvent;  // used to let us know when the connection was established and we got the report
 		AutoResetEvent resolutionEvent;  // used to let us know when the connection was established and we got the report
-		string host;
+		ConnectionManager manager;
 		NWConnection connection;
 		NWEstablishmentReport report;
 		NWResolutionReport resolutionReport;
 
-		void ConnectionStateHandler (NWConnectionState state, NWError error)
-		{
-			switch (state) {
-			case NWConnectionState.Ready:
-				connectedEvent.Set ();
-				break;
-			case NWConnectionState.Invalid:
-			case NWConnectionState.Failed:
-				Assert.Inconclusive ("Network connection could not be performed.");
-				break;
-			}
-		}
-
 		[OneTimeSetUp]
 		public void Init ()
 		{
-			TestRuntime.AssertXcodeVersion (13, 0);
 			TestRuntime.AssertDevice ();
 			// connect so that we can later when the report and test with it
-			connectedEvent = new AutoResetEvent (false);
 			reportEvent = new AutoResetEvent (false);
 			resolutionEvent = new AutoResetEvent (false);
-			host = NetworkResources.MicrosoftUri.Host;
-			// we create a connection which we are going to use to get the availabe
-			// interfaces, that way we can later test protperties of the NWParameters class.
-			using (var parameters = NWParameters.CreateUdp ())
-			using (var endpoint = NWEndpoint.Create (host, "80")) {
-				using (var protocolStack = parameters.ProtocolStack) {
-					var ipOptions = protocolStack.InternetProtocol;
-					ipOptions.SetVersion (NWIPVersion.Version4);
-				}
-				connection = new NWConnection (endpoint, parameters);
-				connection.SetQueue (DispatchQueue.DefaultGlobalQueue); // important, else we will get blocked
-				connection.SetStateChangeHandler (ConnectionStateHandler);
-				connection.Start ();
-				Assert.True (connectedEvent.WaitOne (20000), "Connection timed out.");
-				connection.GetEstablishmentReport (DispatchQueue.DefaultGlobalQueue, (r) => {
-					report = r;
-					reportEvent.Set ();
-				});
-				Assert.True (reportEvent.WaitOne (20000), "Connection timed out.");
-				report.EnumerateResolutionReports ((r) => {
-					resolutionReport = r;
-					resolutionEvent.Set ();
-				});
-				Assert.True (resolutionEvent.WaitOne (20000), "Connection timed out.");
-			}
+
+			manager = new ConnectionManager ();
+			connection = manager.CreateConnection ();
+
+			connection.GetEstablishmentReport (DispatchQueue.DefaultGlobalQueue, (r) => {
+				report = r;
+				reportEvent.Set ();
+			});
+			Assert.True (reportEvent.WaitOne (20000), "Timed out fetching establishment reports.");
+			report.EnumerateResolutionReports ((r) => {
+				resolutionReport = r;
+				resolutionEvent.Set ();
+			});
+			Assert.True (resolutionEvent.WaitOne (20000), "Timed out enumerating resolution reports.");
 		}
 
 		[OneTimeTearDown]
@@ -73,7 +46,7 @@ namespace MonoTouchFixtures.Network {
 		{
 			report?.Dispose ();
 			resolutionReport?.Dispose ();
-			connection?.Dispose ();
+			manager?.Dispose ();
 		}
 
 		[Test]


### PR DESCRIPTION
And most importantly: handle exceptions in callbacks, so that the process
doesn't terminate due to unhandled exceptions on background threads.