### PR TITLE
[tests] Fix a few build warnings in the .NET test project.

### DIFF
--- a/tests/dotnet/UnitTests/DotNetUnitTests.csproj
+++ b/tests/dotnet/UnitTests/DotNetUnitTests.csproj
@@ -4,7 +4,7 @@
 		<IsPackable>false</IsPackable>
 		<DefineConstants>$(DefineConstants);NET;TESTS</DefineConstants>
 		<Nullable>enable</Nullable>
-		<WarningsAsErrors>Nullable</WarningsAsErrors>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -13,7 +13,6 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
 		<PackageReference Include="Mono.Cecil" Version="$(MonoCecilPackageVersion)" />
 		<PackageReference Include="MSBuild.StructuredLogger" Version="$(MSBuildStructuredLoggerPackageVersion)" />
-		<PackageReference Include="System.Text.Json" Version="5.0.2" />
 		<PackageReference Include="NUnitXml.TestLogger" Version="$(NUnitXmlTestLoggerPackageVersion)" />
 	</ItemGroup>
 

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -997,7 +997,6 @@ namespace Xamarin.Tests {
 			Clean (project_path);
 
 			Dictionary<string, string>? extraProperties = null;
-			string? tmpdir;
 
 			var properties = GetDefaultProperties (runtimeIdentifiers, extraProperties);
 			properties ["Configuration"] = config;


### PR DESCRIPTION
And make sure no more warnings creep up on us.

Fixes:

    tests/dotnet/UnitTests/DotNetUnitTests.csproj : warning NU1510: PackageReference System.Text.Json will not be pruned. Consider removing this package from your dependencies, as it is likely unnecessary.
    tests/dotnet/UnitTests/ProjectTest.cs(1041,12): warning CS0168: The variable 'tmpdir' is declared but never used