### PR TITLE
[RGen] Add validations for the BindingType attribute for a Category.

### DIFF
--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.Designer.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.Designer.cs
@@ -1352,5 +1352,194 @@ namespace Microsoft.Macios.Bindings.Analyzer {
                 return ResourceManager.GetString("RBI0047Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A category name cannot be an empty string or have spaces..
+        /// </summary>
+        internal static string RBI0048Description {
+            get {
+                return ResourceManager.GetString("RBI0048Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Category &apos;{0}&apos; name &apos;{1}&apos; is empty an empty string or has white spaces.
+        /// </summary>
+        internal static string RBI0048MessageFormat {
+            get {
+                return ResourceManager.GetString("RBI0048MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Category names cannot be a empty string or have white spaces.
+        /// </summary>
+        internal static string RBI0048Title {
+            get {
+                return ResourceManager.GetString("RBI0048Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A category type must be a INativeObject..
+        /// </summary>
+        internal static string RBI0049Description {
+            get {
+                return ResourceManager.GetString("RBI0049Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Category &apos;{0}&apos; type &apos;{1}&apos; does not implement INativeObject.
+        /// </summary>
+        internal static string RBI0049MessageFormat {
+            get {
+                return ResourceManager.GetString("RBI0049MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Category types must be INativeObjects.
+        /// </summary>
+        internal static string RBI0049Title {
+            get {
+                return ResourceManager.GetString("RBI0049Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DefaultCtorVisibility is ignored in categories..
+        /// </summary>
+        internal static string RBI0050Description {
+            get {
+                return ResourceManager.GetString("RBI0050Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Category &apos;{0}&apos; has DefaultCtorVisibility set to &apos;{1}&apos; but it will be ignored.
+        /// </summary>
+        internal static string RBI0050MessageFormat {
+            get {
+                return ResourceManager.GetString("RBI0050MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DefaultCtorVisibility is ignored in categories.
+        /// </summary>
+        internal static string RBI0050Title {
+            get {
+                return ResourceManager.GetString("RBI0050Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ErrorDomain is ignored in categories..
+        /// </summary>
+        internal static string RBI0051Description {
+            get {
+                return ResourceManager.GetString("RBI0051Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Category &apos;{0}&apos; has ErrorDomain set to &apos;{1}&apos; but it will be ignored.
+        /// </summary>
+        internal static string RBI0051MessageFormat {
+            get {
+                return ResourceManager.GetString("RBI0051MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ErrorDomain is ignored in categories.
+        /// </summary>
+        internal static string RBI0051Title {
+            get {
+                return ResourceManager.GetString("RBI0051Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to IntPtrCtorVisibility is ignored in categories..
+        /// </summary>
+        internal static string RBI0052Description {
+            get {
+                return ResourceManager.GetString("RBI0052Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Category &apos;{0}&apos; has IntPtrCtorVisibility set to &apos;{1}&apos; but it will be ignored.
+        /// </summary>
+        internal static string RBI0052MessageFormat {
+            get {
+                return ResourceManager.GetString("RBI0052MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to IntPtrCtorVisibility is ignored in categories.
+        /// </summary>
+        internal static string RBI0052Title {
+            get {
+                return ResourceManager.GetString("RBI0052Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ModelName is ignored in categories..
+        /// </summary>
+        internal static string RBI0053Description {
+            get {
+                return ResourceManager.GetString("RBI0053Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Category &apos;{0}&apos; has ModelName set to &apos;{1}&apos; but it will be ignored.
+        /// </summary>
+        internal static string RBI0053MessageFormat {
+            get {
+                return ResourceManager.GetString("RBI0053MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ModelName is ignored in categories.
+        /// </summary>
+        internal static string RBI0053Title {
+            get {
+                return ResourceManager.GetString("RBI0053Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StringCtorVisibility is ignored in categories..
+        /// </summary>
+        internal static string RBI0054Description {
+            get {
+                return ResourceManager.GetString("RBI0054Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Category &apos;{0}&apos; has StringCtorVisibility set to &apos;{1}&apos; but it will be ignored.
+        /// </summary>
+        internal static string RBI0054MessageFormat {
+            get {
+                return ResourceManager.GetString("RBI0054MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to StringCtorVisibility is ignored in categories.
+        /// </summary>
+        internal static string RBI0054Title {
+            get {
+                return ResourceManager.GetString("RBI0054Title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.resx
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Resources.resx
@@ -638,4 +638,95 @@
         <value>Properties are not supported on categories</value>
     </data>
     
+    <!-- RBI0048 -->
+    
+    <data name="RBI0048Description" xml:space="preserve">
+        <value>A category name cannot be an empty string or have spaces.</value>
+    </data>
+    <data name="RBI0048MessageFormat" xml:space="preserve">
+        <value>Category '{0}' name '{1}' is empty an empty string or has white spaces</value>
+        <comment>{0} is the name of the category, {1} is what we found</comment>
+    </data>
+    <data name="RBI0048Title" xml:space="preserve">
+        <value>Category names cannot be a empty string or have white spaces</value>
+    </data>
+    
+    <!-- RBI0049 -->
+    
+    <data name="RBI0049Description" xml:space="preserve">
+        <value>A category type must be a INativeObject.</value>
+    </data>
+    <data name="RBI0049MessageFormat" xml:space="preserve">
+        <value>Category '{0}' type '{1}' does not implement INativeObject</value>
+        <comment>{0} is the name of the category, {1} is the category type</comment>
+    </data>
+    <data name="RBI0049Title" xml:space="preserve">
+        <value>Category types must be INativeObjects</value>
+    </data>
+    
+    <!-- RBI0050 -->
+    
+    <data name="RBI0050Description" xml:space="preserve">
+        <value>DefaultCtorVisibility is ignored in categories.</value>
+    </data>
+    <data name="RBI0050MessageFormat" xml:space="preserve">
+        <value>Category '{0}' has DefaultCtorVisibility set to '{1}' but it will be ignored</value>
+        <comment>{0} is the name of the category, {1} is the value</comment>
+    </data>
+    <data name="RBI0050Title" xml:space="preserve">
+        <value>DefaultCtorVisibility is ignored in categories</value>
+    </data>
+    
+    <!-- RBI0051 -->
+    
+    <data name="RBI0051Description" xml:space="preserve">
+        <value>ErrorDomain is ignored in categories.</value>
+    </data>
+    <data name="RBI0051MessageFormat" xml:space="preserve">
+        <value>Category '{0}' has ErrorDomain set to '{1}' but it will be ignored</value>
+        <comment>{0} is the name of the category, {1} is the value</comment>
+    </data>
+    <data name="RBI0051Title" xml:space="preserve">
+        <value>ErrorDomain is ignored in categories</value>
+    </data>
+    
+    <!-- RBI0052 -->
+    
+    <data name="RBI0052Description" xml:space="preserve">
+        <value>IntPtrCtorVisibility is ignored in categories.</value>
+    </data>
+    <data name="RBI0052MessageFormat" xml:space="preserve">
+        <value>Category '{0}' has IntPtrCtorVisibility set to '{1}' but it will be ignored</value>
+        <comment>{0} is the name of the category, {1} is the value</comment>
+    </data>
+    <data name="RBI0052Title" xml:space="preserve">
+        <value>IntPtrCtorVisibility is ignored in categories</value>
+    </data>
+    
+    <!-- RBI0053 -->
+    
+    <data name="RBI0053Description" xml:space="preserve">
+        <value>ModelName is ignored in categories.</value>
+    </data>
+    <data name="RBI0053MessageFormat" xml:space="preserve">
+        <value>Category '{0}' has ModelName set to '{1}' but it will be ignored</value>
+        <comment>{0} is the name of the category, {1} is the value</comment>
+    </data>
+    <data name="RBI0053Title" xml:space="preserve">
+        <value>ModelName is ignored in categories</value>
+    </data>
+    
+    <!-- RBI0054 -->
+    
+    <data name="RBI0054Description" xml:space="preserve">
+        <value>StringCtorVisibility is ignored in categories.</value>
+    </data>
+    <data name="RBI0054MessageFormat" xml:space="preserve">
+        <value>Category '{0}' has StringCtorVisibility set to '{1}' but it will be ignored</value>
+        <comment>{0} is the name of the category, {1} is the value</comment>
+    </data>
+    <data name="RBI0054Title" xml:space="preserve">
+        <value>StringCtorVisibility is ignored in categories</value>
+    </data>
+    
 </root>

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/RgenDiagnostics.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/RgenDiagnostics.cs
@@ -721,4 +721,109 @@ public static class RgenDiagnostics {
 		description: new LocalizableResourceString (nameof (Resources.RBI0047Description), Resources.ResourceManager,
 			typeof (Resources))
 	);
+	
+	/// <summary>
+	/// Diagnostic descriptor for when a category name is incorrect.
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0048 = new (
+		"RBI0048",
+		new LocalizableResourceString (nameof (Resources.RBI0048Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0048MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
+		"Usage",
+		DiagnosticSeverity.Error,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof (Resources.RBI0048Description), Resources.ResourceManager,
+			typeof (Resources))
+	);
+	
+	/// <summary>
+	/// Diagnostic descriptor for when a category type is not a INativeObject.
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0049 = new (
+		"RBI0049",
+		new LocalizableResourceString (nameof (Resources.RBI0049Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0049MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
+		"Usage",
+		DiagnosticSeverity.Error,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof (Resources.RBI0049Description), Resources.ResourceManager,
+			typeof (Resources))
+	);
+	
+	/// <summary>
+	/// Diagnostic descriptor for when a category sets the default constructor visibility.
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0050 = new (
+		"RBI0050",
+		new LocalizableResourceString (nameof (Resources.RBI0050Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0050MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
+		"Usage",
+		DiagnosticSeverity.Warning,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof (Resources.RBI0050Description), Resources.ResourceManager,
+			typeof (Resources))
+	);
+	
+	/// <summary>
+	/// Diagnostic descriptor for when a category sets the default constructor visibility.
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0051 = new (
+		"RBI0051",
+		new LocalizableResourceString (nameof (Resources.RBI0051Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0051MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
+		"Usage",
+		DiagnosticSeverity.Warning,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof (Resources.RBI0051Description), Resources.ResourceManager,
+			typeof (Resources))
+	);
+	
+	/// <summary>
+	/// Diagnostic descriptor for when a category sets the IntPtr constructor visibility.
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0052 = new (
+		"RBI0052",
+		new LocalizableResourceString (nameof (Resources.RBI0052Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0052MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
+		"Usage",
+		DiagnosticSeverity.Warning,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof (Resources.RBI0052Description), Resources.ResourceManager,
+			typeof (Resources))
+	);
+	
+	/// <summary>
+	/// Diagnostic descriptor for when a category sets a model name.
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0053 = new (
+		"RBI0053",
+		new LocalizableResourceString (nameof (Resources.RBI0053Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0053MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
+		"Usage",
+		DiagnosticSeverity.Warning,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof (Resources.RBI0053Description), Resources.ResourceManager,
+			typeof (Resources))
+	);
+	
+	/// <summary>
+	/// Diagnostic descriptor for when a category sets a model name.
+	/// </summary>
+	internal static readonly DiagnosticDescriptor RBI0054 = new (
+		"RBI0054",
+		new LocalizableResourceString (nameof (Resources.RBI0054Title), Resources.ResourceManager, typeof (Resources)),
+		new LocalizableResourceString (nameof (Resources.RBI0054MessageFormat), Resources.ResourceManager,
+			typeof (Resources)),
+		"Usage",
+		DiagnosticSeverity.Warning,
+		isEnabledByDefault: true,
+		description: new LocalizableResourceString (nameof (Resources.RBI0054Description), Resources.ResourceManager,
+			typeof (Resources))
+	);
 }

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/RgenDiagnostics.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/RgenDiagnostics.cs
@@ -721,7 +721,7 @@ public static class RgenDiagnostics {
 		description: new LocalizableResourceString (nameof (Resources.RBI0047Description), Resources.ResourceManager,
 			typeof (Resources))
 	);
-	
+
 	/// <summary>
 	/// Diagnostic descriptor for when a category name is incorrect.
 	/// </summary>
@@ -736,7 +736,7 @@ public static class RgenDiagnostics {
 		description: new LocalizableResourceString (nameof (Resources.RBI0048Description), Resources.ResourceManager,
 			typeof (Resources))
 	);
-	
+
 	/// <summary>
 	/// Diagnostic descriptor for when a category type is not a INativeObject.
 	/// </summary>
@@ -751,7 +751,7 @@ public static class RgenDiagnostics {
 		description: new LocalizableResourceString (nameof (Resources.RBI0049Description), Resources.ResourceManager,
 			typeof (Resources))
 	);
-	
+
 	/// <summary>
 	/// Diagnostic descriptor for when a category sets the default constructor visibility.
 	/// </summary>
@@ -766,7 +766,7 @@ public static class RgenDiagnostics {
 		description: new LocalizableResourceString (nameof (Resources.RBI0050Description), Resources.ResourceManager,
 			typeof (Resources))
 	);
-	
+
 	/// <summary>
 	/// Diagnostic descriptor for when a category sets the default constructor visibility.
 	/// </summary>
@@ -781,7 +781,7 @@ public static class RgenDiagnostics {
 		description: new LocalizableResourceString (nameof (Resources.RBI0051Description), Resources.ResourceManager,
 			typeof (Resources))
 	);
-	
+
 	/// <summary>
 	/// Diagnostic descriptor for when a category sets the IntPtr constructor visibility.
 	/// </summary>
@@ -796,7 +796,7 @@ public static class RgenDiagnostics {
 		description: new LocalizableResourceString (nameof (Resources.RBI0052Description), Resources.ResourceManager,
 			typeof (Resources))
 	);
-	
+
 	/// <summary>
 	/// Diagnostic descriptor for when a category sets a model name.
 	/// </summary>
@@ -811,7 +811,7 @@ public static class RgenDiagnostics {
 		description: new LocalizableResourceString (nameof (Resources.RBI0053Description), Resources.ResourceManager,
 			typeof (Resources))
 	);
-	
+
 	/// <summary>
 	/// Diagnostic descriptor for when a category sets a model name.
 	/// </summary>

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/CategoryValidator.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/CategoryValidator.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Immutable;
+using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.Macios.Generator.Attributes;
 using Microsoft.Macios.Generator.Context;
@@ -110,6 +111,92 @@ sealed class CategoryValidator : BindingValidator {
 		return diagnostics.Length == 0;
 	}
 
+	/// <summary>
+	/// Validates the Export attribute data for a category binding, ensuring proper naming conventions,
+	/// type constraints, and constructor visibility settings.
+	/// </summary>
+	/// <param name="binding">The binding to validate.</param>
+	/// <param name="context">The root context for validation.</param>
+	/// <param name="diagnostics">When this method returns, contains diagnostics for any validation failures; otherwise, an empty array.</param>
+	/// <param name="location">The code location to be used for the diagnostics.</param>
+	/// <returns><c>true</c> if the Export attribute data is valid; otherwise, <c>false</c>.</returns>
+	bool ValidateExportData (Binding binding, RootContext context, out ImmutableArray<Diagnostic> diagnostics, Location? location)
+	{
+		var data = (BindingTypeData<Category>) binding.BindingInfo;
+		var builder = ImmutableArray.CreateBuilder<Diagnostic> ();
+		
+		// validate the name if specified
+		if (data.Name is not null) {
+			// validate that we do not have any whitespaces in the name
+			if (string.IsNullOrWhiteSpace (data.Name) || data.Name.Contains (' ')) {
+				// the name is not valid
+				builder.Add (Diagnostic.Create (
+					RBI0048, // Category '{0}' name '{1}' is empty an empty string or has white spaces
+					location,
+					binding.Name,
+					data.Name));
+			}
+		}
+		// the category types must be a INativeObject or a NSObject
+		if (!data.CategoryType.IsINativeObject) {
+			// the type is not valid
+			builder.Add (Diagnostic.Create (
+				RBI0049, // Category '{0}' type '{1}' does not implement INativeObject
+				location,
+				binding.Name,
+				data.CategoryType.FullyQualifiedName));
+		}
+		// the default ctor visibility must be the default value, else throw a warning
+		if (data.DefaultCtorVisibility != MethodAttributes.Public) {
+			// warning for the user
+			builder.Add (Diagnostic.Create (
+				RBI0050, // Category '{0}' has DefaultCtorVisibility set to '{1}' but it will be ignored
+				location,
+				binding.Name,
+				data.DefaultCtorVisibility.ToString ()));
+		}
+
+		if (data.ErrorDomain is not null) {
+			// warning for the user
+			builder.Add (Diagnostic.Create (
+				RBI0051, // Category '{0}' has set ErrorDomain to '{1}' but it will be ignored
+				location,
+				binding.Name,
+				data.ErrorDomain));
+		}
+
+		// intptr ctor visibility must be private scope since it will be ignored
+		if (data.IntPtrCtorVisibility != MethodAttributes.PrivateScope) {
+			// warning for the user
+			builder.Add (Diagnostic.Create (
+				RBI0052, // The IntPtr constructor visibility for a category must be PrivateScope.
+				location,
+				binding.Name,
+				data.IntPtrCtorVisibility.ToString ()));
+		}
+
+		if (data.ModelName is not null) {
+			// warning for the user
+			builder.Add (Diagnostic.Create (
+				RBI0053, // Category '{0}' has set ModelName to '{1}' but it will be ignored
+				location,
+				binding.Name,
+				data.ModelName));
+		}
+
+		// string ctor visibility must be private scope since it will be ignored
+		if (data.StringCtorVisibility != MethodAttributes.PrivateScope) {
+			// warning for the user
+			builder.Add (Diagnostic.Create (
+				RBI0054, // Category '{0}' has set StringCtorVisibility to '{1}' but it will be ignored
+				location,
+				binding.Name,
+				data.StringCtorVisibility.ToString ()));
+		}
+		
+		diagnostics = builder.ToImmutable ();
+		return diagnostics.Length == 0;
+	}
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="CategoryValidator"/> class.
@@ -120,6 +207,10 @@ sealed class CategoryValidator : BindingValidator {
 		AddGlobalStrategy (RBI0001, IsPartial);
 		// categories must be static
 		AddGlobalStrategy (RBI0004, IsStatic);
+		// validate the export attr of the category
+		AddGlobalStrategy (
+			descriptor: [RBI0048, RBI0049, RBI0050, RBI0051, RBI0052, RBI0053, RBI0054], 
+			validation: ValidateExportData);
 		// validate all methods in the category binding
 		AddGlobalStrategy ([RBI0042, RBI0043, RBI0044], ValidMethods);
 		// make sure that we do not have constructors, properties, fields or events

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/CategoryValidator.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/CategoryValidator.cs
@@ -124,7 +124,7 @@ sealed class CategoryValidator : BindingValidator {
 	{
 		var data = (BindingTypeData<Category>) binding.BindingInfo;
 		var builder = ImmutableArray.CreateBuilder<Diagnostic> ();
-		
+
 		// validate the name if specified
 		if (data.Name is not null) {
 			// validate that we do not have any whitespaces in the name
@@ -193,7 +193,7 @@ sealed class CategoryValidator : BindingValidator {
 				binding.Name,
 				data.StringCtorVisibility.ToString ()));
 		}
-		
+
 		diagnostics = builder.ToImmutable ();
 		return diagnostics.Length == 0;
 	}
@@ -209,7 +209,7 @@ sealed class CategoryValidator : BindingValidator {
 		AddGlobalStrategy (RBI0004, IsStatic);
 		// validate the export attr of the category
 		AddGlobalStrategy (
-			descriptor: [RBI0048, RBI0049, RBI0050, RBI0051, RBI0052, RBI0053, RBI0054], 
+			descriptor: [RBI0048, RBI0049, RBI0050, RBI0051, RBI0052, RBI0053, RBI0054],
 			validation: ValidateExportData);
 		// validate all methods in the category binding
 		AddGlobalStrategy ([RBI0042, RBI0043, RBI0044], ValidMethods);

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/BindingTypeData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/BindingTypeData.cs
@@ -289,7 +289,7 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 		if (TryExtractNamedParameters (attributeData, out name, ref flags, out string? modelName, out string? errorDomain, out string? libraryName, out categoryType, out MethodAttributes defaultCtorVisibility, out MethodAttributes intPtrCtorVisibility, out MethodAttributes stringCtorVisibility)) {
 			if (isCategory) {
 				data = flags is not null
-					? new  (categoryType, flags) {
+					? new (categoryType, flags) {
 						Name = name,
 						ModelName = modelName,
 						ErrorDomain = errorDomain,
@@ -308,7 +308,7 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 						StringCtorVisibility = stringCtorVisibility,
 					};
 			} else if (isProtocol) {
-				data = flags is not null ? 
+				data = flags is not null ?
 					new (name, flags) {
 						ModelName = modelName,
 						ErrorDomain = errorDomain,
@@ -365,13 +365,13 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 	/// <param name="stringCtorVisibility">The visibility of the string constructor.</param>
 	/// <returns>True if the data was parsed.</returns>
 	static bool TryExtractNamedParameters (AttributeData attributeData,
-		out string? name, 
-		ref T? flags, 
-		out string? modelName, 
-		out string? errorDomain, 
+		out string? name,
+		ref T? flags,
+		out string? modelName,
+		out string? errorDomain,
 		out string? libraryPath,
 		out TypeInfo categoryType,
-		out MethodAttributes defaultCtorVisibility, 
+		out MethodAttributes defaultCtorVisibility,
 		out MethodAttributes intPtrCtorVisibility,
 		out MethodAttributes stringCtorVisibility)
 	{

--- a/src/rgen/Microsoft.Macios.Generator/Attributes/BindingTypeData.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Attributes/BindingTypeData.cs
@@ -127,7 +127,7 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 	/// <summary>
 	/// Original name of the ObjC class or protocol.
 	/// </summary>
-	public string? Name { get; }
+	public string? Name { get; init; }
 
 	/// <summary>
 	/// The domain of an error enumerator. This has to be used with the SmartEnum flag.
@@ -237,7 +237,6 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 		// category related data
 		TypeInfo categoryType = TypeInfo.Default;
 		// protocol related data
-		string? modelName = null;
 
 		// check if we have a category type, we can do that by checking the type of the flag
 		var isCategory = typeof (T) == typeof (ObjCBindings.Category);
@@ -285,82 +284,70 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 			return true;
 		}
 
-		// the named types are different depending on the type of the flag, if we are dealing with a category or not.
-		if (isCategory && TryExtractCategoryNamedParameters (attributeData, out name, ref flags, out categoryType)) {
-			data = CreateCategoryBindingData (flags, categoryType);
-			return true;
-		} else if (isProtocol && TryExtractProtocolNamedParameters (attributeData, out name, ref flags, out modelName)) {
-			data = CreateProtocolBindingData (flags, name, modelName);
-			return true;
-		} else if (TryExtractClassNamedParameters (attributeData, out name, ref flags, out string? errorDomain, out string? libraryName, out MethodAttributes defaultCtorVisibility, out MethodAttributes intPtrCtorVisibility, out MethodAttributes stringCtorVisibility)) {
-			data = CreateClassBindingData (flags, name, errorDomain, libraryName, defaultCtorVisibility, intPtrCtorVisibility, stringCtorVisibility);
+		// get all the data from the attribute even when in certain use cases like categories and protocols we do no
+		// need all the data. Later the analyzer/validator will check if the data is correct and will report any issues.
+		if (TryExtractNamedParameters (attributeData, out name, ref flags, out string? modelName, out string? errorDomain, out string? libraryName, out categoryType, out MethodAttributes defaultCtorVisibility, out MethodAttributes intPtrCtorVisibility, out MethodAttributes stringCtorVisibility)) {
+			if (isCategory) {
+				data = flags is not null
+					? new  (categoryType, flags) {
+						Name = name,
+						ModelName = modelName,
+						ErrorDomain = errorDomain,
+						LibraryPath = libraryName,
+						DefaultCtorVisibility = defaultCtorVisibility,
+						IntPtrCtorVisibility = intPtrCtorVisibility,
+						StringCtorVisibility = stringCtorVisibility,
+					}
+					: new (categoryType) {
+						Name = name,
+						ModelName = modelName,
+						ErrorDomain = errorDomain,
+						LibraryPath = libraryName,
+						DefaultCtorVisibility = defaultCtorVisibility,
+						IntPtrCtorVisibility = intPtrCtorVisibility,
+						StringCtorVisibility = stringCtorVisibility,
+					};
+			} else if (isProtocol) {
+				data = flags is not null ? 
+					new (name, flags) {
+						ModelName = modelName,
+						ErrorDomain = errorDomain,
+						LibraryPath = libraryName,
+						DefaultCtorVisibility = defaultCtorVisibility,
+						IntPtrCtorVisibility = intPtrCtorVisibility,
+						StringCtorVisibility = stringCtorVisibility,
+					}
+					: new (name) {
+						ModelName = modelName,
+						ErrorDomain = errorDomain,
+						LibraryPath = libraryName,
+						DefaultCtorVisibility = defaultCtorVisibility,
+						IntPtrCtorVisibility = intPtrCtorVisibility,
+						StringCtorVisibility = stringCtorVisibility,
+					};
+			} else {
+				data = flags is not null ?
+					new (name, flags) {
+						ModelName = modelName,
+						ErrorDomain = errorDomain,
+						LibraryPath = libraryName,
+						DefaultCtorVisibility = defaultCtorVisibility,
+						IntPtrCtorVisibility = intPtrCtorVisibility,
+						StringCtorVisibility = stringCtorVisibility,
+					}
+					: new (name) {
+						ModelName = modelName,
+						ErrorDomain = errorDomain,
+						LibraryPath = libraryName,
+						DefaultCtorVisibility = defaultCtorVisibility,
+						IntPtrCtorVisibility = intPtrCtorVisibility,
+						StringCtorVisibility = stringCtorVisibility,
+					};
+			}
 			return true;
 		}
 
 		return false;
-	}
-
-	/// <summary>
-	/// Creates a new instance of <see cref="BindingTypeData{T}"/> for a class.
-	/// </summary>
-	/// <param name="flags">The configuration flags.</param>
-	/// <param name="name">The original name of the ObjC class or protocol.</param>
-	/// <param name="errorDomain">The domain of an error enumerator.</param>
-	/// <param name="libraryPath">The library name of an error/smart enum.</param>
-	/// <param name="defaultCtorVisibility">The visibility of the default constructor.</param>
-	/// <param name="intPtrCtorVisibility">The visibility of the IntPtr constructor.</param>
-	/// <param name="stringCtorVisibility">The visibility of the string constructor.</param>
-	/// <returns>A new instance of <see cref="BindingTypeData{T}"/>.</returns>
-	static BindingTypeData<T> CreateClassBindingData (T? flags, string? name, string? errorDomain,
-		string? libraryPath, MethodAttributes defaultCtorVisibility, MethodAttributes intPtrCtorVisibility,
-		MethodAttributes stringCtorVisibility)
-	{
-		return flags is not null
-			? new (name, flags) {
-				ErrorDomain = errorDomain,
-				LibraryPath = libraryPath,
-				DefaultCtorVisibility = defaultCtorVisibility,
-				IntPtrCtorVisibility = intPtrCtorVisibility,
-				StringCtorVisibility = stringCtorVisibility,
-			}
-			: new (name) {
-				ErrorDomain = errorDomain,
-				LibraryPath = libraryPath,
-				DefaultCtorVisibility = defaultCtorVisibility,
-				IntPtrCtorVisibility = intPtrCtorVisibility,
-				StringCtorVisibility = stringCtorVisibility,
-			};
-	}
-
-	/// <summary>
-	/// Creates a new instance of <see cref="BindingTypeData{T}"/> for a protocol.
-	/// </summary>
-	/// <param name="flags">The configuration flags.</param>
-	/// <param name="name">The original name of the ObjC protocol.</param>
-	/// <param name="modelName">The name of the model class for the protocol.</param>
-	/// <returns>A new instance of <see cref="BindingTypeData{T}"/>.</returns>
-	static BindingTypeData<T> CreateProtocolBindingData (T? flags, string? name, string? modelName)
-	{
-		return flags is not null
-			? new (name, flags) {
-				ModelName = modelName,
-			}
-			: new (name) {
-				ModelName = modelName,
-			};
-	}
-
-	/// <summary>
-	/// Creates a new instance of <see cref="BindingTypeData{T}"/> for a category.
-	/// </summary>
-	/// <param name="flags">The configuration flags.</param>
-	/// <param name="categoryType">The type that the category extends.</param>
-	/// <returns>A new instance of <see cref="BindingTypeData{T}"/>.</returns>
-	static BindingTypeData<T> CreateCategoryBindingData (T? flags, TypeInfo categoryType)
-	{
-		return flags is not null
-			? new (categoryType, flags)
-			: new (categoryType);
 	}
 
 	/// <summary>
@@ -369,20 +356,30 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 	/// <param name="attributeData">The attribute data to be parsed.</param>
 	/// <param name="name">The original name of the ObjC class or protocol.</param>
 	/// <param name="flags">The configuration flags.</param>
+	/// <param name="modelName">The name of the model.</param>
 	/// <param name="errorDomain">The domain of an error enumerator.</param>
 	/// <param name="libraryPath">The library name of an error/smart enum.</param>
+	/// <param name="categoryType">The category type that is being extended.</param>
 	/// <param name="defaultCtorVisibility">The visibility of the default constructor.</param>
 	/// <param name="intPtrCtorVisibility">The visibility of the IntPtr constructor.</param>
 	/// <param name="stringCtorVisibility">The visibility of the string constructor.</param>
 	/// <returns>True if the data was parsed.</returns>
-	static bool TryExtractClassNamedParameters (AttributeData attributeData,
-		out string? name, ref T? flags, out string? errorDomain, out string? libraryPath,
-		out MethodAttributes defaultCtorVisibility, out MethodAttributes intPtrCtorVisibility,
+	static bool TryExtractNamedParameters (AttributeData attributeData,
+		out string? name, 
+		ref T? flags, 
+		out string? modelName, 
+		out string? errorDomain, 
+		out string? libraryPath,
+		out TypeInfo categoryType,
+		out MethodAttributes defaultCtorVisibility, 
+		out MethodAttributes intPtrCtorVisibility,
 		out MethodAttributes stringCtorVisibility)
 	{
 		name = null;
+		modelName = null;
 		errorDomain = null;
 		libraryPath = null;
+		categoryType = TypeInfo.Default;
 		defaultCtorVisibility = MethodAttributes.PrivateScope;
 		intPtrCtorVisibility = MethodAttributes.PrivateScope;
 		stringCtorVisibility = MethodAttributes.PrivateScope;
@@ -401,6 +398,12 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 			case "LibraryPath":
 				libraryPath = (string?) value.Value!;
 				break;
+			case "ModelName":
+				modelName = (string?) value.Value!;
+				break;
+			case "CategoryType":
+				categoryType = new ((INamedTypeSymbol) value.Value!);
+				break;
 			case "DefaultCtorVisibility":
 				defaultCtorVisibility = (MethodAttributes) Convert.ToSingle ((int) value.Value!);
 				break;
@@ -409,68 +412,6 @@ readonly struct BindingTypeData<T> : IEquatable<BindingTypeData<T>> where T : En
 				break;
 			case "StringCtorVisibility":
 				stringCtorVisibility = (MethodAttributes) Convert.ToSingle ((int) value.Value!);
-				break;
-			default:
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	/// <summary>
-	/// Tries to extract the named parameters for a category from the attribute data.
-	/// </summary>
-	/// <param name="attributeData">The attribute data to be parsed.</param>
-	/// <param name="name">The original name of the ObjC class or protocol.</param>
-	/// <param name="flags">The configuration flags.</param>
-	/// <param name="categoryType">The type that the category extends.</param>
-	/// <returns>True if the data was parsed.</returns>
-	static bool TryExtractCategoryNamedParameters (AttributeData attributeData, out string? name, ref T? flags, out TypeInfo categoryType)
-	{
-		name = null;
-		categoryType = TypeInfo.Default;
-		foreach (var (paramName, value) in attributeData.NamedArguments) {
-			switch (paramName) {
-			case "Name":
-				name = (string?) value.Value!;
-				break;
-			case "Flags":
-				flags = (T) value.Value!;
-				break;
-			case "CategoryType":
-				categoryType = new ((INamedTypeSymbol) value.Value!);
-				break;
-			default:
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	/// <summary>
-	/// Tries to extract the named parameters for a protocol from the attribute data.
-	/// </summary>
-	/// <param name="attributeData">The attribute data to be parsed.</param>
-	/// <param name="name">The original name of the ObjC protocol.</param>
-	/// <param name="flags">The configuration flags.</param>
-	/// <param name="modelName">The name of the model class for the protocol.</param>
-	/// <returns>True if the data was parsed.</returns>
-	static bool TryExtractProtocolNamedParameters (AttributeData attributeData, out string? name, ref T? flags, out string? modelName)
-	{
-		name = null;
-		modelName = null;
-		foreach (var (paramName, value) in attributeData.NamedArguments) {
-			switch (paramName) {
-			case "Name":
-				name = (string?) value.Value!;
-				break;
-			case "Flags":
-				flags = (T) value.Value!;
-				break;
-			case "ModelName":
-				modelName = (string?) value.Value!;
 				break;
 			default:
 				return false;

--- a/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/CategoryAnalyzerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/CategoryAnalyzerTests.cs
@@ -244,6 +244,237 @@ public partial class TestClass{
 				DiagnosticSeverity.Error,
 				"Category 'TestClass' has properties (found 1), but properties are not supported on categories"
 			];
+			
+			// wrong name, is empty spaces
+			yield return [
+				@"
+#pragma warning disable APL0003
+
+using System;
+using System.Runtime.Versioning;
+using AVFoundation;
+using CoreGraphics;
+using Foundation;
+using ObjCBindings;
+using ObjCRuntime;
+using nfloat = System.Runtime.InteropServices.NFloat;
+
+namespace TestNamespace;
+
+[SupportedOSPlatform (""macos"")]
+[SupportedOSPlatform (""ios"")]
+[SupportedOSPlatform (""tvos"")]
+[SupportedOSPlatform (""maccatalyst13.1"")]
+[BindingType<Category> (typeof (NSObject), Name = ""    "")]
+public partial static class TestClass{
+}",
+				"RBI0048",
+				DiagnosticSeverity.Error,
+				"Category 'TestClass' name '    ' is empty an empty string or has white spaces"
+			];
+			
+			// wrong name, contains spaces
+			yield return [
+				@"
+#pragma warning disable APL0003
+
+using System;
+using System.Runtime.Versioning;
+using AVFoundation;
+using CoreGraphics;
+using Foundation;
+using ObjCBindings;
+using ObjCRuntime;
+using nfloat = System.Runtime.InteropServices.NFloat;
+
+namespace TestNamespace;
+
+[SupportedOSPlatform (""macos"")]
+[SupportedOSPlatform (""ios"")]
+[SupportedOSPlatform (""tvos"")]
+[SupportedOSPlatform (""maccatalyst13.1"")]
+[BindingType<Category> (typeof (NSObject), Name = ""Category Name   "")]
+public partial static class TestClass{
+}",
+				"RBI0048",
+				DiagnosticSeverity.Error,
+				"Category 'TestClass' name 'Category Name   ' is empty an empty string or has white spaces"
+			];
+			
+			// not INativeObject
+			yield return [
+				@"
+#pragma warning disable APL0003
+
+using System;
+using System.Runtime.Versioning;
+using AVFoundation;
+using CoreGraphics;
+using Foundation;
+using ObjCBindings;
+using ObjCRuntime;
+using nfloat = System.Runtime.InteropServices.NFloat;
+
+namespace TestNamespace;
+
+public class MyClass {}
+
+[SupportedOSPlatform (""macos"")]
+[SupportedOSPlatform (""ios"")]
+[SupportedOSPlatform (""tvos"")]
+[SupportedOSPlatform (""maccatalyst13.1"")]
+[BindingType<Category> (typeof (MyClass))]
+public partial static class TestClass{
+}",
+				"RBI0049",
+				DiagnosticSeverity.Error,
+				"Category 'TestClass' type 'TestNamespace.MyClass' does not implement INativeObject"
+			];
+			
+			// DefaultCtorVisibility is ignored
+			yield return [
+				@"
+#pragma warning disable APL0003
+
+using System;
+using System.Reflection;
+using System.Runtime.Versioning;
+using AVFoundation;
+using CoreGraphics;
+using Foundation;
+using ObjCBindings;
+using ObjCRuntime;
+using nfloat = System.Runtime.InteropServices.NFloat;
+
+namespace TestNamespace;
+
+[SupportedOSPlatform (""macos"")]
+[SupportedOSPlatform (""ios"")]
+[SupportedOSPlatform (""tvos"")]
+[SupportedOSPlatform (""maccatalyst13.1"")]
+[BindingType<Category> (typeof (NSObject), DefaultCtorVisibility = MethodAttributes.PrivateScope)]
+public partial static class TestClass{
+}",
+				"RBI0050",
+				DiagnosticSeverity.Warning,
+				"Category 'TestClass' has DefaultCtorVisibility set to 'PrivateScope' but it will be ignored"
+			];
+			
+			// IntPtrCtorVisibility is ignored
+			yield return [
+				@"
+#pragma warning disable APL0003
+
+using System;
+using System.Reflection;
+using System.Runtime.Versioning;
+using AVFoundation;
+using CoreGraphics;
+using Foundation;
+using ObjCBindings;
+using ObjCRuntime;
+using nfloat = System.Runtime.InteropServices.NFloat;
+
+namespace TestNamespace;
+
+[SupportedOSPlatform (""macos"")]
+[SupportedOSPlatform (""ios"")]
+[SupportedOSPlatform (""tvos"")]
+[SupportedOSPlatform (""maccatalyst13.1"")]
+[BindingType<Category> (typeof (NSObject), IntPtrCtorVisibility = MethodAttributes.Public)]
+public partial static class TestClass{
+}",
+				"RBI0052",
+				DiagnosticSeverity.Warning,
+				"Category 'TestClass' has IntPtrCtorVisibility set to 'Public' but it will be ignored"
+			];
+			
+			// StringCtorVisibility is ignored
+			yield return [
+				@"
+#pragma warning disable APL0003
+
+using System;
+using System.Reflection;
+using System.Runtime.Versioning;
+using AVFoundation;
+using CoreGraphics;
+using Foundation;
+using ObjCBindings;
+using ObjCRuntime;
+using nfloat = System.Runtime.InteropServices.NFloat;
+
+namespace TestNamespace;
+
+[SupportedOSPlatform (""macos"")]
+[SupportedOSPlatform (""ios"")]
+[SupportedOSPlatform (""tvos"")]
+[SupportedOSPlatform (""maccatalyst13.1"")]
+[BindingType<Category> (typeof (NSObject), StringCtorVisibility = MethodAttributes.Public)]
+public partial static class TestClass{
+}",
+				"RBI0054",
+				DiagnosticSeverity.Warning,
+				"Category 'TestClass' has StringCtorVisibility set to 'Public' but it will be ignored"
+			];
+			
+			// ErrorDomain is ignored
+			yield return [
+				@"
+#pragma warning disable APL0003
+
+using System;
+using System.Reflection;
+using System.Runtime.Versioning;
+using AVFoundation;
+using CoreGraphics;
+using Foundation;
+using ObjCBindings;
+using ObjCRuntime;
+using nfloat = System.Runtime.InteropServices.NFloat;
+
+namespace TestNamespace;
+
+[SupportedOSPlatform (""macos"")]
+[SupportedOSPlatform (""ios"")]
+[SupportedOSPlatform (""tvos"")]
+[SupportedOSPlatform (""maccatalyst13.1"")]
+[BindingType<Category> (typeof (NSObject), ErrorDomain = ""MyErrorDomain"")]
+public partial static class TestClass{
+}",
+				"RBI0051",
+				DiagnosticSeverity.Warning,
+				"Category 'TestClass' has ErrorDomain set to 'MyErrorDomain' but it will be ignored"
+			];
+			
+			// ModelName is ignored
+			yield return [
+				@"
+#pragma warning disable APL0003
+
+using System;
+using System.Reflection;
+using System.Runtime.Versioning;
+using AVFoundation;
+using CoreGraphics;
+using Foundation;
+using ObjCBindings;
+using ObjCRuntime;
+using nfloat = System.Runtime.InteropServices.NFloat;
+
+namespace TestNamespace;
+
+[SupportedOSPlatform (""macos"")]
+[SupportedOSPlatform (""ios"")]
+[SupportedOSPlatform (""tvos"")]
+[SupportedOSPlatform (""maccatalyst13.1"")]
+[BindingType<Category> (typeof (NSObject), ModelName = ""MyModelName"")]
+public partial static class TestClass{
+}",
+				"RBI0053",
+				DiagnosticSeverity.Warning,
+				"Category 'TestClass' has ModelName set to 'MyModelName' but it will be ignored"
+			];
 		}
 
 		IEnumerator IEnumerable.GetEnumerator () => GetEnumerator ();

--- a/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/CategoryAnalyzerTests.cs
+++ b/tests/rgen/Microsoft.Macios.Bindings.Analyzer.Tests/CategoryAnalyzerTests.cs
@@ -244,7 +244,7 @@ public partial class TestClass{
 				DiagnosticSeverity.Error,
 				"Category 'TestClass' has properties (found 1), but properties are not supported on categories"
 			];
-			
+
 			// wrong name, is empty spaces
 			yield return [
 				@"
@@ -272,7 +272,7 @@ public partial static class TestClass{
 				DiagnosticSeverity.Error,
 				"Category 'TestClass' name '    ' is empty an empty string or has white spaces"
 			];
-			
+
 			// wrong name, contains spaces
 			yield return [
 				@"
@@ -300,7 +300,7 @@ public partial static class TestClass{
 				DiagnosticSeverity.Error,
 				"Category 'TestClass' name 'Category Name   ' is empty an empty string or has white spaces"
 			];
-			
+
 			// not INativeObject
 			yield return [
 				@"
@@ -330,7 +330,7 @@ public partial static class TestClass{
 				DiagnosticSeverity.Error,
 				"Category 'TestClass' type 'TestNamespace.MyClass' does not implement INativeObject"
 			];
-			
+
 			// DefaultCtorVisibility is ignored
 			yield return [
 				@"
@@ -359,7 +359,7 @@ public partial static class TestClass{
 				DiagnosticSeverity.Warning,
 				"Category 'TestClass' has DefaultCtorVisibility set to 'PrivateScope' but it will be ignored"
 			];
-			
+
 			// IntPtrCtorVisibility is ignored
 			yield return [
 				@"
@@ -388,7 +388,7 @@ public partial static class TestClass{
 				DiagnosticSeverity.Warning,
 				"Category 'TestClass' has IntPtrCtorVisibility set to 'Public' but it will be ignored"
 			];
-			
+
 			// StringCtorVisibility is ignored
 			yield return [
 				@"
@@ -417,7 +417,7 @@ public partial static class TestClass{
 				DiagnosticSeverity.Warning,
 				"Category 'TestClass' has StringCtorVisibility set to 'Public' but it will be ignored"
 			];
-			
+
 			// ErrorDomain is ignored
 			yield return [
 				@"
@@ -446,7 +446,7 @@ public partial static class TestClass{
 				DiagnosticSeverity.Warning,
 				"Category 'TestClass' has ErrorDomain set to 'MyErrorDomain' but it will be ignored"
 			];
-			
+
 			// ModelName is ignored
 			yield return [
 				@"


### PR DESCRIPTION
Ensure that the correct named parameters are used when using the Category flag. This will raise the following:

1. Name contains spaces (error).
2. Category type is not a INativeObject (error).
3. DefaultCtorVisibility is ignored (warning).
4. ErrorDomain is ignored (warning).
5. IntPtrCtorVisibility is ignored (warning).
6. ModelName is ignored (warning).
7. StringCtorVisibility is ignored (warning).

We updated the way the BingdingTypeAttribute is parsed to get all the data and use that data to decide if named parameters were used that are not supported.