### PR TITLE
[UIKit] Enable nullability and clean up UISearchDisplayController.

### DIFF
--- a/src/UIKit/UISearchDisplayController.cs
+++ b/src/UIKit/UISearchDisplayController.cs
@@ -1,26 +1,13 @@
 #if !TVOS && !__MACCATALYST__ // __TVOS_PROHIBITED
-using System.Drawing;
-using CoreFoundation;
-using CoreAnimation;
-using CoreLocation;
-using MapKit;
-using UIKit;
-using CoreGraphics;
 
-// Disable until we get around to enable + fix any issues.
-#nullable disable
+#nullable enable
 
 namespace UIKit {
 	public partial class UISearchDisplayController {
-		/// <summary>The UITableViewSource holding the search results.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		public UITableViewSource SearchResultsSource {
+		/// <summary>Gets or sets the <see cref="UITableViewSource" /> holding the search results.</summary>
+		public UITableViewSource? SearchResultsSource {
 			get {
-				var d = SearchResultsWeakDelegate as UITableViewSource;
-				if (d is not null)
-					return d;
-				return null;
+				return SearchResultsWeakDelegate as UITableViewSource;
 			}
 
 			set {


### PR DESCRIPTION
This is file 21 of 30 files with nullability disabled in UIKit.

* Enable nullability (#nullable enable).
* Remove unused using directives (System.Drawing, CoreFoundation,
  CoreAnimation, CoreLocation, MapKit, UIKit, CoreGraphics).
* Make SearchResultsSource nullable (UITableViewSource?) since the
  getter returns null when the delegate is not a UITableViewSource.
* Simplify getter by returning the 'as' cast directly instead of
  assigning to a variable and checking for null.
* Improve XML documentation comments: remove 'To be added.' placeholders,
  use 'Gets or sets' phrasing, add 'see cref' reference.

Contributes towards https://github.com/dotnet/macios/issues/17285.