### PR TITLE
[UIKit] Enable nullability and clean up UIViewControllerTransitionCoordinatorContext.

### DIFF
--- a/src/UIKit/UIViewControllerTransitionCoordinatorContext.cs
+++ b/src/UIKit/UIViewControllerTransitionCoordinatorContext.cs
@@ -6,17 +6,19 @@
 // Copyright 2014 Xamarin
 //
 
-// Disable until we get around to enable + fix any issues.
-#nullable disable
+#nullable enable
 
 namespace UIKit {
 	public static partial class UIViewControllerTransitionCoordinatorContext_Extensions {
-		/// <summary>Gets a view controller that controls a transition.</summary>
+		/// <summary>Gets the view associated with a transition.</summary>
+		/// <param name="This">The transition coordinator context.</param>
+		/// <param name="kind">The kind of transition view to retrieve.</param>
+		/// <returns>The transition <see cref="UIView" />, or <see langword="null" /> if <paramref name="kind" /> is not recognized.</returns>
 		[SupportedOSPlatform ("tvos")]
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[UnsupportedOSPlatform ("macos")]
-		public static UIView GetTransitionViewController (this IUIViewControllerTransitionCoordinatorContext This, UITransitionViewControllerKind kind)
+		public static UIView? GetTransitionViewController (this IUIViewControllerTransitionCoordinatorContext This, UITransitionViewControllerKind kind)
 		{
 			switch (kind) {
 			case UITransitionViewControllerKind.ToView:


### PR DESCRIPTION
This is file 30 of 30 files with nullability disabled in UIKit.

* Enable nullability (#nullable enable).
* Add nullable annotation to return type (UIView?) since the method can return null.
* Improve XML documentation comments: fix inaccurate summary, add missing param/returns docs, add 'see cref' and 'see langword' references.

Contributes towards https://github.com/dotnet/macios/issues/17285.