### PR TITLE
[net11.0] Cache R2R image when only user assemblies are changed

### DIFF
--- a/dotnet/targets/Microsoft.Sdk.R2R.targets
+++ b/dotnet/targets/Microsoft.Sdk.R2R.targets
@@ -94,6 +94,25 @@
 		</_CreateR2RFrameworkDependsOn>
 	</PropertyGroup>
 
+	<Target Name="_FilterR2RCompositeInputs"
+			Condition="'$(FilterReadyToRunAssemblies)' == 'true'"
+			AfterTargets="_PrepareForReadyToRunCompilation"
+			BeforeTargets="_CreateR2RImages">
+
+		<PropertyGroup>
+			<_UserAssemblyFilenames>;@(_UserAssemblies->'%(Filename)', ';');</_UserAssemblyFilenames>
+		</PropertyGroup>
+		
+		<!-- TODO: Disable CreateR2RFramework and CreateR2RDylib -->
+		<ItemGroup>
+			<_ChangedNonUserTrimmedDlls Include="@(_ChangedTrimmedDlls)"
+				Condition="!$(_UserAssemblyFilenames.Contains(';%(Filename);'))" />
+		</ItemGroup>
+
+		<Touch Files="@(_ReadyToRunCompileList->'%(OutputR2RImage)')"
+			Condition="@(_ChangedTrimmedDlls->Count()) > 0 And @(_ChangedNonUserTrimmedDlls->Count()) == 0 And @(_ReadyToRunCompileList->Count()) > 0" />
+	</Target>
+
 	<!-- Prepare properties and item groups for r2r framework creation -->
 	<Target Name="_PrepareR2RFrameworkCreation"
 			DependsOnTargets="CreateReadyToRunImages"

--- a/dotnet/targets/Microsoft.Sdk.R2R.targets
+++ b/dotnet/targets/Microsoft.Sdk.R2R.targets
@@ -76,6 +76,33 @@
 			<_UserAssemblies Include="@(_ResolvedAssembliesToPublish)" Exclude="@(_NonUserAssemblies)" />
 			<PublishReadyToRunExcludeTest Include="@(_UserAssemblies -> '%(Filename)')" />
 		</ItemGroup>
+
+		<!-- Hash the R2R input assemblies so we can detect when the set actually changes -->
+		<Hash ItemsToHash="@(_NonUserAssemblies)" IgnoreCase="false">
+			<Output TaskParameter="HashResult" PropertyName="_R2RInputHash" />
+		</Hash>
+
+		<PropertyGroup>
+			<_R2RInputHashFile>$(IntermediateOutputPath)r2r-input.hash</_R2RInputHashFile>
+		</PropertyGroup>
+		<!-- Create trigger file before writing hash, so we can compare timestamps -->
+		<Touch Files="$(_R2RInputHashFile).trigger" AlwaysCreate="true" />
+
+		<WriteLinesToFile Lines="$(_R2RInputHash)" File="$(_R2RInputHashFile)" Overwrite="true" WriteOnlyWhenDifferent="true" />
+
+		<ItemGroup>
+			<FileWrites Include="$(_R2RInputHashFile)" />
+			<FileWrites Include="$(_R2RInputHashFile).trigger" />
+		</ItemGroup>
+	</Target>
+
+	<!-- Touch R2R outputs when only user assemblies changed. If hash file is older than trigger, hash didn't change, so touch outputs to skip R2R -->
+	<Target Name="_TouchR2ROutputs"
+			Condition="'$(FilterReadyToRunAssemblies)' == 'true' And Exists('$(_R2RInputHashFile)') And Exists('$(_R2RInputHashFile).trigger') And $([System.IO.File]::GetLastWriteTime('$(_R2RInputHashFile)').Ticks) &lt; $([System.IO.File]::GetLastWriteTime('$(_R2RInputHashFile).trigger').Ticks)"
+			AfterTargets="_PrepareForReadyToRunCompilation"
+			BeforeTargets="_CreateR2RImages">
+		<Touch Files="%(_ReadyToRunCompileList.OutputR2RImage)"
+			Condition="Exists('%(_ReadyToRunCompileList.OutputR2RImage)')" />
 	</Target>
 
 	<!--
@@ -93,25 +120,6 @@
 			_LinkR2RFramework;
 		</_CreateR2RFrameworkDependsOn>
 	</PropertyGroup>
-
-	<Target Name="_FilterR2RCompositeInputs"
-			Condition="'$(FilterReadyToRunAssemblies)' == 'true'"
-			AfterTargets="_PrepareForReadyToRunCompilation"
-			BeforeTargets="_CreateR2RImages">
-
-		<PropertyGroup>
-			<_UserAssemblyFilenames>;@(_UserAssemblies->'%(Filename)', ';');</_UserAssemblyFilenames>
-		</PropertyGroup>
-		
-		<!-- TODO: Disable CreateR2RFramework and CreateR2RDylib -->
-		<ItemGroup>
-			<_ChangedNonUserTrimmedDlls Include="@(_ChangedTrimmedDlls)"
-				Condition="!$(_UserAssemblyFilenames.Contains(';%(Filename);'))" />
-		</ItemGroup>
-
-		<Touch Files="@(_ReadyToRunCompileList->'%(OutputR2RImage)')"
-			Condition="@(_ChangedTrimmedDlls->Count()) > 0 And @(_ChangedNonUserTrimmedDlls->Count()) == 0 And @(_ReadyToRunCompileList->Count()) > 0" />
-	</Target>
 
 	<!-- Prepare properties and item groups for r2r framework creation -->
 	<Target Name="_PrepareR2RFrameworkCreation"

--- a/dotnet/targets/Microsoft.Sdk.R2R.targets
+++ b/dotnet/targets/Microsoft.Sdk.R2R.targets
@@ -78,7 +78,10 @@
 		</ItemGroup>
 
 		<!-- Hash the R2R input assemblies so we can detect when the set actually changes -->
-		<Hash ItemsToHash="@(_NonUserAssemblies)" IgnoreCase="false">
+		<GetFileHash Files="@(_NonUserAssemblies)" Algorithm="SHA256">
+			<Output TaskParameter="Items" ItemName="_NonUserAssembliesWithHash" />
+		</GetFileHash>
+		<Hash ItemsToHash="@(_NonUserAssembliesWithHash->'%(FileHash)')" IgnoreCase="false">
 			<Output TaskParameter="HashResult" PropertyName="_R2RInputHash" />
 		</Hash>
 

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1396,35 +1396,6 @@
 		</ItemGroup>
 	</Target>
 
-	<Target Name="_PrintChangedTrimmedAssemblies" AfterTargets="ILLink">
-		<PropertyGroup>
-			<_TrimHashesFile>$(IntermediateOutputPath)trimmed-hashes.txt</_TrimHashesFile>
-			<_PreviousTrimHashesContent Condition="Exists('$(_TrimHashesFile)')">$([System.IO.File]::ReadAllText('$(_TrimHashesFile)'))</_PreviousTrimHashesContent>
-			<_PreviousTrimHashesContent Condition="'$(_PreviousTrimHashesContent)' == ''">EMPTY</_PreviousTrimHashesContent>
-		</PropertyGroup>
-
-		<ItemGroup>
-			<_TrimmedDlls Include="$(IntermediateLinkDir)*.dll" />
-		</ItemGroup>
-
-		<GetFileHash Files="@(_TrimmedDlls)" Algorithm="SHA256">
-			<Output TaskParameter="Items" ItemName="_TrimmedDllsWithHash" />
-		</GetFileHash>
-
-		<ItemGroup>
-			<_ChangedTrimmedDlls Include="@(_TrimmedDllsWithHash)" Condition="!$(_PreviousTrimHashesContent.Contains('%(FileHash)'))" />
-		</ItemGroup>
-
-		<WriteLinesToFile
-			File="$(_TrimHashesFile)"
-			Lines="@(_TrimmedDllsWithHash->'%(Identity)|%(FileHash)')"
-			Overwrite="true" />
-
-		<ItemGroup>
-			<FileWrites Include="$(_TrimHashesFile)" />
-		</ItemGroup>
-	</Target>
-
 	<Target Name="_CreateAOTDedupAssembly"
 			Condition="'$(_IsDedupEnabled)' == 'true'"
 			DependsOnTargets="_ComputeManagedAssemblyToLink"

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1396,6 +1396,35 @@
 		</ItemGroup>
 	</Target>
 
+	<Target Name="_PrintChangedTrimmedAssemblies" AfterTargets="ILLink">
+		<PropertyGroup>
+			<_TrimHashesFile>$(IntermediateOutputPath)trimmed-hashes.txt</_TrimHashesFile>
+			<_PreviousTrimHashesContent Condition="Exists('$(_TrimHashesFile)')">$([System.IO.File]::ReadAllText('$(_TrimHashesFile)'))</_PreviousTrimHashesContent>
+			<_PreviousTrimHashesContent Condition="'$(_PreviousTrimHashesContent)' == ''">EMPTY</_PreviousTrimHashesContent>
+		</PropertyGroup>
+
+		<ItemGroup>
+			<_TrimmedDlls Include="$(IntermediateLinkDir)*.dll" />
+		</ItemGroup>
+
+		<GetFileHash Files="@(_TrimmedDlls)" Algorithm="SHA256">
+			<Output TaskParameter="Items" ItemName="_TrimmedDllsWithHash" />
+		</GetFileHash>
+
+		<ItemGroup>
+			<_ChangedTrimmedDlls Include="@(_TrimmedDllsWithHash)" Condition="!$(_PreviousTrimHashesContent.Contains('%(FileHash)'))" />
+		</ItemGroup>
+
+		<WriteLinesToFile
+			File="$(_TrimHashesFile)"
+			Lines="@(_TrimmedDllsWithHash->'%(Identity)|%(FileHash)')"
+			Overwrite="true" />
+
+		<ItemGroup>
+			<FileWrites Include="$(_TrimHashesFile)" />
+		</ItemGroup>
+	</Target>
+
 	<Target Name="_CreateAOTDedupAssembly"
 			Condition="'$(_IsDedupEnabled)' == 'true'"
 			DependsOnTargets="_ComputeManagedAssemblyToLink"


### PR DESCRIPTION
## Desription

In non-Release R2R composite mode when user assemblies change, they are treated as entry points and used as inputs to the _CreateR2RImages target. As a result the ILLink task always writes new assemblies to disk, which forces the _CreateR2RImages task to execute every time.

The caching mechanism works by computing a content-based hash of non-user assemblies, then writing this hash to an intermediate file. A .trigger file is touched on every build to track when the hash was last computed. If the hash file is older than the trigger file (meaning the hash didn't change), the R2R outputs are touched to satisfy msbuild incremental build checks, skipping the R2R compilation step.

With this change, incremental build time for user assembly changes is reduced from ~39s to ~26s.