### PR TITLE
[msbuild] Add support for ACToolPath, IBToolPath and TextureAtlasPath.

### DIFF
--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -17,6 +17,12 @@ The full path to the `altool` tool.
 
 The default behavior is to use `xcrun altool`.
 
+## ACToolPath
+
+The full path to the `actool` tool.
+
+The default behavior is to use `xcrun actool`.
+
 ## AppBundleResourcePrefix
 
 The directory where resources are stored (this prefix will be removed when copying resources to the app bundle).
@@ -516,6 +522,12 @@ Default: true
 ## GeneratedSourcesDir
 
 Where the generated source from the generator are saved.
+
+## IBToolPath
+
+The full path to the `ibtool` tool.
+
+The default behavior is to use `xcrun ibtool`.
 
 ## IncludeAllAppIcons
 
@@ -1260,6 +1272,12 @@ It's also possible to use a platform-specific property:
 * [tvOSMinimumVersion](#tvosminimumversion)
 * [macOSMinimumVersion](#macosminimumversion)
 * [MacCatalystMinimumVersion](#maccatalystminimumversion)
+
+## TextureAtlasPath
+
+The full path to the `TextureAtlas` tool.
+
+The default behavior is to use `xcrun TextureAtlas`.
 
 ## TrimMode
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ACTool.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ACTool.cs
@@ -12,7 +12,7 @@ using Xamarin.Messaging.Build.Client;
 using Xamarin.Utils;
 
 namespace Xamarin.MacDev.Tasks {
-	public class ACTool : XcodeCompilerToolTask, ICancelableTask {
+	public class ACTool : XcodeCompilerToolTask {
 		string? outputSpecs;
 		string? partialAppManifestPath;
 
@@ -57,10 +57,6 @@ namespace Xamarin.MacDev.Tasks {
 		HashSet<string> appIconsInAssets = new (); // iOS, macOS and Mac Catalyst
 		HashSet<string> brandAssetsInAssets = new (); // tvOS
 		HashSet<string> imageStacksInAssets = new (); // tvOS
-
-		protected override string DefaultBinDir {
-			get { return DeveloperRootBinDir; }
-		}
 
 		protected override string ToolName {
 			get { return "actool"; }
@@ -543,12 +539,6 @@ namespace Xamarin.MacDev.Tasks {
 			OutputManifests = outputManifests.ToArray ();
 
 			return !Log.HasLoggedErrors;
-		}
-
-		public void Cancel ()
-		{
-			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/IBTool.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/IBTool.cs
@@ -11,7 +11,7 @@ using Xamarin.Messaging.Build.Client;
 using Xamarin.Utils;
 
 namespace Xamarin.MacDev.Tasks {
-	public class IBTool : XcodeCompilerToolTask, ICancelableTask {
+	public class IBTool : XcodeCompilerToolTask {
 		static readonly string [] WatchAppExtensions = { "-glance.plist", "-notification.plist" };
 
 		#region Inputs
@@ -29,10 +29,6 @@ namespace Xamarin.MacDev.Tasks {
 		public string SdkRoot { get; set; } = string.Empty;
 
 		#endregion
-
-		protected override string DefaultBinDir {
-			get { return DeveloperRootBinDir; }
-		}
 
 		protected override string ToolName {
 			get { return "ibtool"; }
@@ -458,12 +454,6 @@ namespace Xamarin.MacDev.Tasks {
 			Log.LogTaskProperty ("OutputManifests Output", OutputManifests);
 
 			return !Log.HasLoggedErrors;
-		}
-
-		public void Cancel ()
-		{
-			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/TextureAtlas.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/TextureAtlas.cs
@@ -11,7 +11,7 @@ using Xamarin.Messaging.Build.Client;
 #nullable enable
 
 namespace Xamarin.MacDev.Tasks {
-	public class TextureAtlas : XcodeToolTaskBase, ICancelableTask {
+	public class TextureAtlas : XcodeToolTaskBase {
 		readonly Dictionary<string, (ITaskItem Item, List<ITaskItem> Items)> atlases = new ();
 
 		#region Inputs
@@ -20,15 +20,11 @@ namespace Xamarin.MacDev.Tasks {
 
 		#endregion
 
-		protected override string DefaultBinDir {
-			get { return DeveloperRootBinDir; }
-		}
-
 		protected override string ToolName {
 			get { return "TextureAtlas"; }
 		}
 
-		protected override void AppendCommandLineArguments (IDictionary<string, string?> environment, List<string> args, ITaskItem input, ITaskItem output)
+		protected override void AppendCommandLineArguments (List<string> args, ITaskItem input, ITaskItem output)
 		{
 			args.Add (input.GetMetadata ("FullPath"));
 			args.Add (Path.GetDirectoryName (output.GetMetadata ("FullPath"))!);
@@ -116,12 +112,6 @@ namespace Xamarin.MacDev.Tasks {
 				return ExecuteRemotely ();
 
 			return base.Execute ();
-		}
-
-		public void Cancel ()
-		{
-			if (ShouldExecuteRemotely ())
-				BuildConnection.CancelAsync (BuildEngine4).Wait ();
 		}
 	}
 }

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -893,7 +893,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<IBTool
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
-			ToolExe="$(IBToolExe)"
 			ToolPath="$(IBToolPath)"
 			BundleIdentifier="$(_BundleIdentifier)"
 			CLKComplicationGroup="$(_CLKComplicationGroup)"
@@ -1020,7 +1019,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<ACTool
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' And '@(ImageAsset)' != ''"
-			ToolExe="$(ACToolExe)"
 			ToolPath="$(ACToolPath)"
 			AccentColor="$(AccentColor)"
 			AlternateAppIcons="@(AlternateAppIcon)"
@@ -1446,7 +1444,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<TextureAtlas
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
-			ToolExe="$(TextureAtlasExe)"
 			ToolPath="$(TextureAtlasPath)"
 			AtlasTextures="@(AtlasTexture)"
 			IntermediateOutputPath="$(DeviceSpecificIntermediateOutputPath)"


### PR DESCRIPTION
Add support for ACToolPath, IBToolPath and TextureAtlasPath to specify the location
of the corresponding executables.

And if not specified, then locate these executables using `xcrun`.

Also make these process invocations cancellable.