### PR TITLE
[tests] Fix Microsoft.Macios.Transformer.Tests.csproj to only build apidefinition-*.dll variants that are enabled when building locally.

### DIFF
--- a/tests/rgen/Microsoft.Macios.Transformer.Tests/Microsoft.Macios.Transformer.Tests.csproj
+++ b/tests/rgen/Microsoft.Macios.Transformer.Tests/Microsoft.Macios.Transformer.Tests.csproj
@@ -65,10 +65,7 @@
     
     <Target Name="BuildTestLibraries" BeforeTargets="BeforeBuild">
         <Message Text="Processing platform: %(Platform.Identity)" /> 
-        <Exec Condition="$(BUILD_BUILDID) == '' Or $(DOTNET_PLATFORMS.Contains('iOS'))" Command="make -j8 -C $(SourceDirectory) $(DotnetBuildDirectory)/ios/apidefinition-ios.dll"/>
-        <Exec Condition="$(BUILD_BUILDID) == '' Or $(DOTNET_PLATFORMS.Contains('macOS'))" Command="make -j8 -C $(SourceDirectory) $(DotnetBuildDirectory)/macos/apidefinition-macos.dll"/>
-        <Exec Condition="$(BUILD_BUILDID) == '' Or $(DOTNET_PLATFORMS.Contains('tvOS'))" Command="make -j8 -C $(SourceDirectory) $(DotnetBuildDirectory)/tvos/apidefinition-tvos.dll"/>
-        <Exec Condition="$(BUILD_BUILDID) == '' Or $(DOTNET_PLATFORMS.Contains('MacCatalyst'))" Command="make -j8 -C $(SourceDirectory) $(DotnetBuildDirectory)/maccatalyst/apidefinition-maccatalyst.dll"/>
+        <Exec Command="make -j8 -C $(SourceDirectory) apidefinition"/>
     </Target>
 
 </Project>


### PR DESCRIPTION
The 'apidefinition' target already only builds the enabled target platforms,
so there's no need to duplicate the platform selection logic in this csproj.