### PR TITLE
[xharness] Fix processing log files that are supposed to have timestamps, but don't.

### DIFF
--- a/tests/xharness/Jenkins/Reports/HtmlReportWriter.cs
+++ b/tests/xharness/Jenkins/Reports/HtmlReportWriter.cs
@@ -474,7 +474,7 @@ namespace Xharness.Jenkins.Reports {
 														continue;
 													// Skip any timestamps if the file is timestamped
 													const string timestamp_format = "HH:mm:ss.fffffff";
-													if (log.Timestamp && line.Length >= timestamp_format.Length && DateTime.TryParseExact (line[..timestamp_format.Length], timestamp_format, null, System.Globalization.DateTimeStyles.None, out _))
+													if (log.Timestamp && line.Length >= timestamp_format.Length && DateTime.TryParseExact (line [..timestamp_format.Length], timestamp_format, null, System.Globalization.DateTimeStyles.None, out _))
 														if (line.Length > timestamp_format.Length)
 															line = line.Substring (timestamp_format.Length).Trim ();
 														else if (line.Length == timestamp_format.Length)


### PR DESCRIPTION
Instead of assuming such files have timestamps, actually parse them to make sure.

This way we properly end up detecting test failures (lines that start with
'[FAIL]').