### PR TITLE
[net10.0] A few minor xml docs updates.

### DIFF
--- a/src/AudioToolbox/Enums.cs
+++ b/src/AudioToolbox/Enums.cs
@@ -65,22 +65,18 @@ namespace AudioToolbox {
 	/// <summary>This enum specifies properties for <see cref="AudioUnitSubType.AUAudioMix" /> audio units.</summary>
 	[Mac (26, 0), iOS (26, 0), MacCatalyst (26, 0), NoTV]
 	public enum AUAudioMixProperty {
-		/// <summary>Remix the data from the file asset.</summary>
-		/// <remarks>This is a read-write <see cref="NSData" /> property.</remarks>
+		/// <summary>Remix the data from the file asset, using an <see cref="NSData" />.</summary>
 		SpatialAudioMixMetadata = 5000,
-		/// <summary>If spatialization is enabled or not.</summary>
-		/// <remarks>This is a read-write <see langword="uint" /> property, with two possible values: 0 or 1.</remarks>
+		/// <summary>If spatialization is enabled or not. Specified with a <see langword="uint" />, which is either 0 (false) or 1 (true).</summary>
 		EnableSpatialization = 5001,
 	}
 
 	/// <summary>This enum specifies parameters for <see cref="AudioUnitSubType.AUAudioMix" /> audio units.</summary>
 	public enum AUAudioMixParameter {
-		/// <summary>Get or set the style of the audio mixing.</summary>
-		/// <remarks>This property is an enum of type <see cref="AUAudioMixRenderingStyle" />.</remarks>
+		/// <summary>Get or set the style of the audio mixing, using a value of the <see cref="AUAudioMixRenderingStyle" /> enum.</summary>
 		[Mac (26, 0), iOS (26, 0), MacCatalyst (26, 0), NoTV]
 		Style = 0,
-		/// <summary>The remix amount.</summary>
-		/// <remarks>This property is a <see langword="float" />, with valid values ranging from 0.0f to 1.0f. The default value is 0.5f.</remarks>
+		/// <summary>The remix amount, which is a <see langword="float" />, with valid values ranging from 0.0f to 1.0f. The default value is 0.5f.</summary>
 		[Mac (26, 0), iOS (26, 0), MacCatalyst (26, 0), NoTV]
 		RemixAmount = 1,
 	}

--- a/src/AudioUnit/AUEnums.cs
+++ b/src/AudioUnit/AUEnums.cs
@@ -1482,14 +1482,11 @@ namespace AudioUnit {
 		/// <summary>To be added.</summary>
 		AudioFilePlayer = 0x6166706C, // 'afpl'
 		/// <summary>A light reverb.</summary>
-		/// <remarks>The FourCC value for 'rvb2', for the native constant kAudioUnitSubType_Reverb2.</remarks>
 		Reverb2 = 0x72766232, // 'rvb2'
 		/// <summary>An audio unit that can be used to isolate a sound type.</summary>
-		/// <remarks>The FourCC value for 'vois', for the native constant kAudioUnitSubType_AUSoundIsolation.</remarks>
 		[iOS (16, 0), Mac (13, 0), MacCatalyst (16, 0), NoTV]
 		AUSoundIsolation = 0x766f6973, // 'vois'
 		/// <summary>An audio unit that supports AudioMix separate-and-remix.</summary>
-		/// <remarks>The FourCC value for 'amix', for the native constant kAudioUnitSubType_AUAudioMix.</remarks>
 		[iOS (26, 0), Mac (26, 0), MacCatalyst (26, 0), NoTV]
 		AUAudioMix = 0x616d6978, // 'amix'
 #if MONOMAC

--- a/src/CoreGraphics/CGRect.cs
+++ b/src/CoreGraphics/CGRect.cs
@@ -524,10 +524,8 @@ namespace CoreGraphics {
 		}
 
 #if !COREBUILD
-		/// <summary>Gets the y-coordinate of the top edge of this <see cref="CoreGraphics.CGRect" /> structure.</summary>
-		///         <returns />
-		///         <remarks>
-		///         </remarks>
+		/// <summary>Converts this instance to a human readable string.</summary>
+		/// <returns>A string that represents this instance.</returns>
 		public override string? ToString ()
 		{
 			return CFString.FromHandle (NSStringFromCGRect (this));

--- a/src/CoreMedia/CoreMedia.cs
+++ b/src/CoreMedia/CoreMedia.cs
@@ -259,30 +259,27 @@ namespace CoreMedia {
 
 	// CMVideoDimensions => int32_t width + int32_t height
 	/// <summary>Struct that contains the width and height of video media.</summary>
-	///     <remarks>To be added.</remarks>
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("tvos")]
 	public struct CMVideoDimensions {
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>The width of the video media.</summary>
 		public int Width;
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>The height of the video media.</summary>
 		public int Height;
 
-		/// <param name="width">To be added.</param>
-		///         <param name="height">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Create a new <see cref="CMVideoDimensions" /> instance with the specified width and height.</summary>
+		/// <param name="width">The width of the video media.</param>
+		/// <param name="height">The height of the video media.</param>
 		public CMVideoDimensions (int width, int height)
 		{
 			Width = width;
 			Height = height;
 		}
 
-		/// <inheritdoc />
+		/// <summary>Converts this instance to a human readable string.</summary>
+		/// <returns>A string that represents this instance.</returns>
 		public override string ToString ()
 		{
 			return $"[{Width}, {Height}]";


### PR DESCRIPTION
* Don't use the 'remarks' element for enum fields, they're ignored in the publishing process.
* Fix the 'inheritdocs' element on CMVideoDimensions, the docs pipeline says it can't be resolved, so just provide explicit docs.
* Update all the other xml docs for CMVideoDimensions as well.
* Fix horribly incorrect docs for CGRect.ToString.