### PR TITLE
[net11.0.] [tests] Stop ignoring a few tests that work on CoreCLR. Fixes #19781.

### DIFF
--- a/tests/monotouch-test/ObjCRuntime/RegistrarTestGenerated.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTestGenerated.cs
@@ -5,6 +5,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 	public partial class RegistrarTestGenerated {
 		void AssertIfIgnored ([CallerMemberName] string testCase = null)
 		{
+			if (TestRuntime.IsCoreCLR)
+				return;
+
 			switch (testCase) {
 #if __MACCATALYST__ || __IOS__ || __TVOS__
 			case "NSNumberBindAs_Boolean_Array_Overrides":


### PR DESCRIPTION
Fixes https://github.com/dotnet/macios/issues/19781.