### PR TITLE
[NSAction] Unify code between platforms.

### DIFF
--- a/src/Foundation/NSAction.cs
+++ b/src/Foundation/NSAction.cs
@@ -118,19 +118,7 @@ namespace Foundation {
 		public override void Apply ()
 		{
 			gch.Free ();
-
-			//
-			// Although I would like to call Dispose here, to
-			// reduce the load on the GC, we have some useful diagnostic
-			// code in our runtime that is useful to track down
-			// problems, so we are removing the Dispose and letting
-			// the GC and our pipeline do their job.
-			// 
-#if MONOTOUCH
-			// MonoTouch has fixed the above problems, and we can call
-			// Dispose here.
 			Dispose ();
-#endif
 		}
 	}
 


### PR DESCRIPTION
Once upon a time, over a decade ago, Xamarin.iOS and Xamarin.Mac were
different in many ways, and a workaround was required for Xamarin.Mac.

This is no longer the case, all our platforms are very similar, so make the
code behave the same everywhere.