### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 14411: Build ID 13334765

### DIFF
--- a/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.cs.resx
+++ b/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.cs.resx
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ErrorMessageNotFound" xml:space="preserve">
+		<value>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/dotnet/macios/issues/new</value>
+		<comment>
+			This is the default message when an error code can not be found.
+		</comment>
+	</data>
+  <data name="SHARPIE0000" xml:space="preserve">
+		<value>An unexpected error occurred: {0}. Please fill a bug report at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0001" xml:space="preserve">
+		<value>Unsupported construct: {0}. Generated bindings may be incomplete. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0002" xml:space="preserve">
+		<value>The output directory must be specified.</value>
+	</data>
+  <data name="SHARPIE0003" xml:space="preserve">
+		<value>Failed to parse translation unit (error: {0}).</value>
+	</data>
+  <data name="SHARPIE0004" xml:space="preserve">
+		<value>Failed to create translation unit for unknown reasons. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0005" xml:space="preserve">
+		<value>Compilation failed with error: {0}</value>
+	</data>
+  <data name="SHARPIE0006" xml:space="preserve">
+		<value>Failed to compute platform assembly location for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0007" xml:space="preserve">
+		<value>Computed platform assembly path does not exist for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0008" xml:space="preserve">
+		<value>Failed to compute the toolchain path for the platform '{0}': {1}</value>
+	</data>
+  <data name="SHARPIE0009" xml:space="preserve">
+		<value>Failed to the SDK path ('xcrun --show-sdk-path' failed): {0}</value>
+	</data>
+  <data name="SHARPIE0010" xml:space="preserve">
+		<value>The path to clang's resource directory is required.</value>
+	</data>
+  <data name="SHARPIE0011" xml:space="preserve">
+		<value>The specified clang resource directory does not exist: {0}</value>
+	</data>
+  <data name="SHARPIE0012" xml:space="preserve">
+		<value>Could not find the clang resource directory, because it doesn't look like we're executing from inside a NuGet.</value>
+	</data>
+  <data name="SHARPIE0013" xml:space="preserve">
+		<value>Could not find the clang resource directory, because the directory {0} doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0014" xml:space="preserve">
+		<value>The framework '{0}' was specified in the excluded frameworks list but was not found in the SDK.</value>
+	</data>
+  <data name="SHARPIE0015" xml:space="preserve">
+		<value>Unknown argument: {0}</value>
+	</data>
+  <data name="SHARPIE0016" xml:space="preserve">
+		<value>Cannot specify both a source framework and a source file.</value>
+	</data>
+  <data name="SHARPIE0017" xml:space="preserve">
+		<value>The framework '{0}' doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0018" xml:space="preserve">
+		<value>The framework '{0}' does not have an umbrella header or module map.</value>
+	</data>
+  <data name="SHARPIE0099" xml:space="preserve">
+		<value>Internal error: {0}. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE1000" xml:space="preserve">
+		<value>A warning occurred during compilation: {0}</value>
+	</data>
+</root>

--- a/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.de.resx
+++ b/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.de.resx
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ErrorMessageNotFound" xml:space="preserve">
+		<value>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/dotnet/macios/issues/new</value>
+		<comment>
+			This is the default message when an error code can not be found.
+		</comment>
+	</data>
+  <data name="SHARPIE0000" xml:space="preserve">
+		<value>An unexpected error occurred: {0}. Please fill a bug report at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0001" xml:space="preserve">
+		<value>Unsupported construct: {0}. Generated bindings may be incomplete. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0002" xml:space="preserve">
+		<value>The output directory must be specified.</value>
+	</data>
+  <data name="SHARPIE0003" xml:space="preserve">
+		<value>Failed to parse translation unit (error: {0}).</value>
+	</data>
+  <data name="SHARPIE0004" xml:space="preserve">
+		<value>Failed to create translation unit for unknown reasons. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0005" xml:space="preserve">
+		<value>Compilation failed with error: {0}</value>
+	</data>
+  <data name="SHARPIE0006" xml:space="preserve">
+		<value>Failed to compute platform assembly location for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0007" xml:space="preserve">
+		<value>Computed platform assembly path does not exist for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0008" xml:space="preserve">
+		<value>Failed to compute the toolchain path for the platform '{0}': {1}</value>
+	</data>
+  <data name="SHARPIE0009" xml:space="preserve">
+		<value>Failed to the SDK path ('xcrun --show-sdk-path' failed): {0}</value>
+	</data>
+  <data name="SHARPIE0010" xml:space="preserve">
+		<value>The path to clang's resource directory is required.</value>
+	</data>
+  <data name="SHARPIE0011" xml:space="preserve">
+		<value>The specified clang resource directory does not exist: {0}</value>
+	</data>
+  <data name="SHARPIE0012" xml:space="preserve">
+		<value>Could not find the clang resource directory, because it doesn't look like we're executing from inside a NuGet.</value>
+	</data>
+  <data name="SHARPIE0013" xml:space="preserve">
+		<value>Could not find the clang resource directory, because the directory {0} doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0014" xml:space="preserve">
+		<value>The framework '{0}' was specified in the excluded frameworks list but was not found in the SDK.</value>
+	</data>
+  <data name="SHARPIE0015" xml:space="preserve">
+		<value>Unknown argument: {0}</value>
+	</data>
+  <data name="SHARPIE0016" xml:space="preserve">
+		<value>Cannot specify both a source framework and a source file.</value>
+	</data>
+  <data name="SHARPIE0017" xml:space="preserve">
+		<value>The framework '{0}' doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0018" xml:space="preserve">
+		<value>The framework '{0}' does not have an umbrella header or module map.</value>
+	</data>
+  <data name="SHARPIE0099" xml:space="preserve">
+		<value>Internal error: {0}. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE1000" xml:space="preserve">
+		<value>A warning occurred during compilation: {0}</value>
+	</data>
+</root>

--- a/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.es.resx
+++ b/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.es.resx
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ErrorMessageNotFound" xml:space="preserve">
+		<value>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/dotnet/macios/issues/new</value>
+		<comment>
+			This is the default message when an error code can not be found.
+		</comment>
+	</data>
+  <data name="SHARPIE0000" xml:space="preserve">
+		<value>An unexpected error occurred: {0}. Please fill a bug report at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0001" xml:space="preserve">
+		<value>Unsupported construct: {0}. Generated bindings may be incomplete. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0002" xml:space="preserve">
+		<value>The output directory must be specified.</value>
+	</data>
+  <data name="SHARPIE0003" xml:space="preserve">
+		<value>Failed to parse translation unit (error: {0}).</value>
+	</data>
+  <data name="SHARPIE0004" xml:space="preserve">
+		<value>Failed to create translation unit for unknown reasons. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0005" xml:space="preserve">
+		<value>Compilation failed with error: {0}</value>
+	</data>
+  <data name="SHARPIE0006" xml:space="preserve">
+		<value>Failed to compute platform assembly location for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0007" xml:space="preserve">
+		<value>Computed platform assembly path does not exist for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0008" xml:space="preserve">
+		<value>Failed to compute the toolchain path for the platform '{0}': {1}</value>
+	</data>
+  <data name="SHARPIE0009" xml:space="preserve">
+		<value>Failed to the SDK path ('xcrun --show-sdk-path' failed): {0}</value>
+	</data>
+  <data name="SHARPIE0010" xml:space="preserve">
+		<value>The path to clang's resource directory is required.</value>
+	</data>
+  <data name="SHARPIE0011" xml:space="preserve">
+		<value>The specified clang resource directory does not exist: {0}</value>
+	</data>
+  <data name="SHARPIE0012" xml:space="preserve">
+		<value>Could not find the clang resource directory, because it doesn't look like we're executing from inside a NuGet.</value>
+	</data>
+  <data name="SHARPIE0013" xml:space="preserve">
+		<value>Could not find the clang resource directory, because the directory {0} doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0014" xml:space="preserve">
+		<value>The framework '{0}' was specified in the excluded frameworks list but was not found in the SDK.</value>
+	</data>
+  <data name="SHARPIE0015" xml:space="preserve">
+		<value>Unknown argument: {0}</value>
+	</data>
+  <data name="SHARPIE0016" xml:space="preserve">
+		<value>Cannot specify both a source framework and a source file.</value>
+	</data>
+  <data name="SHARPIE0017" xml:space="preserve">
+		<value>The framework '{0}' doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0018" xml:space="preserve">
+		<value>The framework '{0}' does not have an umbrella header or module map.</value>
+	</data>
+  <data name="SHARPIE0099" xml:space="preserve">
+		<value>Internal error: {0}. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE1000" xml:space="preserve">
+		<value>A warning occurred during compilation: {0}</value>
+	</data>
+</root>

--- a/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.fr.resx
+++ b/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.fr.resx
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ErrorMessageNotFound" xml:space="preserve">
+		<value>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/dotnet/macios/issues/new</value>
+		<comment>
+			This is the default message when an error code can not be found.
+		</comment>
+	</data>
+  <data name="SHARPIE0000" xml:space="preserve">
+		<value>An unexpected error occurred: {0}. Please fill a bug report at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0001" xml:space="preserve">
+		<value>Unsupported construct: {0}. Generated bindings may be incomplete. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0002" xml:space="preserve">
+		<value>The output directory must be specified.</value>
+	</data>
+  <data name="SHARPIE0003" xml:space="preserve">
+		<value>Failed to parse translation unit (error: {0}).</value>
+	</data>
+  <data name="SHARPIE0004" xml:space="preserve">
+		<value>Failed to create translation unit for unknown reasons. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0005" xml:space="preserve">
+		<value>Compilation failed with error: {0}</value>
+	</data>
+  <data name="SHARPIE0006" xml:space="preserve">
+		<value>Failed to compute platform assembly location for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0007" xml:space="preserve">
+		<value>Computed platform assembly path does not exist for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0008" xml:space="preserve">
+		<value>Failed to compute the toolchain path for the platform '{0}': {1}</value>
+	</data>
+  <data name="SHARPIE0009" xml:space="preserve">
+		<value>Failed to the SDK path ('xcrun --show-sdk-path' failed): {0}</value>
+	</data>
+  <data name="SHARPIE0010" xml:space="preserve">
+		<value>The path to clang's resource directory is required.</value>
+	</data>
+  <data name="SHARPIE0011" xml:space="preserve">
+		<value>The specified clang resource directory does not exist: {0}</value>
+	</data>
+  <data name="SHARPIE0012" xml:space="preserve">
+		<value>Could not find the clang resource directory, because it doesn't look like we're executing from inside a NuGet.</value>
+	</data>
+  <data name="SHARPIE0013" xml:space="preserve">
+		<value>Could not find the clang resource directory, because the directory {0} doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0014" xml:space="preserve">
+		<value>The framework '{0}' was specified in the excluded frameworks list but was not found in the SDK.</value>
+	</data>
+  <data name="SHARPIE0015" xml:space="preserve">
+		<value>Unknown argument: {0}</value>
+	</data>
+  <data name="SHARPIE0016" xml:space="preserve">
+		<value>Cannot specify both a source framework and a source file.</value>
+	</data>
+  <data name="SHARPIE0017" xml:space="preserve">
+		<value>The framework '{0}' doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0018" xml:space="preserve">
+		<value>The framework '{0}' does not have an umbrella header or module map.</value>
+	</data>
+  <data name="SHARPIE0099" xml:space="preserve">
+		<value>Internal error: {0}. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE1000" xml:space="preserve">
+		<value>A warning occurred during compilation: {0}</value>
+	</data>
+</root>

--- a/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.it.resx
+++ b/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.it.resx
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ErrorMessageNotFound" xml:space="preserve">
+		<value>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/dotnet/macios/issues/new</value>
+		<comment>
+			This is the default message when an error code can not be found.
+		</comment>
+	</data>
+  <data name="SHARPIE0000" xml:space="preserve">
+		<value>An unexpected error occurred: {0}. Please fill a bug report at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0001" xml:space="preserve">
+		<value>Unsupported construct: {0}. Generated bindings may be incomplete. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0002" xml:space="preserve">
+		<value>The output directory must be specified.</value>
+	</data>
+  <data name="SHARPIE0003" xml:space="preserve">
+		<value>Failed to parse translation unit (error: {0}).</value>
+	</data>
+  <data name="SHARPIE0004" xml:space="preserve">
+		<value>Failed to create translation unit for unknown reasons. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0005" xml:space="preserve">
+		<value>Compilation failed with error: {0}</value>
+	</data>
+  <data name="SHARPIE0006" xml:space="preserve">
+		<value>Failed to compute platform assembly location for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0007" xml:space="preserve">
+		<value>Computed platform assembly path does not exist for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0008" xml:space="preserve">
+		<value>Failed to compute the toolchain path for the platform '{0}': {1}</value>
+	</data>
+  <data name="SHARPIE0009" xml:space="preserve">
+		<value>Failed to the SDK path ('xcrun --show-sdk-path' failed): {0}</value>
+	</data>
+  <data name="SHARPIE0010" xml:space="preserve">
+		<value>The path to clang's resource directory is required.</value>
+	</data>
+  <data name="SHARPIE0011" xml:space="preserve">
+		<value>The specified clang resource directory does not exist: {0}</value>
+	</data>
+  <data name="SHARPIE0012" xml:space="preserve">
+		<value>Could not find the clang resource directory, because it doesn't look like we're executing from inside a NuGet.</value>
+	</data>
+  <data name="SHARPIE0013" xml:space="preserve">
+		<value>Could not find the clang resource directory, because the directory {0} doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0014" xml:space="preserve">
+		<value>The framework '{0}' was specified in the excluded frameworks list but was not found in the SDK.</value>
+	</data>
+  <data name="SHARPIE0015" xml:space="preserve">
+		<value>Unknown argument: {0}</value>
+	</data>
+  <data name="SHARPIE0016" xml:space="preserve">
+		<value>Cannot specify both a source framework and a source file.</value>
+	</data>
+  <data name="SHARPIE0017" xml:space="preserve">
+		<value>The framework '{0}' doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0018" xml:space="preserve">
+		<value>The framework '{0}' does not have an umbrella header or module map.</value>
+	</data>
+  <data name="SHARPIE0099" xml:space="preserve">
+		<value>Internal error: {0}. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE1000" xml:space="preserve">
+		<value>A warning occurred during compilation: {0}</value>
+	</data>
+</root>

--- a/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.ja.resx
+++ b/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.ja.resx
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ErrorMessageNotFound" xml:space="preserve">
+		<value>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/dotnet/macios/issues/new</value>
+		<comment>
+			This is the default message when an error code can not be found.
+		</comment>
+	</data>
+  <data name="SHARPIE0000" xml:space="preserve">
+		<value>An unexpected error occurred: {0}. Please fill a bug report at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0001" xml:space="preserve">
+		<value>Unsupported construct: {0}. Generated bindings may be incomplete. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0002" xml:space="preserve">
+		<value>The output directory must be specified.</value>
+	</data>
+  <data name="SHARPIE0003" xml:space="preserve">
+		<value>Failed to parse translation unit (error: {0}).</value>
+	</data>
+  <data name="SHARPIE0004" xml:space="preserve">
+		<value>Failed to create translation unit for unknown reasons. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0005" xml:space="preserve">
+		<value>Compilation failed with error: {0}</value>
+	</data>
+  <data name="SHARPIE0006" xml:space="preserve">
+		<value>Failed to compute platform assembly location for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0007" xml:space="preserve">
+		<value>Computed platform assembly path does not exist for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0008" xml:space="preserve">
+		<value>Failed to compute the toolchain path for the platform '{0}': {1}</value>
+	</data>
+  <data name="SHARPIE0009" xml:space="preserve">
+		<value>Failed to the SDK path ('xcrun --show-sdk-path' failed): {0}</value>
+	</data>
+  <data name="SHARPIE0010" xml:space="preserve">
+		<value>The path to clang's resource directory is required.</value>
+	</data>
+  <data name="SHARPIE0011" xml:space="preserve">
+		<value>The specified clang resource directory does not exist: {0}</value>
+	</data>
+  <data name="SHARPIE0012" xml:space="preserve">
+		<value>Could not find the clang resource directory, because it doesn't look like we're executing from inside a NuGet.</value>
+	</data>
+  <data name="SHARPIE0013" xml:space="preserve">
+		<value>Could not find the clang resource directory, because the directory {0} doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0014" xml:space="preserve">
+		<value>The framework '{0}' was specified in the excluded frameworks list but was not found in the SDK.</value>
+	</data>
+  <data name="SHARPIE0015" xml:space="preserve">
+		<value>Unknown argument: {0}</value>
+	</data>
+  <data name="SHARPIE0016" xml:space="preserve">
+		<value>Cannot specify both a source framework and a source file.</value>
+	</data>
+  <data name="SHARPIE0017" xml:space="preserve">
+		<value>The framework '{0}' doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0018" xml:space="preserve">
+		<value>The framework '{0}' does not have an umbrella header or module map.</value>
+	</data>
+  <data name="SHARPIE0099" xml:space="preserve">
+		<value>Internal error: {0}. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE1000" xml:space="preserve">
+		<value>A warning occurred during compilation: {0}</value>
+	</data>
+</root>

--- a/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.ko.resx
+++ b/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.ko.resx
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ErrorMessageNotFound" xml:space="preserve">
+		<value>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/dotnet/macios/issues/new</value>
+		<comment>
+			This is the default message when an error code can not be found.
+		</comment>
+	</data>
+  <data name="SHARPIE0000" xml:space="preserve">
+		<value>An unexpected error occurred: {0}. Please fill a bug report at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0001" xml:space="preserve">
+		<value>Unsupported construct: {0}. Generated bindings may be incomplete. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0002" xml:space="preserve">
+		<value>The output directory must be specified.</value>
+	</data>
+  <data name="SHARPIE0003" xml:space="preserve">
+		<value>Failed to parse translation unit (error: {0}).</value>
+	</data>
+  <data name="SHARPIE0004" xml:space="preserve">
+		<value>Failed to create translation unit for unknown reasons. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0005" xml:space="preserve">
+		<value>Compilation failed with error: {0}</value>
+	</data>
+  <data name="SHARPIE0006" xml:space="preserve">
+		<value>Failed to compute platform assembly location for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0007" xml:space="preserve">
+		<value>Computed platform assembly path does not exist for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0008" xml:space="preserve">
+		<value>Failed to compute the toolchain path for the platform '{0}': {1}</value>
+	</data>
+  <data name="SHARPIE0009" xml:space="preserve">
+		<value>Failed to the SDK path ('xcrun --show-sdk-path' failed): {0}</value>
+	</data>
+  <data name="SHARPIE0010" xml:space="preserve">
+		<value>The path to clang's resource directory is required.</value>
+	</data>
+  <data name="SHARPIE0011" xml:space="preserve">
+		<value>The specified clang resource directory does not exist: {0}</value>
+	</data>
+  <data name="SHARPIE0012" xml:space="preserve">
+		<value>Could not find the clang resource directory, because it doesn't look like we're executing from inside a NuGet.</value>
+	</data>
+  <data name="SHARPIE0013" xml:space="preserve">
+		<value>Could not find the clang resource directory, because the directory {0} doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0014" xml:space="preserve">
+		<value>The framework '{0}' was specified in the excluded frameworks list but was not found in the SDK.</value>
+	</data>
+  <data name="SHARPIE0015" xml:space="preserve">
+		<value>Unknown argument: {0}</value>
+	</data>
+  <data name="SHARPIE0016" xml:space="preserve">
+		<value>Cannot specify both a source framework and a source file.</value>
+	</data>
+  <data name="SHARPIE0017" xml:space="preserve">
+		<value>The framework '{0}' doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0018" xml:space="preserve">
+		<value>The framework '{0}' does not have an umbrella header or module map.</value>
+	</data>
+  <data name="SHARPIE0099" xml:space="preserve">
+		<value>Internal error: {0}. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE1000" xml:space="preserve">
+		<value>A warning occurred during compilation: {0}</value>
+	</data>
+</root>

--- a/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.pl.resx
+++ b/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.pl.resx
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ErrorMessageNotFound" xml:space="preserve">
+		<value>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/dotnet/macios/issues/new</value>
+		<comment>
+			This is the default message when an error code can not be found.
+		</comment>
+	</data>
+  <data name="SHARPIE0000" xml:space="preserve">
+		<value>An unexpected error occurred: {0}. Please fill a bug report at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0001" xml:space="preserve">
+		<value>Unsupported construct: {0}. Generated bindings may be incomplete. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0002" xml:space="preserve">
+		<value>The output directory must be specified.</value>
+	</data>
+  <data name="SHARPIE0003" xml:space="preserve">
+		<value>Failed to parse translation unit (error: {0}).</value>
+	</data>
+  <data name="SHARPIE0004" xml:space="preserve">
+		<value>Failed to create translation unit for unknown reasons. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0005" xml:space="preserve">
+		<value>Compilation failed with error: {0}</value>
+	</data>
+  <data name="SHARPIE0006" xml:space="preserve">
+		<value>Failed to compute platform assembly location for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0007" xml:space="preserve">
+		<value>Computed platform assembly path does not exist for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0008" xml:space="preserve">
+		<value>Failed to compute the toolchain path for the platform '{0}': {1}</value>
+	</data>
+  <data name="SHARPIE0009" xml:space="preserve">
+		<value>Failed to the SDK path ('xcrun --show-sdk-path' failed): {0}</value>
+	</data>
+  <data name="SHARPIE0010" xml:space="preserve">
+		<value>The path to clang's resource directory is required.</value>
+	</data>
+  <data name="SHARPIE0011" xml:space="preserve">
+		<value>The specified clang resource directory does not exist: {0}</value>
+	</data>
+  <data name="SHARPIE0012" xml:space="preserve">
+		<value>Could not find the clang resource directory, because it doesn't look like we're executing from inside a NuGet.</value>
+	</data>
+  <data name="SHARPIE0013" xml:space="preserve">
+		<value>Could not find the clang resource directory, because the directory {0} doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0014" xml:space="preserve">
+		<value>The framework '{0}' was specified in the excluded frameworks list but was not found in the SDK.</value>
+	</data>
+  <data name="SHARPIE0015" xml:space="preserve">
+		<value>Unknown argument: {0}</value>
+	</data>
+  <data name="SHARPIE0016" xml:space="preserve">
+		<value>Cannot specify both a source framework and a source file.</value>
+	</data>
+  <data name="SHARPIE0017" xml:space="preserve">
+		<value>The framework '{0}' doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0018" xml:space="preserve">
+		<value>The framework '{0}' does not have an umbrella header or module map.</value>
+	</data>
+  <data name="SHARPIE0099" xml:space="preserve">
+		<value>Internal error: {0}. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE1000" xml:space="preserve">
+		<value>A warning occurred during compilation: {0}</value>
+	</data>
+</root>

--- a/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.pt-BR.resx
+++ b/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.pt-BR.resx
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ErrorMessageNotFound" xml:space="preserve">
+		<value>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/dotnet/macios/issues/new</value>
+		<comment>
+			This is the default message when an error code can not be found.
+		</comment>
+	</data>
+  <data name="SHARPIE0000" xml:space="preserve">
+		<value>An unexpected error occurred: {0}. Please fill a bug report at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0001" xml:space="preserve">
+		<value>Unsupported construct: {0}. Generated bindings may be incomplete. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0002" xml:space="preserve">
+		<value>The output directory must be specified.</value>
+	</data>
+  <data name="SHARPIE0003" xml:space="preserve">
+		<value>Failed to parse translation unit (error: {0}).</value>
+	</data>
+  <data name="SHARPIE0004" xml:space="preserve">
+		<value>Failed to create translation unit for unknown reasons. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0005" xml:space="preserve">
+		<value>Compilation failed with error: {0}</value>
+	</data>
+  <data name="SHARPIE0006" xml:space="preserve">
+		<value>Failed to compute platform assembly location for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0007" xml:space="preserve">
+		<value>Computed platform assembly path does not exist for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0008" xml:space="preserve">
+		<value>Failed to compute the toolchain path for the platform '{0}': {1}</value>
+	</data>
+  <data name="SHARPIE0009" xml:space="preserve">
+		<value>Failed to the SDK path ('xcrun --show-sdk-path' failed): {0}</value>
+	</data>
+  <data name="SHARPIE0010" xml:space="preserve">
+		<value>The path to clang's resource directory is required.</value>
+	</data>
+  <data name="SHARPIE0011" xml:space="preserve">
+		<value>The specified clang resource directory does not exist: {0}</value>
+	</data>
+  <data name="SHARPIE0012" xml:space="preserve">
+		<value>Could not find the clang resource directory, because it doesn't look like we're executing from inside a NuGet.</value>
+	</data>
+  <data name="SHARPIE0013" xml:space="preserve">
+		<value>Could not find the clang resource directory, because the directory {0} doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0014" xml:space="preserve">
+		<value>The framework '{0}' was specified in the excluded frameworks list but was not found in the SDK.</value>
+	</data>
+  <data name="SHARPIE0015" xml:space="preserve">
+		<value>Unknown argument: {0}</value>
+	</data>
+  <data name="SHARPIE0016" xml:space="preserve">
+		<value>Cannot specify both a source framework and a source file.</value>
+	</data>
+  <data name="SHARPIE0017" xml:space="preserve">
+		<value>The framework '{0}' doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0018" xml:space="preserve">
+		<value>The framework '{0}' does not have an umbrella header or module map.</value>
+	</data>
+  <data name="SHARPIE0099" xml:space="preserve">
+		<value>Internal error: {0}. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE1000" xml:space="preserve">
+		<value>A warning occurred during compilation: {0}</value>
+	</data>
+</root>

--- a/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.ru.resx
+++ b/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.ru.resx
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ErrorMessageNotFound" xml:space="preserve">
+		<value>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/dotnet/macios/issues/new</value>
+		<comment>
+			This is the default message when an error code can not be found.
+		</comment>
+	</data>
+  <data name="SHARPIE0000" xml:space="preserve">
+		<value>An unexpected error occurred: {0}. Please fill a bug report at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0001" xml:space="preserve">
+		<value>Unsupported construct: {0}. Generated bindings may be incomplete. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0002" xml:space="preserve">
+		<value>The output directory must be specified.</value>
+	</data>
+  <data name="SHARPIE0003" xml:space="preserve">
+		<value>Failed to parse translation unit (error: {0}).</value>
+	</data>
+  <data name="SHARPIE0004" xml:space="preserve">
+		<value>Failed to create translation unit for unknown reasons. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0005" xml:space="preserve">
+		<value>Compilation failed with error: {0}</value>
+	</data>
+  <data name="SHARPIE0006" xml:space="preserve">
+		<value>Failed to compute platform assembly location for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0007" xml:space="preserve">
+		<value>Computed platform assembly path does not exist for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0008" xml:space="preserve">
+		<value>Failed to compute the toolchain path for the platform '{0}': {1}</value>
+	</data>
+  <data name="SHARPIE0009" xml:space="preserve">
+		<value>Failed to the SDK path ('xcrun --show-sdk-path' failed): {0}</value>
+	</data>
+  <data name="SHARPIE0010" xml:space="preserve">
+		<value>The path to clang's resource directory is required.</value>
+	</data>
+  <data name="SHARPIE0011" xml:space="preserve">
+		<value>The specified clang resource directory does not exist: {0}</value>
+	</data>
+  <data name="SHARPIE0012" xml:space="preserve">
+		<value>Could not find the clang resource directory, because it doesn't look like we're executing from inside a NuGet.</value>
+	</data>
+  <data name="SHARPIE0013" xml:space="preserve">
+		<value>Could not find the clang resource directory, because the directory {0} doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0014" xml:space="preserve">
+		<value>The framework '{0}' was specified in the excluded frameworks list but was not found in the SDK.</value>
+	</data>
+  <data name="SHARPIE0015" xml:space="preserve">
+		<value>Unknown argument: {0}</value>
+	</data>
+  <data name="SHARPIE0016" xml:space="preserve">
+		<value>Cannot specify both a source framework and a source file.</value>
+	</data>
+  <data name="SHARPIE0017" xml:space="preserve">
+		<value>The framework '{0}' doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0018" xml:space="preserve">
+		<value>The framework '{0}' does not have an umbrella header or module map.</value>
+	</data>
+  <data name="SHARPIE0099" xml:space="preserve">
+		<value>Internal error: {0}. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE1000" xml:space="preserve">
+		<value>A warning occurred during compilation: {0}</value>
+	</data>
+</root>

--- a/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.tr.resx
+++ b/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.tr.resx
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ErrorMessageNotFound" xml:space="preserve">
+		<value>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/dotnet/macios/issues/new</value>
+		<comment>
+			This is the default message when an error code can not be found.
+		</comment>
+	</data>
+  <data name="SHARPIE0000" xml:space="preserve">
+		<value>An unexpected error occurred: {0}. Please fill a bug report at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0001" xml:space="preserve">
+		<value>Unsupported construct: {0}. Generated bindings may be incomplete. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0002" xml:space="preserve">
+		<value>The output directory must be specified.</value>
+	</data>
+  <data name="SHARPIE0003" xml:space="preserve">
+		<value>Failed to parse translation unit (error: {0}).</value>
+	</data>
+  <data name="SHARPIE0004" xml:space="preserve">
+		<value>Failed to create translation unit for unknown reasons. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0005" xml:space="preserve">
+		<value>Compilation failed with error: {0}</value>
+	</data>
+  <data name="SHARPIE0006" xml:space="preserve">
+		<value>Failed to compute platform assembly location for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0007" xml:space="preserve">
+		<value>Computed platform assembly path does not exist for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0008" xml:space="preserve">
+		<value>Failed to compute the toolchain path for the platform '{0}': {1}</value>
+	</data>
+  <data name="SHARPIE0009" xml:space="preserve">
+		<value>Failed to the SDK path ('xcrun --show-sdk-path' failed): {0}</value>
+	</data>
+  <data name="SHARPIE0010" xml:space="preserve">
+		<value>The path to clang's resource directory is required.</value>
+	</data>
+  <data name="SHARPIE0011" xml:space="preserve">
+		<value>The specified clang resource directory does not exist: {0}</value>
+	</data>
+  <data name="SHARPIE0012" xml:space="preserve">
+		<value>Could not find the clang resource directory, because it doesn't look like we're executing from inside a NuGet.</value>
+	</data>
+  <data name="SHARPIE0013" xml:space="preserve">
+		<value>Could not find the clang resource directory, because the directory {0} doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0014" xml:space="preserve">
+		<value>The framework '{0}' was specified in the excluded frameworks list but was not found in the SDK.</value>
+	</data>
+  <data name="SHARPIE0015" xml:space="preserve">
+		<value>Unknown argument: {0}</value>
+	</data>
+  <data name="SHARPIE0016" xml:space="preserve">
+		<value>Cannot specify both a source framework and a source file.</value>
+	</data>
+  <data name="SHARPIE0017" xml:space="preserve">
+		<value>The framework '{0}' doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0018" xml:space="preserve">
+		<value>The framework '{0}' does not have an umbrella header or module map.</value>
+	</data>
+  <data name="SHARPIE0099" xml:space="preserve">
+		<value>Internal error: {0}. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE1000" xml:space="preserve">
+		<value>A warning occurred during compilation: {0}</value>
+	</data>
+</root>

--- a/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.zh-Hans.resx
+++ b/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.zh-Hans.resx
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ErrorMessageNotFound" xml:space="preserve">
+		<value>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/dotnet/macios/issues/new</value>
+		<comment>
+			This is the default message when an error code can not be found.
+		</comment>
+	</data>
+  <data name="SHARPIE0000" xml:space="preserve">
+		<value>An unexpected error occurred: {0}. Please fill a bug report at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0001" xml:space="preserve">
+		<value>Unsupported construct: {0}. Generated bindings may be incomplete. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0002" xml:space="preserve">
+		<value>The output directory must be specified.</value>
+	</data>
+  <data name="SHARPIE0003" xml:space="preserve">
+		<value>Failed to parse translation unit (error: {0}).</value>
+	</data>
+  <data name="SHARPIE0004" xml:space="preserve">
+		<value>Failed to create translation unit for unknown reasons. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0005" xml:space="preserve">
+		<value>Compilation failed with error: {0}</value>
+	</data>
+  <data name="SHARPIE0006" xml:space="preserve">
+		<value>Failed to compute platform assembly location for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0007" xml:space="preserve">
+		<value>Computed platform assembly path does not exist for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0008" xml:space="preserve">
+		<value>Failed to compute the toolchain path for the platform '{0}': {1}</value>
+	</data>
+  <data name="SHARPIE0009" xml:space="preserve">
+		<value>Failed to the SDK path ('xcrun --show-sdk-path' failed): {0}</value>
+	</data>
+  <data name="SHARPIE0010" xml:space="preserve">
+		<value>The path to clang's resource directory is required.</value>
+	</data>
+  <data name="SHARPIE0011" xml:space="preserve">
+		<value>The specified clang resource directory does not exist: {0}</value>
+	</data>
+  <data name="SHARPIE0012" xml:space="preserve">
+		<value>Could not find the clang resource directory, because it doesn't look like we're executing from inside a NuGet.</value>
+	</data>
+  <data name="SHARPIE0013" xml:space="preserve">
+		<value>Could not find the clang resource directory, because the directory {0} doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0014" xml:space="preserve">
+		<value>The framework '{0}' was specified in the excluded frameworks list but was not found in the SDK.</value>
+	</data>
+  <data name="SHARPIE0015" xml:space="preserve">
+		<value>Unknown argument: {0}</value>
+	</data>
+  <data name="SHARPIE0016" xml:space="preserve">
+		<value>Cannot specify both a source framework and a source file.</value>
+	</data>
+  <data name="SHARPIE0017" xml:space="preserve">
+		<value>The framework '{0}' doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0018" xml:space="preserve">
+		<value>The framework '{0}' does not have an umbrella header or module map.</value>
+	</data>
+  <data name="SHARPIE0099" xml:space="preserve">
+		<value>Internal error: {0}. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE1000" xml:space="preserve">
+		<value>A warning occurred during compilation: {0}</value>
+	</data>
+</root>

--- a/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.zh-Hant.resx
+++ b/macios/tools/sharpie/Sharpie.Bind/TranslatedAssemblies/Resources.zh-Hant.resx
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ErrorMessageNotFound" xml:space="preserve">
+		<value>The error message for code {0} could not be found. Please report this missing message on GitHub at https://github.com/dotnet/macios/issues/new</value>
+		<comment>
+			This is the default message when an error code can not be found.
+		</comment>
+	</data>
+  <data name="SHARPIE0000" xml:space="preserve">
+		<value>An unexpected error occurred: {0}. Please fill a bug report at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0001" xml:space="preserve">
+		<value>Unsupported construct: {0}. Generated bindings may be incomplete. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0002" xml:space="preserve">
+		<value>The output directory must be specified.</value>
+	</data>
+  <data name="SHARPIE0003" xml:space="preserve">
+		<value>Failed to parse translation unit (error: {0}).</value>
+	</data>
+  <data name="SHARPIE0004" xml:space="preserve">
+		<value>Failed to create translation unit for unknown reasons. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE0005" xml:space="preserve">
+		<value>Compilation failed with error: {0}</value>
+	</data>
+  <data name="SHARPIE0006" xml:space="preserve">
+		<value>Failed to compute platform assembly location for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0007" xml:space="preserve">
+		<value>Computed platform assembly path does not exist for the platform {0}: {1}</value>
+	</data>
+  <data name="SHARPIE0008" xml:space="preserve">
+		<value>Failed to compute the toolchain path for the platform '{0}': {1}</value>
+	</data>
+  <data name="SHARPIE0009" xml:space="preserve">
+		<value>Failed to the SDK path ('xcrun --show-sdk-path' failed): {0}</value>
+	</data>
+  <data name="SHARPIE0010" xml:space="preserve">
+		<value>The path to clang's resource directory is required.</value>
+	</data>
+  <data name="SHARPIE0011" xml:space="preserve">
+		<value>The specified clang resource directory does not exist: {0}</value>
+	</data>
+  <data name="SHARPIE0012" xml:space="preserve">
+		<value>Could not find the clang resource directory, because it doesn't look like we're executing from inside a NuGet.</value>
+	</data>
+  <data name="SHARPIE0013" xml:space="preserve">
+		<value>Could not find the clang resource directory, because the directory {0} doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0014" xml:space="preserve">
+		<value>The framework '{0}' was specified in the excluded frameworks list but was not found in the SDK.</value>
+	</data>
+  <data name="SHARPIE0015" xml:space="preserve">
+		<value>Unknown argument: {0}</value>
+	</data>
+  <data name="SHARPIE0016" xml:space="preserve">
+		<value>Cannot specify both a source framework and a source file.</value>
+	</data>
+  <data name="SHARPIE0017" xml:space="preserve">
+		<value>The framework '{0}' doesn't exist.</value>
+	</data>
+  <data name="SHARPIE0018" xml:space="preserve">
+		<value>The framework '{0}' does not have an umbrella header or module map.</value>
+	</data>
+  <data name="SHARPIE0099" xml:space="preserve">
+		<value>Internal error: {0}. Please file an issue at https://github.com/dotnet/macios/issues.</value>
+	</data>
+  <data name="SHARPIE1000" xml:space="preserve">
+		<value>A warning occurred during compilation: {0}</value>
+	</data>
+</root>


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.