### PR TITLE
[msbuild] Avoid using deprecated API

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateAssetPackManifest.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateAssetPackManifest.cs
@@ -137,7 +137,7 @@ namespace Xamarin.MacDev.Tasks {
 				}
 
 				// update AssetPackManifestTemplate.plist
-				resource.Add ("URL", new PString ("http://127.0.0.1" + Uri.EscapeUriString (Path.GetFullPath (dir))));
+				resource.Add ("URL", new PString (new Uri ("http://127.0.0.1" + Path.GetFullPath (dir), UriKind.Absolute).AbsoluteUri));
 				resource.Add ("bundleKey", new PString (bundleIdentifier));
 
 				if (!double.IsNaN (priority))


### PR DESCRIPTION
Uri.EscapeUriString is deprecated, so create a Uri instance instead, which
does the escaping we want (for instance: escape spaces in the uri we
construct, but doesn't escape any directory separators).