### PR TITLE
[release/9.0.1xx] [devops] Install Powershell Core if it's not already installed.

### DIFF
--- a/tools/devops/automation/templates/common/checkout.yml
+++ b/tools/devops/automation/templates/common/checkout.yml
@@ -37,33 +37,13 @@ steps:
       Invoke-WebRequest -Uri $url -OutFile $output
       Write-Host "installing $output result: $LASTEXITCODE"
       msiexec.exe /package $output /quiet ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=1 ENABLE_PSREMOTING=1 REGISTER_MANIFEST=1
-      Write-Host "install completed: $LASTEXITCODE"
+      Write-Host "install completed: $LASTEXITCODE, updating PATH"
       Write-Host "##vso[task.prependpath]$($Env:ProgramFiles)\PowerShell\7\"
-      Write-Host "PROGRAM FILES:"
-      Get-ChildItem -Path "$Env:ProgramFiles"
-      Write-Host "PROGRAM FILES/PowerShell:"
-      Get-ChildItem -Path "$($Env:ProgramFiles)\PowerShell"
-      Write-Host "PROGRAM FILES/PowerShell/7:"
-      Get-ChildItem -Path "$($Env:ProgramFiles)\PowerShell\7"
     } else {
       Write-Host "pwsh is already installed: $LASTEXITCODE"
     }
     exit 0
   displayName: 'Install PowerShell Core'
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
-  env:
-    POWERSHELL_VERSION: 7.4.0
-
-# some bots don't seem to have pwsh installed, so make sure it is
-- powershell: |
-    if (-not $(where.exe pwsh)) {
-      Write-Host "pwsh not found: $LASTEXITCODE"
-      Write-Host "PATH: $env:PATH"
-    } else {
-      Write-Host "pwsh is already installed: $LASTEXITCODE"
-    }
-    exit 0
-  displayName: 'Is PowerShell Core there?'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
   env:
     POWERSHELL_VERSION: 7.4.0

--- a/tools/devops/automation/templates/windows/stage.yml
+++ b/tools/devops/automation/templates/windows/stage.yml
@@ -86,7 +86,6 @@ stages:
       name: ${{ parameters.windowsPool }}
       demands:
       - agent.os -equals Windows_NT
-      - agent.name -equals VSM-XAM-138
 
     variables:
       DOTNET_IOS_RUNTIME_IDENTIFIERS:  $[ stageDependencies.configure_build.configure.outputs['configure_platforms.DOTNET_IOS_RUNTIME_IDENTIFIERS'] ]


### PR DESCRIPTION
Hopefully fixes this:

> ##[error]The term 'pwsh.exe' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.

Backport of #23319.