### PR TITLE
[release/10.0.1xx] Bump API references to .NET 9/26.0

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -44,10 +44,10 @@ include $(TOP)/Make.versions
 # The value is taken from the name + version of the Ref pack.
 # Example: given the Ref pack "Microsoft.iOS.Ref.net8.0_17.5" with the version "17.5.8030", the value
 # to write here would be the part after "Microsoft.iOS.Ref." + "/" + version: "net8.0_17.5/17.5.8030"
-STABLE_NUGET_VERSION_iOS=net9.0_18.5/18.5.9199
-STABLE_NUGET_VERSION_tvOS=net9.0_18.5/18.5.9199
-STABLE_NUGET_VERSION_MacCatalyst=net9.0_18.5/18.5.9199
-STABLE_NUGET_VERSION_macOS=net9.0_15.5/15.5.9199
+STABLE_NUGET_VERSION_iOS=net9.0_26.0/26.0.9752
+STABLE_NUGET_VERSION_tvOS=net9.0_26.0/26.0.9752
+STABLE_NUGET_VERSION_MacCatalyst=net9.0_26.0/26.0.9752
+STABLE_NUGET_VERSION_macOS=net9.0_26.0/26.0.9752
 
 PACKAGE_HEAD_REV=$(shell git rev-parse HEAD)
 

--- a/tools/apidiff/suppression-files/MacCatalyst.xml
+++ b/tools/apidiff/suppression-files/MacCatalyst.xml
@@ -1,28 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:ObjCBindings.BindingTypeAttribute`1.get_LibraryName</Target>
-    <Left>temp/comparison/MacCatalyst/Microsoft.MacCatalyst.dll</Left>
-    <Right>temp/updated/MacCatalyst/Microsoft.MacCatalyst.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:ObjCBindings.BindingTypeAttribute`1.set_LibraryName(System.String)</Target>
-    <Left>temp/comparison/MacCatalyst/Microsoft.MacCatalyst.dll</Left>
-    <Right>temp/updated/MacCatalyst/Microsoft.MacCatalyst.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:ObjCBindings.FieldAttribute`1.get_LibraryName</Target>
-    <Left>temp/comparison/MacCatalyst/Microsoft.MacCatalyst.dll</Left>
-    <Right>temp/updated/MacCatalyst/Microsoft.MacCatalyst.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:ObjCBindings.FieldAttribute`1.set_LibraryName(System.String)</Target>
-    <Left>temp/comparison/MacCatalyst/Microsoft.MacCatalyst.dll</Left>
-    <Right>temp/updated/MacCatalyst/Microsoft.MacCatalyst.dll</Right>
-  </Suppression>
 </Suppressions>

--- a/tools/apidiff/suppression-files/iOS.xml
+++ b/tools/apidiff/suppression-files/iOS.xml
@@ -1,28 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:ObjCBindings.BindingTypeAttribute`1.get_LibraryName</Target>
-    <Left>temp/comparison/iOS/Microsoft.iOS.dll</Left>
-    <Right>temp/updated/iOS/Microsoft.iOS.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:ObjCBindings.BindingTypeAttribute`1.set_LibraryName(System.String)</Target>
-    <Left>temp/comparison/iOS/Microsoft.iOS.dll</Left>
-    <Right>temp/updated/iOS/Microsoft.iOS.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:ObjCBindings.FieldAttribute`1.get_LibraryName</Target>
-    <Left>temp/comparison/iOS/Microsoft.iOS.dll</Left>
-    <Right>temp/updated/iOS/Microsoft.iOS.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:ObjCBindings.FieldAttribute`1.set_LibraryName(System.String)</Target>
-    <Left>temp/comparison/iOS/Microsoft.iOS.dll</Left>
-    <Right>temp/updated/iOS/Microsoft.iOS.dll</Right>
-  </Suppression>
 </Suppressions>

--- a/tools/apidiff/suppression-files/macOS.xml
+++ b/tools/apidiff/suppression-files/macOS.xml
@@ -1,28 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:ObjCBindings.BindingTypeAttribute`1.get_LibraryName</Target>
-    <Left>temp/comparison/macOS/Microsoft.macOS.dll</Left>
-    <Right>temp/updated/macOS/Microsoft.macOS.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:ObjCBindings.BindingTypeAttribute`1.set_LibraryName(System.String)</Target>
-    <Left>temp/comparison/macOS/Microsoft.macOS.dll</Left>
-    <Right>temp/updated/macOS/Microsoft.macOS.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:ObjCBindings.FieldAttribute`1.get_LibraryName</Target>
-    <Left>temp/comparison/macOS/Microsoft.macOS.dll</Left>
-    <Right>temp/updated/macOS/Microsoft.macOS.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:ObjCBindings.FieldAttribute`1.set_LibraryName(System.String)</Target>
-    <Left>temp/comparison/macOS/Microsoft.macOS.dll</Left>
-    <Right>temp/updated/macOS/Microsoft.macOS.dll</Right>
-  </Suppression>
 </Suppressions>

--- a/tools/apidiff/suppression-files/tvOS.xml
+++ b/tools/apidiff/suppression-files/tvOS.xml
@@ -1,28 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:ObjCBindings.BindingTypeAttribute`1.get_LibraryName</Target>
-    <Left>temp/comparison/tvOS/Microsoft.tvOS.dll</Left>
-    <Right>temp/updated/tvOS/Microsoft.tvOS.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:ObjCBindings.BindingTypeAttribute`1.set_LibraryName(System.String)</Target>
-    <Left>temp/comparison/tvOS/Microsoft.tvOS.dll</Left>
-    <Right>temp/updated/tvOS/Microsoft.tvOS.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:ObjCBindings.FieldAttribute`1.get_LibraryName</Target>
-    <Left>temp/comparison/tvOS/Microsoft.tvOS.dll</Left>
-    <Right>temp/updated/tvOS/Microsoft.tvOS.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0002</DiagnosticId>
-    <Target>M:ObjCBindings.FieldAttribute`1.set_LibraryName(System.String)</Target>
-    <Left>temp/comparison/tvOS/Microsoft.tvOS.dll</Left>
-    <Right>temp/updated/tvOS/Microsoft.tvOS.dll</Right>
-  </Suppression>
 </Suppressions>


### PR DESCRIPTION
Backport of #24027.