### PR TITLE
[UIKit] Enable nullability and clean up UIPopoverPresentationController.

### DIFF
--- a/src/UIKit/UIPopoverPresentationController.cs
+++ b/src/UIKit/UIPopoverPresentationController.cs
@@ -4,18 +4,15 @@
 
 using CoreGraphics;
 
-// Disable until we get around to enable + fix any issues.
-#nullable disable
+#nullable enable
 
 namespace UIKit {
 
 	public partial class UIPopoverPresentationController {
 
 		// cute helper to avoid using `Class` in the public API
-		/// <summary>Gets or sets the type that is used to display background content for the popover.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		public virtual Type PopoverBackgroundViewType {
+		/// <summary>Gets or sets the type used to display background content for the popover.</summary>
+		public virtual Type? PopoverBackgroundViewType {
 			get {
 				IntPtr p = PopoverBackgroundViewClass;
 				if (p == IntPtr.Zero)


### PR DESCRIPTION
This is file 19 of 30 files with nullability disabled in UIKit.

* Enable nullability (#nullable enable).
* Make PopoverBackgroundViewType nullable (Type?) since the getter
  can return null when no background view class is set.
* Improve XML documentation comments: remove 'To be added.' placeholders,
  fix formatting.

Contributes towards https://github.com/dotnet/macios/issues/17285.