### PR TITLE
[Foundation] Fix nullability in NSNotificationCenter.

### DIFF
--- a/src/Foundation/NSNotificationCenter.cs
+++ b/src/Foundation/NSNotificationCenter.cs
@@ -78,7 +78,7 @@ namespace Foundation {
 		/// <param name="fromObject">If not <see langword="null"/>, filters the notifications to those sent by this object.</param>
 		/// <returns>An observer token that can be used later as the parameter passed to <see cref="RemoveObserver(NSObject)"/>.</returns>
 		/// <exception cref="ArgumentNullException">Thrown when <paramref name="notify"/> is <see langword="null"/>.</exception>
-		public NSObject AddObserver (NSString aName, Action<NSNotification> notify, NSObject? fromObject)
+		public NSObject AddObserver (NSString? aName, Action<NSNotification> notify, NSObject? fromObject)
 		{
 			ArgumentNullException.ThrowIfNull (notify);
 
@@ -96,7 +96,7 @@ namespace Foundation {
 		/// <param name="notify">The delegate that will be invoked when the notification is posted.</param>
 		/// <returns>An observer token that can be used later as the parameter passed to <see cref="RemoveObserver(NSObject)"/>.</returns>
 		/// <exception cref="ArgumentNullException">Thrown when <paramref name="notify"/> is <see langword="null"/>.</exception>
-		public NSObject AddObserver (NSString aName, Action<NSNotification> notify)
+		public NSObject AddObserver (NSString? aName, Action<NSNotification> notify)
 		{
 			return AddObserver (aName, notify, null);
 		}


### PR DESCRIPTION
This is file 29 of 47 files with nullability disabled in Foundation.

Changes made:
- Enabled nullable reference types
- Made internal field notificationCenter nullable (NSNotificationCenter?)
- Made ObservedData fields nullable to properly reflect optional values
- Made method parameters nullable where appropriate (fromObject, keys, aName, anObject)
- Replaced ArgumentNullException with ArgumentNullException.ThrowIfNull
- Removed 'To be added.' placeholder documentation
- Added comprehensive XML documentation for all public methods
- Added proper 'see cref' attributes throughout documentation
- Removed unnecessary whitespace in XML comments
- Improved documentation clarity and consistency
- Added missing exception documentation for ArgumentNullException

Contributes towards https://github.com/dotnet/macios/issues/17285.