### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 14411: Build ID 13145291

### DIFF
--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
@@ -1278,4 +1278,7 @@
   <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
+  <data name="E7169" xml:space="preserve">
+        <value>The task '{0}' requires the property '{1}' to be set. Please file an issue at https://github.com/dotnet/macios/issues/new/choose.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
@@ -1278,4 +1278,7 @@
   <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
+  <data name="E7169" xml:space="preserve">
+        <value>The task '{0}' requires the property '{1}' to be set. Please file an issue at https://github.com/dotnet/macios/issues/new/choose.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
@@ -1278,4 +1278,7 @@
   <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
+  <data name="E7169" xml:space="preserve">
+        <value>The task '{0}' requires the property '{1}' to be set. Please file an issue at https://github.com/dotnet/macios/issues/new/choose.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
@@ -1278,4 +1278,7 @@
   <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
+  <data name="E7169" xml:space="preserve">
+        <value>The task '{0}' requires the property '{1}' to be set. Please file an issue at https://github.com/dotnet/macios/issues/new/choose.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
@@ -1278,4 +1278,7 @@
   <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
+  <data name="E7169" xml:space="preserve">
+        <value>The task '{0}' requires the property '{1}' to be set. Please file an issue at https://github.com/dotnet/macios/issues/new/choose.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
@@ -1278,4 +1278,7 @@
   <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
+  <data name="E7169" xml:space="preserve">
+        <value>The task '{0}' requires the property '{1}' to be set. Please file an issue at https://github.com/dotnet/macios/issues/new/choose.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
@@ -1278,4 +1278,7 @@
   <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
+  <data name="E7169" xml:space="preserve">
+        <value>The task '{0}' requires the property '{1}' to be set. Please file an issue at https://github.com/dotnet/macios/issues/new/choose.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
@@ -1278,4 +1278,7 @@
   <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
+  <data name="E7169" xml:space="preserve">
+        <value>The task '{0}' requires the property '{1}' to be set. Please file an issue at https://github.com/dotnet/macios/issues/new/choose.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
@@ -1278,4 +1278,7 @@
   <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
+  <data name="E7169" xml:space="preserve">
+        <value>The task '{0}' requires the property '{1}' to be set. Please file an issue at https://github.com/dotnet/macios/issues/new/choose.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
@@ -1278,4 +1278,7 @@
   <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
+  <data name="E7169" xml:space="preserve">
+        <value>The task '{0}' requires the property '{1}' to be set. Please file an issue at https://github.com/dotnet/macios/issues/new/choose.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
@@ -1278,4 +1278,7 @@
   <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
+  <data name="E7169" xml:space="preserve">
+        <value>The task '{0}' requires the property '{1}' to be set. Please file an issue at https://github.com/dotnet/macios/issues/new/choose.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
@@ -1278,4 +1278,7 @@
   <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
+  <data name="E7169" xml:space="preserve">
+        <value>The task '{0}' requires the property '{1}' to be set. Please file an issue at https://github.com/dotnet/macios/issues/new/choose.</value>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
@@ -1278,4 +1278,7 @@
   <data name="E7163" xml:space="preserve">
         <value>Unable to copy the inputs to this task to the remote build server for unknown reasons. The build log may have more information.</value>
     </data>
+  <data name="E7169" xml:space="preserve">
+        <value>The task '{0}' requires the property '{1}' to be set. Please file an issue at https://github.com/dotnet/macios/issues/new/choose.</value>
+    </data>
 </root>


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.