### PR TITLE
[Foundation] Treat any exception during X509Chain.Build as a remote certificate chain error. Fixes #24739.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -829,7 +829,7 @@ namespace Foundation {
 					} else if (!chain.Build (certificate)) {
 						sslPolicyErrors |= SslPolicyErrors.RemoteCertificateChainErrors;
 					}
-				} catch (ArgumentException) {
+				} catch {
 					sslPolicyErrors |= SslPolicyErrors.RemoteCertificateChainErrors;
 				}
 


### PR DESCRIPTION
In iOS 26.4 beta 4, X509Chain.Build started throwing CryptographicException:

```
System.Security.Cryptography.Interop+AppleCrypto+AppleCommonCryptoCryptographicException: Unable to decode the provided data.
    at System.Security.Cryptography.X509Certificates.SecTrustChainPal.Execute(:0)
    at System.Security.Cryptography.X509Certificates.ChainPal.BuildChain(:0)
    at System.Security.Cryptography.X509Certificates.X509Chain.Build(:0)
    at Foundation.NSUrlSessionHandler+ServerCertificateCustomValidationCallbackHelper.EvaluateSslPolicyErrors(:0)
    at Foundation.NSUrlSessionHandler+ServerCertificateCustomValidationCallbackHelper.Invoke(:0)
    at Foundation.NSUrlSessionHandler.TryInvokeServerCertificateCustomValidationCallback(:0)
    at Foundation.NSUrlSessionHandler+NSUrlSessionHandlerDelegate.DidReceiveChallengeImpl(:0)
    at Foundation.NSUrlSessionHandler+NSUrlSessionHandlerDelegate.DidReceiveChallenge(:0)
    at InvokeStub_NSUrlSessionHandlerDelegate.DidReceiveChallenge(:0)
```

The underlying cause of these exceptions is handled in this issue: https://github.com/dotnet/runtime/issues/124552, this change is only dealing with the fact that the process crashes when an unexpected exception occurs in this code path in NSUrlSessionHandler.

The fix is to handle all exceptions in the call X509Chain.Build, and report them as a certificate chain error in the custom server validation callback; then the app developer can handle them as they see fit.

Fixes https://github.com/dotnet/macios/issues/24739.

See also:

* https://github.com/dotnet/runtime/issues/124552