### PR TITLE
[Foundation] Fix nullability in NSOrderedSet.

### DIFF
--- a/src/Foundation/NSOrderedSet.cs
+++ b/src/Foundation/NSOrderedSet.cs
@@ -30,60 +30,57 @@
 using System.Collections;
 using System.Collections.Generic;
 
-// Disable until we get around to enable + fix any issues.
-#nullable disable
+#nullable enable
 
 namespace Foundation {
 
 	public partial class NSOrderedSet : IEnumerable<NSObject> {
-		internal const string selSetWithArray = "orderedSetWithArray:";
+		const string selSetWithArray = "orderedSetWithArray:";
 
-		/// <param name="objs">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Initializes a new instance of the <see cref="NSOrderedSet" /> class from an array of <see cref="NSObject" /> instances.</summary>
+		/// <param name="objs">An array of <see cref="NSObject" /> instances to include in the set.</param>
 		public NSOrderedSet (params NSObject [] objs) : this (NSArray.FromNSObjects (objs))
 		{
 		}
 
-		/// <param name="objs">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Initializes a new instance of the <see cref="NSOrderedSet" /> class from an array of objects.</summary>
+		/// <param name="objs">An array of objects to include in the set.</param>
 		public NSOrderedSet (params object [] objs) : this (NSArray.FromObjects (objs))
 		{
 		}
 
-		/// <param name="strings">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Initializes a new instance of the <see cref="NSOrderedSet" /> class from an array of strings.</summary>
+		/// <param name="strings">An array of strings to include in the set.</param>
 		public NSOrderedSet (params string [] strings) : this (NSArray.FromStrings (strings))
 		{
 		}
 
+		/// <summary>Gets the object at the specified index.</summary>
+		/// <param name="idx">The zero-based index of the object to get.</param>
+		/// <returns>The object at the specified index.</returns>
 		public NSObject this [nint idx] {
 			get {
 				return GetObject (idx);
 			}
 		}
 
-		/// <typeparam name="T">To be added.</typeparam>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Returns the contents of the ordered set as a strongly typed array.</summary>
+		/// <typeparam name="T">The type of values in the array, must be a class that implements <see cref="INativeObject" />.</typeparam>
+		/// <returns>An array of type <typeparamref name="T" /> with the contents of the ordered set.</returns>
 		public T [] ToArray<T> () where T : class, INativeObject
 		{
 			IntPtr nsarr = _ToArray ();
 			return NSArray.ArrayFromHandle<T> (nsarr);
 		}
 
-		/// <typeparam name="T">To be added.</typeparam>
-		///         <param name="values">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Creates a new <see cref="NSOrderedSet" /> from an array of strongly typed values.</summary>
+		/// <typeparam name="T">The type of values in the array, must be a class that derives from <see cref="NSObject" />.</typeparam>
+		/// <param name="values">An array of strongly typed values to include in the ordered set.</param>
+		/// <returns>A new <see cref="NSOrderedSet" /> containing the specified values.</returns>
 		public static NSOrderedSet MakeNSOrderedSet<T> (T [] values) where T : NSObject
 		{
 			NSArray a = NSArray.FromNSObjects (values);
-			var result = (NSOrderedSet) Runtime.GetNSObject (ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr (class_ptr, Selector.GetHandle (selSetWithArray), a.Handle));
+			var result = (NSOrderedSet) Runtime.GetNSObject (ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr (class_ptr, Selector.GetHandle (selSetWithArray), a.Handle))!;
 			GC.KeepAlive (a);
 			return result;
 		}
@@ -99,9 +96,8 @@ namespace Foundation {
 				yield return obj as NSObject;
 		}
 
-		/// <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Returns an enumerator that iterates through the ordered set.</summary>
+		/// <returns>An enumerator that can be used to iterate through the ordered set.</returns>
 		IEnumerator IEnumerable.GetEnumerator ()
 		{
 			var enumerator = _GetEnumerator ();
@@ -111,10 +107,14 @@ namespace Foundation {
 				yield return obj;
 		}
 
-		public static NSOrderedSet operator + (NSOrderedSet first, NSOrderedSet second)
+		/// <summary>Adds two ordered sets together, creating a new ordered set that contains all elements from both sets.</summary>
+		/// <param name="first">The first ordered set.</param>
+		/// <param name="second">The second ordered set.</param>
+		/// <returns>A new <see cref="NSOrderedSet" /> containing all elements from both ordered sets.</returns>
+		public static NSOrderedSet? operator + (NSOrderedSet? first, NSOrderedSet? second)
 		{
 			if (first is null)
-				return new NSOrderedSet (second);
+				return second is not null ? new NSOrderedSet (second) : null;
 			if (second is null)
 				return new NSOrderedSet (first);
 			var copy = new NSMutableOrderedSet (first);
@@ -122,10 +122,14 @@ namespace Foundation {
 			return copy;
 		}
 
-		public static NSOrderedSet operator + (NSOrderedSet first, NSSet second)
+		/// <summary>Adds an ordered set and a set together, creating a new ordered set that contains all elements from both.</summary>
+		/// <param name="first">The ordered set.</param>
+		/// <param name="second">The set.</param>
+		/// <returns>A new <see cref="NSOrderedSet" /> containing all elements from both the ordered set and the set.</returns>
+		public static NSOrderedSet? operator + (NSOrderedSet? first, NSSet? second)
 		{
 			if (first is null)
-				return new NSOrderedSet (second);
+				return second is not null ? new NSOrderedSet (second) : null;
 			if (second is null)
 				return new NSOrderedSet (first);
 			var copy = new NSMutableOrderedSet (first);
@@ -133,7 +137,11 @@ namespace Foundation {
 			return copy;
 		}
 
-		public static NSOrderedSet operator - (NSOrderedSet first, NSOrderedSet second)
+		/// <summary>Subtracts the elements of the second ordered set from the first ordered set.</summary>
+		/// <param name="first">The ordered set to subtract from.</param>
+		/// <param name="second">The ordered set whose elements should be removed.</param>
+		/// <returns>A new <see cref="NSOrderedSet" /> containing the elements in <paramref name="first" /> that are not in <paramref name="second" />, or <see langword="null" /> if <paramref name="first" /> is <see langword="null" />.</returns>
+		public static NSOrderedSet? operator - (NSOrderedSet? first, NSOrderedSet? second)
 		{
 			if (first is null)
 				return null;
@@ -144,7 +152,11 @@ namespace Foundation {
 			return copy;
 		}
 
-		public static NSOrderedSet operator - (NSOrderedSet first, NSSet second)
+		/// <summary>Subtracts the elements of a set from an ordered set.</summary>
+		/// <param name="first">The ordered set to subtract from.</param>
+		/// <param name="second">The set whose elements should be removed.</param>
+		/// <returns>A new <see cref="NSOrderedSet" /> containing the elements in <paramref name="first" /> that are not in <paramref name="second" />, or <see langword="null" /> if <paramref name="first" /> is <see langword="null" />.</returns>
+		public static NSOrderedSet? operator - (NSOrderedSet? first, NSSet? second)
 		{
 			if (first is null)
 				return null;
@@ -155,7 +167,11 @@ namespace Foundation {
 			return copy;
 		}
 
-		public static bool operator == (NSOrderedSet first, NSOrderedSet second)
+		/// <summary>Determines whether two <see cref="NSOrderedSet" /> instances are equal.</summary>
+		/// <param name="first">The first ordered set to compare.</param>
+		/// <param name="second">The second ordered set to compare.</param>
+		/// <returns><see langword="true" /> if both ordered sets are equal; otherwise, <see langword="false" />.</returns>
+		public static bool operator == (NSOrderedSet? first, NSOrderedSet? second)
 		{
 			// IsEqualToOrderedSet does not allow null
 			if (object.ReferenceEquals (null, first))
@@ -166,7 +182,11 @@ namespace Foundation {
 			return first.IsEqualToOrderedSet (second);
 		}
 
-		public static bool operator != (NSOrderedSet first, NSOrderedSet second)
+		/// <summary>Determines whether two <see cref="NSOrderedSet" /> instances are not equal.</summary>
+		/// <param name="first">The first ordered set to compare.</param>
+		/// <param name="second">The second ordered set to compare.</param>
+		/// <returns><see langword="true" /> if the ordered sets are not equal; otherwise, <see langword="false" />.</returns>
+		public static bool operator != (NSOrderedSet? first, NSOrderedSet? second)
 		{
 			// IsEqualToOrderedSet does not allow null
 			if (object.ReferenceEquals (null, first))
@@ -177,30 +197,28 @@ namespace Foundation {
 			return !first.IsEqualToOrderedSet (second);
 		}
 
-		/// <param name="other">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
-		public override bool Equals (object other)
+		/// <summary>Determines whether this <see cref="NSOrderedSet" /> and the specified object are equal.</summary>
+		/// <param name="other">The object to compare with this instance.</param>
+		/// <returns><see langword="true" /> if <paramref name="other" /> is an <see cref="NSOrderedSet" /> and has the same elements in the same order as this instance; otherwise, <see langword="false" />.</returns>
+		public override bool Equals (object? other)
 		{
-			NSOrderedSet o = other as NSOrderedSet;
+			var o = other as NSOrderedSet;
 			if (o is null)
 				return false;
 			return IsEqualToOrderedSet (o);
 		}
 
 		/// <summary>Generates a hash code for the current instance.</summary>
-		///         <returns>A int containing the hash code for this instance.</returns>
-		///         <remarks>The algorithm used to generate the hash code is unspecified.</remarks>
+		/// <returns>A 32-bit signed integer hash code for this instance.</returns>
+		/// <remarks>The algorithm used to generate the hash code is unspecified.</remarks>
 		public override int GetHashCode ()
 		{
 			return (int) GetNativeHash ();
 		}
 
-		/// <param name="obj">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Determines whether the ordered set contains the specified object.</summary>
+		/// <param name="obj">The object to locate in the ordered set.</param>
+		/// <returns><see langword="true" /> if the ordered set contains the specified object; otherwise, <see langword="false" />.</returns>
 		public bool Contains (object obj)
 		{
 			return Contains (NSObject.FromObject (obj));
@@ -208,27 +226,27 @@ namespace Foundation {
 	}
 
 	public partial class NSMutableOrderedSet {
-		/// <param name="objs">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Initializes a new instance of the <see cref="NSMutableOrderedSet" /> class from an array of <see cref="NSObject" /> instances.</summary>
+		/// <param name="objs">An array of <see cref="NSObject" /> instances to include in the set.</param>
 		public NSMutableOrderedSet (params NSObject [] objs) : this (NSArray.FromNSObjects (objs))
 		{
 		}
 
-		/// <param name="objs">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Initializes a new instance of the <see cref="NSMutableOrderedSet" /> class from an array of objects.</summary>
+		/// <param name="objs">An array of objects to include in the set.</param>
 		public NSMutableOrderedSet (params object [] objs) : this (NSArray.FromObjects (objs))
 		{
 		}
 
-		/// <param name="strings">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Initializes a new instance of the <see cref="NSMutableOrderedSet" /> class from an array of strings.</summary>
+		/// <param name="strings">An array of strings to include in the set.</param>
 		public NSMutableOrderedSet (params string [] strings) : this (NSArray.FromStrings (strings))
 		{
 		}
 
+		/// <summary>Gets or sets the object at the specified index.</summary>
+		/// <param name="idx">The zero-based index of the object to get or set.</param>
+		/// <returns>The object at the specified index.</returns>
 		public new NSObject this [nint idx] {
 			get {
 				return GetObject (idx);

--- a/src/Foundation/NSOrderedSet_1.cs
+++ b/src/Foundation/NSOrderedSet_1.cs
@@ -245,10 +245,10 @@ namespace Foundation {
 			return !first.IsEqualToOrderedSet (second);
 		}
 
-		/// <summary>Determines whether the specified object is equal to the current ordered set.</summary>
-		/// <param name="other">The object to compare with the current ordered set.</param>
-		/// <returns><see langword="true"/> if the specified object is equal to the current ordered set; otherwise, <see langword="false"/>.</returns>
-		public override bool Equals (object other)
+		/// <summary>Determines whether this <see cref="NSOrderedSet{TKey}" /> and the specified object are equal.</summary>
+		/// <param name="other">The object to compare with this instance.</param>
+		/// <returns><see langword="true" /> if <paramref name="other" /> is an <see cref="NSOrderedSet{TKey}" /> and has the same elements in the same order as this instance; otherwise, <see langword="false" />.</returns>
+		public override bool Equals (object? other)
 		{
 			var o = other as NSOrderedSet<TKey>;
 			if (o is null)

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -11976,12 +11976,6 @@ M:Foundation.NSOperatingSystemVersion.Equals(System.Object)
 M:Foundation.NSOperatingSystemVersion.GetHashCode
 M:Foundation.NSOperatingSystemVersion.op_Equality(Foundation.NSOperatingSystemVersion,Foundation.NSOperatingSystemVersion)
 M:Foundation.NSOperatingSystemVersion.op_Inequality(Foundation.NSOperatingSystemVersion,Foundation.NSOperatingSystemVersion)
-M:Foundation.NSOrderedSet.op_Addition(Foundation.NSOrderedSet,Foundation.NSOrderedSet)
-M:Foundation.NSOrderedSet.op_Addition(Foundation.NSOrderedSet,Foundation.NSSet)
-M:Foundation.NSOrderedSet.op_Equality(Foundation.NSOrderedSet,Foundation.NSOrderedSet)
-M:Foundation.NSOrderedSet.op_Inequality(Foundation.NSOrderedSet,Foundation.NSOrderedSet)
-M:Foundation.NSOrderedSet.op_Subtraction(Foundation.NSOrderedSet,Foundation.NSOrderedSet)
-M:Foundation.NSOrderedSet.op_Subtraction(Foundation.NSOrderedSet,Foundation.NSSet)
 M:Foundation.NSPort.Dispose(System.Boolean)
 M:Foundation.NSStream.add_OnEvent(System.EventHandler{Foundation.NSStreamEventArgs})
 M:Foundation.NSStream.Dispose(System.Boolean)
@@ -21071,7 +21065,6 @@ P:Foundation.NSMutableDictionary.Item(Foundation.NSObject)
 P:Foundation.NSMutableDictionary.Item(Foundation.NSString)
 P:Foundation.NSMutableDictionary.Item(System.String)
 P:Foundation.NSMutableDictionary`2.Item(`0)
-P:Foundation.NSMutableOrderedSet.Item(System.IntPtr)
 P:Foundation.NSMutableOrderedSet`1.Item(System.IntPtr)
 P:Foundation.NSNetDomainEventArgs.Domain
 P:Foundation.NSNetDomainEventArgs.MoreComing
@@ -21087,7 +21080,6 @@ P:Foundation.NSObject.AccessibilityTextualContext
 P:Foundation.NSObject.AccessibilityUserInputLabels
 P:Foundation.NSObject.ExposedBindings
 P:Foundation.NSObjectEventArgs.Obj
-P:Foundation.NSOrderedSet.Item(System.IntPtr)
 P:Foundation.NSProcessInfo.IsiOSApplicationOnMac
 P:Foundation.NSProcessInfo.IsiOSAppOnVision
 P:Foundation.NSProcessInfo.IsMacCatalystApplication


### PR DESCRIPTION
This is file 25 of 47 files with nullability disabled in Foundation.

Changes:
- Enabled nullable reference types in NSOrderedSet.cs
- Made operator return types nullable where appropriate (operator +, operator -)
- Made operator parameters nullable for consistency
- Made Equals(object) parameter nullable (object?) as per standard pattern
- Improved null handling in operators to return null when appropriate
- Added null-forgiving operator to Runtime.GetNSObject call in MakeNSOrderedSet
- Replaced "To be added." XML documentation with proper documentation for all members
- Added comprehensive documentation for constructors, indexers, methods, and operators
- Added see cref attributes throughout for better cross-referencing
- Removed unnecessary whitespace in XML comments while preserving correct indentation
- Added detailed parameter and returns documentation
- Fixed NSOrderedSet_1.cs Equals method parameter to be nullable to match base class override

Contributes towards https://github.com/dotnet/macios/issues/17285.