### PR TITLE
[release/10.0.1xx] Bump mlaunch to get improved launch failure message. Fixes #23923.

### DIFF
--- a/mk/xamarin.mk
+++ b/mk/xamarin.mk
@@ -12,7 +12,7 @@ endif
 
 # Available versions can be seen here:
 # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.Tools.Mlaunch/versions
-MLAUNCH_NUGET_VERSION=1.1.89
+MLAUNCH_NUGET_VERSION=1.1.92
 
 define CheckVersionTemplate
 check-$(1)::


### PR DESCRIPTION
Fixes https://github.com/dotnet/macios/issues/23923.
Backport of #24101.