### PR TITLE
[RGen] Fix extension tests to work when iOS is not enabled.

### DIFF
--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/MemberDeclarationSyntaxExtensionsTests.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/MemberDeclarationSyntaxExtensionsTests.cs
@@ -235,10 +235,10 @@ public class TestClass {
 	}
 
 	[Theory]
-	[ClassData (typeof (GetBindingTypeTestData))]
-	void GetBindingType (string input, BindingType expectedBindingType)
+	[AllSupportedPlatformsClassData<GetBindingTypeTestData>]
+	void GetBindingType (ApplePlatform platform, string input, BindingType expectedBindingType)
 	{
-		var (compilation, sourceTrees) = CreateCompilation (ApplePlatform.iOS, sources: [input]);
+		var (compilation, sourceTrees) = CreateCompilation (platform, sources: [input]);
 		Assert.Single (sourceTrees);
 		var classDeclaration = sourceTrees [0].GetRoot ()
 			.DescendantNodes ()


### PR DESCRIPTION
We are doing a compilation step in the test, therefore we need to use the AllSupportedPlatformsClassData attribute to get the enabled platforms that will be used to run the tests.