### PR TITLE
[release/10.0.1xx] [dotnet-linker] Mark field references in trimmed INativeObject/NSObject constructors. Fixes #24663.

### DIFF
--- a/tests/linker/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/link sdk/LinkSdkRegressionTest.cs
@@ -1075,5 +1075,17 @@ namespace LinkSdk {
 			Thread.CurrentPrincipal = new CustomPrincipal ();
 			Assert.That (Thread.CurrentPrincipal.Identity.Name, Is.EqualTo ("abc"), "Name");
 		}
+
+		[Test]
+		// https://github.com/dotnet/macios/issues/24663
+		public void TrimmedINativeObjectConstructorFieldsMustBePreserved ()
+		{
+			// Reference AudioBuffers (an INativeObject) as a type without calling
+			// any of its constructors. This causes the type to be preserved but its
+			// constructors to be trimmed. The managed static registrar's lookup table
+			// step re-marks the constructor, and must also mark the fields referenced
+			// by the constructor body.
+			GC.KeepAlive (typeof (AudioToolbox.AudioBuffers));
+		}
 	}
 }

--- a/tools/dotnet-linker/Steps/ManagedRegistrarLookupTablesStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarLookupTablesStep.cs
@@ -335,8 +335,7 @@ namespace Xamarin.Linker {
 				}
 
 				var ctor = abr.CurrentAssembly.MainModule.ImportReference (ctorRef);
-				if (IsTrimmed (ctor))
-					Annotations.Mark (ctor.Resolve ());
+				MarkConstructorIfTrimmed (ctor);
 
 				// We can only add a type to the table if it's not an open type.
 				if (!ManagedRegistrarStep.IsOpenType (type)) {
@@ -393,14 +392,7 @@ namespace Xamarin.Linker {
 					var ctor = abr.CurrentAssembly.MainModule.ImportReference (ctorRef);
 
 					// we need to preserve the constructor because it might not be used anywhere else
-					if (IsTrimmed (ctor)) {
-						var ctorDefinition = ctor.Resolve ();
-						Annotations.Mark (ctorDefinition);
-						foreach (var instr in ctorDefinition.Body.Instructions) {
-							if (instr.Operand is MethodReference mr)
-								Annotations.Mark (mr.Resolve ());
-						}
-					}
+					MarkConstructorIfTrimmed (ctor);
 
 					if (!ManagedRegistrarStep.IsOpenType (type)) {
 						EnsureVisible (createInstanceMethod, ctor);
@@ -431,6 +423,25 @@ namespace Xamarin.Linker {
 			il.Emit (OpCodes.Ret);
 
 			body.GenerateILOffsets ();
+		}
+
+		// We need to preserve the constructor because it might not be used anywhere else.
+		// We also need to preserve all method and field references from the constructor body,
+		// because the mark step has already completed and won't transitively mark them.
+		// Ref: https://github.com/dotnet/macios/issues/24663
+		void MarkConstructorIfTrimmed (MethodReference ctor)
+		{
+			if (!IsTrimmed (ctor))
+				return;
+
+			var ctorDefinition = ctor.Resolve ();
+			Annotations.Mark (ctorDefinition);
+			foreach (var instr in ctorDefinition.Body.Instructions) {
+				if (instr.Operand is MethodReference mr)
+					Annotations.Mark (mr.Resolve ());
+				else if (instr.Operand is FieldReference fr)
+					Annotations.Mark (fr.Resolve ());
+			}
 		}
 
 		void AddTypeInterfaceImplementation (TypeDefinition type, TypeReference iface)


### PR DESCRIPTION
When the ManagedRegistrarLookupTablesStep re-marks a trimmed INativeObject
or NSObject constructor (for the ConstructINativeObject/ConstructNSObject
lookup tables), it was only marking MethodReference operands in the
constructor body but not FieldReference operands. This caused the linker's
SweepStep to remove fields referenced by the constructor (setting their
DeclaringType to null), and Cecil would then fail with 'Member is declared
in another module' when writing the assembly.

The fix extracts the marking logic into a new MarkConstructorIfTrimmed
method (eliminating code duplication) and adds marking of FieldReference
operands alongside the existing MethodReference marking.

Fixes https://github.com/dotnet/macios/issues/24663

Backport of #24687.