### PR TITLE
[dotnet-linker] Don't add the target framework to the output path.

### DIFF
--- a/tools/dotnet-linker/Makefile
+++ b/tools/dotnet-linker/Makefile
@@ -3,7 +3,7 @@ TOP=../..
 include $(TOP)/Make.config
 include $(TOP)/mk/rules.mk
 
-BUILD_DIR=bin/Debug/$(DOTNET_TFM)
+BUILD_DIR=bin/Debug
 
 DOTNET_TARGETS += \
 	$(BUILD_DIR)/dotnet-linker.dll \

--- a/tools/dotnet-linker/dotnet-linker.csproj
+++ b/tools/dotnet-linker/dotnet-linker.csproj
@@ -5,6 +5,7 @@
     <DefineConstants>$(DefineConstants);BUNDLER</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <WarningsAsErrors>nullable</WarningsAsErrors>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <Import Project="..\..\eng\Versions.props" />


### PR DESCRIPTION
This simplifies logic when new .NET versions come out.