### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 14411: Build ID 12571055

### DIFF
--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
@@ -1288,4 +1288,7 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
+  <data name="E7160" xml:space="preserve">
+        <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
@@ -1288,4 +1288,7 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
+  <data name="E7160" xml:space="preserve">
+        <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
@@ -1288,4 +1288,7 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
+  <data name="E7160" xml:space="preserve">
+        <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
@@ -1288,4 +1288,7 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
+  <data name="E7160" xml:space="preserve">
+        <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
@@ -1288,4 +1288,7 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
+  <data name="E7160" xml:space="preserve">
+        <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
@@ -1288,4 +1288,7 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
+  <data name="E7160" xml:space="preserve">
+        <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
@@ -1288,4 +1288,7 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
+  <data name="E7160" xml:space="preserve">
+        <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
@@ -1288,4 +1288,7 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
+  <data name="E7160" xml:space="preserve">
+        <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
@@ -1288,4 +1288,7 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
+  <data name="E7160" xml:space="preserve">
+        <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
@@ -1288,4 +1288,7 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
+  <data name="E7160" xml:space="preserve">
+        <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
@@ -1288,4 +1288,7 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
+  <data name="E7160" xml:space="preserve">
+        <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
@@ -1288,4 +1288,7 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
+  <data name="E7160" xml:space="preserve">
+        <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
@@ -1288,4 +1288,7 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
+  <data name="E7160" xml:space="preserve">
+        <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
+    </data>
 </root>


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.