### PR TITLE
Bump mlaunch.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -12,7 +12,7 @@ endif
 
 # Available versions can be seen here:
 # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.Tools.Mlaunch/versions
-MLAUNCH_NUGET_VERSION=1.1.85
+MLAUNCH_NUGET_VERSION=1.1.89
 
 define CheckVersionTemplate
 check-$(1)::


### PR DESCRIPTION
This gets a fix for multiple simulator runtimes with the same major+minor version.