### PR TITLE
[release/10.0.1xx] [bgen] Preserve all public methods supporting protocol methos as events. Fixes #24236.

### DIFF
--- a/tests/bindings-test/ApiDefinition.cs
+++ b/tests/bindings-test/ApiDefinition.cs
@@ -853,6 +853,14 @@ namespace Bindings.Test {
 		[EventArgs ("")]
 		[Export ("buildIntergalacticHighway:")]
 		void BuildIntergalacticHighway (Hitchhiker sender);
+
+		[EventArgs ("")]
+		[Export ("byeByeDolphins:")]
+		void ByeByeDolphins (Hitchhiker sender);
+
+		[EventArgs ("")]
+		[Export ("hitchhikeWithVogons:")]
+		void HitchhikeWithVogons (Hitchhiker sender);
 	}
 
 	[BaseType (typeof (NSObject), Delegates = new string [] { "Delegate" }, Events = new Type [] { typeof (HitchhikerDelegate) })]
@@ -862,5 +870,8 @@ namespace Bindings.Test {
 
 		[Export ("destroyEarth")]
 		void DestroyEarth ();
+
+		[Export ("buildHighway")]
+		void BuildHighway ();
 	}
 }

--- a/tests/test-libraries/libtest.h
+++ b/tests/test-libraries/libtest.h
@@ -367,14 +367,18 @@ typedef void (^outerBlock) (innerBlock callback);
 
 @class Hitchhiker;
 @protocol HitchhikerDelegate <NSObject>
+@required
+	-(void) byeByeDolphins: (Hitchhiker *) sender;
 @optional
 	-(void) buildIntergalacticHighway: (Hitchhiker *) sender;
+	-(void) hitchhikeWithVogons: (Hitchhiker *) sender;
 @end
 
 @interface Hitchhiker : NSObject {
 }
 @property (retain) id<HitchhikerDelegate> delegate;
 -(void) destroyEarth;
+-(void) buildHighway;
 @end
 
 #pragma clang diagnostic pop

--- a/tests/test-libraries/libtest.m
+++ b/tests/test-libraries/libtest.m
@@ -1543,6 +1543,12 @@ static void block_called ()
 }
 -(void) destroyEarth
 {
+	[self.delegate byeByeDolphins: self];
+	[self.delegate buildIntergalacticHighway: self];
+	[self.delegate hitchhikeWithVogons: self];
+}
+-(void) buildHighway
+{
 	[self.delegate buildIntergalacticHighway: self];
 }
 @end


### PR DESCRIPTION
This has the same underlying cause as #24262, but the fix for #24262 was insufficient.

The fix for #24262 ensured that if an event is listening for a protocol callback, then the corresponding protocol member implementation wouldn't be trimmed away.

However, it didn't prevent protocol members from being trimmed if no event was listening for that protocol member to be called, which is a problem when the protocol member in question is a required protocol member, and native code would just call it without checking whether an implemented existed.

For the bug in question, what happens is this:

```cs
var mgr = new CBCentralManager (new DispatchQueue ("com.xamarin.tests.ios-plain"));
// Uncomment to trigger bug, 'CBCentralManagerDelegate centralManagerDidUpdateState:' is a required protocol member
// mgr.UpdatedState += (sender, e) => {
//	Console.WriteLine ("State: " + mgr.State);
// };
mgr.DiscoveredPeripheral += (sender, e) => { };
mgr.ScanForPeripherals ();
```

In this case, there's an `ICBCentralManagerDelegate` instance assigned to `mgr.Delegate` (when an event handler was attached to the `DiscoveredPeripheral` event), but that `ICBCentralManagerDelegate` instance does not have an implementation for `ICBCentralManagerDelegate.UpdateState` (aka `CBCentralManagerDelegate centralManagerDidUpdateState:`), because it was trimmed away.

This causes the bug when `CBCentralManager` calls its delegate's `centralManagerDidUpdateState:` selector.

The fix is to always preserve all protocol members implemented by the internal class that implements the protocol for event handling purposes.

Fixes https://github.com/dotnet/macios/issues/24236.

Backport of #24566.