### PR TITLE
Unify paths for custom runtime packs

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -70,7 +70,7 @@ ifdef CUSTOM_DOTNET
 DOWNLOAD_DOTNET_VERSION=$(CUSTOM_DOTNET_VERSION)
 ALL_NUGET_FEEDS:=$(shell grep '^[[:space:]]*<add.*value="https.*' $(TOP)/NuGet.config | sed -e 's/.*value="//' -e 's/".*//')
 CUSTOM_DOTNET_NUGET_FEED=\
-	--source $(DOTNET_RUNTIME_PATH)/artifacts/packages/Debug/Shipping \
+	--source $(DOTNET_RUNTIME_PATH)/artifacts/packages/Release/Shipping \
 	$(foreach feed,$(ALL_NUGET_FEEDS), --source $(feed))
 else
 ifneq ($(BUNDLED_NETCORE_PLATFORMS_PACKAGE_VERSION),)


### PR DESCRIPTION
Fixes #24339 according to the proposed solution.

In summary:

- The updated Makefile was the only place where we looked for custom runtime packs under `Debug`
  - This was introduced recently in https://github.com/dotnet/macios/commit/f4fb0e88e046558d89de7882f69996da4a6a3029
- The rest of the code base (e.g. `build-custom-runtime.sh`) uses `Release`
- This PR unifies the paths to use `Release`, as it was before.