### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 14411: Build ID 12106807

### DIFF
--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
@@ -1281,4 +1281,11 @@
             {2} and {3}: the different LogicalName metadata
         </comment>
     </data>
+  <data name="M7159" xml:space="preserve">
+        <value>Skipping {0} - {1} is empty.</value>
+        <comment>
+            {0}: the name of the MSBuild task that's being skipped (Copy, GetFullPaths, FilterStaticFrameworks, etc.).
+            {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
+        </comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
@@ -1281,4 +1281,11 @@
             {2} and {3}: the different LogicalName metadata
         </comment>
     </data>
+  <data name="M7159" xml:space="preserve">
+        <value>Skipping {0} - {1} is empty.</value>
+        <comment>
+            {0}: the name of the MSBuild task that's being skipped (Copy, GetFullPaths, FilterStaticFrameworks, etc.).
+            {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
+        </comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
@@ -1281,4 +1281,11 @@
             {2} and {3}: the different LogicalName metadata
         </comment>
     </data>
+  <data name="M7159" xml:space="preserve">
+        <value>Skipping {0} - {1} is empty.</value>
+        <comment>
+            {0}: the name of the MSBuild task that's being skipped (Copy, GetFullPaths, FilterStaticFrameworks, etc.).
+            {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
+        </comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
@@ -1281,4 +1281,11 @@
             {2} and {3}: the different LogicalName metadata
         </comment>
     </data>
+  <data name="M7159" xml:space="preserve">
+        <value>Skipping {0} - {1} is empty.</value>
+        <comment>
+            {0}: the name of the MSBuild task that's being skipped (Copy, GetFullPaths, FilterStaticFrameworks, etc.).
+            {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
+        </comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
@@ -1281,4 +1281,11 @@
             {2} and {3}: the different LogicalName metadata
         </comment>
     </data>
+  <data name="M7159" xml:space="preserve">
+        <value>Skipping {0} - {1} is empty.</value>
+        <comment>
+            {0}: the name of the MSBuild task that's being skipped (Copy, GetFullPaths, FilterStaticFrameworks, etc.).
+            {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
+        </comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
@@ -1281,4 +1281,11 @@
             {2} and {3}: the different LogicalName metadata
         </comment>
     </data>
+  <data name="M7159" xml:space="preserve">
+        <value>Skipping {0} - {1} is empty.</value>
+        <comment>
+            {0}: the name of the MSBuild task that's being skipped (Copy, GetFullPaths, FilterStaticFrameworks, etc.).
+            {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
+        </comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
@@ -1281,4 +1281,11 @@
             {2} and {3}: the different LogicalName metadata
         </comment>
     </data>
+  <data name="M7159" xml:space="preserve">
+        <value>Skipping {0} - {1} is empty.</value>
+        <comment>
+            {0}: the name of the MSBuild task that's being skipped (Copy, GetFullPaths, FilterStaticFrameworks, etc.).
+            {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
+        </comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
@@ -1281,4 +1281,11 @@
             {2} and {3}: the different LogicalName metadata
         </comment>
     </data>
+  <data name="M7159" xml:space="preserve">
+        <value>Skipping {0} - {1} is empty.</value>
+        <comment>
+            {0}: the name of the MSBuild task that's being skipped (Copy, GetFullPaths, FilterStaticFrameworks, etc.).
+            {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
+        </comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
@@ -1281,4 +1281,11 @@
             {2} and {3}: the different LogicalName metadata
         </comment>
     </data>
+  <data name="M7159" xml:space="preserve">
+        <value>Skipping {0} - {1} is empty.</value>
+        <comment>
+            {0}: the name of the MSBuild task that's being skipped (Copy, GetFullPaths, FilterStaticFrameworks, etc.).
+            {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
+        </comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
@@ -1281,4 +1281,11 @@
             {2} and {3}: the different LogicalName metadata
         </comment>
     </data>
+  <data name="M7159" xml:space="preserve">
+        <value>Skipping {0} - {1} is empty.</value>
+        <comment>
+            {0}: the name of the MSBuild task that's being skipped (Copy, GetFullPaths, FilterStaticFrameworks, etc.).
+            {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
+        </comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
@@ -1281,4 +1281,11 @@
             {2} and {3}: the different LogicalName metadata
         </comment>
     </data>
+  <data name="M7159" xml:space="preserve">
+        <value>Skipping {0} - {1} is empty.</value>
+        <comment>
+            {0}: the name of the MSBuild task that's being skipped (Copy, GetFullPaths, FilterStaticFrameworks, etc.).
+            {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
+        </comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
@@ -1281,4 +1281,11 @@
             {2} and {3}: the different LogicalName metadata
         </comment>
     </data>
+  <data name="M7159" xml:space="preserve">
+        <value>Skipping {0} - {1} is empty.</value>
+        <comment>
+            {0}: the name of the MSBuild task that's being skipped (Copy, GetFullPaths, FilterStaticFrameworks, etc.).
+            {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
+        </comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
@@ -1281,4 +1281,11 @@
             {2} and {3}: the different LogicalName metadata
         </comment>
     </data>
+  <data name="M7159" xml:space="preserve">
+        <value>Skipping {0} - {1} is empty.</value>
+        <comment>
+            {0}: the name of the MSBuild task that's being skipped (Copy, GetFullPaths, FilterStaticFrameworks, etc.).
+            {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
+        </comment>
+    </data>
 </root>


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.