### PR TITLE
[release/10.0.1xx] [tests] https://dotnetbuilds.blob.core.windows.net will be replaced with https://ci.dot.net, so update our usage.

### DIFF
--- a/tests/dotnet/Windows/InstallDotNet.csproj
+++ b/tests/dotnet/Windows/InstallDotNet.csproj
@@ -57,7 +57,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <DotNetFeedUrl>https://dotnetbuilds.blob.core.windows.net/public</DotNetFeedUrl>
+    <DotNetFeedUrl>https://ci.dot.net/public</DotNetFeedUrl>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('windows'))">
     <DotNetInstallScriptUrl>https://builds.dotnet.microsoft.com/dotnet/scripts/v1/dotnet-install.ps1</DotNetInstallScriptUrl>


### PR DESCRIPTION
Backport of #24213.