### PR TITLE
[net11.0] Bump minimum library version for .NET 11.

### DIFF
--- a/Make.versions
+++ b/Make.versions
@@ -28,10 +28,10 @@ MACCATALYST_NUGET_OS_VERSION=26.1
 
 # The following are the OS versions we first supported with the current .NET version.
 # These versions must *not* change with minor .NET updates, only major .NET releases.
-IOS_TARGET_PLATFORM_VERSION_LIBRARY=26.0
-TVOS_TARGET_PLATFORM_VERSION_LIBRARY=26.0
-MACOS_TARGET_PLATFORM_VERSION_LIBRARY=26.0
-MACCATALYST_TARGET_PLATFORM_VERSION_LIBRARY=26.0
+IOS_TARGET_PLATFORM_VERSION_LIBRARY=26.1
+TVOS_TARGET_PLATFORM_VERSION_LIBRARY=26.1
+MACOS_TARGET_PLATFORM_VERSION_LIBRARY=26.1
+MACCATALYST_TARGET_PLATFORM_VERSION_LIBRARY=26.1
 
 # In theory we should define the default platform version if it's not specified in the TFM. The default should not change for a given .NET version:
 # * We release support for iOS 14.5 with .NET 6

--- a/tools/common/SdkVersions.cs
+++ b/tools/common/SdkVersions.cs
@@ -43,10 +43,10 @@ namespace Xamarin {
 		public const string TargetPlatformVersionExecutablemacOS = "26.1";
 		public const string TargetPlatformVersionExecutableMacCatalyst = "26.1";
 
-		public const string TargetPlatformVersionLibraryiOS = "26.0";
-		public const string TargetPlatformVersionLibrarytvOS = "26.0";
-		public const string TargetPlatformVersionLibrarymacOS = "26.0";
-		public const string TargetPlatformVersionLibraryMacCatalyst = "26.0";
+		public const string TargetPlatformVersionLibraryiOS = "26.1";
+		public const string TargetPlatformVersionLibrarytvOS = "26.1";
+		public const string TargetPlatformVersionLibrarymacOS = "26.1";
+		public const string TargetPlatformVersionLibraryMacCatalyst = "26.1";
 
 		public static Version OSXVersion { get { return new Version (OSX); } }
 		public static Version iOSVersion { get { return new Version (iOS); } }


### PR DESCRIPTION
This will eventually become 27.0, when .NET 11 goes stable (for now there's no
Xcode 26.0 support in .NET 11, only Xcode 26.1).