### PR TITLE
[devops] Make sure the pwsh test script always fail on failures.

### DIFF
--- a/tools/devops/automation/scripts/run-remote-windows-tests.ps1
+++ b/tools/devops/automation/scripts/run-remote-windows-tests.ps1
@@ -26,3 +26,5 @@ if ("$Env:TESTFILTER" -eq "") {
     "--logger:trx;LogFileName=$Env:BUILD_SOURCESDIRECTORY/$Env:BUILD_REPOSITORY_TITLE/jenkins-results/windows-remote-dotnet-tests.trx" `
     "--logger:html;LogFileName=$Env:BUILD_SOURCESDIRECTORY/$Env:BUILD_REPOSITORY_TITLE/jenkins-results/windows-remote-dotnet-tests.html" `
     "-bl:$Env:BUILD_SOURCESDIRECTORY/$Env:BUILD_REPOSITORY_TITLE/tests/dotnet/Windows/windows-remote-dotnet-tests.binlog"
+
+exit $LASTEXITCODE


### PR DESCRIPTION
1. This shouldn't ever be necessary.
2. If it were necessary, it should always be necessary.
3. Powershell's exit code handling is 🤯

For reference / amusement / scaring children: https://stackoverflow.com/a/57468523.