### PR TITLE
[Foundation] Fix nullability in NSNull.

### DIFF
--- a/src/Foundation/NSNull.cs
+++ b/src/Foundation/NSNull.cs
@@ -1,16 +1,18 @@
 
-// Disable until we get around to enable + fix any issues.
-#nullable disable
+#nullable enable
 
 namespace Foundation {
 	public partial class NSNull {
 
-		static NSNull _null;
+		static NSNull? _null;
 
-		// helper to avoid all, but one, native calls when called repeatedly
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>
+		/// Gets the singleton <see cref="NSNull"/> instance.
+		/// </summary>
+		/// <value>The singleton <see cref="NSNull"/> instance representing a null value in Objective-C collections.</value>
+		/// <remarks>
+		/// This property caches the native <see cref="NSNull"/> instance to avoid repeated native calls.
+		/// </remarks>
 		static public NSNull Null {
 			get {
 				if (_null is null)


### PR DESCRIPTION
This is file 28 of 47 files with nullability disabled in Foundation.

Changes made:
- Enabled nullable reference types
- Made static field _null nullable (NSNull?)
- Removed 'To be added.' placeholder documentation
- Added comprehensive XML documentation for the Null property
- Added proper 'see cref' attributes
- Removed unnecessary whitespace in XML comments
- Improved documentation clarity describing the singleton pattern and caching behavior

Contributes towards https://github.com/dotnet/macios/issues/17285.