### PR TITLE
[msbuild] Fix the PropertyListEditor task to correctly handle two input files. Fixes #24091.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/PropertyListEditor.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/PropertyListEditor.cs
@@ -198,7 +198,7 @@ namespace Xamarin.MacDev.Tasks {
 
 		bool Clear (ref PObject plist)
 		{
-			if (Type is not null) {
+			if (!string.IsNullOrEmpty (Type)) {
 				switch (Type.ToLowerInvariant ()) {
 				case "string": plist = new PString (string.Empty); break;
 				case "array": plist = new PArray (); break;
@@ -391,7 +391,7 @@ namespace Xamarin.MacDev.Tasks {
 
 		bool Merge (PObject plist)
 		{
-			if (Entry is not null) {
+			if (!string.IsNullOrEmpty (Entry)) {
 				var path = GetPropertyPath ();
 				PObject? current = plist;
 				PDictionary? dict;


### PR DESCRIPTION
Fix the PropertyListEditor task to not only check for null input, but also
empty empty - this fixes an regression where we changed the default property
value for the task inputs from null to an empty string, and then any null
checks later on would fail.

Fixes https://github.com/dotnet/macios/issues/24091.