### PR TITLE
[Foundation] Fix nullability in NSLocale.

### DIFF
--- a/src/Foundation/NSLocale.cs
+++ b/src/Foundation/NSLocale.cs
@@ -27,216 +27,196 @@
 //
 //
 
-// Disable until we get around to enable + fix any issues.
-#nullable disable
+#nullable enable
 
 namespace Foundation {
 
 	public partial class NSLocale {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		public string Identifier {
+		/// <summary>Gets the locale identifier string.</summary>
+		/// <value>The locale identifier.</value>
+		public string? Identifier {
 			get {
-				return (string) (NSString) ObjectForKey (_Identifier);
+				return (string?) (NSString?) ObjectForKey (_Identifier);
 			}
 		}
 
-		/// <param name="value">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
-		public string GetIdentifierDisplayName (string value)
+		/// <summary>Gets the display name for the specified locale identifier.</summary>
+		/// <param name="value">The locale identifier.</param>
+		/// <returns>The localized display name for the identifier, or <see langword="null" /> if not available.</returns>
+		public string? GetIdentifierDisplayName (string value)
 		{
+			ArgumentNullException.ThrowIfNull (value);
 			return DisplayNameForKey (_Identifier, value);
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		public string LanguageCode {
+		/// <summary>Gets the language code for the locale.</summary>
+		/// <value>The language code.</value>
+		public string? LanguageCode {
 			get {
-				return (string) (NSString) ObjectForKey (_LanguageCode);
+				return (string?) (NSString?) ObjectForKey (_LanguageCode);
 			}
 		}
 
-		/// <param name="value">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
-		public string GetLanguageCodeDisplayName (string value)
+		/// <summary>Gets the display name for the specified language code.</summary>
+		/// <param name="value">The language code.</param>
+		/// <returns>The localized display name for the language code, or <see langword="null" /> if not available.</returns>
+		public string? GetLanguageCodeDisplayName (string value)
 		{
+			ArgumentNullException.ThrowIfNull (value);
 			return DisplayNameForKey (_LanguageCode, value);
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		public string CountryCode {
+		/// <summary>Gets the country code for the locale.</summary>
+		/// <value>The country code.</value>
+		public string? CountryCode {
 			get {
-				return (string) (NSString) ObjectForKey (_CountryCode);
+				return (string?) (NSString?) ObjectForKey (_CountryCode);
 			}
 		}
 
-		/// <param name="value">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
-		public string GetCountryCodeDisplayName (string value)
+		/// <summary>Gets the display name for the specified country code.</summary>
+		/// <param name="value">The country code.</param>
+		/// <returns>The localized display name for the country code, or <see langword="null" /> if not available.</returns>
+		public string? GetCountryCodeDisplayName (string value)
 		{
+			ArgumentNullException.ThrowIfNull (value);
 			return DisplayNameForKey (_CountryCode, value);
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		public string ScriptCode {
+		/// <summary>Gets the script code for the locale.</summary>
+		/// <value>The script code.</value>
+		public string? ScriptCode {
 			get {
-				return (string) (NSString) ObjectForKey (_ScriptCode);
+				return (string?) (NSString?) ObjectForKey (_ScriptCode);
 			}
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		public string VariantCode {
+		/// <summary>Gets the variant code for the locale.</summary>
+		/// <value>The variant code.</value>
+		public string? VariantCode {
 			get {
-				return (string) (NSString) ObjectForKey (_VariantCode);
+				return (string?) (NSString?) ObjectForKey (_VariantCode);
 			}
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		public NSCharacterSet ExemplarCharacterSet {
+		/// <summary>Gets the exemplar character set for the locale.</summary>
+		/// <value>The character set containing exemplar characters.</value>
+		public NSCharacterSet? ExemplarCharacterSet {
 			get {
 				return ObjectForKey (_ExemplarCharacterSet) as NSCharacterSet;
 			}
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		public NSCalendar Calendar {
+		/// <summary>Gets the calendar for the locale.</summary>
+		/// <value>The <see cref="NSCalendar" /> object associated with the locale.</value>
+		public NSCalendar? Calendar {
 			get {
 				return ObjectForKey (_Calendar) as NSCalendar;
 			}
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		public string CollationIdentifier {
+		/// <summary>Gets the collation identifier for the locale.</summary>
+		/// <value>The collation identifier.</value>
+		public string? CollationIdentifier {
 			get {
-				return (string) (NSString) ObjectForKey (_CollationIdentifier);
+				return (string?) (NSString?) ObjectForKey (_CollationIdentifier);
 			}
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets a value indicating whether the locale uses the metric system.</summary>
+		/// <value><see langword="true" /> if the locale uses the metric system; otherwise, <see langword="false" />.</value>
 		public bool UsesMetricSystem {
 			get {
-				return ((NSNumber) ObjectForKey (_UsesMetricSystem)).Int32Value != 0;
+				return (ObjectForKey (_UsesMetricSystem) as NSNumber)?.BoolValue == true;
 			}
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		public string MeasurementSystem {
+		/// <summary>Gets the measurement system for the locale.</summary>
+		/// <value>The measurement system identifier.</value>
+		public string? MeasurementSystem {
 			get {
-				return (string) (NSString) ObjectForKey (_MeasurementSystem);
+				return (string?) (NSString?) ObjectForKey (_MeasurementSystem);
 			}
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		public string DecimalSeparator {
+		/// <summary>Gets the decimal separator for the locale.</summary>
+		/// <value>The decimal separator character.</value>
+		public string? DecimalSeparator {
 			get {
-				return (string) (NSString) ObjectForKey (_DecimalSeparator);
+				return (string?) (NSString?) ObjectForKey (_DecimalSeparator);
 			}
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		public string GroupingSeparator {
+		/// <summary>Gets the grouping separator for the locale.</summary>
+		/// <value>The grouping separator character used in numbers.</value>
+		public string? GroupingSeparator {
 			get {
-				return (string) (NSString) ObjectForKey (_GroupingSeparator);
+				return (string?) (NSString?) ObjectForKey (_GroupingSeparator);
 			}
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		public string CurrencySymbol {
+		/// <summary>Gets the currency symbol for the locale.</summary>
+		/// <value>The currency symbol.</value>
+		public string? CurrencySymbol {
 			get {
-				return (string) (NSString) ObjectForKey (_CurrencySymbol);
+				return (string?) (NSString?) ObjectForKey (_CurrencySymbol);
 			}
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		public string CurrencyCode {
+		/// <summary>Gets the currency code for the locale.</summary>
+		/// <value>The ISO 4217 currency code.</value>
+		public string? CurrencyCode {
 			get {
-				return (string) (NSString) ObjectForKey (_CurrencyCode);
+				return (string?) (NSString?) ObjectForKey (_CurrencyCode);
 			}
 		}
 
-		/// <param name="value">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
-		public string GetCurrencyCodeDisplayName (string value)
+		/// <summary>Gets the display name for the specified currency code.</summary>
+		/// <param name="value">The currency code.</param>
+		/// <returns>The localized display name for the currency code, or <see langword="null" /> if not available.</returns>
+		public string? GetCurrencyCodeDisplayName (string value)
 		{
+			ArgumentNullException.ThrowIfNull (value);
 			return DisplayNameForKey (_CurrencyCode, value);
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		public string CollatorIdentifier {
+		/// <summary>Gets the collator identifier for the locale.</summary>
+		/// <value>The collator identifier.</value>
+		public string? CollatorIdentifier {
 			get {
-				return (string) (NSString) ObjectForKey (_CollatorIdentifier);
+				return (string?) (NSString?) ObjectForKey (_CollatorIdentifier);
 			}
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		public string QuotationBeginDelimiterKey {
+		/// <summary>Gets the quotation begin delimiter for the locale.</summary>
+		/// <value>The character or string used to begin a quotation.</value>
+		public string? QuotationBeginDelimiterKey {
 			get {
-				return (string) (NSString) ObjectForKey (_QuotationBeginDelimiterKey);
+				return (string?) (NSString?) ObjectForKey (_QuotationBeginDelimiterKey);
 			}
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		public string QuotationEndDelimiterKey {
+		/// <summary>Gets the quotation end delimiter for the locale.</summary>
+		/// <value>The character or string used to end a quotation.</value>
+		public string? QuotationEndDelimiterKey {
 			get {
-				return (string) (NSString) ObjectForKey (_QuotationEndDelimiterKey);
+				return (string?) (NSString?) ObjectForKey (_QuotationEndDelimiterKey);
 			}
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		public string AlternateQuotationBeginDelimiterKey {
+		/// <summary>Gets the alternate quotation begin delimiter for the locale.</summary>
+		/// <value>The character or string used to begin an alternate (nested) quotation.</value>
+		public string? AlternateQuotationBeginDelimiterKey {
 			get {
-				return (string) (NSString) ObjectForKey (_AlternateQuotationBeginDelimiterKey);
+				return (string?) (NSString?) ObjectForKey (_AlternateQuotationBeginDelimiterKey);
 			}
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		public string AlternateQuotationEndDelimiterKey {
+		/// <summary>Gets the alternate quotation end delimiter for the locale.</summary>
+		/// <value>The character or string used to end an alternate (nested) quotation.</value>
+		public string? AlternateQuotationEndDelimiterKey {
 			get {
-				return (string) (NSString) ObjectForKey (_AlternateQuotationEndDelimiterKey);
+				return (string?) (NSString?) ObjectForKey (_AlternateQuotationEndDelimiterKey);
 			}
 		}
 	}

--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -6952,9 +6952,11 @@ namespace Foundation {
 		[Notification]
 		NSString CurrentLocaleDidChangeNotification { get; }
 
+		[return: NullAllowed]
 		[Export ("objectForKey:"), Internal]
 		NSObject ObjectForKey (NSString key);
 
+		[return: NullAllowed]
 		[Export ("displayNameForKey:value:"), Internal]
 		NSString DisplayNameForKey (NSString key, string value);
 

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-Foundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-Foundation.ignore
@@ -1008,7 +1008,6 @@
 !missing-null-allowed! 'Foundation.NSObject Foundation.NSKeyedArchiverDelegate::WillEncode(Foundation.NSKeyedArchiver,Foundation.NSObject)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject Foundation.NSKeyedUnarchiverDelegate::DecodedObject(Foundation.NSKeyedUnarchiver,Foundation.NSObject)' is missing an [NullAllowed] on parameter #1
 !missing-null-allowed! 'Foundation.NSObject Foundation.NSKeyedUnarchiverDelegate::DecodedObject(Foundation.NSKeyedUnarchiver,Foundation.NSObject)' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'Foundation.NSObject Foundation.NSLocale::ObjectForKey(Foundation.NSString)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject Foundation.NSMetadataItem::ValueForAttribute(System.String)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject Foundation.NSMetadataQuery::ValueOfAttribute(System.String,System.IntPtr)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSObject Foundation.NSMetadataQueryAttributeValueTuple::get_Value()' is missing an [NullAllowed] on return type
@@ -1027,7 +1026,6 @@
 !missing-null-allowed! 'Foundation.NSOrthography Foundation.NSTextCheckingResult::get_Orthography()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSProgress Foundation.NSProgress::get_CurrentProgress()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSRegularExpression Foundation.NSRegularExpression::Create(Foundation.NSString,Foundation.NSRegularExpressionOptions,Foundation.NSError&)' is missing an [NullAllowed] on return type
-!missing-null-allowed! 'Foundation.NSString Foundation.NSLocale::DisplayNameForKey(Foundation.NSString,System.String)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSString Foundation.NSRunLoop::get_CurrentMode()' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSString Foundation.NSString::AppendPathExtension(Foundation.NSString)' is missing an [NullAllowed] on return type
 !missing-null-allowed! 'Foundation.NSString Foundation.NSUrlUtilities_NSString::CreateStringByAddingPercentEncoding(Foundation.NSString,Foundation.NSCharacterSet)' is missing an [NullAllowed] on return type


### PR DESCRIPTION
This is file 36 of 47 files with nullability disabled in Foundation.

Changes:
- Enabled nullability
- Added proper XML documentation for all public members
- Made return types nullable where appropriate
- Added ArgumentNullException.ThrowIfNull checks for method parameters
- Added see cref attributes for better documentation cross-referencing
- Add a few missing NullAllowed attributes.

Contributes towards https://github.com/dotnet/macios/issues/17285.