### PR TITLE
[tests] Try to ignore tests that fail due the connection timeout errors.

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -1583,6 +1583,7 @@ partial class TestRuntime {
 		IgnoreInCIIfNetworkConnectionLost (ex);
 		IgnoreInCIIfDnsResolutionFailed (ex);
 		IgnoreInCIIfSshConnectionError (ex);
+		IgnoreInCIIfTimedOut (ex);
 	}
 
 	public static void IgnoreInCIIfBadNetwork (NSError? error)
@@ -1622,6 +1623,16 @@ partial class TestRuntime {
 	public static void IgnoreInCIIfTimedOut (NSError error)
 	{
 		IgnoreNetworkError (error, CFNetworkErrors.TimedOut);
+	}
+
+	public static void IgnoreInCIIfTimedOut (Exception ex)
+	{
+		if (ex is WebException wex) {
+			var msg = wex.Message;
+			if (msg.Contains ("The operation has timed out.")) {
+				IgnoreInCI ($"Ignored due to network error: {wex}");
+			}
+		}
 	}
 
 	public static void IgnoreInCIIfForbidden (Exception ex)


### PR DESCRIPTION
Hopefully fixes:

    [FAIL] TrustUsingNewCallback : System.Net.WebException : The operation has timed out.
    	   at System.Net.HttpWebRequest.GetResponse()
    	   at System.Net.WebClient.GetWebResponse(WebRequest request)
    	   at System.Net.WebClient.DownloadBits(WebRequest request, Stream writeStream)
    	   at System.Net.WebClient.DownloadDataInternal(Uri address, WebRequest& request)
    	   at System.Net.WebClient.DownloadString(Uri address)
    	   at System.Net.WebClient.DownloadString(String address)
    	   at LinkSdk.CryptoTest.TrustUsingNewCallback() in /Users/builder/azdo/_work/1/s/macios/tests/linker/link sdk/CryptoTest.cs:line 59
    	   at System.Reflection.MethodBaseInvoker.InterpretedInvoke_Method(Object obj, IntPtr* args)
    	   at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)