### PR TITLE
[ObjCRuntime] Enable nullability and clean up TrampolineBlockBase.

### DIFF
--- a/src/ObjCRuntime/TrampolineBlockBase.cs
+++ b/src/ObjCRuntime/TrampolineBlockBase.cs
@@ -3,12 +3,12 @@
 
 using System.ComponentModel;
 
-// Disable until we get around to enable + fix any issues.
-#nullable disable
+#nullable enable
 
 namespace ObjCRuntime {
 
-	// infrastucture code - not intended to be used directly by user code
+	/// <summary>Base type for Objective-C trampoline blocks.</summary>
+	// infrastructure code - not intended to be used directly by user code
 	[EditorBrowsable (EditorBrowsableState.Never)]
 	public abstract class TrampolineBlockBase {
 
@@ -23,6 +23,8 @@ namespace ObjCRuntime {
 			}
 		}
 
+		/// <summary>Initializes a new instance from a block literal pointer.</summary>
+		/// <param name="block">A pointer to a native <see cref="BlockLiteral"/>.</param>
 		protected unsafe TrampolineBlockBase (BlockLiteral* block)
 			: this ((IntPtr) block, false)
 		{
@@ -33,12 +35,19 @@ namespace ObjCRuntime {
 			Runtime.ReleaseBlockOnMainThread (blockPtr);
 		}
 
+		/// <summary>Gets the native block pointer for this instance.</summary>
+		/// <value>The native block pointer.</value>
 		protected IntPtr BlockPointer {
 			get { return blockPtr; }
 		}
 
-		protected unsafe static object GetExistingManagedDelegate (IntPtr block)
+		/// <summary>Gets the existing managed delegate for a block if it wraps managed code.</summary>
+		/// <param name="block">The native block pointer.</param>
+		/// <returns>The managed delegate if this is a managed block; otherwise, <see langword="null"/>.</returns>
+		protected unsafe static object? GetExistingManagedDelegate (IntPtr block)
 		{
+			if (block == IntPtr.Zero)
+				return null;
 			if (!BlockLiteral.IsManagedBlock (block))
 				return null;
 			return ((BlockLiteral*) block)->Target;

--- a/src/UIKit/UICellAccessory.cs
+++ b/src/UIKit/UICellAccessory.cs
@@ -90,7 +90,7 @@ namespace UIKit {
 		{
 			if (block == IntPtr.Zero)
 				return null;
-			var del = (UICellAccessoryPosition) GetExistingManagedDelegate (block);
+			var del = (UICellAccessoryPosition?) GetExistingManagedDelegate (block);
 			return del ?? new NIDUICellAccessoryPosition ((BlockLiteral*) block).Invoke;
 		}
 

--- a/src/UIKit/UIConfigurationColorTransformer.cs
+++ b/src/UIKit/UIConfigurationColorTransformer.cs
@@ -64,7 +64,7 @@ namespace UIKit {
 		{
 			if (block == IntPtr.Zero)
 				return null;
-			var del = (UIConfigurationColorTransformerHandler) GetExistingManagedDelegate (block);
+			var del = (UIConfigurationColorTransformerHandler?) GetExistingManagedDelegate (block);
 			return del ?? new NIDUIConfigurationColorTransformerHandler ((BlockLiteral*) block).Invoke;
 		}
 

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -1681,7 +1681,7 @@ public partial class Generator : IMemberGatherer {
 			print ("public unsafe static {0}? Create (IntPtr block)\n{{", ti.UserDelegate); indent++;
 			print ("if (block == IntPtr.Zero)"); indent++;
 			print ("return null;"); indent--;
-			print ($"var del = ({ti.UserDelegate}) GetExistingManagedDelegate (block);");
+			print ($"var del = ({ti.UserDelegate}?) GetExistingManagedDelegate (block);");
 			print ($"return del ?? new {ti.NativeInvokerName} ((BlockLiteral *) block).Invoke;");
 			indent--; print ("}");
 			print ("");

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -15322,9 +15322,7 @@ M:ObjCRuntime.ThrowHelper.ThrowArgumentNullException(System.String)
 M:ObjCRuntime.ThrowHelper.ThrowArgumentOutOfRangeException(System.String,System.Object,System.String)
 M:ObjCRuntime.ThrowHelper.ThrowArgumentOutOfRangeException(System.String,System.String)
 M:ObjCRuntime.ThrowHelper.ThrowObjectDisposedException(System.Object)
-M:ObjCRuntime.TrampolineBlockBase.#ctor(ObjCRuntime.BlockLiteral*)
 M:ObjCRuntime.TrampolineBlockBase.Finalize
-M:ObjCRuntime.TrampolineBlockBase.GetExistingManagedDelegate(System.IntPtr)
 M:ObjCRuntime.TransientAttribute.#ctor
 M:OpenGL.CGLContext.Release
 M:OpenGL.CGLContext.Retain
@@ -22960,7 +22958,6 @@ P:ObjCRuntime.ObjCException.Message
 P:ObjCRuntime.ObjCException.Name
 P:ObjCRuntime.ObjCException.NSException
 P:ObjCRuntime.ObjCException.Reason
-P:ObjCRuntime.TrampolineBlockBase.BlockPointer
 P:OSLog.IOSLogEntryFromProcess.ActivityIdentifier
 P:OSLog.IOSLogEntryFromProcess.Process
 P:OSLog.IOSLogEntryFromProcess.ProcessIdentifier


### PR DESCRIPTION
This is file 5 of 7 files with nullability disabled in ObjCRuntime.

* Enable nullability (#nullable enable).
* Add nullability annotations and validation for block pointers and managed delegate retrieval.
* Add missing XML documentation for the public type and protected members.
* Fix wording typo in infrastructure comment.

Contributes towards https://github.com/dotnet/macios/issues/17285.