### PR TITLE
[release/9.0.1xx] [autoformat] Fix autoformat.

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -11,9 +11,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: 'Checkout'
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.sha }}
+    - name: 'Install .NET'
+      uses: actions/setup-dotnet@v5
+      with:
+        global-json-file: ./global.json
     - name: 'Autoformat'
-      uses: rolfbjarne/autoformat@v0.5
+      uses: rolfbjarne/autoformat@v0.6
       with:
         script: ./tools/autoformat.sh
         git_user_email: 'github-actions-autoformatter@xamarin.com'
         git_user_name: 'GitHub Actions Autoformatter'
+        checkoutSource: false

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/ExportMethodAttributeValidator.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/ExportMethodAttributeValidator.cs
@@ -10,6 +10,7 @@ using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 using static Microsoft.Macios.Generator.RgenDiagnostics;
 
 namespace Microsoft.Macios.Bindings.Analyzer.Validators;
+
 using ExportMethod = ExportData<Method>;
 
 /// <summary>

--- a/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/FieldValidator.cs
+++ b/src/rgen/Microsoft.Macios.Bindings.Analyzer/Validators/FieldValidator.cs
@@ -9,6 +9,7 @@ using static Microsoft.Macios.Generator.RgenDiagnostics;
 using static Microsoft.Macios.Bindings.Analyzer.Validators.PropertyStrategies;
 
 namespace Microsoft.Macios.Bindings.Analyzer.Validators;
+
 using PropertyFlag = ObjCBindings.Property;
 
 /// <summary>

--- a/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Arguments.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Emitters/BindingSyntaxFactory.Arguments.cs
@@ -12,6 +12,7 @@ using static Microsoft.Macios.Generator.Nomenclator;
 using TypeInfo = Microsoft.Macios.Generator.DataModel.TypeInfo;
 
 namespace Microsoft.Macios.Generator.Emitters;
+
 static partial class BindingSyntaxFactory {
 
 	/// <summary>

--- a/tools/autoformat.sh
+++ b/tools/autoformat.sh
@@ -41,6 +41,9 @@ if test -z "${DOTNET:-}"; then
 	DOTNET=dotnet
 fi
 
+which $DOTNET
+$DOTNET --info
+
 function af_whitespace ()
 {
 	echo "Processing $1..."


### PR DESCRIPTION
For some reason 'dotnet format' doesn't work when:

* The .NET version we're using (in global.json) is .NET 10
* The system .NET is not .NET 10

or the other way around.

_even when the system .NET is executed outside the root repository directory_.

So fix this by installing the .NET version we use on the bot before doing the formatting.

Also update to an autoformat version that supports skipping checking out the source code (because we've already done that).

Backport of #23918.