### PR TITLE
[release/10.0.1xx] [dotnet] Disable any default 'PublishRuntimeIdentifier' values.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -137,6 +137,11 @@
 
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<!-- Disable the default PublishRuntimeIdentifier behavior: https://github.com/dotnet/sdk/pull/52566 -->
+		<UseDefaultPublishRuntimeIdentifier>false</UseDefaultPublishRuntimeIdentifier>
+	</PropertyGroup>
+
 	<!-- Now that we know the runtime identifier, we can determine if we're building for a simulator -->
 	<PropertyGroup>
 		<_SdkIsSimulator Condition="$(RuntimeIdentifier.Contains('simulator')) Or $(RuntimeIdentifiers.Contains('simulator'))">true</_SdkIsSimulator>


### PR DESCRIPTION
References:

* https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2691518
* https://github.com/dotnet/sdk/commit/3d6f592eacd10c3af8bca9fd0723b907edf4d2a0
* https://github.com/dotnet/sdk/pull/52566

Backport of #24562.