### PR TITLE
[msbuild] It seems that the 'get-task-allow' entitlement is allowed on all platforms.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileEntitlements.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileEntitlements.cs
@@ -863,7 +863,7 @@ namespace Xamarin.MacDev.Tasks {
 					new EntitlementData ("com.apple.vm.device-access", desktop, EntitlementType.Boolean ),
 					new EntitlementData ("com.apple.vm.hypervisor", desktop, EntitlementType.Boolean ),
 					new EntitlementData ("com.apple.vm.networking", desktop, EntitlementType.Boolean ),
-					new EntitlementData ("get-task-allow", mobile, EntitlementType.Boolean ),
+					new EntitlementData ("get-task-allow", allPlatforms, EntitlementType.Boolean ),
 					new EntitlementData ("inter-app-audio", iOS, EntitlementType.Boolean ),
 					new EntitlementData ("keychain-access-groups", allPlatforms, EntitlementType.ArrayOfStrings ),
 				};


### PR DESCRIPTION
It shows up in desktop provisioning profiles, so it's not only allowed on mobile platforms.