### PR TITLE
[CoreVideo] Expose CVPixelBufferAttributes.AllocateWithIOSurface|MetalCompatibility on macOS. Fixes #24584.

### DIFF
--- a/src/CoreVideo/CVPixelBufferAttributes.cs
+++ b/src/CoreVideo/CVPixelBufferAttributes.cs
@@ -259,12 +259,7 @@ namespace CoreVideo {
 			}
 		}
 
-		// TODO: kCVPixelBufferIOSurfacePropertiesKey
-#if !MONOMAC
-		// The presence of the IOSurfacePropertiesKey mandates the allocation via IOSurfaceProperty
-		/// <summary>If this key is set, this instructs CoreVideo to allocate the video buffers using the IOSurface.    This is required for some uses of pixel buffers.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>If this key is set, this instructs CoreVideo to allocate the video buffers using the <see cref="IOSurface.IOSurface" />. This is required for some uses of pixel buffers.</summary>
 		public bool? AllocateWithIOSurface {
 			set {
 				if (value.HasValue && value.Value)
@@ -277,11 +272,9 @@ namespace CoreVideo {
 			}
 		}
 
-#if !__MACCATALYST__
+#if !__MACCATALYST__ && !__MACOS__
 		/// <summary>Indicates whether the pixel buffer is compatible with OpenGL for Embedded Systems contexts.</summary>
-		///         <value>
-		///         </value>
-		///         <remarks>The property uses constant kCVPixelBufferOpenGLESCompatibilityKey value to access the underlying dictionary.</remarks>
+		/// <remarks>The property uses the <c>kCVPixelBufferOpenGLESCompatibilityKey</c> constant to access the underlying dictionary.</remarks>
 		[SupportedOSPlatform ("ios")]
 		[UnsupportedOSPlatform ("maccatalyst")]
 		[UnsupportedOSPlatform ("macos")]
@@ -297,12 +290,6 @@ namespace CoreVideo {
 #endif
 
 		/// <summary>Indicates whether the pixel buffer is compatible with Metal.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		[SupportedOSPlatform ("ios")]
-		[SupportedOSPlatform ("maccatalyst")]
-		[SupportedOSPlatform ("tvos")]
-		[UnsupportedOSPlatform ("macos")]
 		public bool? MetalCompatibility {
 			set {
 				SetBooleanValue (CVPixelBuffer.MetalCompatibilityKey, value);
@@ -311,7 +298,6 @@ namespace CoreVideo {
 				return GetBoolValue (CVPixelBuffer.MetalCompatibilityKey);
 			}
 		}
-#endif
-#endif
+#endif // !COREBUILD
 	}
 }


### PR DESCRIPTION
CVPixelBufferAttributes.AllocateWithIOSurface was initially exposed, but due
to an incorrect merge conflict resolution got removed on macOS
(https://github.com/xamarin/maccore/commit/0feda2d8613a818c2e72c092a4cd8e5b20c5e88e).

CVPixelBufferAttributes.MetalCompatibility was added to iOS first, and then a
year later on macOS, but we never removed the macOS exclusion.

Fixes https://github.com/dotnet/macios/issues/24584.