### PR TITLE
[devops] Always use a local .NET installation.

### DIFF
--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -161,6 +161,7 @@ steps:
 - task: UseDotNet@2
   inputs:
     version: $(DotNetSdkVersion).x
+    installationPath: $(Agent.TempDirectory)/dotnet
 
 - template: ../common/install-qa-provisioning-profiles.yml
   parameters:

--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -149,6 +149,7 @@ stages:
         inputs:
           version: $(DotNetSdkVersion).x
           includePreviewVersions: true
+          installationPath: $(Agent.TempDirectory)/dotnet
 
       - task: DownloadPipelineArtifact@2
         inputs:

--- a/tools/devops/automation/templates/tests/build.yml
+++ b/tools/devops/automation/templates/tests/build.yml
@@ -228,6 +228,7 @@ steps:
 - task: UseDotNet@2
   inputs:
     version: $(DotNetSdkVersion).x
+    installationPath: $(Agent.TempDirectory)/dotnet
 
 - bash: |
     set -x

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -98,6 +98,7 @@ steps:
 - task: UseDotNet@2
   inputs:
     version: $(DotNetSdkVersion).x
+    installationPath: $(Agent.TempDirectory)/dotnet
 
 - pwsh: '& "$(Build.SourcesDirectory)/$Env:BUILD_REPOSITORY_TITLE/tools/devops/automation/scripts/initialize-test-output-variables.ps1"'
   displayName: Set output variables

--- a/tools/devops/automation/templates/windows/reserve-mac.yml
+++ b/tools/devops/automation/templates/windows/reserve-mac.yml
@@ -110,6 +110,7 @@ steps:
 - task: UseDotNet@2
   inputs:
     version: $(DotNetSdkVersion).x
+    installationPath: $(Agent.TempDirectory)/dotnet
 
 - bash: $(Build.SourcesDirectory)/$(BUILD_REPOSITORY_TITLE)/system-dependencies.sh --ignore-mono --ignore-visual-studio --ignore-mono --ignore-sharpie --ignore-shellcheck --ignore-yamllint --provision-simulators
   displayName: 'Provision simulators'


### PR DESCRIPTION
This way we avoid any trouble if there are problems with the shared version.

Example failure upgrading the shared version:

> ##[error]Failed while installing version: 9.0.304 at path: /Users/builder/azdo/_work/_tool/dotnet with error: Error: Failed cp: Error: EACCES: permission denied, copyfile '/Users/builder/azdo/_work/_temp/c64932dc-f06a-441f-8327-5a5f1e2f2123/sdk-manifests/8.0.100/microsoft.net.sdk.aspire/8.2.2/WorkloadManifest.Aspire.targets' -> '/Users/builder/azdo/_work/_tool/dotnet/sdk-manifests/8.0.100/microsoft.net.sdk.aspire/8.2.2/WorkloadManifest.Aspire.targets'