### PR TITLE
[msbuild] Renumber msbuild error codes to avoid duplicating them.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1614,19 +1614,19 @@
         </comment>
     </data>
 
-    <data name="E7160" xml:space="preserve">
-        <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
-    </data>
-
-    <data name="E7161" xml:space="preserve">
-        <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
-    </data>
-
     <data name="W7160" xml:space="preserve">
         <value>Creating a compressed binding resource package to avoid MAX_PATH problems on Windows.</value>
     </data>
 
     <data name="W7161" xml:space="preserve">
         <value>Not creating a compressed binding resource package, because all the native references are already compressed.</value>
+    </data>
+
+    <data name="E7162" xml:space="preserve">
+        <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
+    </data>
+
+    <data name="E7163" xml:space="preserve">
+        <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
 </root>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/XamarinTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/XamarinTask.cs
@@ -196,7 +196,7 @@ namespace Xamarin.MacDev.Tasks {
 				var rv = taskRunner.RunAsync (task).Result;
 				if (!rv && !task.Log.HasLoggedErrors) {
 					// if we failed to execute remotely, but no error has been reported, then report an error
-					task.Log.LogError (MSBStrings.E7160 /* Unable to execute this task remotely for unknown reasons. The build log may have more information. */);
+					task.Log.LogError (MSBStrings.E7162 /* Unable to execute this task remotely for unknown reasons. The build log may have more information. */);
 				}
 				return rv;
 			} catch (Exception ex) {
@@ -211,7 +211,7 @@ namespace Xamarin.MacDev.Tasks {
 			try {
 				var rv = new TaskRunner (task.SessionId, task.BuildEngine4).CopyInputsAsync2 (task).Result;
 				if (!rv)
-					task.Log.LogError (MSBStrings.E7161 /* Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information. */);
+					task.Log.LogError (MSBStrings.E7163 /* Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information. */);
 				return rv;
 			} catch (Exception ex) {
 				task.Log.LogErrorFromException (ex);


### PR DESCRIPTION
New error codes were introduced in both main and net10.0; this makes sure the
error number between those branches isn't duplicated.