### PR TITLE
[release/9.0.1xx] [msbuild] Compute DOTNET_DiagnosticPorts using MSBuild properties.

### DIFF
--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -327,7 +327,7 @@ listening mode component of
 
 Implicitly sets [EnableDiagnostics](#enablediagnostics) to `true`.
 
-Defaults to `connect`.
+Defaults to `listen`.
 
 ## DiagnosticPort
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -244,7 +244,7 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		<DiagnosticAddress Condition="'$(DiagnosticAddress)' == ''">127.0.0.1</DiagnosticAddress>
 		<DiagnosticPort Condition="'$(DiagnosticPort)' == ''">9000</DiagnosticPort>
 		<DiagnosticSuspend Condition="'$(DiagnosticSuspend)' == ''">false</DiagnosticSuspend>
-		<DiagnosticListenMode Condition="'$(DiagnosticListenMode)' == ''">connect</DiagnosticListenMode>
+		<DiagnosticListenMode Condition="'$(DiagnosticListenMode)' == ''">listen</DiagnosticListenMode>
 		<DiagnosticConfiguration>$(DiagnosticAddress):$(DiagnosticPort),$(DiagnosticListenMode)</DiagnosticConfiguration>
 		<DiagnosticConfiguration Condition="'$(DiagnosticSuspend)' == 'true'">$(DiagnosticConfiguration),suspend</DiagnosticConfiguration>
 		<DiagnosticConfiguration Condition="'$(DiagnosticSuspend)' != 'true'">$(DiagnosticConfiguration),nosuspend</DiagnosticConfiguration>


### PR DESCRIPTION
If you run `dotnet-dsrouter ios`, it says:

    Start an application on ios device with ONE of the following environment variables set:
    [Default Tracing]
    DOTNET_DiagnosticPorts=127.0.0.1:9000,nosuspend,listen
    [Startup Tracing]
    DOTNET_DiagnosticPorts=127.0.0.1:9000,suspend,listen

Setting `$DOTNET_DiagnosticPorts` is non-trivial, so as a step to simplify this, we are adding multiple MSBuild properties to configure this value.

This would allow the log message to say:

    Build and run an iOS application such as:
    [Default Tracing]
    dotnet run -c Release -p:ios-arm64 -p:DiagnosticAddress=127.0.0.1 -p:DiagnosticPort=9000 -p:DiagnosticSuspend=false -p:DiagnosticListenMode=listen
    [Startup Tracing]
    dotnet run -c Release -p:ios-arm64 -p:DiagnosticAddress=127.0.0.1 -p:DiagnosticPort=9000 -p:DiagnosticSuspend=true -p:DiagnosticListenMode=listen

Since these are all default values, it can be simplified to:

    Build and run an iOS application such as:
    [Default Tracing]
    dotnet run -p:ios-arm64 -c Release -p:EnableDiagnostics=true
    [Startup Tracing]
    dotnet run -p:ios-arm64 -c Release -p:EnableDiagnostics=true

Setting any of the new properties also implicitly means that `$(EnableDiagnostics)` is set to `true` (first example), or alternatively `$(EnableDiagnostics)` can be set to true to get the default value for all the new properties (second example).

Ref: https://github.com/dotnet/android/pull/10351

Backport of #23429.