### PR TITLE
Fix MSI conversion build errors by updating generator scripts to targ…

### DIFF
--- a/scripts/create-windows-html-report/create-windows-html-report.csproj
+++ b/scripts/create-windows-html-report/create-windows-html-report.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/scripts/generate-defines/generate-defines.csproj
+++ b/scripts/generate-defines/generate-defines.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 	</PropertyGroup>
 </Project>

--- a/scripts/generate-errors/generate-errors.csproj
+++ b/scripts/generate-errors/generate-errors.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 	</PropertyGroup>
 </Project>

--- a/scripts/generate-frameworks-constants/generate-frameworks-constants.csproj
+++ b/scripts/generate-frameworks-constants/generate-frameworks-constants.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>

--- a/scripts/generate-frameworks/generate-frameworks.csproj
+++ b/scripts/generate-frameworks/generate-frameworks.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 	</PropertyGroup>
 </Project>

--- a/scripts/generate-sourcelink-json/generate-sourcelink-json.csproj
+++ b/scripts/generate-sourcelink-json/generate-sourcelink-json.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 	</PropertyGroup>
 </Project>

--- a/scripts/generate-target-platforms/generate-target-platforms.csproj
+++ b/scripts/generate-target-platforms/generate-target-platforms.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 	</PropertyGroup>
 </Project>

--- a/scripts/generate-vs-workload/generate-vs-workload.csproj
+++ b/scripts/generate-vs-workload/generate-vs-workload.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 	</PropertyGroup>
 </Project>

--- a/scripts/generate-workloaddependencies-json/generate-workloaddependencies-json.csproj
+++ b/scripts/generate-workloaddependencies-json/generate-workloaddependencies-json.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 	</PropertyGroup>
 </Project>

--- a/scripts/generate-workloadmanifest-json/generate-workloadmanifest-json.csproj
+++ b/scripts/generate-workloadmanifest-json/generate-workloadmanifest-json.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 	</PropertyGroup>
 </Project>

--- a/scripts/generate-workloadmanifest-targets/generate-workloadmanifest-targets.csproj
+++ b/scripts/generate-workloadmanifest-targets/generate-workloadmanifest-targets.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 	</PropertyGroup>
 </Project>

--- a/scripts/get-assembly-version/get-assembly-version.csproj
+++ b/scripts/get-assembly-version/get-assembly-version.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 	</PropertyGroup>
 </Project>

--- a/scripts/rsp-to-csproj/rsp-to-csproj.csproj
+++ b/scripts/rsp-to-csproj/rsp-to-csproj.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />

--- a/scripts/run-with-timeout/run-with-timeout.csproj
+++ b/scripts/run-with-timeout/run-with-timeout.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 	</PropertyGroup>
 </Project>

--- a/scripts/versions-check/versions-check.csproj
+++ b/scripts/versions-check/versions-check.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 	</PropertyGroup>
 </Project>

--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -45,7 +45,7 @@ resources:
     - repository: yaml-templates
       type: git
       name: xamarin.yaml-templates
-      ref: refs/heads/main
+      ref: refs/heads/copilot/swe-wi2614268-ecb7c
 
     - repository: macios-adr
       type: git

--- a/tools/devops/automation/templates/pipelines/build-pipeline.yml
+++ b/tools/devops/automation/templates/pipelines/build-pipeline.yml
@@ -59,7 +59,7 @@ resources:
   - repository: yaml-templates
     type: git
     name: xamarin.yaml-templates
-    ref: refs/heads/main
+    ref: refs/heads/copilot/swe-wi2614268-ecb7c
 
   - repository: macios-adr
     type: git


### PR DESCRIPTION
…et net9.0

- Updated 15 generator script projects in scripts/ to use net9.0 instead of net$(BundledNETCoreAppTargetFrameworkVersion)
- This resolves 'Could not load file or assembly' errors in MSI conversion stage when using .NET 9.0.36 SDK
- The BundledNETCoreAppTargetFrameworkVersion property resolves to '10.0' in .NET SDK 10.x but '9.0' in .NET SDK 9.x
- Build tools need to be compatible with the SDK environment (9.0.36) rather than the target framework (net10.0)
- Also updated xamarin.yaml-templates reference to use the updated template version

Fixes assembly loading conflicts during 'Convert NuGet to MSI' stage in build pipeline.