### PR TITLE
[dotnet] Specify the path to our local .NET installation in global.json.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,14 @@ all-local:: global.json
 global.json: $(TOP)/dotnet.config Makefile $(GIT_DIRECTORY)/HEAD $(GIT_DIRECTORY)/index
 	$(Q_GEN) \
 		printf "{\n" > $@; \
-		printf "  \"sdk\": {\n    \"version\": \"$(DOTNET_VERSION)\"\n  },\n" >> $@; \
+		printf "  \"sdk\": {\n" >> $@; \
+		printf "    \"version\": \"$(DOTNET_VERSION)\",\n" >> $@; \
+		printf "    \"paths\": [\n" >> $@; \
+		printf "      \"builds/downloads/dotnet\",\n" >> $@; \
+		printf "      \"\$$host\$$\"\n" >> $@; \
+		printf "    ],\n" >> $@; \
+		printf "    \"errorMessage\": \"The .NET SDK could not be found, please run 'make dotnet -C builds'.\"\n" >> $@; \
+		printf "  },\n" >> $@; \
 		printf "  \"tools\": {\n    \"dotnet\": \"$(DOTNET_VERSION)\"\n  },\n" >> $@; \
 		printf "  \"msbuild-sdks\": {\n    \"Microsoft.DotNet.Arcade.Sdk\": \"$(ARCADE_VERSION)\"\n  }\n" >> $@; \
 		printf "}\n" >> $@

--- a/global.json
+++ b/global.json
@@ -1,6 +1,11 @@
 {
   "sdk": {
-    "version": "10.0.100-preview.7.25359.101"
+    "version": "10.0.100-preview.7.25359.101",
+    "paths": [
+      "builds/downloads/dotnet",
+      "$host$"
+    ],
+    "errorMessage": "The .NET SDK could not be found, please run 'make dotnet -C builds'."
   },
   "tools": {
     "dotnet": "10.0.100-preview.7.25359.101"


### PR DESCRIPTION
This way running 'dotnet' inside the repository will automatically use the
local .NET installation (so no need for the "donut" script anymore).

Note that this only works if a recent preview of .NET 10 has been installed
into the system.

Ref: https://github.com/dotnet/designs/blob/main/accepted/2025/local-sdk-global-json.md