### PR TITLE
Ensure UrlSession is cleaned up on dispose

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -293,7 +293,7 @@ namespace Foundation {
 
 				inflightRequests.Clear ();
 			}
-			session.InvalidateAndCancel();
+			session.InvalidateAndCancel ();
 			base.Dispose (disposing);
 		}
 
@@ -450,7 +450,7 @@ namespace Foundation {
 					configuration.HttpCookieStorage = null;
 				}
 				session = NSUrlSession.FromConfiguration (configuration, (INSUrlSessionDelegate) new NSUrlSessionHandlerDelegate (this), null);
-				oldSession.FinishTasksAndInvalidate();
+				oldSession.FinishTasksAndInvalidate ();
 				oldSession.Dispose ();
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/dotnet/macios/issues/24376

Doc references:
- https://developer.apple.com/documentation/foundation/urlsession/invalidateandcancel()
- https://developer.apple.com/documentation/foundation/urlsession/finishtasksandinvalidate()