### PR TITLE
[mtouch] Call Application.InitializeCommon before running the registrar.

### DIFF
--- a/tests/introspection/ApiProtocolTest.cs
+++ b/tests/introspection/ApiProtocolTest.cs
@@ -926,6 +926,13 @@ namespace Introspection {
 					return true;
 				}
 				break;
+			case "AVMetricEventStreamPublisher":
+				switch (type.Name) {
+				case "AVPlayerItem":
+					// AVPlayerItem started implementing AVMetricEventStreamPublisher in Xcode 16
+					return !TestRuntime.CheckXcodeVersion (16, 0);
+				}
+				break;
 			}
 			return false;
 		}

--- a/tools/mtouch/mtouch.cs
+++ b/tools/mtouch/mtouch.cs
@@ -58,6 +58,7 @@ namespace Xamarin.Bundler {
 			if (action != Action.RunRegistrar)
 				throw ErrorHelper.CreateError (99, Errors.MX0099, "Only --runregistrar is supported.");
 
+			app.InitializeCommon ();
 			app.RunRegistrar ();
 
 			return 0;


### PR DESCRIPTION
* This fixes an issue with incorrect registrar code generation due to not finding assemblies that InitializeCommon sets up.
* mmp already does this.