### PR TITLE
[release/10.0.1xx] Revert "[dotnet] Pass --preserve-symbol-paths to the trimmer to ensure trimmed assemblies aren't different between architectures. (#23858)"

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -640,17 +640,6 @@
 			<_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) -b</_ExtraTrimmerArgs>
 
 			<!--
-				Always preserve symbol paths, which will preserve the original path to the pdb in the trimmed assembly.
-				This ensures that building for different architectures don't end up with different trimmed assemblies
-				only because the path to the pdb in the trimmed assembly is different between those builds.
-				References:
-				* https://github.com/dotnet/runtime/pull/103295
-				* https://github.com/jbevain/cecil/pull/554
-				* https://github.com/rolfbjarne/macios/commit/53874c863996656eaba43a5582731b93eb6f53b7
-			-->
-			<_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --preserve-symbol-paths</_ExtraTrimmerArgs>
-
-			<!--
 
 				The linker will treat type checks as a constant value (false),
 				if the type in question is not instantiated, but we're

--- a/tests/dotnet/UnitTests/BundleStructureTest.cs
+++ b/tests/dotnet/UnitTests/BundleStructureTest.cs
@@ -290,9 +290,7 @@ namespace Xamarin.Tests {
 			AddExpectedFrameworkFiles (platform, expectedFiles, "FrameworkTest4", isSigned);
 			AddExpectedFrameworkFiles (platform, expectedFiles, "FrameworkTest5", isSigned);
 
-			expectedFiles.Add (Path.Combine (assemblyDirectory, "bindings-framework-test.dll"));
-			if (includeDebugFiles)
-				expectedFiles.Add (Path.Combine (assemblyDirectory, "bindings-framework-test.pdb"));
+			AddMultiRidAssembly (platform, expectedFiles, assemblyDirectory, "bindings-framework-test", runtimeIdentifiers, forceSingleRid: platform != ApplePlatform.MacCatalyst, includeDebugFiles: includeDebugFiles);
 			AddExpectedFrameworkFiles (platform, expectedFiles, "XTest", isSigned);
 
 			AddExpectedFrameworkFiles (platform, expectedFiles, "FrameworkWithLongFileNames", isSigned, longHeader: true);
@@ -313,9 +311,7 @@ namespace Xamarin.Tests {
 			expectedFiles.Add (Path.Combine (assemblyDirectory, "nunit.framework.dll"));
 			expectedFiles.Add (Path.Combine (assemblyDirectory, "nunitlite.dll"));
 			expectedFiles.Add (Path.Combine (assemblyDirectory, "Mono.Options.dll"));
-			expectedFiles.Add (Path.Combine (assemblyDirectory, "Touch.Client.dll"));
-			if (includeDebugFiles)
-				expectedFiles.Add (Path.Combine (assemblyDirectory, "Touch.Client.pdb"));
+			AddMultiRidAssembly (platform, expectedFiles, assemblyDirectory, "Touch.Client", runtimeIdentifiers, platform == ApplePlatform.MacOSX || (platform == ApplePlatform.MacCatalyst && !isReleaseBuild), includeDebugFiles: includeDebugFiles);
 			AddMultiRidAssembly (platform, expectedFiles, assemblyDirectory, Path.GetFileNameWithoutExtension (Configuration.GetBaseLibraryName (platform)), runtimeIdentifiers, platform == ApplePlatform.MacOSX, includeDebugFiles: includeDebugFiles);
 			expectedFiles.Add (Path.Combine (assemblyDirectory, "runtimeconfig.bin"));
 


### PR DESCRIPTION
This reverts commit dc79f3e89f1e122b2ccd94a9a35ae634d1a4e1ff.

The problem is that we need the assembly to point to the linked version of the
pdb, otherwise the debugger will refuse to load debug info, saying the pdb
doesn't match the dll.

Eventually we might need a way to write just the filename of the pdb in the
assembly, and not a full path, that that's a much more involved fix (https://github.com/dotnet/macios/issues/24174).

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2614232.
Backport of #24173.