### PR TITLE
[UIKit] Enable nullability and clean up UITraitCollection.

### DIFF
--- a/src/UIKit/UITraitCollection.cs
+++ b/src/UIKit/UITraitCollection.cs
@@ -9,16 +9,21 @@
 
 using System.ComponentModel;
 
-// Disable until we get around to enable + fix any issues.
-#nullable disable
+#nullable enable
 
 namespace UIKit {
 	public partial class UITraitCollection {
-		/// <summary>Static factory method to create a <see cref="UITraitCollection" /> with the specified <see cref="UIContentSizeCategory" />.</summary>
+		/// <summary>Creates a <see cref="UITraitCollection" /> with the specified <see cref="UIContentSizeCategory" />.</summary>
+		/// <param name="category">The preferred content size category for the trait collection.</param>
+		/// <returns>A new <see cref="UITraitCollection" /> configured with the specified content size category.</returns>
 		public static UITraitCollection Create (UIContentSizeCategory category)
-			=> FromPreferredContentSizeCategory (category.GetConstant ());
+			=> FromPreferredContentSizeCategory (category.GetConstant ()!);
 
 #if !XAMCORE_5_0
+		/// <summary>This method is obsolete and always throws <see cref="NotSupportedException" />.</summary>
+		/// <param name="mutations">Unused.</param>
+		/// <returns>This method never returns.</returns>
+		/// <exception cref="NotSupportedException">Always thrown. Use the overload that takes a <c>UITraitMutations</c> parameter instead.</exception>
 		[Obsolete ("Use the overload that takes a 'UITraitMutations' parameter instead.", false)]
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		[SupportedOSPlatform ("tvos17.0")]


### PR DESCRIPTION
This is file 27 of 30 files with nullability disabled in UIKit.

* Enable nullability (#nullable enable).
* Add null-forgiving operator on GetConstant() call for smart enum value.
* Improve XML documentation comments: add missing param/returns/exception docs, add 'see cref' references.

Contributes towards https://github.com/dotnet/macios/issues/17285.