### PR TITLE
[devops] start using only the arm64 bots in preparation of macOS 26.3

### DIFF
--- a/tools/devops/automation/run-nightly-codeql.yml
+++ b/tools/devops/automation/run-nightly-codeql.yml
@@ -44,6 +44,7 @@ stages:
       demands:
       - Agent.OS -equals Darwin
       - Agent.OSVersion -gtVersion $(minimumMacOSVersion)
+      - macOS.Architecture -equals $(defaultMacOSArchitecture)
       - macOS.Name -equals ${{ parameters.macOSName }}
       - XcodeChannel -equals $(xcodeChannel)
     workspace:

--- a/tools/devops/automation/templates/build/api-diff-stage.yml
+++ b/tools/devops/automation/templates/build/api-diff-stage.yml
@@ -49,6 +49,7 @@ jobs:
     demands:
     - Agent.OS -equals Darwin
     - Agent.OSVersion -gtVersion $(minimumMacOSVersion)
+    - macOS.Architecture -equals $(defaultMacOSArchitecture)
     - macOS.Name -equals ${{ parameters.macOSName }}
     - XcodeChannel -equals ${{ parameters.xcodeChannel }}
   workspace:

--- a/tools/devops/automation/templates/build/build-mac-tests-stage.yml
+++ b/tools/devops/automation/templates/build/build-mac-tests-stage.yml
@@ -55,6 +55,7 @@ jobs:
     demands:
     - Agent.OS -equals Darwin
     - Agent.OSVersion -gtVersion $(minimumMacOSVersion)
+    - macOS.Architecture -equals $(defaultMacOSArchitecture)
     - macOS.Name -equals ${{ parameters.macOSName }}
     - XcodeChannel -equals ${{ parameters.xcodeChannel }}
 

--- a/tools/devops/automation/templates/build/build-stage.yml
+++ b/tools/devops/automation/templates/build/build-stage.yml
@@ -72,6 +72,7 @@ jobs:
       demands:
         - Agent.OS -equals Darwin
         - Agent.OSVersion -gtVersion $(minimumMacOSVersion)
+        - macOS.Architecture -equals $(defaultMacOSArchitecture)
         - macOS.Name -equals ${{ parameters.macOSName }}
         - XcodeChannel -equals ${{ parameters.xcodeChannel }}
 

--- a/tools/devops/automation/templates/variables/common.yml
+++ b/tools/devops/automation/templates/variables/common.yml
@@ -73,5 +73,8 @@ variables:
 - name: minimumMacOSVersion
   value: 15.6
 
+- name: defaultMacOSArchitecture
+  value: arm64
+
 - name: xcodeChannel
   value: Stable


### PR DESCRIPTION
Our intel bots are unable to be updated to macOS 26 so this is the first step to be moving into an arm64 only world