### PR TITLE
[msbuild] Ensure all resources are available on Windows before packing them. Fixes #23928.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2079,6 +2079,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 	<Target Name="_PackLibraryResources" Condition="'$(_CanOutputAppBundle)' == 'false'" DependsOnTargets="$(_PackLibraryResourcesDependsOn)">
 		<PackLibraryResources
+			SessionId="$(BuildSessionId)"
 			Prefix="$(_EmbeddedResourcePrefix)"
 			BundleResourcesWithLogicalNames="@(_BundleResourceWithLogicalName)"
 			BundleOriginalResourcesWithLogicalNames="@(_BundleOriginalResourceWithLogicalName)"

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -870,7 +870,8 @@ namespace Xamarin.Tests {
 			Assert.That (asm, Does.Exist, "Assembly existence");
 
 			using var ad = AssemblyDefinition.ReadAssembly (asm, new ReaderParameters { ReadingMode = ReadingMode.Deferred });
-			var actualResources = ad.MainModule.Resources.Select (v => v.Name).OrderBy (v => v).ToArray ();
+			var actualAssemblyResources = ad.MainModule.Resources;
+			var actualResources = actualAssemblyResources.Select (v => v.Name).OrderBy (v => v).ToArray ();
 
 			List<string> expectedResources;
 
@@ -957,6 +958,9 @@ namespace Xamarin.Tests {
 				expectedResources = new List<string> ();
 			}
 			CollectionAssert.AreEquivalent (expectedResources, actualResources, "Resources");
+
+			var zeroLengthResources = actualAssemblyResources.Where (v => v.ResourceType == ResourceType.Embedded && ((EmbeddedResource) v).GetResourceData ().Length == 0).Select (v => v.Name).ToArray ();
+			Assert.That (zeroLengthResources, Is.Empty, $"0-length resources");
 		}
 
 		[TestCase (ApplePlatform.iOS, "ios-arm64", false)]


### PR DESCRIPTION
Library projects might compile resources on the Mac before those compiled
resources are embedded into the resulting assembly.

However, some tasks will only create a 0-length stamp/output file on Windows,
and we don't want to embed those 0-length files into the assembly.

So if we find any such 0-length files, then copy them from the Mac to Windows
before packing them.

Fixes https://github.com/dotnet/macios/issues/23928.