### PR TITLE
Fix dependencies for the $(TOP)/Build.props rule.

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -350,7 +350,7 @@ endif
 	$(Q) grep '<MicrosoftDotNetArcadeSdkPackageVersion>' $(TOP)/eng/Version.Details.props | sed -e 's/<*\/*MicrosoftDotNetArcadeSdkPackageVersion>//g' -e 's/[ \t]*/ARCADE_VERSION=/' >> $@.tmp
 	$(Q) mv $@.tmp $@
 
-$(TOP)/Build.props: Make.config
+$(TOP)/Build.props: $(TOP)/Make.config
 	$(Q) rm -f $@.tmp
 	$(Q) printf "<Project>\n" >> $@.tmp
 	$(Q) printf "\t<PropertyGroup>\n" >> $@.tmp


### PR DESCRIPTION
The 'Make.config' file can be included from makefiles in subdirectories, so
paths need to be explicit to work.