### PR TITLE
[monotouch-test] Improve diagnostics for CWKeychainTests.TrySetWiFiEAPIdentityTest.

### DIFF
--- a/tests/monotouch-test/CoreWlan/CWKeychainTests.cs
+++ b/tests/monotouch-test/CoreWlan/CWKeychainTests.cs
@@ -91,9 +91,9 @@ namespace MonoTouchFixtures.CoreWlan {
 		[Test]
 		public void TrySetWiFiEAPIdentityTest ()
 		{
+			var identity = IdentityTest.GetIdentity ();
 			RunOnBackgroundThread (() => {
 				// false because the ssid is not present
-				var identity = IdentityTest.GetIdentity ();
 				Assert.True (CWKeychain.TrySetWiFiEAPIdentity (domain, ssid, identity), "A");
 
 				Assert.True (CWKeychain.TrySetWiFiEAPIdentity (domain, ssid, identity, out var status), "B");

--- a/tests/monotouch-test/Security/IdentityTest.cs
+++ b/tests/monotouch-test/Security/IdentityTest.cs
@@ -21,8 +21,8 @@ namespace MonoTouchFixtures.Security {
 		{
 			using (var options = NSDictionary.FromObjectAndKey (new NSString ("farscape"), SecImportExport.Passphrase)) {
 				NSDictionary [] array;
-				if (SecImportExport.ImportPkcs12 (ImportExportTest.farscape_pfx, options, out array) != SecStatusCode.Success)
-					Assert.Fail ("ImportPkcs12");
+				var rv = SecImportExport.ImportPkcs12 (ImportExportTest.farscape_pfx, options, out array);
+				Assert.That (rv, Is.EqualTo (SecStatusCode.Success), "ImportPkcs12");
 				return Runtime.GetINativeObject<SecIdentity> (array [0].LowlevelObjectForKey (SecImportExport.Identity.Handle), false);
 			}
 		}


### PR DESCRIPTION
Trying to diagnose this random test failure:

    SecIdentitySetPreference failed errSecInvalidItemRef (-25304)
    	[FAIL] TrySetWiFiEAPIdentityTest : Multiple failures or warnings in test:
            1) ImportPkcs12
            2)   A
            Expected: True
            But was:  False

            3)   No exception
            Expected: null
            But was:  <NUnit.Framework.MultipleAssertException: Multiple failures or warnings in test:
            1) ImportPkcs12
            2)   A
            Expected: True
            But was:  False

            at NUnit.Framework.Assert.Multiple(TestDelegate testDelegate)
            at MonoTouchFixtures.CoreWlan.CWKeychainTests.<>c__DisplayClass11_0.<RunOnBackgroundThread>b__0()>

    		   at MonoTouchFixtures.CoreWlan.CWKeychainTests.RunOnBackgroundThread(Action action)
    		   at MonoTouchFixtures.CoreWlan.CWKeychainTests.TrySetWiFiEAPIdentityTest()