### PR TITLE
[tests] Try to ignore tests that fail due the ssl connection errors.

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -1582,6 +1582,7 @@ partial class TestRuntime {
 		IgnoreInCIfHttpStatusCodes (ex, HttpStatusCode.BadGateway, HttpStatusCode.GatewayTimeout, HttpStatusCode.ServiceUnavailable);
 		IgnoreInCIIfNetworkConnectionLost (ex);
 		IgnoreInCIIfDnsResolutionFailed (ex);
+		IgnoreInCIIfSshConnectionError (ex);
 	}
 
 	public static void IgnoreInCIIfBadNetwork (NSError? error)
@@ -1670,6 +1671,14 @@ partial class TestRuntime {
 	{
 		// Error Domain=NSURLErrorDomain Code=-1009 "The Internet connection appears to be offline."
 		IgnoreNetworkError (error, CFNetworkErrors.NotConnectedToInternet);
+	}
+
+	public static void IgnoreInCIIfSshConnectionError (Exception ex)
+	{
+		var msg = ex.Message;
+		if (msg.Contains ("The SSL connection could not be established")) {
+			IgnoreInCI ($"Ignored due to network error: {ex}");
+		}
 	}
 
 	static void IgnoreNetworkError (NSError error, params CFNetworkErrors [] errors)


### PR DESCRIPTION
Such as:

    [FAIL] TrustUsingNewCallback : System.Net.WebException : The SSL connection could not be established, see inner exception.
     ----> System.Net.Http.HttpRequestException : The SSL connection could not be established, see inner exception.
     ----> System.IO.IOException : Received an unexpected EOF or 0 bytes from the transport stream.
    	   at System.Net.HttpWebRequest.GetResponse()
    	   at System.Net.WebClient.GetWebResponse(WebRequest request)
    	   at System.Net.WebClient.DownloadBits(WebRequest request, Stream writeStream)
    	   at System.Net.WebClient.DownloadDataInternal(Uri address, WebRequest& request)
    	   at System.Net.WebClient.DownloadString(Uri address)
    	   at System.Net.WebClient.DownloadString(String address)
    	   at LinkSdk.CryptoTest.TrustUsingNewCallback() in /Users/builder/azdo/_work/1/s/macios/tests/linker/link sdk/CryptoTest.cs:line 53
    	   at System.RuntimeMethodHandle.InvokeMethod(ObjectHandleOnStack target, Void** arguments, ObjectHandleOnStack sig, BOOL isConstructor, ObjectHandleOnStack result)
    	   at System.RuntimeMethodHandle.InvokeMethod(ObjectHandleOnStack target, Void** arguments, ObjectHandleOnStack sig, BOOL isConstructor, ObjectHandleOnStack result)
    	   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
    	   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
    	   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
    	--HttpRequestException
    	   at System.Net.Http.ConnectHelper.EstablishSslConnectionAsync(SslClientAuthenticationOptions sslOptions, HttpRequestMessage request, Boolean async, Stream stream, CancellationToken cancellationToken)
    	   at System.Net.Http.HttpConnectionPool.ConnectAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
    	   at System.Net.Http.HttpConnectionPool.CreateHttp11ConnectionAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
    	   at System.Net.Http.HttpConnectionPool.InjectNewHttp11ConnectionAsync(QueueItem queueItem)
    	   at System.Threading.Tasks.TaskCompletionSourceWithCancellation`1.WaitWithCancellation(CancellationToken cancellationToken)
    	   at System.Threading.Tasks.TaskCompletionSourceWithCancellation`1.WaitWithCancellationAsync(Boolean async, CancellationToken cancellationToken)
    	   at System.Net.Http.HttpConnectionWaiter`1.WaitForConnectionAsync(HttpRequestMessage request, HttpConnectionPool pool, Boolean async, CancellationToken requestCancellationToken)
    	   at System.Net.Http.HttpConnectionPool.SendWithVersionDetectionAndRetryAsync(HttpRequestMessage request, Boolean async, Boolean doRequestAuth, CancellationToken cancellationToken)
    	   at System.Net.Http.HttpMessageHandlerStage.Send(HttpRequestMessage request, CancellationToken cancellationToken)
    	   at System.Net.Http.Metrics.MetricsHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
    	   at System.Net.Http.HttpMessageHandlerStage.Send(HttpRequestMessage request, CancellationToken cancellationToken)
    	   at System.Net.Http.DiagnosticsHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
    	   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, Boolean async, CancellationToken cancellationToken)
    	   at System.Net.Http.HttpMessageHandlerStage.Send(HttpRequestMessage request, CancellationToken cancellationToken)
    	   at System.Net.Http.SocketsHttpHandler.Send(HttpRequestMessage request, CancellationToken cancellationToken)
    	   at System.Net.Http.HttpMessageInvoker.Send(HttpRequestMessage request, CancellationToken cancellationToken)
    	   at System.Net.Http.HttpClient.Send(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken cancellationToken)
    	   at System.Net.HttpWebRequest.SendRequest(Boolean async, HttpContent content)
    	   at System.Net.HttpWebRequest.HandleResponse(Boolean async)
    	   at System.Net.HttpWebRequest.GetResponse()
    	--IOException
    	   at System.Net.Security.SslStream.ReceiveHandshakeFrameAsync[TIOAdapter](CancellationToken cancellationToken)
    	   at System.Net.Security.SslStream.ForceAuthenticationAsync[TIOAdapter](Boolean receiveFirst, Byte[] reAuthenticationData, CancellationToken cancellationToken)
    	   at System.Net.Http.ConnectHelper.EstablishSslConnectionAsync(SslClientAuthenticationOptions sslOptions, HttpRequestMessage request, Boolean async, Stream stream, CancellationToken cancellationToken)