### PR TITLE
[msbuild] Remove the SdkBinPath and SdkUsrPath properties.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -111,11 +111,7 @@
     <!-- E0029: not used anymore -->
     <!-- E0030: not used anymore -->
     <!-- E0031: not used anymore -->
-    
-    <data name="E0032" xml:space="preserve">
-        <value>Could not locate SDK bin directory</value>
-    </data>
-    
+    <!-- E0032: not used anymore -->
     <!-- E0033: not used anymore -->
     <!-- E0034: not used anymore -->
     <!-- E0035: not used anymore -->
@@ -294,13 +290,7 @@
         <value>Could not locate the {0} '{1}' SDK at path '{}'</value>
     </data>
     
-    <data name="E0085" xml:space="preserve">
-        <value>Could not locate the {0} '{1}' SDK usr path at '{2}'</value>
-        <comment>The provided SDK path is missing a 'usr' directory. The following are literal names and should not be translated: SDK, usr
-{0} - The platform name, such as 'iOS'.
-{1} - The version number of the SDK.
-{2} - The file path of the SDK.</comment>
-    </data>
+    <!-- E0085: not used anymore -->
         
     <data name="E0086" xml:space="preserve">
         <value>Could not find a valid Xcode developer path</value>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSdkLocation.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSdkLocation.cs
@@ -33,17 +33,7 @@ namespace Xamarin.MacDev.Tasks {
 		} = "";
 
 		[Output]
-		public string SdkBinPath {
-			get; set;
-		} = "";
-
-		[Output]
 		public string SdkDevPath {
-			get; set;
-		} = "";
-
-		[Output]
-		public string SdkUsrPath {
 			get; set;
 		} = "";
 
@@ -130,14 +120,6 @@ namespace Xamarin.MacDev.Tasks {
 			SdkRoot = currentSdk.GetSdkPath (SdkVersion, SdkIsSimulator);
 			if (string.IsNullOrEmpty (SdkRoot))
 				Log.LogError (MSBStrings.E0084 /* Could not locate the {0} '{1}' SDK at path '{2}' */, PlatformName, SdkVersion, SdkRoot);
-
-			SdkUsrPath = DirExists ("SDK usr directory", Path.Combine (currentSdk.DeveloperRoot, "usr")) ?? "";
-			if (string.IsNullOrEmpty (SdkUsrPath))
-				Log.LogError (MSBStrings.E0085 /* Could not locate the {0} '{1}' SDK usr path at '{2}' */, PlatformName, SdkVersion, SdkRoot);
-
-			SdkBinPath = DirExists ("SDK bin directory", Path.Combine (SdkUsrPath, "bin")) ?? "";
-			if (string.IsNullOrEmpty (SdkBinPath))
-				Log.LogError (MSBStrings.E0032 /* Could not locate SDK bin directory */);
 		}
 
 		void EnsureXamarinSdkRoot ()

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/XcodeCompilerToolTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/XcodeCompilerToolTask.cs
@@ -38,8 +38,6 @@ namespace Xamarin.MacDev.Tasks {
 		[Required]
 		public string ResourcePrefix { get; set; } = string.Empty;
 
-		public string SdkBinPath { get; set; } = string.Empty;
-
 		[Required]
 		public string SdkPlatform { get; set; } = string.Empty;
 
@@ -52,8 +50,6 @@ namespace Xamarin.MacDev.Tasks {
 #endif
 			set { sdkDevPath = value; }
 		}
-
-		public string SdkUsrPath { get; set; } = string.Empty;
 
 		[Required]
 		public string SdkVersion { get; set; } = string.Empty;
@@ -183,12 +179,6 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			var environment = new Dictionary<string, string?> ();
 			var args = new List<string> ();
-
-			if (!string.IsNullOrEmpty (SdkBinPath))
-				environment.Add ("PATH", SdkBinPath);
-
-			if (!string.IsNullOrEmpty (SdkUsrPath))
-				environment.Add ("XCODE_DEVELOPER_USR_PATH", SdkUsrPath);
 
 			if (!string.IsNullOrEmpty (SdkDevPath))
 				environment.Add ("DEVELOPER_DIR", SdkDevPath);

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/XcodeTool.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/XcodeTool.cs
@@ -28,13 +28,7 @@ namespace Xamarin.MacDev.Tasks {
 		public string ResourcePrefix { get; set; } = string.Empty;
 
 		[Required]
-		public string SdkBinPath { get; set; } = string.Empty;
-
-		[Required]
 		public string SdkDevPath { get; set; } = string.Empty;
-
-		[Required]
-		public string SdkUsrPath { get; set; } = string.Empty;
 
 		public string ToolExe {
 			get { return toolExe ?? ToolName; }
@@ -106,9 +100,6 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			var environment = new Dictionary<string, string?> ();
 			var args = new List<string> ();
-
-			environment.Add ("PATH", SdkBinPath);
-			environment.Add ("XCODE_DEVELOPER_USR_PATH", SdkUsrPath);
 
 			AppendCommandLineArguments (environment, args, input, output);
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -907,8 +907,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			ProjectDir="$(MSBuildProjectDirectory)"
 			ResourcePrefix="$(_ResourcePrefix)"
 			SdkDevPath="$(_SdkDevPath)"
-			SdkBinPath="$(_SdkBinPath)"
-			SdkUsrPath="$(_SdkUsrPath)"
 			SdkRoot="$(_SdkRoot)"
 			SdkPlatform="$(_SdkPlatform)"
 			SdkVersion="$(_SdkVersion)"
@@ -1043,8 +1041,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			ProjectDir="$(MSBuildProjectDirectory)"
 			ResourcePrefix="$(_ResourcePrefix)"
 			SdkDevPath="$(_SdkDevPath)"
-			SdkBinPath="$(_SdkBinPath)"
-			SdkUsrPath="$(_SdkUsrPath)"
 			SdkPlatform="$(_SdkPlatform)"
 			SdkVersion="$(_SdkVersion)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
@@ -1457,8 +1453,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			ProjectDir="$(MSBuildProjectDirectory)"
 			ResourcePrefix="$(_ResourcePrefix)"
 			SdkDevPath="$(_SdkDevPath)"
-			SdkBinPath="$(_SdkBinPath)"
-			SdkUsrPath="$(_SdkUsrPath)">
+			>
 			<Output TaskParameter="BundleResources" ItemName="_BundleResourceWithLogicalName" />
 
 			<!-- Local items to be persisted to items files -->
@@ -2081,9 +2076,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 			<Output TaskParameter="SdkVersion" PropertyName="_SdkVersion" />
 			<Output TaskParameter="SdkRoot" PropertyName="_SdkRoot" />
-			<Output TaskParameter="SdkBinPath" PropertyName="_SdkBinPath" />
 			<Output TaskParameter="SdkDevPath" PropertyName="_SdkDevPath" />
-			<Output TaskParameter="SdkUsrPath" PropertyName="_SdkUsrPath" />
 			<Output TaskParameter="SdkPlatform" PropertyName="_SdkPlatform" />
 			<Output TaskParameter="SdkIsSimulator" PropertyName="_SdkIsSimulator" />
 			<Output TaskParameter="XamarinSdkRoot" PropertyName="_XamarinSdkRoot" />

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ACToolTaskTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ACToolTaskTest.cs
@@ -25,8 +25,6 @@ namespace Xamarin.MacDev.Tasks {
 			var sdk = Sdks.GetAppleSdk (platform);
 			var version = AppleSdkVersion.UseDefault.ToString ();
 			var root = sdk.GetSdkPath (version, false);
-			var usr = Path.Combine (sdk.DeveloperRoot, "usr");
-			var bin = Path.Combine (usr, "bin");
 			string sdkPlatform;
 			var uiDeviceFamily = "";
 
@@ -66,8 +64,6 @@ namespace Xamarin.MacDev.Tasks {
 			task.SdkDevPath = Configuration.xcode_root;
 			task.SdkPlatform = sdkPlatform;
 			task.SdkVersion = version.ToString ();
-			task.SdkUsrPath = usr;
-			task.SdkBinPath = bin;
 			task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (platform).ToString ();
 			task.UIDeviceFamily = uiDeviceFamily;
 			return task;

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/IBToolTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/IBToolTaskTests.cs
@@ -22,8 +22,6 @@ namespace Xamarin.MacDev.Tasks {
 			var sdk = Sdks.GetSdk (framework);
 			var version = AppleSdkVersion.GetDefault (sdk, false);
 			var root = sdk.GetSdkPath (version, false);
-			var usr = Path.Combine (sdk.DeveloperRoot, "usr");
-			var bin = Path.Combine (usr, "bin");
 			string platform;
 
 			switch (framework) {
@@ -50,8 +48,6 @@ namespace Xamarin.MacDev.Tasks {
 			task.SdkDevPath = Configuration.xcode_root;
 			task.SdkPlatform = platform;
 			task.SdkVersion = version.ToString ();
-			task.SdkUsrPath = usr;
-			task.SdkBinPath = bin;
 			task.SdkRoot = root;
 			task.TargetFrameworkMoniker = TargetFramework.DotNet_iOS_String;
 			return task;


### PR DESCRIPTION
They're not necessary anymore (and probably hasn't been for years).