### PR TITLE
[release/10.0.1xx] [dotnet] Fix loading oldest reference assemblies for library projects Fixes #24043.

### DIFF
--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -1325,6 +1325,35 @@ Specifies the minimum tvOS version the app can run on.
 
 Applicable to tvOS; setting this value will set [SupportedOSPlatformVersion](#supportedosplatformversion) for tvOS projects (only).
 
+## UseFloatingTargetPlatformVersion
+
+A boolean property that controls whether library projects should use a floating target platform version or the oldest available platform version.
+
+By default (starting in .NET 10), library projects without an explicit `TargetPlatformVersion` will use the oldest available reference assemblies for the current .NET version. This ensures maximum compatibility and allows library code to compile against the minimum API surface available for the target framework.
+
+However, this default behavior means that library projects are built differently than executable projects (which use the latest platform version). Code that works in an executable project may not compile when moved to a library project if it uses APIs only available in newer platform versions.
+
+Setting this property to `true` disables the automatic selection of the oldest platform version, allowing the library project to use the default (latest) platform version like executable projects do.
+
+Example:
+
+```xml
+<PropertyGroup>
+  <!-- Use the latest platform version instead of the oldest -->
+  <UseFloatingTargetPlatformVersion>true</UseFloatingTargetPlatformVersion>
+</PropertyGroup>
+```
+
+Default: `false` (use oldest platform version for library projects in .NET 10+).
+
+This property only applies to library projects (`OutputType=Library`) that are
+not app extensions and have not specified an explicit target platform version
+(the target platform version is the optional version number at the end of the
+`TargetFramework` property, for example for the TargetFramework
+`net10.0-ios26.0` the target platform version is explicitly `26.0`).
+
+This property was introduced in .NET 10.
+
 ## UseHardenedRuntime
 
 A boolean property that specifies if a hardened runtime is enabled.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -65,6 +65,7 @@ test.config: Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk $(TOP)/eng/Version.De
 	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),$(platform)_NUGET_RUNTIME_MANAGED_NAME=$($(platform)_NUGET_RUNTIME_MANAGED_NAME)\\n)" | sed 's/^ //' >> $@
 	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(rid)_NUGET_RUNTIME_NAME=$($(rid)_NUGET_RUNTIME_NAME)\\n))" | sed 's/^ //' >> $@
 	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),SUPPORTED_API_VERSIONS_$(platform)='$(SUPPORTED_API_VERSIONS_$(platform))'\\n)" | sed 's/^ //' >> $@
+	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),$(platform)_TARGET_PLATFORM_VERSION_LIBRARY=$($(platform)_TARGET_PLATFORM_VERSION_LIBRARY)\\n)" | sed 's/^ //' >> $@
 	@printf "ENABLE_XAMARIN=$(ENABLE_XAMARIN)\n" >> $@
 	@printf "ENABLE_ADR=$(ENABLE_ADR)\n" >> $@
 	@printf "XCODE_IS_STABLE=$(XCODE_IS_STABLE)\n" >> $@
@@ -97,6 +98,7 @@ test-system.config: Makefile $(TOP)/Make.config $(TOP)/mk/mono.mk $(TOP)/eng/Ver
 	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),$(platform)_NUGET_RUNTIME_MANAGED_NAME=$($(platform)_NUGET_RUNTIME_MANAGED_NAME)\\n)" | sed 's/^ //' >> $@
 	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(rid)_NUGET_RUNTIME_NAME=$($(rid)_NUGET_RUNTIME_NAME)\\n))" | sed 's/^ //' >> $@
 	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),SUPPORTED_API_VERSIONS_$(platform)='$(SUPPORTED_API_VERSIONS_$(platform))'\\n)" | sed 's/^ //' >> $@
+	@printf "$(foreach platform,$(DOTNET_PLATFORMS_UPPERCASE),$(platform)_TARGET_PLATFORM_VERSION_LIBRARY=$($(platform)_TARGET_PLATFORM_VERSION_LIBRARY)\\n)" | sed 's/^ //' >> $@
 	@printf "ENABLE_XAMARIN=$(ENABLE_XAMARIN)\n" >> $@
 	@printf "ENABLE_ADR=$(ENABLE_ADR)\n" >> $@
 	@printf "XCODE_IS_STABLE=$(XCODE_IS_STABLE)\n" >> $@

--- a/tests/common/Configuration.cs
+++ b/tests/common/Configuration.cs
@@ -180,6 +180,7 @@ namespace Xamarin.Tests {
 			ParseConfigFiles (FindConfigFiles ("configure.inc"));
 			ParseConfigFiles (FindConfigFiles ("Make.config.local"));
 			ParseConfigFiles (FindConfigFiles ("Make.config"));
+			ParseConfigFiles (FindConfigFiles ("Make.versions"));
 		}
 
 		static void ParseConfigFiles (IEnumerable<string> files)

--- a/tests/dotnet/MyClassLibrary/MacCatalyst/MyClass.cs
+++ b/tests/dotnet/MyClassLibrary/MacCatalyst/MyClass.cs
@@ -1,8 +1,0 @@
-using System;
-namespace MyClassLibrary {
-	public class MyClass {
-		public MyClass ()
-		{
-		}
-	}
-}

--- a/tests/dotnet/MyClassLibrary/MacCatalyst/MyClassLibrary.csproj
+++ b/tests/dotnet/MyClassLibrary/MacCatalyst/MyClassLibrary.csproj
@@ -3,5 +3,6 @@
 	<PropertyGroup>
 		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
 	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
 </Project>
 

--- a/tests/dotnet/MyClassLibrary/MyClass.cs
+++ b/tests/dotnet/MyClassLibrary/MyClass.cs
@@ -1,6 +1,9 @@
 using System;
+
+using Foundation;
+
 namespace MyClassLibrary {
-	public class MyClass {
+	public class MyClass : NSObject {
 		public MyClass ()
 		{
 		}

--- a/tests/dotnet/MyClassLibrary/iOS/MyClass.cs
+++ b/tests/dotnet/MyClassLibrary/iOS/MyClass.cs
@@ -1,8 +1,0 @@
-using System;
-namespace MyClassLibrary {
-	public class MyClass {
-		public MyClass ()
-		{
-		}
-	}
-}

--- a/tests/dotnet/MyClassLibrary/iOS/MyClassLibrary.csproj
+++ b/tests/dotnet/MyClassLibrary/iOS/MyClassLibrary.csproj
@@ -3,5 +3,6 @@
 	<PropertyGroup>
 		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
 	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
 </Project>
 

--- a/tests/dotnet/MyClassLibrary/macOS/MyClass.cs
+++ b/tests/dotnet/MyClassLibrary/macOS/MyClass.cs
@@ -1,8 +1,0 @@
-using System;
-namespace MyClassLibrary {
-	public class MyClass {
-		public MyClass ()
-		{
-		}
-	}
-}

--- a/tests/dotnet/MyClassLibrary/macOS/MyClassLibrary.csproj
+++ b/tests/dotnet/MyClassLibrary/macOS/MyClassLibrary.csproj
@@ -3,5 +3,6 @@
 	<PropertyGroup>
 		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-macos</TargetFramework>
 	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
 </Project>
 

--- a/tests/dotnet/MyClassLibrary/shared.csproj
+++ b/tests/dotnet/MyClassLibrary/shared.csproj
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+	<ItemGroup>
+		<Compile Include="../*.cs" />
+	</ItemGroup>
+</Project>

--- a/tests/dotnet/MyClassLibrary/tvOS/MyClass.cs
+++ b/tests/dotnet/MyClassLibrary/tvOS/MyClass.cs
@@ -1,8 +1,0 @@
-using System;
-namespace MyClassLibrary {
-	public class MyClass {
-		public MyClass ()
-		{
-		}
-	}
-}

--- a/tests/dotnet/MyClassLibrary/tvOS/MyClassLibrary.csproj
+++ b/tests/dotnet/MyClassLibrary/tvOS/MyClassLibrary.csproj
@@ -3,5 +3,6 @@
 	<PropertyGroup>
 		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-tvos</TargetFramework>
 	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
 </Project>
 

--- a/tests/xharness/Harness.cs
+++ b/tests/xharness/Harness.cs
@@ -568,7 +568,8 @@ namespace Xharness {
 			return FindConfigFiles (useSystemXamarinIOSMac ? "test-system.config" : "test.config")
 				.Concat (FindConfigFiles ("configure.inc"))
 				.Concat (FindConfigFiles ("Make.config"))
-				.Concat (FindConfigFiles ("Make.config.local"));
+				.Concat (FindConfigFiles ("Make.config.local"))
+				.Concat (FindConfigFiles ("Make.versions"));
 		}
 
 		void ParseConfigFile (string file, Dictionary<string, string> configuration)


### PR DESCRIPTION
Since this may result in unintuitive behavior (library projects are built differently than executable projects, so code that works in an executable project may not compile when moved to a library project), an escape hatch was implemented as well.

One unintuitive behavior was when building an executable project with a library project from Windows: if the library project needs the remote connection, it would use a different workload, and different remote connection, than the executable project, which just wouldn't work. So we don't enable this new behavior when library projects need the remote connection (which is when bundle resources are precompiled for the library project; aka when `BundleOriginalResources=false` - note that it's enabled by default in .NET 10, so developers must opt in to run into this problem and thus not getting this new behavior).

Fixes https://github.com/dotnet/macios/issues/24043.