### PR TITLE
[runtime] Adopt safer native compiler flags: Wcast-function-type-mismatch

### DIFF
--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -38,6 +38,7 @@ CFLAGS=\
 	-Wno-objc-protocol-property-synthesis \
 	-Wignored-qualifiers \
 	-Wmissing-field-initializers \
+	-Wcast-function-type-mismatch \
 	-g \
 	-I.
 SWIFTFLAGS=-g -emit-library

--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -714,7 +714,7 @@ xamarin_copyWithZone_trampoline2 (id self, SEL sel, NSZone *zone)
 		xamarin_set_gchandle_with_flags (self, INVALID_GCHANDLE, XamarinGCHandleFlags_None);
 
 	// Call the managed implementation
-	id (*invoke) (id, SEL, NSZone*) = (id (*)(id, SEL, NSZone*)) xamarin_trampoline;
+	id (*invoke) (id, SEL, NSZone*) = (id (*)(id, SEL, NSZone*)) (void *) xamarin_trampoline;
 	rv = invoke (self, sel, zone);
 
 	// Restore our GCHandle
@@ -1674,7 +1674,7 @@ xamarin_get_managed_to_nsvalue_func (MonoClass *managedType, MonoMethod *method,
 	return (xamarin_managed_to_id_func) xamarin_get_nsvalue_converter (managedType, method, false, exception_gchandle);
 }
 
-void *
+id
 xamarin_smart_enum_to_nsstring (MonoObject *value, void *context /* token ref */, GCHandle *exception_gchandle)
 {
 	guint32 context_ref = GPOINTER_TO_UINT (context);

--- a/runtime/xamarin/trampolines.h
+++ b/runtime/xamarin/trampolines.h
@@ -121,7 +121,7 @@ NSArray *   xamarin_convert_managed_to_nsarray_with_func (MonoArray *array, xama
 MonoArray * xamarin_convert_nsarray_to_managed_with_func (NSArray *array, MonoClass *managedElementType, xamarin_id_to_managed_func convert, void *context, GCHandle *exception_gchandle);
 
 void * xamarin_nsstring_to_smart_enum (id value, void *ptr, MonoClass *managedType, void *context, GCHandle *exception_gchandle);
-void * xamarin_smart_enum_to_nsstring (MonoObject *value, void *context /* token ref */, GCHandle *exception_gchandle);
+id xamarin_smart_enum_to_nsstring (MonoObject *value, void *context /* token ref */, GCHandle *exception_gchandle);
 
 // Returns a pointer to the value type, which must be freed using xamarin_free.
 void *xamarin_nsnumber_to_bool   (NSNumber *number, void *ptr, MonoClass *managedType, void *context, GCHandle *exception_gchandle);


### PR DESCRIPTION
Example warning:

```
macios/runtime/trampolines.m:1784:9: error: cast from 'void *(*)(MonoObject *, void *, GCHandle *)' (aka 'void *(*)(_MonoObject *, void *, void **)') to 'xamarin_managed_to_id_func' (aka 'id (*)(_MonoObject *, void *, void **)') converts to incompatible function type [-Werror,-Wcast-function-type-mismatch]
 1784 |         return (xamarin_managed_to_id_func) xamarin_smart_enum_to_nsstring;
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

References:

* https://developer.apple.com/documentation/xcode/enabling-enhanced-security-for-your-app
* https://releases.llvm.org/8.0.0/tools/clang/docs/ReleaseNotes.html#major-new-features (for -ftrivial-auto-var-init=zero)

Contributes towards #23023.