### PR TITLE
[tests] Attempt to fix a random crash in UIDocumentTest.

### DIFF
--- a/tests/monotouch-test/UIKit/UIDocumentTest.cs
+++ b/tests/monotouch-test/UIKit/UIDocumentTest.cs
@@ -54,8 +54,6 @@ namespace MonoTouchFixtures.UIKit {
 			}
 		}
 
-		MyDocument doc;
-
 		string GetFileName ()
 		{
 			string file = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.MyDocuments), "mydocument.txt");
@@ -72,7 +70,7 @@ namespace MonoTouchFixtures.UIKit {
 			TestRuntime.AssertIfSimulatorThenARM64 ();
 
 			using (NSUrl url = NSUrl.FromFilename (GetFileName ())) {
-				doc = new MyDocument (url);
+				using var doc = new MyDocument (url);
 				doc.Save (url, UIDocumentSaveOperation.ForCreating, OperationHandler);
 			}
 		}


### PR DESCRIPTION
Attempt to fix a random crash in UIDocumentTest by using a local variable
(that is later disposed) instead of an instance variable.

The idea is that the instance variable might be freed _during_ the Save method
call, while the local variable won't, because it's implicitly disposed
(because of the using clause).

Hopefully fixes https://github.com/xamarin/maccore/issues/2283.