### PR TITLE
[release/10.0.1xx] Hardcode our manifest version band to 10.0.100

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -409,7 +409,7 @@ endif
 
 # This is the manifest version band we use for our .Manifest-$(VERSION_BAND) packages.
 # It should typically be $(DOTNET_MANIFEST_VERSION_BAND_WITH_PRERELEASE_COMPONENT), unless we decide to hardcode it to something else
-MACIOS_MANIFEST_VERSION_BAND=$(DOTNET_MANIFEST_VERSION_BAND_WITH_PRERELEASE_COMPONENT)
+MACIOS_MANIFEST_VERSION_BAND=10.0.100
 
 # The location of csc changes depending on whether we're using a preview or a stable/service release :/
 DOTNET_CSC_PATH_PREVIEW=$(DOTNET_DIR)/sdk/$(DOTNET_VERSION)/Roslyn/bincore/csc.dll


### PR DESCRIPTION
since we now have a 10.0.200 SDK follow suit with android https://github.com/dotnet/android/blob/release/10.0.1xx/eng/Versions.props#L27-L30