### PR TITLE
[builds] Find '<Sdk Name="..." Version="..." />' nodes when collecting all packages to download.

### DIFF
--- a/builds/create-csproj-for-all-packagereferences.sh
+++ b/builds/create-csproj-for-all-packagereferences.sh
@@ -50,6 +50,9 @@ cd "$(git rev-parse --show-toplevel)"
 # Find all <PackageReference /> items that has an Include="..." and a Version="..."
 git grep -e '<PackageReference.*Include="[a-zA-Z0-9._-]*".*Version="[a-zA-Z0-9._-]*".*>' -h > "$TMPPATH"
 
+# Find all <Sdk Name="..." Version=".."> nodes
+git grep -e '^[[:space:]]*<Sdk Name="[a-zA-Z0-9._-]*".*Version="['\$'()a-zA-Z0-9._-]*".*>' -h | sed -e 's/Name=/Include=/' -e 's/<Sdk/<PackageReference/' >> "$TMPPATH"
+
 # Replace double double quotes with a single double quote. This happens in source code that generates project files (for tests).
 sed "${SED_INPLACE_FLAGS[@]}" 's/""/"/g' "$TMPPATH"
 
@@ -60,7 +63,7 @@ sed "${SED_INPLACE_FLAGS[@]}" '/Xamarin.Tests.XCFrameworkWithStaticLibraryInRunt
 sed "${SED_INPLACE_FLAGS[@]}" '/Xamarin.Tests.XCFrameworkWithSymlinks/d' "$TMPPATH"
 
 # Get only the name and version of each package, and write that back in a PackageDownload item
-sed "${SED_INPLACE_FLAGS[@]}" 's@.*<PackageReference.*Include="\([a-zA-Z0-9._-]*\)".*Version="\([a-zA-Z0-9._-]*\)".*>.*@\t\t<PackageDownload Include="\1" Version="[\2]" />@g' "$TMPPATH"
+sed "${SED_INPLACE_FLAGS[@]}" 's@.*<PackageReference.*Include="\([a-zA-Z0-9._-]*\)".*Version="\(['\$'()a-zA-Z0-9._-]*\)".*>.*@\t\t<PackageDownload Include="\1" Version="[\2]" />@g' "$TMPPATH"
 
 # Sort the references and only list each once.
 sort -u -o "$TMPPATH" "$TMPPATH"


### PR DESCRIPTION
Hopefully fixes this random build error:

    /Users/builder/azdo/_work/1/a/change-detection/tmp/src/macios/dotnet/package/Microsoft.tvOS.Runtime.tvos/package.csproj : error : Could not resolve SDK "Microsoft.DotNet.SharedFramework.Sdk". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
    /Users/builder/azdo/_work/1/a/change-detection/tmp/src/macios/dotnet/package/Microsoft.tvOS.Runtime.tvos/package.csproj : error :   SDK resolver "Microsoft.DotNet.MSBuildWorkloadSdkResolver" returned null.
    /Users/builder/azdo/_work/1/a/change-detection/tmp/src/macios/dotnet/package/Microsoft.tvOS.Runtime.tvos/package.csproj : error :   Failed to resolve SDK 'Microsoft.DotNet.SharedFramework.Sdk/10.0.0-beta.26102.104'. Package restore was successful but a package with the ID of "Microsoft.DotNet.SharedFramework.Sdk" was not installed.
    /Users/builder/azdo/_work/1/a/change-detection/tmp/src/macios/dotnet/package/Microsoft.tvOS.Runtime.tvos/package.csproj : error MSB4236: The SDK 'Microsoft.DotNet.SharedFramework.Sdk/10.0.0-beta.26102.104' specified could not be found.