### PR TITLE
[docs] Add a step to API docs publishing about flipping monikers from 'prelease' to 'live'.

### DIFF
--- a/docs/update-api-docs.md
+++ b/docs/update-api-docs.md
@@ -49,7 +49,7 @@ The steps are:
 
 7. Create a pull request in the [binaries](https://apidrop.visualstudio.com/_git/binaries) repository for the `netX.Y-xcodeZ.W` we created with the new assemblies (into the `master` branch).
 
-8. The final step is to flip the monikers from prelease to live monikers (another ticket has to be created for this).
+8. The final step is to flip the monikers from prerelease to live monikers (another ticket has to be created for this).
 
 ## How to create new monikers
 


### PR DESCRIPTION
Also fix some markdown formatting.