### PR TITLE
[UIKit] Enable nullability and clean up UIKitSynchronizationContext.

### DIFF
--- a/src/UIKit/UIKitSynchronizationContext.cs
+++ b/src/UIKit/UIKitSynchronizationContext.cs
@@ -9,8 +9,7 @@
 
 using System.Threading;
 
-// Disable until we get around to enable + fix any issues.
-#nullable disable
+#nullable enable
 
 namespace UIKit {
 
@@ -20,12 +19,12 @@ namespace UIKit {
 			return new UIKitSynchronizationContext ();
 		}
 
-		public override void Post (SendOrPostCallback d, object state)
+		public override void Post (SendOrPostCallback d, object? state)
 		{
 			NSRunLoop.Main.BeginInvokeOnMainThread (d, state);
 		}
 
-		public override void Send (SendOrPostCallback d, object state)
+		public override void Send (SendOrPostCallback d, object? state)
 		{
 			NSRunLoop.Main.InvokeOnMainThread (d, state);
 		}


### PR DESCRIPTION
This is file 14 of 30 files with nullability disabled in UIKit.

* Enable nullability (#nullable enable).
* Make 'state' parameter nullable (object?) in Post and Send to match
  the base SynchronizationContext signature.

Contributes towards https://github.com/dotnet/macios/issues/17285.