### PR TITLE
Use the full GitHub url for submodules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "external/Xamarin.MacDev"]
     path = external/Xamarin.MacDev
-    url = ../../dotnet/macios-devtools 
+    url = https://github.com/dotnet/macios-devtools
     branch = main
 


### PR DESCRIPTION
This is necessary to build this repository in our internal mirror.