### PR TITLE
[introspection] Fix PKAddIdentityDocumentMetadata failures on macOS 26.

### DIFF
--- a/tests/introspection/ApiProtocolTest.cs
+++ b/tests/introspection/ApiProtocolTest.cs
@@ -307,6 +307,7 @@ namespace Introspection {
 				// Xcode 26.0 Conformance not in headers
 				case "ASPickerDisplaySettings":
 				case "ASPropertyCompareString":
+				case "PKAddIdentityDocumentMetadata":
 					return true;
 				}
 				break;
@@ -537,6 +538,7 @@ namespace Introspection {
 				// Xcode 26.0 Conformance not in headers
 				case "ASPickerDisplaySettings":
 				case "ASPropertyCompareString":
+				case "PKAddIdentityDocumentMetadata":
 					return true;
 				}
 				break;
@@ -770,6 +772,7 @@ namespace Introspection {
 				// Xcode 26.0 Conformance not in headers
 				case "ASPickerDisplaySettings":
 				case "ASPropertyCompareString":
+				case "PKAddIdentityDocumentMetadata":
 					return true;
 				}
 				break;


### PR DESCRIPTION
Fixes:

    [FAIL] Coding :   1 types conforms to NSCoding but does not implement INSCoding: PKAddIdentityDocumentMetadata
    [FAIL] PKAddIdentityDocumentMetadata conforms to NSCoding but does not implement INSCoding
    [FAIL] Copying :   1 types conforms to NSCopying but does not implement INSCopying: PKAddIdentityDocumentMetadata
    [FAIL] PKAddIdentityDocumentMetadata conforms to NSCopying but does not implement INSCopying
    [FAIL] SecureCoding :   1 types conforms to NSSecureCoding but does not implement INSSecureCoding:
    [FAIL] PKAddIdentityDocumentMetadata conforms to NSSecureCoding but does not implement INSSecureCoding