### PR TITLE
[tests] Use 'ExecuteTask' to execute a task instead of 'Assert.IsTrue (task.Execute ())'

### DIFF
--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CollectBundleResourcesTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CollectBundleResourcesTaskTests.cs
@@ -29,14 +29,9 @@ namespace Xamarin.MacDev.Tasks {
 				item.SetMetadata ("LocalDefiningProjectFullPath", Path.Combine (tmpdir, "A", "SDK.csproj"));
 				item.SetMetadata ("LocalMSBuildProjectFullPath", Path.Combine (projDir, "Project.csproj"));
 				task.BundleResources = [item];
-				var rv = task.Execute ();
-
-				Assert.That (Engine.Logger.ErrorEvents.Count, Is.EqualTo (0), "Errors");
-
+				ExecuteTask (task);
 				Assert.That (Engine.Logger.WarningsEvents.Count, Is.EqualTo (1), "Warnings");
 				Assert.That (Engine.Logger.WarningsEvents [0].Message, Is.EqualTo ("The path '../B/image.png' would result in a file outside of the app bundle and cannot be used."), "Warning Message");
-
-				Assert.That (rv, Is.True, "Execute");
 			} finally {
 				Environment.CurrentDirectory = currentDirectory;
 			}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CollectITunesArtworkTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CollectITunesArtworkTaskTests.cs
@@ -16,8 +16,7 @@ namespace Xamarin.MacDev.Tasks {
 			var task = CreateTask<CollectITunesArtwork> ();
 			task.ITunesArtwork = new TaskItem [] { new TaskItem (Assembly.GetExecutingAssembly ().Location) };
 
-			Assert.IsFalse (task.Execute (), "Execute failure");
-			Assert.AreEqual (1, Engine.Logger.ErrorEvents.Count, "ErrorCount");
+			ExecuteTask (task, 1);
 			Assert.That (Engine.Logger.ErrorEvents [0].Message, Does.Match ("Error loading '.*/Xamarin.MacDev.Tasks.Tests.dll': Unknown image format."), "ErrorMessage");
 		}
 
@@ -27,8 +26,7 @@ namespace Xamarin.MacDev.Tasks {
 			var task = CreateTask<CollectITunesArtwork> ();
 			task.ITunesArtwork = new TaskItem [] { new TaskItem ("this-file-does-not-exist.tiff") };
 
-			Assert.IsFalse (task.Execute (), "Execute failure");
-			Assert.AreEqual (1, Engine.Logger.ErrorEvents.Count, "ErrorCount");
+			ExecuteTask (task, 1);
 			Assert.That (Engine.Logger.ErrorEvents [0].Message, Does.Match ("'.*/this-file-does-not-exist.tiff' not found."), "ErrorMessage");
 		}
 
@@ -40,8 +38,7 @@ namespace Xamarin.MacDev.Tasks {
 			var task = CreateTask<CollectITunesArtwork> ();
 			task.ITunesArtwork = new TaskItem [] { new TaskItem (Path.Combine (AppPath, "Resources", "iTunesArtwork-invalid-size." + extension)) };
 
-			Assert.IsFalse (task.Execute (), "Execute failure");
-			Assert.AreEqual (1, Engine.Logger.ErrorEvents.Count, "ErrorCount");
+			ExecuteTask (task, 1);
 			Assert.That (Engine.Logger.ErrorEvents [0].Message, Does.Match ($"Invalid iTunesArtwork dimensions [(]124x124[)] for '.*/iTunesArtwork-invalid-size.{extension}'."), "ErrorMessage");
 		}
 
@@ -56,8 +53,7 @@ namespace Xamarin.MacDev.Tasks {
 				new TaskItem (Path.Combine (AppPath, "Resources", $"iTunesArtwork{size}.png")),
 			};
 
-			Assert.IsFalse (task.Execute (), "Execute failure");
-			Assert.AreEqual (1, Engine.Logger.ErrorEvents.Count, "ErrorCount");
+			ExecuteTask (task, 1);
 			Assert.That (Engine.Logger.ErrorEvents [0].Message, Does.Match ($"Multiple iTunesArtwork files with the same dimensions detected [(]{dimension}[)] for '.*/Resources/iTunesArtwork{size}.png'."), "ErrorMessage");
 		}
 
@@ -72,8 +68,7 @@ namespace Xamarin.MacDev.Tasks {
 				new TaskItem (Path.Combine (AppPath, "Resources", $"iTunesArtwork@2x.{extension}")),
 			};
 
-			Assert.IsTrue (task.Execute (), "Execute");
-			Assert.AreEqual (0, Engine.Logger.ErrorEvents.Count, "ErrorCount");
+			ExecuteTask (task);
 			Assert.AreEqual (2, task.ITunesArtworkWithLogicalNames.Length, "ITunesArtworkWithLogicalNames.Count");
 			for (var i = 0; i < task.ITunesArtworkWithLogicalNames.Length; i++) {
 				Assert.AreEqual (Path.GetFileNameWithoutExtension (task.ITunesArtwork [i].GetMetadata ("FullPath")), task.ITunesArtworkWithLogicalNames [i].GetMetadata ("LogicalName"), $"LogicalName #{i}");

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ComputeCodesignItemsTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ComputeCodesignItemsTaskTests.cs
@@ -344,7 +344,7 @@ namespace Xamarin.MacDev.Tasks {
 				task.GenerateDSymItems = generateDSymItems.ToArray ();
 				task.NativeStripItems = nativeStripItems.ToArray ();
 				task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (platform).ToString ();
-				Assert.IsTrue (task.Execute (), "Execute");
+				ExecuteTask (task);
 				Assert.AreEqual (0, Engine.Logger.WarningsEvents.Count, "Warning Count");
 
 				VerifyCodesigningResults (infos, task.OutputCodesignItems, platform);
@@ -412,7 +412,7 @@ namespace Xamarin.MacDev.Tasks {
 				task.CodesignBundle = codesignBundle.ToArray ();
 				task.CodesignStampPath = "codesign-stamp-path/";
 				task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (platform).ToString ();
-				Assert.IsTrue (task.Execute (), "Execute");
+				ExecuteTask (task);
 				Assert.AreEqual (0, Engine.Logger.WarningsEvents.Count, "Warning Count");
 
 				VerifyCodesigningResults (infos, task.OutputCodesignItems, platform);
@@ -493,7 +493,7 @@ namespace Xamarin.MacDev.Tasks {
 				task.CodesignBundle = codesignBundle.ToArray ();
 				task.CodesignStampPath = "codesign-stamp-path/";
 				task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (platform).ToString ();
-				Assert.IsTrue (task.Execute (), "Execute");
+				ExecuteTask (task);
 				Assert.AreEqual (0, Engine.Logger.WarningsEvents.Count, "Warning Count");
 
 				VerifyCodesigningResults (infos, task.OutputCodesignItems, platform);
@@ -556,7 +556,7 @@ namespace Xamarin.MacDev.Tasks {
 				task.CodesignItems = codesignItems.ToArray ();
 				task.CodesignStampPath = "codesign-stamp-path/";
 				task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (platform).ToString ();
-				Assert.IsTrue (task.Execute (), "Execute");
+				ExecuteTask (task);
 				Assert.AreEqual (0, Engine.Logger.WarningsEvents.Count, "Warning Count");
 
 				VerifyCodesigningResults (infos, task.OutputCodesignItems, platform);
@@ -630,7 +630,7 @@ namespace Xamarin.MacDev.Tasks {
 				task.CodesignItems = codesignItems.ToArray ();
 				task.CodesignStampPath = "codesign-stamp-path/";
 				task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (platform).ToString ();
-				Assert.IsTrue (task.Execute (), "Execute");
+				ExecuteTask (task);
 				Assert.AreEqual (3, Engine.Logger.WarningsEvents.Count, "Warning Count");
 				Assert.AreEqual ("Code signing has been requested multiple times for 'Bundle.app/Contents/MonoBundle/createdump', with different metadata. The metadata 'OnlyIn1=true' has been set for one item, but not the other.", Engine.Logger.WarningsEvents [0].Message, "Message #0");
 				Assert.AreEqual ("Code signing has been requested multiple times for 'Bundle.app/Contents/MonoBundle/createdump', with different metadata. The metadata 'InOneAndTwoWithDifferentValues' has different values for each item (once it's '1', another time it's '2').", Engine.Logger.WarningsEvents [1].Message, "Message #1");

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CreateBindingResourceTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CreateBindingResourceTaskTests.cs
@@ -26,7 +26,7 @@ namespace Xamarin.MacDev.Tasks {
 			var currentDir = Environment.CurrentDirectory;
 			try {
 				Environment.CurrentDirectory = tmpdir;
-				Assert.IsTrue (task.Execute (), "Execute");
+				ExecuteTask (task);
 			} finally {
 				Environment.CurrentDirectory = currentDir;
 			}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/DetectSdkLocationsTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/DetectSdkLocationsTaskTests.cs
@@ -16,7 +16,7 @@ namespace Xamarin.MacDev.Tasks {
 			var task = CreateTask<DetectSdkLocations> ();
 			task.XamarinSdkRoot = "XYZ";
 			task.TargetFrameworkMoniker = TargetFramework.DotNet_iOS_String;
-			task.Execute ();
+			ExecuteTask (task, 1);
 
 			Assert.AreEqual ("XYZ", task.XamarinSdkRoot, "#1");
 		}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetBundleNameTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetBundleNameTaskTests.cs
@@ -11,8 +11,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void GetBundleName_MissingName ()
 		{
 			var task = CreateTask<GenerateBundleName> ();
-			Assert.IsFalse (task.Execute (), "#1");
-			Assert.AreEqual (1, Engine.Logger.ErrorEvents.Count, "#2");
+			ExecuteTask (task, 1);
 		}
 
 		[Test]
@@ -21,9 +20,8 @@ namespace Xamarin.MacDev.Tasks {
 			var task = CreateTask<GenerateBundleName> ();
 			task.ProjectName = "!@£///Hello_World%£";
 
-			Assert.IsTrue (task.Execute (), "#1");
+			ExecuteTask (task);
 			Assert.AreEqual ("Hello_World", task.BundleName, "#2");
-			Assert.AreEqual (0, Engine.Logger.ErrorEvents.Count, "#3");
 		}
 	}
 }

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetPropertyListValueTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetPropertyListValueTaskTests.cs
@@ -17,11 +17,11 @@ namespace Xamarin.MacDev.Tasks {
 			task.Property = property;
 
 			if (expected is null) {
-				Assert.IsFalse (task.Execute (), "Task was expected to fail.");
+				ExecuteTask (task, 1);
 				return;
 			}
 
-			Assert.IsTrue (task.Execute (), "Task was expected to execute successfully.");
+			ExecuteTask (task);
 
 			Assert.AreEqual (expected, task.Value, "Task produced the incorrect plist output.");
 		}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/LocalizationStringTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/LocalizationStringTest.cs
@@ -41,8 +41,7 @@ namespace Xamarin.MacDev.Tasks {
 				var task = CreateTask<CollectITunesArtwork> ();
 				task.ITunesArtwork = new TaskItem [] { new TaskItem (Assembly.GetExecutingAssembly ().Location) };
 
-				Assert.IsFalse (task.Execute (), "Execute failure");
-				Assert.AreEqual (1, Engine.Logger.ErrorEvents.Count, "ErrorCount");
+				ExecuteTask (task, 1);
 				bool isTranslated = Engine.Logger.ErrorEvents [0].Message.Contains (errorMessage);
 				Assert.IsTrue (isTranslated, $"Should contain \"{errorMessage}\", but instead has value: \"{Engine.Logger.ErrorEvents [0].Message}\"");
 			} finally {

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/MergeAppBundleTaskTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/MergeAppBundleTaskTest.cs
@@ -129,7 +129,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			var outputBundle = Path.Combine (Cache.CreateTemporaryDirectory (), "Merged.app");
 			var task = CreateTask (outputBundle, bundles);
-			Assert.IsTrue (task.Execute (), "Task execution");
+			ExecuteTask (task);
 
 			// The bundle should have all the files
 			Assert.AreEqual (complexFiles.Length, Directory.GetFileSystemEntries (outputBundle).Length, "Files in bundle");
@@ -151,8 +151,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			var outputBundle = Path.Combine (Cache.CreateTemporaryDirectory (), "Merged.app");
 			var task = CreateTask (outputBundle, bundles);
-			Assert.IsFalse (task.Execute (), "Task execution");
-			Assert.AreEqual (3, Engine.Logger.ErrorEvents.Count, "Errors:\n\t" + string.Join ("\n\t", Engine.Logger.ErrorEvents.Select ((v) => v.Message).ToArray ()));
+			ExecuteTask (task, 3);
 			Assert.AreEqual ("Unable to merge the file 'Something.txt', it's different between the input app bundles.", Engine.Logger.ErrorEvents [0].Message, "Error message");
 			Assert.That (Engine.Logger.ErrorEvents [1].Message, Does.Match ("App bundle file #1: .*/MergeMe.app/Something.txt"), "Error message 2");
 			Assert.That (Engine.Logger.ErrorEvents [2].Message, Does.Match ("App bundle file #2: .*/MergeMe.app/Something.txt"), "Error message 3");
@@ -177,7 +176,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			var outputBundle = Path.Combine (Cache.CreateTemporaryDirectory (), "Merged.app");
 			var task = CreateTask (outputBundle, bundleA, bundleB);
-			Assert.IsTrue (task.Execute (), "Task execution");
+			ExecuteTask (task);
 			Assert.IsTrue (PathUtils.IsSymlink (Path.Combine (outputBundle, "B.txt")), "IsSymlink");
 		}
 
@@ -205,8 +204,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			var outputBundle = Path.Combine (Cache.CreateTemporaryDirectory (), "Merged.app");
 			var task = CreateTask (outputBundle, bundleA, bundleB);
-			Assert.IsFalse (task.Execute (), "Task execution");
-			Assert.AreEqual (3, Engine.Logger.ErrorEvents.Count, "Errors:\n\t" + string.Join ("\n\t", Engine.Logger.ErrorEvents.Select ((v) => v.Message).ToArray ()));
+			ExecuteTask (task, 3);
 			Assert.AreEqual ("Can't merge the symlink 'B.txt', it has different targets.", Engine.Logger.ErrorEvents [0].Message, "Error message");
 			Assert.That (Engine.Logger.ErrorEvents [1].Message, Does.Match ("App bundle file #1: .*/MergeMe.app/B.txt"), "Error message 2");
 			Assert.That (Engine.Logger.ErrorEvents [2].Message, Does.Match ("App bundle file #2: .*/MergeMe.app/B.txt"), "Error message 3");
@@ -239,7 +237,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			var outputBundle = Path.Combine (Cache.CreateTemporaryDirectory (), "Merged.app");
 			var task = CreateTask (outputBundle, bundleA, bundleB);
-			Assert.IsTrue (task.Execute (), "Task execution");
+			ExecuteTask (task);
 			Assert.That (Path.Combine (outputBundle, onlyA), Does.Exist, "onlyA");
 			Assert.That (Path.Combine (outputBundle, onlyB), Does.Exist, "onlyB");
 			Assert.That (Path.Combine (outputBundle, bothAB), Does.Exist, "bothAB");
@@ -261,7 +259,7 @@ namespace Xamarin.MacDev.Tasks {
 			var bundle = CreateAppBundle (Path.GetDirectoryName (fileA), Path.GetFileName (fileA));
 			var outputBundle = Path.Combine (Cache.CreateTemporaryDirectory (), "Merged.app");
 			var task = CreateTask (outputBundle, bundle);
-			Assert.IsTrue (task.Execute (), "Task execution");
+			ExecuteTask (task);
 
 			// The bundle should only contain a single file.
 			Assert.AreEqual (1, Directory.GetFileSystemEntries (outputBundle).Length, "Files in bundle");
@@ -294,7 +292,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			var outputBundle = Path.Combine (Cache.CreateTemporaryDirectory (), "Merged.app");
 			var task = CreateTask (outputBundle, bundleA, bundleB);
-			Assert.IsTrue (task.Execute (), "Task execution");
+			ExecuteTask (task);
 			Assert.IsTrue (PathUtils.IsSymlink (Path.Combine (outputBundle, "B")), "IsSymlink");
 			Assert.IsFalse (PathUtils.IsSymlink (Path.Combine (outputBundle, "A", "A.txt")), "IsSymlink");
 			Assert.IsFalse (PathUtils.IsSymlink (Path.Combine (outputBundle, "B", "A.txt")), "IsSymlink");

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ParseBundlerArgumentsTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ParseBundlerArgumentsTests.cs
@@ -15,13 +15,13 @@ namespace Xamarin.MacDev.Tasks {
 		public void NoExtraArgs ()
 		{
 			var task = CreateTask<CustomParseBundlerArguments> ();
-			Assert.IsTrue (task.Execute (), "execute");
+			ExecuteTask (task);
 			Assert.AreEqual ("false", task.NoSymbolStrip, "nosymbolstrip");
 			Assert.AreEqual ("false", task.NoDSymUtil, "nodsymutil");
 
 			task = CreateTask<CustomParseBundlerArguments> ();
 			task.ExtraArgs = string.Empty;
-			Assert.IsTrue (task.Execute (), "execute");
+			ExecuteTask (task);
 			Assert.AreEqual ("false", task.NoSymbolStrip, "nosymbolstrip");
 			Assert.AreEqual ("false", task.NoDSymUtil, "nodsymutil");
 		}
@@ -47,7 +47,7 @@ namespace Xamarin.MacDev.Tasks {
 			foreach (var variation in false_variations) {
 				var task = CreateTask<CustomParseBundlerArguments> ();
 				task.ExtraArgs = variation;
-				Assert.IsTrue (task.Execute (), "execute: " + variation);
+				ExecuteTask (task, message: "execute: " + variation);
 				Assert.AreEqual ("false", task.NoSymbolStrip, "nosymbolstrip: " + variation);
 				Assert.AreEqual ("false", task.NoDSymUtil, "nodsymutil: " + variation);
 			}
@@ -55,7 +55,7 @@ namespace Xamarin.MacDev.Tasks {
 			foreach (var variation in true_variations) {
 				var task = CreateTask<CustomParseBundlerArguments> ();
 				task.ExtraArgs = variation;
-				Assert.IsTrue (task.Execute (), "execute: " + variation);
+				ExecuteTask (task, message: "execute: " + variation);
 				Assert.AreEqual ("true", task.NoSymbolStrip, "nosymbolstrip: " + variation);
 				Assert.AreEqual ("false", task.NoDSymUtil, "nodsymutil: " + variation);
 			}
@@ -85,7 +85,7 @@ namespace Xamarin.MacDev.Tasks {
 			foreach (var variation in false_variations) {
 				var task = CreateTask<CustomParseBundlerArguments> ();
 				task.ExtraArgs = variation;
-				Assert.IsTrue (task.Execute (), "execute: " + variation);
+				ExecuteTask (task, message: "execute: " + variation);
 				Assert.AreEqual ("false", task.NoSymbolStrip, "nosymbolstrip: " + variation);
 				Assert.AreEqual ("false", task.NoDSymUtil, "nodsymutil: " + variation);
 			}
@@ -93,7 +93,7 @@ namespace Xamarin.MacDev.Tasks {
 			foreach (var variation in true_variations) {
 				var task = CreateTask<CustomParseBundlerArguments> ();
 				task.ExtraArgs = variation;
-				Assert.IsTrue (task.Execute (), "execute: " + variation);
+				ExecuteTask (task, message: "execute: " + variation);
 				Assert.AreEqual ("false", task.NoSymbolStrip, "nosymbolstrip: " + variation);
 				Assert.AreEqual ("true", task.NoDSymUtil, "nodsymutil: " + variation);
 			}
@@ -116,7 +116,7 @@ namespace Xamarin.MacDev.Tasks {
 			var task = CreateTask<CustomParseBundlerArguments> ();
 			task.MarshalManagedExceptionMode = existingValue;
 			task.ExtraArgs = input;
-			Assert.IsTrue (task.Execute (), input);
+			ExecuteTask (task, message: input);
 			Assert.AreEqual (output, task.MarshalManagedExceptionMode, output);
 		}
 
@@ -137,7 +137,7 @@ namespace Xamarin.MacDev.Tasks {
 			var task = CreateTask<CustomParseBundlerArguments> ();
 			task.MarshalObjectiveCExceptionMode = existingValue;
 			task.ExtraArgs = input;
-			Assert.IsTrue (task.Execute (), input);
+			ExecuteTask (task, message: input);
 			Assert.AreEqual (output, task.MarshalObjectiveCExceptionMode, output);
 		}
 
@@ -155,7 +155,7 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			var task = CreateTask<CustomParseBundlerArguments> ();
 			task.ExtraArgs = input;
-			Assert.IsTrue (task.Execute (), input);
+			ExecuteTask (task, message: input);
 			Assert.AreEqual (output, task.Optimize, output);
 		}
 
@@ -171,7 +171,7 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			var task = CreateTask<CustomParseBundlerArguments> ();
 			task.ExtraArgs = input;
-			Assert.IsTrue (task.Execute (), input);
+			ExecuteTask (task, message: input);
 			Assert.AreEqual (output, task.Registrar, output);
 		}
 
@@ -197,7 +197,7 @@ namespace Xamarin.MacDev.Tasks {
 			if (existing is not null)
 				task.XmlDefinitions = existing.Split (new char [] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select (v => new TaskItem (v)).ToArray ();
 			task.ExtraArgs = input;
-			Assert.IsTrue (task.Execute (), input);
+			ExecuteTask (task, message: input);
 			Assert.AreEqual (output, string.Join (";", task.XmlDefinitions.Select (v => v.ItemSpec).ToArray ()), output);
 		}
 
@@ -218,7 +218,7 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			var task = CreateTask<CustomParseBundlerArguments> ();
 			task.ExtraArgs = input;
-			Assert.IsTrue (task.Execute (), input);
+			ExecuteTask (task, message: input);
 			Assert.AreEqual (output, task.CustomBundleName, output);
 		}
 
@@ -235,7 +235,7 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			var task = CreateTask<CustomParseBundlerArguments> ();
 			task.ExtraArgs = input;
-			Assert.IsTrue (task.Execute (), input);
+			ExecuteTask (task, message: input);
 			CollectionAssert.AreEquivalent (output, task.CustomLinkFlags.Select (v => v.ItemSpec).ToArray (), string.Join (" ", output));
 		}
 
@@ -249,7 +249,7 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			var task = CreateTask<CustomParseBundlerArguments> ();
 			task.ExtraArgs = input;
-			Assert.IsTrue (task.Execute (), input);
+			ExecuteTask (task, message: input);
 			Assert.AreEqual (output, task.Verbosity, "Equality");
 		}
 
@@ -263,7 +263,7 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			var task = CreateTask<CustomParseBundlerArguments> ();
 			task.ExtraArgs = input;
-			Assert.IsTrue (task.Execute (), input);
+			ExecuteTask (task, message: input);
 			Assert.AreEqual (output, task.NoWarn, output);
 		}
 
@@ -277,7 +277,7 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			var task = CreateTask<CustomParseBundlerArguments> ();
 			task.ExtraArgs = input;
-			Assert.IsTrue (task.Execute (), input);
+			ExecuteTask (task, message: input);
 			Assert.AreEqual (output, task.WarnAsError, output);
 		}
 	}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/PropertyListEditorTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/PropertyListEditorTaskTests.cs
@@ -82,11 +82,11 @@ namespace Xamarin.MacDev.Tasks {
 			task.Value = value;
 
 			if (expected is null) {
-				Assert.IsFalse (task.Execute (), "Task was expected to fail.");
+				ExecuteTask (task, 1);
 				return;
 			}
 
-			Assert.IsTrue (task.Execute (), "Task was expected to execute successfully.");
+			ExecuteTask (task);
 
 			var output = PObject.FromFile (task.PropertyList);
 

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TestHelpers/TestBase.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TestHelpers/TestBase.cs
@@ -62,7 +62,7 @@ namespace Xamarin.MacDev.Tasks {
 		/// This is the prefered way to run tasks as we want error messages to show up in the test results.</remarks>
 		/// <param name="task">An msbuild task.</param>
 		/// <param name="expectedErrorCount">Expected error count. 0 by default.</param>
-		public void ExecuteTask (Task task, int expectedErrorCount = 0)
+		public void ExecuteTask (Task task, int expectedErrorCount = 0, string message = "")
 		{
 			var rv = task.Execute ();
 			string messages = string.Empty;
@@ -71,9 +71,9 @@ namespace Xamarin.MacDev.Tasks {
 				messages = "\n\t" + string.Join ("\n\t", allEvents.Select ((v) => v.AsString ()).ToArray ());
 			}
 			if (expectedErrorCount != Engine.Logger.ErrorEvents.Count) {
-				Assert.AreEqual (expectedErrorCount, Engine.Logger.ErrorEvents.Count, "#RunTask-ErrorCount" + messages);
+				Assert.AreEqual (expectedErrorCount, Engine.Logger.ErrorEvents.Count, $"#RunTask-ErrorCount{(string.IsNullOrEmpty (message) ? "" : $" ({message})")}" + messages);
 			}
-			Assert.AreEqual (expectedErrorCount == 0, rv, "Failure" + messages);
+			Assert.AreEqual (expectedErrorCount == 0, rv, $"Failure{(string.IsNullOrEmpty (message) ? "" : $" ({message})")}" + messages);
 		}
 
 		protected string CreateTempFile (string path)


### PR DESCRIPTION
Use 'ExecuteTask' to execute a task instead of 'Assert.IsTrue (task.Execute ())',
because 'ExecuteTask' has much better failure reporting.