### PR TITLE
[UIKit] Enable nullability and clean up UITableViewCell.

### DIFF
--- a/docs/api/UIKit/UITableViewCell.xml
+++ b/docs/api/UIKit/UITableViewCell.xml
@@ -79,15 +79,6 @@
     <related type="article" href="https://docs.xamarin.com/guides/ios/user_interface/tables">Working with Tables and Cells</related>
     <related type="externalDocumentation" href="https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITableViewCell_Class/index.html">Apple documentation for <c>UITableViewCell</c></related>
   </Docs>
-  <Docs DocId="M:UIKit.UITableViewCell.#ctor(UIKit.UITableViewCellStyle,System.String)">
-        <param name="style">The style to use for this cell.</param>
-        <param name="reuseIdentifier">A string used to identify the cell object if it should be reused for mutiple rows in a table view. Pass <see langword="null" /> if the object should not be reused. The same reuse identifier string should be used for all cells that use the same class and layout.</param>
-        <summary>Create a table cell with the given style and reuse identifier.</summary>
-        <remarks>
-          <para>The reuse identifier is associated with all cells (rows) in a table view that have the same layout (irrespective of their content) and can therefore be used interchangeably. The <see cref="UIKit.UITableViewSource.GetCell(UIKit.UITableView,Foundation.NSIndexPath)" /> implementation calls <see cref="UIKit.UITableView.DequeueReusableCell(Foundation.NSString)" /> with a specific reuse identifier string to obtain a cached cell object with a particular layout to use as the basis for the row being constructed for viewing.</para>
-          <para>To produce a layout different to those built-in to <see cref="UIKit.UITableViewCell" />, create a custom cell. To set the row height of each cell differently, implement <see cref="UIKit.UITableViewSource.GetHeightForRow(UIKit.UITableView,Foundation.NSIndexPath)" />.</para>
-        </remarks>
-      </Docs>
   <Docs DocId="P:UIKit.UITableViewCell.Highlighted">
         <summary>Whether the cell is highlighted.</summary>
         <value>Default value is <see langword="false" />.</value>

--- a/src/UIKit/UITableViewCell.cs
+++ b/src/UIKit/UITableViewCell.cs
@@ -1,15 +1,16 @@
-using CoreFoundation;
-using UIKit;
-using CoreGraphics;
-
-// Disable until we get around to enable + fix any issues.
-#nullable disable
+#nullable enable
 
 namespace UIKit {
 
 	public partial class UITableViewCell {
-		/// <include file="../../docs/api/UIKit/UITableViewCell.xml" path="/Documentation/Docs[@DocId='M:UIKit.UITableViewCell.#ctor(UIKit.UITableViewCellStyle,System.String)']/*" />
-		public UITableViewCell (UITableViewCellStyle style, string reuseIdentifier) : this (style, reuseIdentifier is null ? (NSString) null : new NSString (reuseIdentifier))
+		/// <summary>Creates a table cell with the given style and reuse identifier.</summary>
+		/// <param name="style">The style to use for this cell.</param>
+		/// <param name="reuseIdentifier">A string used to identify the cell object if it should be reused for multiple rows in a table view. Pass <see langword="null" /> if the object should not be reused. The same reuse identifier string should be used for all cells that use the same class and layout.</param>
+		/// <remarks>
+		///   <para>The reuse identifier is associated with all cells (rows) in a table view that have the same layout (irrespective of their content) and can therefore be used interchangeably. The <see cref="UITableViewSource.GetCell(UITableView,Foundation.NSIndexPath)" /> implementation calls <see cref="UITableView.DequeueReusableCell(Foundation.NSString)" /> with a specific reuse identifier string to obtain a cached cell object with a particular layout to use as the basis for the row being constructed for viewing.</para>
+		///   <para>To produce a layout different to those built-in to <see cref="UITableViewCell" />, create a custom cell. To set the row height of each cell differently, implement <see cref="UITableViewSource.GetHeightForRow(UITableView,Foundation.NSIndexPath)" />.</para>
+		/// </remarks>
+		public UITableViewCell (UITableViewCellStyle style, string? reuseIdentifier) : this (style, reuseIdentifier is null ? (NSString?) null : new NSString (reuseIdentifier))
 		{
 		}
 	} /* class UITableViewCell */


### PR DESCRIPTION
This is file 24 of 30 files with nullability disabled in UIKit.

* Enable nullability (#nullable enable).
* Remove unused using directives (CoreFoundation, UIKit, CoreGraphics).
* Make reuseIdentifier parameter nullable (string?) since null is valid to indicate non-reusable cells.
* Cast null to NSString? instead of NSString for nullable correctness.
* Replace include XML doc attribute with inline content from docs/api/UIKit/UITableViewCell.xml and remove the inlined entry from the XML file.
* Fix typo ('mutiple' → 'multiple') in the inlined documentation.

Contributes towards https://github.com/dotnet/macios/issues/17285.