### PR TITLE
[msbuild] Always run WriteItemsFromFile locally.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1903,7 +1903,6 @@
 	<!-- When we're building a universal app, we need to collect the list of user frameworks we need to run dsymutil on -->
 	<Target Name="_CollectRidSpecificUserFrameworksWithoutDebugSymbols">
 		<ReadItemsFromFile
-			SessionId="$(BuildSessionId)"
 			File="%(_RidSpecificUserFrameworksWithoutDebugSymbolsPath.Identity)"
 			Condition="Exists('%(_RidSpecificUserFrameworksWithoutDebugSymbolsPath.Identity)')"
 		>
@@ -1924,9 +1923,8 @@
 
 		<!-- Read the stored list of files to sign if we're an outer build of a multi-rid build -->
 		<ReadItemsFromFile
-			SessionId="$(BuildSessionId)"
 			File="%(_RidSpecificCodesignItemsPath.Identity)"
-			Condition="@(_RidSpecificCodesignItemsPath->Count()) &gt; 0 And '$(IsMacEnabled)' == 'true'"
+			Condition="@(_RidSpecificCodesignItemsPath->Count()) &gt; 0"
 		>
 			<Output TaskParameter="Items" ItemName="_RidSpecificCodesignItems" />
 		</ReadItemsFromFile>
@@ -2236,8 +2234,7 @@
 
 		<!-- Write a list of files to sign if we're not an outer build of a multi-rid build -->
 		<WriteItemsToFile
-			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true' And '$(_CodesignItemsPath)' != ''"
+			Condition="'$(_CodesignItemsPath)' != ''"
 			Items="@(_CreateDumpExecutableToSign)"
 			ItemName="_CodesignItems"
 			File="$(_CodesignItemsPath)"

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/WriteItemsToFile.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/WriteItemsToFile.cs
@@ -8,10 +8,8 @@ using Microsoft.Build.Utilities;
 using Microsoft.Build.Tasks;
 using System.Xml.Linq;
 
-using Xamarin.Messaging.Build.Client;
-
 namespace Xamarin.MacDev.Tasks {
-	public class WriteItemsToFile : XamarinTask, ICancelableTask {
+	public class WriteItemsToFile : XamarinTask {
 		static readonly XNamespace XmlNs = XNamespace.Get ("http://schemas.microsoft.com/developer/msbuild/2003");
 
 		static readonly XName ProjectElementName = XmlNs + "Project";
@@ -36,9 +34,6 @@ namespace Xamarin.MacDev.Tasks {
 
 		public override bool Execute ()
 		{
-			if (ShouldExecuteRemotely ())
-				return ExecuteRemotely ();
-
 			Write (this, File?.ItemSpec, Items, ItemName, Overwrite, IncludeMetadata);
 			return true;
 		}
@@ -82,12 +77,6 @@ namespace Xamarin.MacDev.Tasks {
 			}
 
 			return Enumerable.Empty<XElement> ();
-		}
-
-		public void Cancel ()
-		{
-			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -372,7 +372,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 		<RemoveDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(AppBundleDir).mSYM;@(_DebugSymbolDir)" />
 		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(DeviceSpecificOutputPath)*.bcsymbolmap" />
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(DeviceSpecificOutputPath)postprocessing.items" />
+		<Delete Files="$(DeviceSpecificOutputPath)postprocessing.items" />
 	</Target>
 
 	<Target Name="_CleanITunesArtwork" Condition="'$(_CanArchive)' == 'true'" DependsOnTargets="_ComputeTargetArchitectures">
@@ -405,9 +405,9 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<_IpaPackageFile Include="$(DeviceSpecificOutputPath)*.ipa" />
 		</ItemGroup>
 
-		<Delete Condition="'$(IsMacEnabled)' == 'true'" Files="$(DeviceSpecificOutputPath)codesign.items" />
-		<Delete Condition="'$(IsMacEnabled)' == 'true'" Files="$(DeviceSpecificOutputPath)codesign-bundle.items" />
-		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(DeviceSpecificOutputPath)native-frameworks.items" />
+		<Delete Files="$(DeviceSpecificOutputPath)codesign.items" />
+		<Delete Files="$(DeviceSpecificOutputPath)codesign-bundle.items" />
+		<Delete Files="$(DeviceSpecificOutputPath)native-frameworks.items" />
 		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="@(_IpaPackageFile)" />
 	</Target>
 
@@ -2529,7 +2529,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		>
 
 		<WriteItemsToFile
-			Condition="'$(IsMacEnabled)' == 'true'"
 			Items="@(_CodesignBundle)"
 			ItemName="_CodesignBundle"
 			File="$(DeviceSpecificOutputPath)codesign-bundle.items"
@@ -2538,7 +2537,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		/>
 
 		<WriteItemsToFile
-			Condition="'$(IsMacEnabled)' == 'true'"
 			Items="@(_CodesignItems)"
 			ItemName="_CodesignItems"
 			File="$(DeviceSpecificOutputPath)codesign.items"
@@ -2994,7 +2992,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		>
 
 		<WriteItemsToFile
-			Condition="'$(IsMacEnabled)' == 'true' And '$(_PostProcessingItemPath)' != ''"
+			Condition="'$(_PostProcessingItemPath)' != ''"
 			Items="@(_PostProcessingItem)"
 			ItemName="_PostProcessingItem"
 			File="$(_PostProcessingItemPath)"


### PR DESCRIPTION
Always run WriteItemsFromFile locally, as these operations just read/write items
from/to an XML file, this is something we don't need to run remotely when building
from Windows. This improves the build performance and also fixes some inconsistencies
we had were sometimes files were written locally and read remotely (or the other
way around).

This means we need to adjust any corresponding ReadItemsFromFile calls accordingly.

It also allows us to remove the remoting support in WriteItemsFromFile, but we
can't remove remoting support for ReadItemsFromFile, because sometimes we have
to read files that aren't written with WriteItemsFromFile (they're written by
other tasks), and these files will have been written remotely.