### PR TITLE
[Foundation] Fix nullability in NSRange.

### DIFF
--- a/src/Foundation/NSRange.cs
+++ b/src/Foundation/NSRange.cs
@@ -22,53 +22,58 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-// Disable until we get around to enable + fix any issues.
-#nullable disable
+#nullable enable
 
 namespace Foundation {
 	/// <summary>Represents a range given by a location and length.</summary>
-	///     <remarks>To be added.</remarks>
-	///     <related type="sample" href="https://github.com/xamarin/ios-samples/tree/master/SimpleTextInput/">SimpleTextInput</related>
-	[SupportedOSPlatform ("ios")]
-	[SupportedOSPlatform ("maccatalyst")]
-	[SupportedOSPlatform ("macos")]
-	[SupportedOSPlatform ("tvos")]
+	/// <remarks>
+	///   <para>The <see cref="NSRange" /> structure is used throughout Foundation to represent ranges of items, such as characters in a string or elements in an array.</para>
+	/// </remarks>
+	/// <related type="sample" href="https://github.com/xamarin/ios-samples/tree/master/SimpleTextInput/">SimpleTextInput</related>
 	public struct NSRange : IEquatable<NSRange> {
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>The starting location of the range.</summary>
 		public nint Location;
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>The length of the range.</summary>
 		public nint Length;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>A constant indicating that a requested item was not found.</summary>
+		/// <remarks>This value is equal to <see cref="nint.MaxValue" />.</remarks>
 		public static readonly nint NotFound = nint.MaxValue;
 
+		/// <summary>Initializes a new instance of the <see cref="NSRange" /> structure with the specified location and length.</summary>
+		/// <param name="start">The starting location of the range.</param>
+		/// <param name="len">The length of the range.</param>
 		public NSRange (nint start, nint len)
 		{
 			Location = start;
 			Length = len;
 		}
 
+		/// <summary>Returns the hash code for this <see cref="NSRange" />.</summary>
+		/// <returns>A 32-bit signed integer hash code.</returns>
 		public override int GetHashCode ()
 		{
 			return HashCode.Combine (Location, Length);
 		}
 
-		public override bool Equals (object obj)
+		/// <summary>Determines whether this <see cref="NSRange" /> and the specified object have the same value.</summary>
+		/// <param name="obj">The object to compare with this instance.</param>
+		/// <returns><see langword="true" /> if <paramref name="obj" /> is an <see cref="NSRange" /> and has the same location and length as this instance; otherwise, <see langword="false" />.</returns>
+		public override bool Equals (object? obj)
 		{
 			return obj is NSRange other && Equals (other);
 		}
 
+		/// <summary>Determines whether this <see cref="NSRange" /> and another <see cref="NSRange" /> have the same value.</summary>
+		/// <param name="other">The <see cref="NSRange" /> to compare with this instance.</param>
+		/// <returns><see langword="true" /> if <paramref name="other" /> has the same location and length as this instance; otherwise, <see langword="false" />.</returns>
 		public bool Equals (NSRange other)
 		{
 			return Location == other.Location && Length == other.Length;
 		}
 
-		/// <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Returns a string representation of this <see cref="NSRange" />.</summary>
+		/// <returns>A string in the format "[Location={Location},Length={Length}]".</returns>
 		public override string ToString ()
 		{
 			return string.Format ("[Location={0},Length={1}]", Location, Length);

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -11989,10 +11989,6 @@ M:Foundation.NSOrderedSet`1.op_Inequality(Foundation.NSOrderedSet{`0},Foundation
 M:Foundation.NSOrderedSet`1.op_Subtraction(Foundation.NSOrderedSet{`0},Foundation.NSOrderedSet{`0})
 M:Foundation.NSOrderedSet`1.op_Subtraction(Foundation.NSOrderedSet{`0},Foundation.NSSet{`0})
 M:Foundation.NSPort.Dispose(System.Boolean)
-M:Foundation.NSRange.#ctor(System.IntPtr,System.IntPtr)
-M:Foundation.NSRange.Equals(Foundation.NSRange)
-M:Foundation.NSRange.Equals(System.Object)
-M:Foundation.NSRange.GetHashCode
 M:Foundation.NSSet.op_Addition(Foundation.NSSet,Foundation.NSOrderedSet)
 M:Foundation.NSSet.op_Addition(Foundation.NSSet,Foundation.NSSet)
 M:Foundation.NSSet.op_Subtraction(Foundation.NSSet,Foundation.NSOrderedSet)


### PR DESCRIPTION
This is file 24 of 47 files with nullability disabled in Foundation.

Changes:
- Enabled nullable reference types
- Removed four [SupportedOSPlatform] attributes without version numbers from NSRange struct
- Made Equals(object) parameter nullable (object?) as per standard pattern
- Replaced "To be added." XML documentation with proper documentation for all members
- Added comprehensive documentation for struct, fields, constructor, and methods
- Enhanced remarks with description of NSRange usage in Foundation
- Added see cref attributes throughout for better cross-referencing
- Removed unnecessary whitespace in XML comments while preserving correct indentation
- Added detailed returns documentation for all methods
- Improved ToString documentation to specify the exact format

Contributes towards https://github.com/dotnet/macios/issues/17285.