### PR TITLE
[Foundation] Fix nullability in NSXpcInterface.

### DIFF
--- a/src/Foundation/NSXpcInterface.cs
+++ b/src/Foundation/NSXpcInterface.cs
@@ -21,43 +21,57 @@
 
 using System.Reflection;
 
-// Disable until we get around to enable + fix any issues.
-#nullable disable
+#nullable enable
 
 namespace Foundation {
 	public partial class NSXpcInterface : NSObject {
+		/// <summary>Creates an <see cref="NSXpcInterface" /> instance for the specified interface type.</summary>
+		/// <param name="interfaceType">The interface type that defines the XPC protocol.</param>
+		/// <returns>A new <see cref="NSXpcInterface" /> instance.</returns>
+		/// <exception cref="ArgumentNullException">Thrown when <paramref name="interfaceType" /> is <see langword="null" />.</exception>
 		public static NSXpcInterface Create (Type interfaceType)
 		{
-			if (interfaceType is null)
-				throw new ArgumentNullException (nameof (interfaceType));
+			ArgumentNullException.ThrowIfNull (interfaceType);
 			return Create (new Protocol (interfaceType));
 		}
 
+		/// <summary>Gets the allowed classes for a specific method argument.</summary>
+		/// <param name="method">the method for which to get the allowed classes.</param>
+		/// <param name="argumentIndex">The zero-based index of the argument.</param>
+		/// <param name="forReplyBlock">A value indicating whether the allowed classes are for a reply block.</param>
+		/// <returns>A set of allowed <see cref="Class" /> objects for the specified method argument.</returns>
+		/// <exception cref="ArgumentNullException">Thrown when <paramref name="method" /> is <see langword="null" />.</exception>
+		/// <exception cref="ArgumentException">Thrown when the method is not exposed to Objective-C.</exception>
 		public NSSet<Class> GetAllowedClasses (MethodInfo method, nuint argumentIndex, bool forReplyBlock)
 		{
-			if (method is null)
-				throw new ArgumentNullException (nameof (method));
+			ArgumentNullException.ThrowIfNull (method);
 
-			ExportAttribute attribute = method.GetCustomAttribute<ExportAttribute> ();
+			var attribute = method.GetCustomAttribute<ExportAttribute> ();
 			if (attribute is null)
 				throw new ArgumentException ($"Method {method.Name} is not exposed to Objective-C", nameof (method));
 
 			// The runtime ensures that the Selector property is non-null and a valid selector.
-			Selector sel = new Selector (attribute.Selector);
+			var sel = new Selector (attribute.Selector!);
 			return GetAllowedClasses (sel, argumentIndex, forReplyBlock);
 		}
 
+		/// <summary>Sets the allowed classes for a specific method argument.</summary>
+		/// <param name="method">the method for which to set the allowed classes.</param>
+		/// <param name="allowedClasses">A set of allowed <see cref="Class" /> objects.</param>
+		/// <param name="argumentIndex">The zero-based index of the argument.</param>
+		/// <param name="forReplyBlock">A value indicating whether the allowed classes are for a reply block.</param>
+		/// <exception cref="ArgumentNullException">Thrown when <paramref name="method" /> is <see langword="null" />.</exception>
+		/// <exception cref="ArgumentException">Thrown when the method is not exposed to Objective-C.</exception>
 		public void SetAllowedClasses (MethodInfo method, NSSet<Class> allowedClasses, nuint argumentIndex, bool forReplyBlock)
 		{
-			if (method is null)
-				throw new ArgumentNullException (nameof (method));
+			ArgumentNullException.ThrowIfNull (method);
 
-			ExportAttribute attribute = method.GetCustomAttribute<ExportAttribute> ();
+			var attribute = method.GetCustomAttribute<ExportAttribute> ();
 			if (attribute is null)
 				throw new ArgumentException ($"Method {method.Name} is not exposed to Objective-C", nameof (method));
 
 			// The runtime ensures that the Selector property is non-null and a valid selector.
-			Selector sel = new Selector (attribute.Selector);
+			var sel = new Selector (attribute.Selector!);
 			SetAllowedClasses (allowedClasses, sel, argumentIndex, forReplyBlock);
 		}
 	}

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -12036,9 +12036,6 @@ M:Foundation.NSUserNotificationCenter.remove_DidDeliverNotification(System.Event
 M:Foundation.NSXpcConnection.CreateRemoteObjectProxy``1
 M:Foundation.NSXpcConnection.CreateRemoteObjectProxy``1(System.Action{Foundation.NSError})
 M:Foundation.NSXpcConnection.CreateSynchronousRemoteObjectProxy``1(System.Action{Foundation.NSError})
-M:Foundation.NSXpcInterface.Create(System.Type)
-M:Foundation.NSXpcInterface.GetAllowedClasses(System.Reflection.MethodInfo,System.UIntPtr,System.Boolean)
-M:Foundation.NSXpcInterface.SetAllowedClasses(System.Reflection.MethodInfo,Foundation.NSSet{ObjCRuntime.Class},System.UIntPtr,System.Boolean)
 M:Foundation.NSXpcListener.Dispose(System.Boolean)
 M:Foundation.NSXpcListenerDelegate_Extensions.ShouldAcceptConnection(Foundation.INSXpcListenerDelegate,Foundation.NSXpcListener,Foundation.NSXpcConnection)
 M:Foundation.OptionalMemberAttribute.#ctor


### PR DESCRIPTION
This is file 9 of 47 files with nullability disabled in Foundation.

Also:

* Add comprehensive XML documentation for all public methods.
* Use ArgumentNullException.ThrowIfNull for null checks.
* Add see cref attributes for types and parameters.
* Add exception documentation for ArgumentNullException and ArgumentException.
* Use var for local variable declarations.
* Add null-suppression operator on attribute.Selector (safe per runtime guarantee).

Contributes towards https://github.com/dotnet/macios/issues/17285.