### PR TITLE
[UIKit] Enable nullability and clean up UIPopoverController.

### DIFF
--- a/src/UIKit/UIPopoverController.cs
+++ b/src/UIKit/UIPopoverController.cs
@@ -1,18 +1,15 @@
 // Copyright 2012 Xamarin Inc. All rights reserved.
 
-// Disable until we get around to enable + fix any issues.
-#nullable disable
+#nullable enable
 
 namespace UIKit {
 
 	public partial class UIPopoverController {
 
 		// cute helper to avoid using `Class` in the public API
-		/// <summary>This is the type that is used to display the background of the popover.</summary>
-		///         <value>
-		///         </value>
-		///         <remarks>The popover controller will use an instance of this type in order to draw the background of the popover.</remarks>
-		public virtual Type PopoverBackgroundViewType {
+		/// <summary>Gets or sets the type used to display the background of the popover.</summary>
+		/// <remarks>The popover controller uses an instance of this type to draw the background of the popover.</remarks>
+		public virtual Type? PopoverBackgroundViewType {
 			get {
 				IntPtr p = PopoverBackgroundViewClass;
 				if (p == IntPtr.Zero)


### PR DESCRIPTION
This is file 18 of 30 files with nullability disabled in UIKit.

* Enable nullability (#nullable enable).
* Make PopoverBackgroundViewType nullable (Type?) since the getter
  can return null when no background view class is set.
* Improve XML documentation comments: remove empty value element,
  remove 'To be added.' placeholders, use 'Gets or sets' phrasing,
  fix formatting.

Contributes towards https://github.com/dotnet/macios/issues/17285.