### PR TITLE
[src] Remove redundant null checks before Class.GetHandle(Type)

### DIFF
--- a/src/AppKit/NSCollectionView.cs
+++ b/src/AppKit/NSCollectionView.cs
@@ -10,7 +10,7 @@ namespace AppKit {
 		///         <remarks>To be added.</remarks>
 		public void RegisterClassForItem (Type itemClass, string identifier)
 		{
-			_RegisterClassForItem (itemClass is null ? IntPtr.Zero : Class.GetHandle (itemClass), identifier);
+			_RegisterClassForItem (Class.GetHandle (itemClass), identifier);
 		}
 
 		/// <param name="viewClass">To be added.</param>
@@ -20,7 +20,7 @@ namespace AppKit {
 		///         <remarks>To be added.</remarks>
 		public void RegisterClassForSupplementaryView (Type viewClass, NSString kind, string identifier)
 		{
-			_RegisterClassForSupplementaryView (viewClass is null ? IntPtr.Zero : Class.GetHandle (viewClass), kind, identifier);
+			_RegisterClassForSupplementaryView (Class.GetHandle (viewClass), kind, identifier);
 		}
 	}
 }

--- a/src/AppKit/NSCollectionViewLayout.cs
+++ b/src/AppKit/NSCollectionViewLayout.cs
@@ -11,7 +11,7 @@ namespace AppKit {
 		///         <remarks>To be added.</remarks>
 		public void RegisterClassForDecorationView (Type itemClass, NSString elementKind)
 		{
-			_RegisterClassForDecorationView (itemClass is null ? IntPtr.Zero : Class.GetHandle (itemClass), elementKind);
+			_RegisterClassForDecorationView (Class.GetHandle (itemClass), elementKind);
 		}
 	}
 }

--- a/src/UIKit/UICollectionViewLayout.cs
+++ b/src/UIKit/UICollectionViewLayout.cs
@@ -17,7 +17,7 @@ namespace UIKit {
 		///         <remarks>To be added.</remarks>
 		public void RegisterClassForDecorationView (Type viewType, NSString kind)
 		{
-			RegisterClassForDecorationView (viewType is null ? IntPtr.Zero : Class.GetHandle (viewType), kind);
+			RegisterClassForDecorationView (Class.GetHandle (viewType), kind);
 		}
 
 		/// <param name="section">To be added.</param>

--- a/src/UIKit/UINavigationController.cs
+++ b/src/UIKit/UINavigationController.cs
@@ -3,7 +3,7 @@ namespace UIKit {
 	public partial class UINavigationController {
 		static IntPtr LookupClass (Type t)
 		{
-			return t is null ? IntPtr.Zero : Class.GetHandle (t);
+			return Class.GetHandle (t);
 		}
 
 		/// <param name="navigationBarType">To be added.</param>

--- a/src/UIKit/UIPopoverController.cs
+++ b/src/UIKit/UIPopoverController.cs
@@ -17,8 +17,7 @@ namespace UIKit {
 				return Class.Lookup (p);
 			}
 			set {
-				PopoverBackgroundViewClass = (value is null) ? IntPtr.Zero :
-					Class.GetHandle (value);
+				PopoverBackgroundViewClass = Class.GetHandle (value);
 			}
 		}
 	}

--- a/src/UIKit/UIPopoverPresentationController.cs
+++ b/src/UIKit/UIPopoverPresentationController.cs
@@ -23,8 +23,7 @@ namespace UIKit {
 				return Class.Lookup (p);
 			}
 			set {
-				PopoverBackgroundViewClass = (value is null) ? IntPtr.Zero :
-					Class.GetHandle (value);
+				PopoverBackgroundViewClass = Class.GetHandle (value);
 			}
 		}
 	}

--- a/src/UIKit/UITableView.cs
+++ b/src/UIKit/UITableView.cs
@@ -37,7 +37,7 @@ namespace UIKit {
 		/// <include file="../../docs/api/UIKit/UITableView.xml" path="/Documentation/Docs[@DocId='M:UIKit.UITableView.RegisterClassForCellReuse(System.Type,Foundation.NSString)']/*" />
 		public void RegisterClassForCellReuse (Type cellType, NSString reuseIdentifier)
 		{
-			RegisterClassForCellReuse (cellType is null ? IntPtr.Zero : Class.GetHandle (cellType), reuseIdentifier);
+			RegisterClassForCellReuse (Class.GetHandle (cellType), reuseIdentifier);
 		}
 
 		/// <param name="cellType">To be added.</param>
@@ -47,7 +47,7 @@ namespace UIKit {
 		public void RegisterClassForCellReuse (Type cellType, string reuseIdentifier)
 		{
 			using (var str = (NSString) reuseIdentifier)
-				RegisterClassForCellReuse (cellType is null ? IntPtr.Zero : Class.GetHandle (cellType), str);
+				RegisterClassForCellReuse (Class.GetHandle (cellType), str);
 		}
 
 		/// <param name="cellType">To be added.</param>
@@ -57,13 +57,13 @@ namespace UIKit {
 		public void RegisterClassForHeaderFooterViewReuse (Type cellType, string reuseIdentifier)
 		{
 			using (var str = (NSString) reuseIdentifier)
-				RegisterClassForHeaderFooterViewReuse (cellType is null ? IntPtr.Zero : Class.GetHandle (cellType), str);
+				RegisterClassForHeaderFooterViewReuse (Class.GetHandle (cellType), str);
 		}
 
 		/// <include file="../../docs/api/UIKit/UITableView.xml" path="/Documentation/Docs[@DocId='M:UIKit.UITableView.RegisterClassForHeaderFooterViewReuse(System.Type,Foundation.NSString)']/*" />
 		public void RegisterClassForHeaderFooterViewReuse (Type cellType, NSString reuseIdentifier)
 		{
-			RegisterClassForHeaderFooterViewReuse (cellType is null ? IntPtr.Zero : Class.GetHandle (cellType), reuseIdentifier);
+			RegisterClassForHeaderFooterViewReuse (Class.GetHandle (cellType), reuseIdentifier);
 		}
 
 		// This is not obsolete, we provide both a (UINib,string) overload and a (UINib,NSString) overload.


### PR DESCRIPTION
`Class.GetHandle(Type?)` already handles null input by returning `NativeHandle.Zero`, making the `x is null ? IntPtr.Zero : Class.GetHandle(x)` ternary patterns unnecessary.