### PR TITLE
[UIKit] Enable nullability and clean up UIPickerView.

### DIFF
--- a/src/UIKit/UIPickerView.cs
+++ b/src/UIKit/UIPickerView.cs
@@ -9,6 +9,7 @@ namespace UIKit {
 		UIPickerViewModel? model;
 
 		/// <summary>Gets or sets the <see cref="UIPickerViewModel" /> that this <see cref="UIPickerView" /> is representing.</summary>
+		/// <value>The model used by the picker view. May be <see langword="null" /> to indicate that no model is set or to clear the current model.</value>
 		public UIPickerViewModel? Model {
 			get {
 				return model;


### PR DESCRIPTION
This is file 17 of 30 files with nullability disabled in UIKit.

* Enable nullability (#nullable enable).
* Make Model property and backing field nullable (UIPickerViewModel?)
  since the field is null before the property is set.
* Remove 'private' access modifier from field (follows codebase convention).
* Improve XML documentation comments: remove 'To be added.' placeholders,
  use 'Gets or sets' phrasing, add 'see cref' references.

Contributes towards https://github.com/dotnet/macios/issues/17285.