### PR TITLE
[src] Remove 'remarks' nodes from enum fields, and add a test.

### DIFF
--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -53,7 +53,6 @@ namespace Foundation {
 	[SupportedOSPlatform ("tvos")]
 	public enum NSObjectFlag {
 		/// <summary>Sentinel instance.</summary>
-		///         <remarks>To be added.</remarks>
 		Empty,
 	}
 

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -433,7 +433,6 @@ namespace AVFoundation {
 		QuickTimeMovie = 0,
 
 		/// <summary>Indicates the MPEG-4 format.</summary>
-		/// <remarks>Typically files using format has an .mp4 extension.</remarks>
 		[Field ("AVFileTypeMPEG4")]
 		Mpeg4 = 1,
 


### PR DESCRIPTION
We get suggestions in the doc publishing workflow about 'remarks' in enum
fields (they're ignored), so avoid this by not having 'remarks' in enum
fields.