### PR TITLE
[UIKit] Enable nullability and clean up UIPasteboard.

### DIFF
--- a/src/UIKit/UIPasteboard.cs
+++ b/src/UIKit/UIPasteboard.cs
@@ -19,7 +19,7 @@ namespace UIKit {
 						ret [i] = new UIImage (data);
 					} else if (obj is UIImage img) {
 						ret [i] = img;
-					} else if (obj != null) {
+					} else if (obj is not null) {
 						throw new System.InvalidOperationException ("Unexpected object type in UIPasteboard images array: " + obj.GetType ().FullName);
 					}
 				}


### PR DESCRIPTION
This is file 16 of 30 files with nullability disabled in UIKit.

* Enable nullability (#nullable enable).
* Remove unused using directives (System.Drawing, System.Diagnostics,
  System.ComponentModel).
* Use pattern matching in GetImageArray to safely handle the nullable
  return from Runtime.GetNSObject without explicit casts.
* Add XML documentation for the Images property.

Contributes towards https://github.com/dotnet/macios/issues/17285.