### PR TITLE
[MediaAccessibility] Tweak nullability in MACaptionAppearance.

### DIFF
--- a/src/MediaAccessibility/MediaAccessibility.cs
+++ b/src/MediaAccessibility/MediaAccessibility.cs
@@ -308,11 +308,13 @@ namespace MediaAccessibility {
 		[DllImport (Constants.MediaAccessibilityLibrary)]
 		static extern void MACaptionAppearanceDidDisplayCaptions (IntPtr /* CFArratRef */ strings);
 
+		/// <summary>Notifies the system that the specified captions were displayed.</summary>
+		/// <param name="strings">The captions that were displayed, or null or an empty array if no captions were displayed.</param>
 		[SupportedOSPlatform ("tvos13.0")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios13.0")]
 		[SupportedOSPlatform ("maccatalyst")]
-		public static void DidDisplayCaptions (string [] strings)
+		public static void DidDisplayCaptions (string []? strings)
 		{
 			if ((strings is null) || (strings.Length == 0))
 				MACaptionAppearanceDidDisplayCaptions (IntPtr.Zero);
@@ -322,11 +324,13 @@ namespace MediaAccessibility {
 			}
 		}
 
+		/// <summary>Notifies the system that the specified captions were displayed.</summary>
+		/// <param name="strings">The captions that were displayed, or null or an empty array if no captions were displayed.</param>
 		[SupportedOSPlatform ("tvos13.0")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios13.0")]
 		[SupportedOSPlatform ("maccatalyst")]
-		public static void DidDisplayCaptions (NSAttributedString [] strings)
+		public static void DidDisplayCaptions (NSAttributedString []? strings)
 		{
 			// CFAttributedString is “toll-free bridged” with its Foundation counterpart, NSAttributedString.
 			// https://developer.apple.com/documentation/corefoundation/cfattributedstring?language=objc

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -12894,8 +12894,6 @@ M:MapKit.MKUserTrackingButton.MKUserTrackingButtonAppearance.#ctor(System.IntPtr
 M:MapKit.MKZoomControl.#ctor(CoreGraphics.CGRect)
 M:MapKit.MKZoomControl.Dispose(System.Boolean)
 M:MapKit.MKZoomControl.MKZoomControlAppearance.#ctor(System.IntPtr)
-M:MediaAccessibility.MACaptionAppearance.DidDisplayCaptions(Foundation.NSAttributedString[])
-M:MediaAccessibility.MACaptionAppearance.DidDisplayCaptions(System.String[])
 M:MediaAccessibility.MAFlashingLightsProcessor.CanProcess(IOSurface.IOSurface)
 M:MediaAccessibility.MAFlashingLightsProcessor.Process(IOSurface.IOSurface,IOSurface.IOSurface,System.Double,Foundation.NSDictionary)
 M:MediaAccessibility.MAImageCaptioning.GetCaption(Foundation.NSUrl,Foundation.NSError@)


### PR DESCRIPTION
Allow null for a few parameters where we handle null values with a defined
(non-throwing) behavior.