### PR TITLE
[UIKit] Enable nullability and clean up UIToolbar.

### DIFF
--- a/src/UIKit/UIToolbar.cs
+++ b/src/UIKit/UIToolbar.cs
@@ -2,8 +2,7 @@
 
 #if IOS
 
-// Disable until we get around to enable + fix any issues.
-#nullable disable
+#nullable enable
 
 namespace UIKit {
 
@@ -13,11 +12,13 @@ namespace UIKit {
 		// previously we 'lost' the managed reference to the array and this caused bug #410
 		// http://bugzilla.xamarin.com/show_bug.cgi?id=410
 
+		/// <summary>Sets the items on the toolbar, optionally animating the transition.</summary>
+		/// <param name="items">The array of <see cref="UIBarButtonItem" /> instances to display on the toolbar.</param>
+		/// <param name="animated">Whether to animate the transition to the new items.</param>
 		[Export ("setItems:animated:")]
 		public virtual void SetItems (UIBarButtonItem [] items, bool animated)
 		{
-			if (items is null)
-				throw new ArgumentNullException ("items");
+			ArgumentNullException.ThrowIfNull (items);
 
 			// must be identical the [get|set]_Items
 			var nsa_items = NSArray.FromNSObjects (items);


### PR DESCRIPTION
This is file 26 of 30 files with nullability disabled in UIKit.

* Enable nullability (#nullable enable).
* Use ArgumentNullException.ThrowIfNull() instead of manual null check.
* Add XML documentation comments for the SetItems method with 'see cref' references.

Contributes towards https://github.com/dotnet/macios/issues/17285.