### PR TITLE
[tests] BitmapContextTest.AdaptiveTest to not crash.

### DIFF
--- a/tests/monotouch-test/CoreGraphics/BitmapContextTest.cs
+++ b/tests/monotouch-test/CoreGraphics/BitmapContextTest.cs
@@ -189,9 +189,9 @@ namespace MonoTouchFixtures.CoreGraphics {
 			Assert.That (calledOnFree, Is.True, "calledOnFree#2");
 			Assert.That (calledOnError, Is.False, "calledOnError#2");
 
-			Assert.That (calledOnLockPointer, Is.True.Or.False, "calledOnLockPointer#2");
-			Assert.That (calledOnUnlockPointer, Is.True.Or.False, "calledOnUnlockPointer#2");
-			Assert.That (calledOnReleaseInfo, Is.True.Or.False, "calledOnReleaseInfo#2");
+			Assert.That (calledOnLockPointer, Is.True, "calledOnLockPointer#2");
+			Assert.That (calledOnUnlockPointer, Is.True, "calledOnUnlockPointer#2");
+			Assert.That (calledOnReleaseInfo, Is.False, "calledOnReleaseInfo#2");
 		}
 
 		[Test]
@@ -264,9 +264,9 @@ namespace MonoTouchFixtures.CoreGraphics {
 			Assert.That (calledOnFree, Is.True, "calledOnFree#3");
 			Assert.That (calledOnError, Is.False, "calledOnError#3");
 
-			Assert.That (calledOnLockPointer, Is.True.Or.False, "calledOnLockPointer#3");
-			Assert.That (calledOnUnlockPointer, Is.True.Or.False, "calledOnUnlockPointer#3");
-			Assert.That (calledOnReleaseInfo, Is.True.Or.False, "calledOnReleaseInfo#3");
+			Assert.That (calledOnLockPointer, Is.True, "calledOnLockPointer#3");
+			Assert.That (calledOnUnlockPointer, Is.True, "calledOnUnlockPointer#3");
+			Assert.That (calledOnReleaseInfo, Is.False, "calledOnReleaseInfo#3");
 		}
 
 		[Test]


### PR DESCRIPTION
1. Split the AdaptiveTest into 4 different tests to make it easier to figure out
   where crashes occur.

2. Use autorelease pools to have more consistent memory management. This means
   the OnReleaseInfo callbacks will be called during the test, so adjust accordingly.

3. Create a CGRenderingBufferProvider in OnAllocate callbacks. This seems to be
   what fixes the crash. This also makes it so that the calls to CGBitmapContext.ToImage()
   succeed, so adjust accordingly.