### PR TITLE
[tools] Remove the IntPtr.Size inline optimization.

### DIFF
--- a/builds/Versions-MacCatalyst.plist.in
+++ b/builds/Versions-MacCatalyst.plist.in
@@ -149,8 +149,6 @@
 	<key>Optimizations</key>
 	<dict>
 		<!-- The key is the value to be passed to mtouch. The string is a very short description. Any IDE UI should also point to the documentation for the optimizations. -->
-		<key>inline-intptr-size</key>
-		<string>Inline IntPtr.Size</string>
 		<key>inline-runtime-arch</key>
 		<string>Inline NSObject.IsDirectBinding</string>
 		<key>dead-code-elimination</key>

--- a/builds/Versions-iOS.plist.in
+++ b/builds/Versions-iOS.plist.in
@@ -173,8 +173,6 @@
 	<key>Optimizations</key>
 	<dict>
 		<!-- The key is the value to be passed to mtouch. The string is a very short description. Any IDE UI should also point to the documentation for the optimizations. -->
-		<key>inline-intptr-size</key>
-		<string>Inline IntPtr.Size</string>
 		<key>inline-runtime-arch</key>
 		<string>Inline NSObject.IsDirectBinding</string>
 		<key>dead-code-elimination</key>

--- a/builds/Versions-macOS.plist.in
+++ b/builds/Versions-macOS.plist.in
@@ -94,8 +94,6 @@
 	<key>Optimizations</key>
 	<dict>
 		<!-- The key is the value to be passed to mmp. The string is a very short description. Any IDE UI should also point to the documentation for the optimizations. -->
-		<key>inline-intptr-size</key>
-		<string>Inline IntPtr.Size</string>
 		<key>inline-runtime-arch</key>
 		<string>Inline Runtime.Arch</string>
 		<key>inline-isdirectbinding</key>

--- a/builds/Versions-tvOS.plist.in
+++ b/builds/Versions-tvOS.plist.in
@@ -123,8 +123,6 @@
 	<key>Optimizations</key>
 	<dict>
 		<!-- The key is the value to be passed to mtouch. The string is a very short description. Any IDE UI should also point to the documentation for the optimizations. -->
-		<key>inline-intptr-size</key>
-		<string>Inline IntPtr.Size</string>
 		<key>inline-runtime-arch</key>
 		<string>Inline NSObject.IsDirectBinding</string>
 		<key>dead-code-elimination</key>

--- a/docs/website/optimizations.md
+++ b/docs/website/optimizations.md
@@ -47,44 +47,6 @@ The default behavior can be overridden by passing `--optimize=[+|-]remove-uithre
 
 [1]: /dotnet/api/UIKit.UIApplication.EnsureUIThread
 
-## Inline IntPtr.Size
-
-Inlines the constant value of `IntPtr.Size` according to the target platform.
-
-This optimization will change the following type of code:
-
-```csharp
-if (IntPtr.Size == 8) {
-    Console.WriteLine ("64-bit platform");
-} else {
-    Console.WriteLine ("32-bit platform");
-}
-```
-
-into the following (when building for a 64-bit platform):
-
-```csharp
-if (8 == 8) {
-    Console.WriteLine ("64-bit platform");
-} else {
-    Console.WriteLine ("32-bit platform");
-}
-```
-
-This optimization requires the linker to be enabled, and is only applied to
-methods with the `[BindingImpl (BindingImplOptions.Optimizable)]` attribute.
-
-By default it's enabled if targeting a single architecture, or for the
-platform assembly (**Xamarin.iOS.dll**, **Xamarin.TVOS.dll**,
-**Xamarin.WatchOS.dll** or **Xamarin.Mac.dll**).
-
-If targeting multiple architectures, this optimization will create different
-assemblies for the 32-bit version and the 64-bit version of the app, and both
-versions will have to be included in the app, effectively increasing the final
-app size instead of decreasing it.
-
-The default behavior can be overridden by passing `--optimize=[+|-]inline-intptr-size` to mtouch/mmp.
-
 ## Inline NSObject.IsDirectBinding
 
 `NSObject.IsDirectBinding` is an instance property that determines whether a
@@ -254,24 +216,12 @@ the binding code for `NFCIso15693ReadMultipleBlocksConfiguration.Range`):
 NSRange ret;
 if (IsDirectBinding) {
     if (Runtime.Arch == Arch.DEVICE) {
-        if (IntPtr.Size == 8) {
-            ret = global::ObjCRuntime.Messaging.NSRange_objc_msgSend (this.Handle, Selector.GetHandle ("range"));
-        } else {
-            global::ObjCRuntime.Messaging.NSRange_objc_msgSend_stret (out ret, this.Handle, Selector.GetHandle ("range"));
-        }
-    } else if (IntPtr.Size == 8) {
         ret = global::ObjCRuntime.Messaging.NSRange_objc_msgSend (this.Handle, Selector.GetHandle ("range"));
     } else {
         ret = global::ObjCRuntime.Messaging.NSRange_objc_msgSend (this.Handle, Selector.GetHandle ("range"));
     }
 } else {
     if (Runtime.Arch == Arch.DEVICE) {
-        if (IntPtr.Size == 8) {
-            ret = global::ObjCRuntime.Messaging.NSRange_objc_msgSendSuper (this.SuperHandle, Selector.GetHandle ("range"));
-        } else {
-            global::ObjCRuntime.Messaging.NSRange_objc_msgSendSuper_stret (out ret, this.SuperHandle, Selector.GetHandle ("range"));
-        }
-    } else if (IntPtr.Size == 8) {
         ret = global::ObjCRuntime.Messaging.NSRange_objc_msgSendSuper (this.SuperHandle, Selector.GetHandle ("range"));
     } else {
         ret = global::ObjCRuntime.Messaging.NSRange_objc_msgSendSuper (this.SuperHandle, Selector.GetHandle ("range"));

--- a/tools/common/Optimizations.cs
+++ b/tools/common/Optimizations.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Bundler {
 			"remove-uithread-checks",
 			"dead-code-elimination",
 			"inline-isdirectbinding",
-			"inline-intptr-size",
+			"inline-intptr-size", // this optimization has been removed, but leave it here so that we won't break customers trying to enable/disable it
 			"inline-runtime-arch",
 			"blockliteral-setupblock",
 			"register-protocols",
@@ -35,7 +35,7 @@ namespace Xamarin.Bundler {
 			/* Opt.RemoveUIThreadChecks               */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.TVOS, ApplePlatform.MacCatalyst },
 			/* Opt.DeadCodeElimination                */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.TVOS, ApplePlatform.MacCatalyst },
 			/* Opt.InlineIsDirectBinding              */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.TVOS, ApplePlatform.MacCatalyst },
-			/* Opt.InlineIntPtrSize                   */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.TVOS, ApplePlatform.MacCatalyst },
+			/* Opt.InlineIntPtrSize                   */ new ApplePlatform [] {                                                                                        },
 			/* Opt.InlineRuntimeArch                  */ new ApplePlatform [] { ApplePlatform.iOS,                       ApplePlatform.TVOS                            },
 			/* Opt.BlockLiteralSetupBlock             */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.TVOS, ApplePlatform.MacCatalyst },
 			/* Opt.RegisterProtocols                  */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.TVOS, ApplePlatform.MacCatalyst },

--- a/tools/linker/CoreOptimizeGeneratedCode.cs
+++ b/tools/linker/CoreOptimizeGeneratedCode.cs
@@ -30,15 +30,6 @@ namespace Xamarin.Linker {
 			}
 		}
 
-		Dictionary<AssemblyDefinition, bool>? _inlineIntPtrSize;
-		Dictionary<AssemblyDefinition, bool> InlineIntPtrSize {
-			get {
-				if (_inlineIntPtrSize is null)
-					_inlineIntPtrSize = new Dictionary<AssemblyDefinition, bool> ();
-				return _inlineIntPtrSize;
-			}
-		}
-
 		public bool Device {
 			get { return LinkContext.App.IsDeviceBuild; }
 		}
@@ -589,35 +580,6 @@ namespace Xamarin.Linker {
 				instructions.RemoveAt (last_reachable + 1);
 		}
 
-		bool GetInlineIntPtrSize (AssemblyDefinition assembly)
-		{
-			if (InlineIntPtrSize.TryGetValue (assembly, out bool inlineIntPtrSize))
-				return inlineIntPtrSize;
-
-			// The "get_Size" is a performance (over size) optimization.
-			// It always makes sense for platform assemblies because:
-			// * Xamarin.TVOS.dll only ship the 64 bits code paths (all 32 bits code is extra weight better removed)
-			// * Xamarin.WatchOS.dll only ship the 32 bits code paths (all 64 bits code is extra weight better removed)
-			// * Xamarin.iOS.dll  ship different 32/64 bits versions of the assembly anyway (nint... support)
-			//   Each is better to be optimized (it will be smaller anyway)
-			//
-			// However for fat (32/64) apps (i.e. iOS only right now) the optimization can duplicate the assembly
-			// (metadata) for 3rd parties binding projects, increasing app size for very minimal performance gains.
-			// For non-fat apps (the AppStore allows 64bits only iOS apps) then it's better to be applied
-			//
-			// TODO: we could make this an option "optimize for size vs optimize for speed" in the future
-			if (Optimizations.InlineIntPtrSize.HasValue) {
-				inlineIntPtrSize = Optimizations.InlineIntPtrSize.Value;
-			} else {
-				inlineIntPtrSize = true;
-			}
-			if (inlineIntPtrSize)
-				Driver.Log (4, "Optimization 'inline-intptr-size' enabled for assembly '{0}'.", assembly.Name);
-
-			InlineIntPtrSize.Add (assembly, inlineIntPtrSize);
-			return inlineIntPtrSize;
-		}
-
 		bool GetIsExtensionType (TypeDefinition type)
 		{
 			// if 'type' inherits from NSObject inside an assembly that has [GeneratedCode]
@@ -681,9 +643,6 @@ namespace Xamarin.Linker {
 			case "EnsureUIThread":
 				ProcessEnsureUIThread (caller, ins);
 				break;
-			case "get_Size":
-				ProcessIntPtrSize (caller, ins);
-				break;
 			case "get_IsDirectBinding":
 				ProcessIsDirectBinding (caller, ins);
 				break;
@@ -732,23 +691,6 @@ namespace Xamarin.Linker {
 
 			// This is simple: just remove the call
 			Nop (ins); // call void UIKit.UIApplication::EnsureUIThread()
-		}
-
-		void ProcessIntPtrSize (MethodDefinition caller, Instruction ins)
-		{
-			if (!GetInlineIntPtrSize (caller.Module.Assembly))
-				return;
-
-			// This will inline IntPtr.Size to load the corresponding constant value instead
-
-			// Verify we're checking the right get_Size call
-			var mr = ins.Operand as MethodReference;
-			if (mr is null || !mr.DeclaringType.Is ("System", "IntPtr"))
-				return;
-
-			// We're fine, inline the get_Size call
-			ins.OpCode = OpCodes.Ldc_I4_8;
-			ins.Operand = null;
 		}
 
 		bool? IsDirectBindingConstant (TypeDefinition type)


### PR DESCRIPTION
We don't have any code paths conditions on IntPtr.Size anymore (because we
only support 64-bit architectures now), so the size benefits for the
optimizations are slim to non-existent (it's used in a few mathematical
expressions, pointer arithmetic, etc., nothing that affects final app size if
IntPtr.Size gets inlined or not).