### PR TITLE
[UIKit] Enable nullability and clean up UICollectionViewLayoutAttributes.

### DIFF
--- a/src/UIKit/UICollectionViewLayoutAttributes.cs
+++ b/src/UIKit/UICollectionViewLayoutAttributes.cs
@@ -12,62 +12,56 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using CoreGraphics;
 
-// Disable until we get around to enable + fix any issues.
-#nullable disable
+#nullable enable
 
 namespace UIKit {
 	public partial class UICollectionViewLayoutAttributes : NSObject {
+		/// <summary>Creates a layout attributes object of the specified type for the cell at the specified index path.</summary>
 		/// <typeparam name="T">The type of the layout attributes object to return.</typeparam>
-		///         <param name="indexPath">The index path describing the cell to create a layout attributes object for.</param>
-		///         <summary>Creates a layout attributes object of the specified type for the cell at the specified index path.</summary>
-		///         <returns>A layout attributes object representing the cell at the specified index path.</returns>
-		///         <remarks>Use this method to create a layout attributes object of a UICollectionViewLayoutAttributes subclass.</remarks>
+		/// <param name="indexPath">The index path describing the cell to create a layout attributes object for.</param>
+		/// <returns>A layout attributes object representing the cell at the specified index path.</returns>
+		/// <remarks>Use this method to create a layout attributes object of a <see cref="UICollectionViewLayoutAttributes" /> subclass.</remarks>
 		[CompilerGenerated]
 		public static T CreateForCell<T> (NSIndexPath indexPath) where T : UICollectionViewLayoutAttributes
 		{
 			global::UIKit.UIApplication.EnsureUIThread ();
-			if (indexPath is null)
-				throw new ArgumentNullException ("indexPath");
-			T result = (T) Runtime.GetNSObject (ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr (Class.GetHandle (typeof (T)), Selector.GetHandle ("layoutAttributesForCellWithIndexPath:"), indexPath.Handle));
+			ArgumentNullException.ThrowIfNull (indexPath);
+			T result = (T) Runtime.GetNSObject (ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr (Class.GetHandle (typeof (T)), Selector.GetHandle ("layoutAttributesForCellWithIndexPath:"), indexPath.Handle))!;
 			GC.KeepAlive (indexPath);
 			return result;
 		}
 
+		/// <summary>Creates a layout attributes object of a specific type representing the decoration view.</summary>
 		/// <typeparam name="T">The type of the layout attributes object to return.</typeparam>
-		///         <param name="kind">The kind identifier for the decoration view.</param>
-		///         <param name="indexPath">An index path related to the decoration view.</param>
-		///         <summary>Creates a layout attributes object of a specific type representing the decoration view.</summary>
-		///         <returns>A layout attributes object of a specific type that represents the decoration view.</returns>
-		///         <remarks>Use this method to create a layout attributes object of a specific type representing a decoration view of a specific kind.</remarks>
+		/// <param name="kind">The kind identifier for the decoration view.</param>
+		/// <param name="indexPath">An index path related to the decoration view.</param>
+		/// <returns>A layout attributes object of a specific type that represents the decoration view.</returns>
+		/// <remarks>Use this method to create a layout attributes object of a specific type representing a decoration view of a specific kind.</remarks>
 		[CompilerGenerated]
 		public static T CreateForDecorationView<T> (NSString kind, NSIndexPath indexPath) where T : UICollectionViewLayoutAttributes
 		{
 			global::UIKit.UIApplication.EnsureUIThread ();
-			if (kind is null)
-				throw new ArgumentNullException ("kind");
-			if (indexPath is null)
-				throw new ArgumentNullException ("indexPath");
-			T result = (T) Runtime.GetNSObject (ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr_IntPtr (Class.GetHandle (typeof (T)), Selector.GetHandle ("layoutAttributesForDecorationViewOfKind:withIndexPath:"), kind.Handle, indexPath.Handle));
+			ArgumentNullException.ThrowIfNull (kind);
+			ArgumentNullException.ThrowIfNull (indexPath);
+			T result = (T) Runtime.GetNSObject (ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr_IntPtr (Class.GetHandle (typeof (T)), Selector.GetHandle ("layoutAttributesForDecorationViewOfKind:withIndexPath:"), kind.Handle, indexPath.Handle))!;
 			GC.KeepAlive (kind);
 			GC.KeepAlive (indexPath);
 			return result;
 		}
 
+		/// <summary>Creates a layout attributes object of a specific type representing the supplementary view.</summary>
 		/// <typeparam name="T">The type of the layout attributes object to return.</typeparam>
-		///         <param name="kind">The kind identifier for the supplementary view.</param>
-		///         <param name="indexPath">An index path for the supplementary view.</param>
-		///         <summary>Creates a layout attributes object of a specific type representing the supplementary view.</summary>
-		///         <returns>A layout attributes object of a specific type that represents the supplementary view.</returns>
-		///         <remarks>Use this method to create a layout attributes object of a specific type representing a supplementary view of the specified.</remarks>
+		/// <param name="kind">The kind identifier for the supplementary view.</param>
+		/// <param name="indexPath">An index path for the supplementary view.</param>
+		/// <returns>A layout attributes object of a specific type that represents the supplementary view.</returns>
+		/// <remarks>Use this method to create a layout attributes object of a specific type representing a supplementary view of the specified kind.</remarks>
 		[CompilerGenerated]
 		public static T CreateForSupplementaryView<T> (NSString kind, NSIndexPath indexPath) where T : UICollectionViewLayoutAttributes
 		{
 			global::UIKit.UIApplication.EnsureUIThread ();
-			if (kind is null)
-				throw new ArgumentNullException ("kind");
-			if (indexPath is null)
-				throw new ArgumentNullException ("indexPath");
-			T result = (T) Runtime.GetNSObject (ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr_IntPtr (Class.GetHandle (typeof (T)), Selector.GetHandle ("layoutAttributesForSupplementaryViewOfKind:withIndexPath:"), kind.Handle, indexPath.Handle));
+			ArgumentNullException.ThrowIfNull (kind);
+			ArgumentNullException.ThrowIfNull (indexPath);
+			T result = (T) Runtime.GetNSObject (ObjCRuntime.Messaging.IntPtr_objc_msgSend_IntPtr_IntPtr (Class.GetHandle (typeof (T)), Selector.GetHandle ("layoutAttributesForSupplementaryViewOfKind:withIndexPath:"), kind.Handle, indexPath.Handle))!;
 			GC.KeepAlive (kind);
 			GC.KeepAlive (indexPath);
 			return result;
@@ -85,22 +79,22 @@ namespace UIKit {
 			}
 		}
 
+		/// <summary>Creates a layout attributes object representing the supplementary view.</summary>
 		/// <param name="section">The supplementary view kind.</param>
-		///         <param name="indexPath">An index path for the supplementary view.</param>
-		///         <summary>Creates a layout attributes object representing the supplementary view.</summary>
-		///         <returns>A layout attributes object that represents the supplementary view.</returns>
-		///         <remarks>Use this method to create a layout attributes object representing a supplementary view of a specific kind. If you've subclassed UICollectionViewLayoutAttributes and need to return an instance of the subclass, use <see cref="UIKit.UICollectionViewLayoutAttributes.CreateForSupplementaryView(Foundation.NSString,Foundation.NSIndexPath)" /> instead. This method is equivalent to calling CreateForSupplementaryView&lt;UICollectionViewLayoutAttributes&gt;.</remarks>
+		/// <param name="indexPath">An index path for the supplementary view.</param>
+		/// <returns>A layout attributes object that represents the supplementary view.</returns>
+		/// <remarks>Use this method to create a layout attributes object representing a supplementary view of a specific kind. If you've subclassed <see cref="UICollectionViewLayoutAttributes" /> and need to return an instance of the subclass, use <see cref="CreateForSupplementaryView{T}(NSString, NSIndexPath)" /> instead. This method is equivalent to calling <c>CreateForSupplementaryView&lt;UICollectionViewLayoutAttributes&gt;</c>.</remarks>
 		public static UICollectionViewLayoutAttributes CreateForSupplementaryView (UICollectionElementKindSection section, NSIndexPath indexPath)
 		{
 			return CreateForSupplementaryView (GetKindForSection (section), indexPath);
 		}
 
+		/// <summary>Creates a layout attributes object representing the supplementary view.</summary>
 		/// <typeparam name="T">The type of the layout attributes object to return.</typeparam>
-		///         <param name="section">The supplementary view kind.</param>
-		///         <param name="indexPath">An index path for the supplementary view.</param>
-		///         <summary>Creates a layout attributes object representing the supplementary view.</summary>
-		///         <returns>A layout attributes object that represents the supplementary view.</returns>
-		///         <remarks>Use this method to create a layout attributes object of a specific type representing a supplementary view of the specified.</remarks>
+		/// <param name="section">The supplementary view kind.</param>
+		/// <param name="indexPath">An index path for the supplementary view.</param>
+		/// <returns>A layout attributes object that represents the supplementary view.</returns>
+		/// <remarks>Use this method to create a layout attributes object of a specific type representing a supplementary view of the specified kind.</remarks>
 		public static T CreateForSupplementaryView<T> (UICollectionElementKindSection section, NSIndexPath indexPath) where T : UICollectionViewLayoutAttributes
 		{
 			return CreateForSupplementaryView<T> (GetKindForSection (section), indexPath);


### PR DESCRIPTION
This is file 6 of 30 files with nullability disabled in UIKit.

* Enable nullability (#nullable enable).
* Use ArgumentNullException.ThrowIfNull() instead of manual null checks.
* Improve XML documentation comments: fix formatting (remove extra whitespace), fix order (summary first, then typeparam, param, returns, remarks), add 'see cref' references, fix incomplete sentences, use <c> for code references.

Contributes towards https://github.com/dotnet/macios/issues/17285.