### PR TITLE
[net11.0] Enable CoreCLR tests on x64.

### DIFF
--- a/tests/xharness/Jenkins/TestVariationsFactory.cs
+++ b/tests/xharness/Jenkins/TestVariationsFactory.cs
@@ -38,8 +38,6 @@ namespace Xharness.Jenkins {
 			var x64_sim_runtime_identifier = string.Empty;
 			var supports_mono = test.Platform != TestPlatform.Mac;
 			var supports_coreclr = true;
-			var coreclr_works = Harness.CanRunArm64 || test.Platform == TestPlatform.Mac; // ignore tests on x64 until https://github.com/dotnet/runtime/issues/121631
-			var ignore_coreclr = coreclr_works ? ignore : true;
 
 			switch (test.Platform) {
 			case TestPlatform.Mac:
@@ -75,13 +73,13 @@ namespace Xharness.Jenkins {
 				break;
 			case "introspection":
 				if (supports_coreclr && supports_mono) { // we only need specific coreclr test if we *also* support mono (otherwise the default test will be coreclr)
-					yield return new TestData { Variation = "CoreCLR", TestVariation = "coreclr", Ignored = ignore_coreclr };
+					yield return new TestData { Variation = "CoreCLR", TestVariation = "coreclr", Ignored = ignore };
 				}
 				break;
 			case "monotouch-test":
 				if (supports_coreclr && supports_mono) { // we only need specific coreclr test if we *also* support mono (otherwise the default test will be coreclr)
-					yield return new TestData { Variation = "Debug (CoreCLR)", TestVariation = "debug|coreclr", Ignored = ignore_coreclr };
-					yield return new TestData { Variation = "Release (CoreCLR)", TestVariation = "release|coreclr", Ignored = ignore_coreclr };
+					yield return new TestData { Variation = "Debug (CoreCLR)", TestVariation = "debug|coreclr", Ignored = ignore };
+					yield return new TestData { Variation = "Release (CoreCLR)", TestVariation = "release|coreclr", Ignored = ignore };
 				}
 				break;
 			}


### PR DESCRIPTION
## Description

This PR enables CoreCLR tests on x64 devices.

Fixes https://github.com/dotnet/macios/issues/24316.

Continued from #24325.