### PR TITLE
[msbuild] Simplify DetectSdkLocation to not detect whether we're building for the simulator or not.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -59,13 +59,8 @@
 		</PropertyGroup>
 	</Target>
 
-	<PropertyGroup Condition="('$(RuntimeIdentifier)' != '' Or '$(RuntimeIdentifiers)' != '') And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS')">
-		<_IsDotNetSimulatorBuild Condition="$(RuntimeIdentifier.Contains('simulator')) Or $(RuntimeIdentifiers.Contains('simulator'))">true</_IsDotNetSimulatorBuild>
-		<_IsDotNetSimulatorBuild Condition="'$(_IsDotNetSimulatorBuild)' == ''">false</_IsDotNetSimulatorBuild>
-	</PropertyGroup>
-
 	<PropertyGroup Condition="'$(ComputedPlatform)' == '' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS') ">
-		<ComputedPlatform Condition="'$(_IsDotNetSimulatorBuild)' == 'true'">iPhoneSimulator</ComputedPlatform>
+		<ComputedPlatform Condition="'$(SdkIsSimulator)' == 'true'">iPhoneSimulator</ComputedPlatform>
 		<ComputedPlatform Condition="'$(ComputedPlatform)' == ''">iPhone</ComputedPlatform>
 	</PropertyGroup>
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSdkLocation.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSdkLocation.cs
@@ -15,13 +15,10 @@ namespace Xamarin.MacDev.Tasks {
 		const string SdkVersionDefaultValue = "default";
 		#region Inputs
 
-		public string TargetArchitectures {
+		[Required]
+		public bool SdkIsSimulator {
 			get; set;
-		} = "";
-
-		public string IsDotNetSimulatorBuild {
-			get; set;
-		} = "";
+		}
 
 		#endregion Inputs
 
@@ -36,11 +33,6 @@ namespace Xamarin.MacDev.Tasks {
 		public string SdkDevPath {
 			get; set;
 		} = "";
-
-		[Output]
-		public bool SdkIsSimulator {
-			get; set;
-		}
 
 		[Output]
 		public string SdkPlatform {
@@ -154,8 +146,6 @@ namespace Xamarin.MacDev.Tasks {
 
 			AppleSdkSettings.Init ();
 
-			SetIsSimulator ();
-
 			if (EnsureAppleSdkRoot ())
 				EnsureSdkPath ();
 			EnsureXamarinSdkRoot ();
@@ -163,25 +153,6 @@ namespace Xamarin.MacDev.Tasks {
 			XcodeVersion = AppleSdkSettings.XcodeVersion.ToString ();
 
 			return !Log.HasLoggedErrors;
-		}
-
-		void SetIsSimulator ()
-		{
-			switch (Platform) {
-			case ApplePlatform.MacCatalyst:
-			case ApplePlatform.MacOSX:
-				return;
-			}
-
-			TargetArchitecture architectures;
-			if (string.IsNullOrEmpty (TargetArchitectures) || !Enum.TryParse (TargetArchitectures, out architectures))
-				architectures = TargetArchitecture.Default;
-
-			if (!string.IsNullOrEmpty (IsDotNetSimulatorBuild)) {
-				SdkIsSimulator = string.Equals (IsDotNetSimulatorBuild, "true", StringComparison.OrdinalIgnoreCase);
-			} else {
-				SdkIsSimulator = (architectures & (TargetArchitecture.i386 | TargetArchitecture.x86_64)) != 0;
-			}
 		}
 
 		protected bool EnsureAppleSdkRoot ()

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2067,10 +2067,9 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<DetectSdkLocations
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
-			IsDotNetSimulatorBuild="$(_IsDotNetSimulatorBuild)"
 			SdkVersion="$(_SdkVersion)"
+			SdkIsSimulator="$(SdkIsSimulator)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
-			TargetArchitectures="$(TargetArchitectures)"
 			XamarinSdkRoot="$(_XamarinSdkRootOnMac)"
 			>
 
@@ -2078,7 +2077,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<Output TaskParameter="SdkRoot" PropertyName="_SdkRoot" />
 			<Output TaskParameter="SdkDevPath" PropertyName="_SdkDevPath" />
 			<Output TaskParameter="SdkPlatform" PropertyName="_SdkPlatform" />
-			<Output TaskParameter="SdkIsSimulator" PropertyName="_SdkIsSimulator" />
 			<Output TaskParameter="XamarinSdkRoot" PropertyName="_XamarinSdkRoot" />
 			<Output TaskParameter="XcodeVersion" PropertyName="_XcodeVersion" />
 		</DetectSdkLocations>


### PR DESCRIPTION
We already know if we're building for the simulator or not when calling the
DetectSdkLocation task, so just tell it.