### PR TITLE
[runtime] Adopt safer native compiler flags: Wignored-qualifiers

### DIFF
--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -36,6 +36,7 @@ CFLAGS=\
 	-Werror=format-security \
 	-fdiagnostics-absolute-paths \
 	-Wno-objc-protocol-property-synthesis \
+	-Wignored-qualifiers \
 	-g \
 	-I.
 SWIFTFLAGS=-g -emit-library

--- a/runtime/monotouch-main.m
+++ b/runtime/monotouch-main.m
@@ -29,7 +29,7 @@
 
 static char original_working_directory_path [MAXPATHLEN];
 
-const char * const
+const char *
 xamarin_get_original_working_directory_path ()
 {
 	return original_working_directory_path;

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -229,7 +229,7 @@ void			xamarin_bridge_raise_unhandled_exception_event (GCHandle exception_gchand
 bool			xamarin_register_monoassembly (MonoAssembly *assembly, GCHandle *exception_gchandle);
 void			xamarin_install_nsautoreleasepool_hooks ();
 void			xamarin_enable_new_refcount ();
-const char * const	xamarin_get_original_working_directory_path ();
+const char *	xamarin_get_original_working_directory_path ();
 int				xamarin_get_runtime_arch ();
 
 MonoObject *	xamarin_new_nsobject (id self, MonoClass *klass, GCHandle *exception_gchandle);


### PR DESCRIPTION
Example warning:

```
macios/runtime/xamarin/runtime.h:232:14: error: 'const' type qualifier on return type has no effect [-Werror,-Wignored-qualifiers]
  232 | const char * const      xamarin_get_original_working_directory_path ();
```

References:

* https://developer.apple.com/documentation/xcode/enabling-enhanced-security-for-your-app
* https://releases.llvm.org/8.0.0/tools/clang/docs/ReleaseNotes.html#major-new-features (for -ftrivial-auto-var-init=zero)

Contributes towards #23023.