### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 14411: Build ID 12593114

### DIFF
--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
@@ -1167,24 +1167,10 @@
             This may be either a warning or an error, depending on build configuration.
         </comment>
     </data>
-  <data name="E7141" xml:space="preserve">
-        <value>The library {0} is a static library, and static libraries are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
-        </comment>
-    </data>
   <data name="E7142" xml:space="preserve">
         <value>Unknown value for 'SkipStaticLibraryValidation': {0}. Valid values are: 'true', 'false', 'warn'.</value>
         <comment>
             The following are literal names and should not be translated: SkipStaticLibraryValidation
-        </comment>
-    </data>
-  <data name="E7143" xml:space="preserve">
-        <value>The file {0} is an object file, and object files are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
         </comment>
     </data>
   <data name="W7144" xml:space="preserve">
@@ -1288,10 +1274,16 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
-  <data name="E7160" xml:space="preserve">
+  <data name="W7160" xml:space="preserve">
+        <value>Creating a compressed binding resource package to avoid MAX_PATH problems on Windows.</value>
+    </data>
+  <data name="W7161" xml:space="preserve">
+        <value>Not creating a compressed binding resource package, because all the native references are already compressed.</value>
+    </data>
+  <data name="E7162" xml:space="preserve">
         <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
     </data>
-  <data name="E7161" xml:space="preserve">
+  <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
@@ -1167,24 +1167,10 @@
             This may be either a warning or an error, depending on build configuration.
         </comment>
     </data>
-  <data name="E7141" xml:space="preserve">
-        <value>The library {0} is a static library, and static libraries are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
-        </comment>
-    </data>
   <data name="E7142" xml:space="preserve">
         <value>Unknown value for 'SkipStaticLibraryValidation': {0}. Valid values are: 'true', 'false', 'warn'.</value>
         <comment>
             The following are literal names and should not be translated: SkipStaticLibraryValidation
-        </comment>
-    </data>
-  <data name="E7143" xml:space="preserve">
-        <value>The file {0} is an object file, and object files are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
         </comment>
     </data>
   <data name="W7144" xml:space="preserve">
@@ -1288,10 +1274,16 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
-  <data name="E7160" xml:space="preserve">
+  <data name="W7160" xml:space="preserve">
+        <value>Creating a compressed binding resource package to avoid MAX_PATH problems on Windows.</value>
+    </data>
+  <data name="W7161" xml:space="preserve">
+        <value>Not creating a compressed binding resource package, because all the native references are already compressed.</value>
+    </data>
+  <data name="E7162" xml:space="preserve">
         <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
     </data>
-  <data name="E7161" xml:space="preserve">
+  <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
@@ -1167,24 +1167,10 @@
             This may be either a warning or an error, depending on build configuration.
         </comment>
     </data>
-  <data name="E7141" xml:space="preserve">
-        <value>The library {0} is a static library, and static libraries are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
-        </comment>
-    </data>
   <data name="E7142" xml:space="preserve">
         <value>Unknown value for 'SkipStaticLibraryValidation': {0}. Valid values are: 'true', 'false', 'warn'.</value>
         <comment>
             The following are literal names and should not be translated: SkipStaticLibraryValidation
-        </comment>
-    </data>
-  <data name="E7143" xml:space="preserve">
-        <value>The file {0} is an object file, and object files are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
         </comment>
     </data>
   <data name="W7144" xml:space="preserve">
@@ -1288,10 +1274,16 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
-  <data name="E7160" xml:space="preserve">
+  <data name="W7160" xml:space="preserve">
+        <value>Creating a compressed binding resource package to avoid MAX_PATH problems on Windows.</value>
+    </data>
+  <data name="W7161" xml:space="preserve">
+        <value>Not creating a compressed binding resource package, because all the native references are already compressed.</value>
+    </data>
+  <data name="E7162" xml:space="preserve">
         <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
     </data>
-  <data name="E7161" xml:space="preserve">
+  <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
@@ -1167,24 +1167,10 @@
             This may be either a warning or an error, depending on build configuration.
         </comment>
     </data>
-  <data name="E7141" xml:space="preserve">
-        <value>The library {0} is a static library, and static libraries are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
-        </comment>
-    </data>
   <data name="E7142" xml:space="preserve">
         <value>Unknown value for 'SkipStaticLibraryValidation': {0}. Valid values are: 'true', 'false', 'warn'.</value>
         <comment>
             The following are literal names and should not be translated: SkipStaticLibraryValidation
-        </comment>
-    </data>
-  <data name="E7143" xml:space="preserve">
-        <value>The file {0} is an object file, and object files are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
         </comment>
     </data>
   <data name="W7144" xml:space="preserve">
@@ -1288,10 +1274,16 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
-  <data name="E7160" xml:space="preserve">
+  <data name="W7160" xml:space="preserve">
+        <value>Creating a compressed binding resource package to avoid MAX_PATH problems on Windows.</value>
+    </data>
+  <data name="W7161" xml:space="preserve">
+        <value>Not creating a compressed binding resource package, because all the native references are already compressed.</value>
+    </data>
+  <data name="E7162" xml:space="preserve">
         <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
     </data>
-  <data name="E7161" xml:space="preserve">
+  <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
@@ -1167,24 +1167,10 @@
             This may be either a warning or an error, depending on build configuration.
         </comment>
     </data>
-  <data name="E7141" xml:space="preserve">
-        <value>The library {0} is a static library, and static libraries are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
-        </comment>
-    </data>
   <data name="E7142" xml:space="preserve">
         <value>Unknown value for 'SkipStaticLibraryValidation': {0}. Valid values are: 'true', 'false', 'warn'.</value>
         <comment>
             The following are literal names and should not be translated: SkipStaticLibraryValidation
-        </comment>
-    </data>
-  <data name="E7143" xml:space="preserve">
-        <value>The file {0} is an object file, and object files are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
         </comment>
     </data>
   <data name="W7144" xml:space="preserve">
@@ -1288,10 +1274,16 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
-  <data name="E7160" xml:space="preserve">
+  <data name="W7160" xml:space="preserve">
+        <value>Creating a compressed binding resource package to avoid MAX_PATH problems on Windows.</value>
+    </data>
+  <data name="W7161" xml:space="preserve">
+        <value>Not creating a compressed binding resource package, because all the native references are already compressed.</value>
+    </data>
+  <data name="E7162" xml:space="preserve">
         <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
     </data>
-  <data name="E7161" xml:space="preserve">
+  <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
@@ -1167,24 +1167,10 @@
             This may be either a warning or an error, depending on build configuration.
         </comment>
     </data>
-  <data name="E7141" xml:space="preserve">
-        <value>The library {0} is a static library, and static libraries are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
-        </comment>
-    </data>
   <data name="E7142" xml:space="preserve">
         <value>Unknown value for 'SkipStaticLibraryValidation': {0}. Valid values are: 'true', 'false', 'warn'.</value>
         <comment>
             The following are literal names and should not be translated: SkipStaticLibraryValidation
-        </comment>
-    </data>
-  <data name="E7143" xml:space="preserve">
-        <value>The file {0} is an object file, and object files are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
         </comment>
     </data>
   <data name="W7144" xml:space="preserve">
@@ -1288,10 +1274,16 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
-  <data name="E7160" xml:space="preserve">
+  <data name="W7160" xml:space="preserve">
+        <value>Creating a compressed binding resource package to avoid MAX_PATH problems on Windows.</value>
+    </data>
+  <data name="W7161" xml:space="preserve">
+        <value>Not creating a compressed binding resource package, because all the native references are already compressed.</value>
+    </data>
+  <data name="E7162" xml:space="preserve">
         <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
     </data>
-  <data name="E7161" xml:space="preserve">
+  <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
@@ -1167,24 +1167,10 @@
             This may be either a warning or an error, depending on build configuration.
         </comment>
     </data>
-  <data name="E7141" xml:space="preserve">
-        <value>The library {0} is a static library, and static libraries are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
-        </comment>
-    </data>
   <data name="E7142" xml:space="preserve">
         <value>Unknown value for 'SkipStaticLibraryValidation': {0}. Valid values are: 'true', 'false', 'warn'.</value>
         <comment>
             The following are literal names and should not be translated: SkipStaticLibraryValidation
-        </comment>
-    </data>
-  <data name="E7143" xml:space="preserve">
-        <value>The file {0} is an object file, and object files are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
         </comment>
     </data>
   <data name="W7144" xml:space="preserve">
@@ -1288,10 +1274,16 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
-  <data name="E7160" xml:space="preserve">
+  <data name="W7160" xml:space="preserve">
+        <value>Creating a compressed binding resource package to avoid MAX_PATH problems on Windows.</value>
+    </data>
+  <data name="W7161" xml:space="preserve">
+        <value>Not creating a compressed binding resource package, because all the native references are already compressed.</value>
+    </data>
+  <data name="E7162" xml:space="preserve">
         <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
     </data>
-  <data name="E7161" xml:space="preserve">
+  <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
@@ -1167,24 +1167,10 @@
             This may be either a warning or an error, depending on build configuration.
         </comment>
     </data>
-  <data name="E7141" xml:space="preserve">
-        <value>The library {0} is a static library, and static libraries are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
-        </comment>
-    </data>
   <data name="E7142" xml:space="preserve">
         <value>Unknown value for 'SkipStaticLibraryValidation': {0}. Valid values are: 'true', 'false', 'warn'.</value>
         <comment>
             The following are literal names and should not be translated: SkipStaticLibraryValidation
-        </comment>
-    </data>
-  <data name="E7143" xml:space="preserve">
-        <value>The file {0} is an object file, and object files are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
         </comment>
     </data>
   <data name="W7144" xml:space="preserve">
@@ -1288,10 +1274,16 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
-  <data name="E7160" xml:space="preserve">
+  <data name="W7160" xml:space="preserve">
+        <value>Creating a compressed binding resource package to avoid MAX_PATH problems on Windows.</value>
+    </data>
+  <data name="W7161" xml:space="preserve">
+        <value>Not creating a compressed binding resource package, because all the native references are already compressed.</value>
+    </data>
+  <data name="E7162" xml:space="preserve">
         <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
     </data>
-  <data name="E7161" xml:space="preserve">
+  <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
@@ -1167,24 +1167,10 @@
             This may be either a warning or an error, depending on build configuration.
         </comment>
     </data>
-  <data name="E7141" xml:space="preserve">
-        <value>The library {0} is a static library, and static libraries are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
-        </comment>
-    </data>
   <data name="E7142" xml:space="preserve">
         <value>Unknown value for 'SkipStaticLibraryValidation': {0}. Valid values are: 'true', 'false', 'warn'.</value>
         <comment>
             The following are literal names and should not be translated: SkipStaticLibraryValidation
-        </comment>
-    </data>
-  <data name="E7143" xml:space="preserve">
-        <value>The file {0} is an object file, and object files are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
         </comment>
     </data>
   <data name="W7144" xml:space="preserve">
@@ -1288,10 +1274,16 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
-  <data name="E7160" xml:space="preserve">
+  <data name="W7160" xml:space="preserve">
+        <value>Creating a compressed binding resource package to avoid MAX_PATH problems on Windows.</value>
+    </data>
+  <data name="W7161" xml:space="preserve">
+        <value>Not creating a compressed binding resource package, because all the native references are already compressed.</value>
+    </data>
+  <data name="E7162" xml:space="preserve">
         <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
     </data>
-  <data name="E7161" xml:space="preserve">
+  <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
@@ -1167,24 +1167,10 @@
             This may be either a warning or an error, depending on build configuration.
         </comment>
     </data>
-  <data name="E7141" xml:space="preserve">
-        <value>The library {0} is a static library, and static libraries are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
-        </comment>
-    </data>
   <data name="E7142" xml:space="preserve">
         <value>Unknown value for 'SkipStaticLibraryValidation': {0}. Valid values are: 'true', 'false', 'warn'.</value>
         <comment>
             The following are literal names and should not be translated: SkipStaticLibraryValidation
-        </comment>
-    </data>
-  <data name="E7143" xml:space="preserve">
-        <value>The file {0} is an object file, and object files are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
         </comment>
     </data>
   <data name="W7144" xml:space="preserve">
@@ -1288,10 +1274,16 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
-  <data name="E7160" xml:space="preserve">
+  <data name="W7160" xml:space="preserve">
+        <value>Creating a compressed binding resource package to avoid MAX_PATH problems on Windows.</value>
+    </data>
+  <data name="W7161" xml:space="preserve">
+        <value>Not creating a compressed binding resource package, because all the native references are already compressed.</value>
+    </data>
+  <data name="E7162" xml:space="preserve">
         <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
     </data>
-  <data name="E7161" xml:space="preserve">
+  <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
@@ -1167,24 +1167,10 @@
             This may be either a warning or an error, depending on build configuration.
         </comment>
     </data>
-  <data name="E7141" xml:space="preserve">
-        <value>The library {0} is a static library, and static libraries are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
-        </comment>
-    </data>
   <data name="E7142" xml:space="preserve">
         <value>Unknown value for 'SkipStaticLibraryValidation': {0}. Valid values are: 'true', 'false', 'warn'.</value>
         <comment>
             The following are literal names and should not be translated: SkipStaticLibraryValidation
-        </comment>
-    </data>
-  <data name="E7143" xml:space="preserve">
-        <value>The file {0} is an object file, and object files are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
         </comment>
     </data>
   <data name="W7144" xml:space="preserve">
@@ -1288,10 +1274,16 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
-  <data name="E7160" xml:space="preserve">
+  <data name="W7160" xml:space="preserve">
+        <value>Creating a compressed binding resource package to avoid MAX_PATH problems on Windows.</value>
+    </data>
+  <data name="W7161" xml:space="preserve">
+        <value>Not creating a compressed binding resource package, because all the native references are already compressed.</value>
+    </data>
+  <data name="E7162" xml:space="preserve">
         <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
     </data>
-  <data name="E7161" xml:space="preserve">
+  <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
@@ -1167,24 +1167,10 @@
             This may be either a warning or an error, depending on build configuration.
         </comment>
     </data>
-  <data name="E7141" xml:space="preserve">
-        <value>The library {0} is a static library, and static libraries are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
-        </comment>
-    </data>
   <data name="E7142" xml:space="preserve">
         <value>Unknown value for 'SkipStaticLibraryValidation': {0}. Valid values are: 'true', 'false', 'warn'.</value>
         <comment>
             The following are literal names and should not be translated: SkipStaticLibraryValidation
-        </comment>
-    </data>
-  <data name="E7143" xml:space="preserve">
-        <value>The file {0} is an object file, and object files are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
         </comment>
     </data>
   <data name="W7144" xml:space="preserve">
@@ -1288,10 +1274,16 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
-  <data name="E7160" xml:space="preserve">
+  <data name="W7160" xml:space="preserve">
+        <value>Creating a compressed binding resource package to avoid MAX_PATH problems on Windows.</value>
+    </data>
+  <data name="W7161" xml:space="preserve">
+        <value>Not creating a compressed binding resource package, because all the native references are already compressed.</value>
+    </data>
+  <data name="E7162" xml:space="preserve">
         <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
     </data>
-  <data name="E7161" xml:space="preserve">
+  <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
@@ -1167,24 +1167,10 @@
             This may be either a warning or an error, depending on build configuration.
         </comment>
     </data>
-  <data name="E7141" xml:space="preserve">
-        <value>The library {0} is a static library, and static libraries are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
-        </comment>
-    </data>
   <data name="E7142" xml:space="preserve">
         <value>Unknown value for 'SkipStaticLibraryValidation': {0}. Valid values are: 'true', 'false', 'warn'.</value>
         <comment>
             The following are literal names and should not be translated: SkipStaticLibraryValidation
-        </comment>
-    </data>
-  <data name="E7143" xml:space="preserve">
-        <value>The file {0} is an object file, and object files are not supported with Hot Restart. Set 'SkipStaticLibraryValidation=true' in the project file to ignore this error.</value>
-        <comment>
-            The following are literal names and should not be translated: SkipStaticLibraryValidation, true
-            {0}: the path to a file
         </comment>
     </data>
   <data name="W7144" xml:space="preserve">
@@ -1288,10 +1274,16 @@
             {1}: the name of the property that is empty (SourceFiles, Items, FrameworkToPublish, etc.).
         </comment>
     </data>
-  <data name="E7160" xml:space="preserve">
+  <data name="W7160" xml:space="preserve">
+        <value>Creating a compressed binding resource package to avoid MAX_PATH problems on Windows.</value>
+    </data>
+  <data name="W7161" xml:space="preserve">
+        <value>Not creating a compressed binding resource package, because all the native references are already compressed.</value>
+    </data>
+  <data name="E7162" xml:space="preserve">
         <value>Unable to execute this task remotely for unknown reasons. The build log may have more information.</value>
     </data>
-  <data name="E7161" xml:space="preserve">
+  <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
 </root>


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.