### PR TITLE
[release/11.0.1xx-preview2] Update dependencies from dotnet/macios

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -10,6 +10,7 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-macios -->
+    <add key="darc-pub-dotnet-macios-f5b6c6f" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-f5b6c6ff/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-macios -->
     <!--  Begin: Package sources from xamarin-xamarin-macios -->
     <!--  End: Package sources from xamarin-xamarin-macios -->

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -18,13 +18,13 @@ This file should be imported by eng/Versions.props
     <MicrosoftTemplateEngineAuthoringTasksPackageVersion>11.0.100-preview.2.26122.107</MicrosoftTemplateEngineAuthoringTasksPackageVersion>
     <!-- dotnet/macios dependencies -->
     <MicrosoftiOSSdknet100_260PackageVersion>26.0.11017</MicrosoftiOSSdknet100_260PackageVersion>
-    <MicrosoftiOSSdknet100_262PackageVersion>26.2.10196</MicrosoftiOSSdknet100_262PackageVersion>
+    <MicrosoftiOSSdknet100_262PackageVersion>26.2.10216</MicrosoftiOSSdknet100_262PackageVersion>
     <MicrosoftMacCatalystSdknet100_260PackageVersion>26.0.11017</MicrosoftMacCatalystSdknet100_260PackageVersion>
-    <MicrosoftMacCatalystSdknet100_262PackageVersion>26.2.10196</MicrosoftMacCatalystSdknet100_262PackageVersion>
+    <MicrosoftMacCatalystSdknet100_262PackageVersion>26.2.10216</MicrosoftMacCatalystSdknet100_262PackageVersion>
     <MicrosoftmacOSSdknet100_260PackageVersion>26.0.11017</MicrosoftmacOSSdknet100_260PackageVersion>
-    <MicrosoftmacOSSdknet100_262PackageVersion>26.2.10196</MicrosoftmacOSSdknet100_262PackageVersion>
+    <MicrosoftmacOSSdknet100_262PackageVersion>26.2.10216</MicrosoftmacOSSdknet100_262PackageVersion>
     <MicrosofttvOSSdknet100_260PackageVersion>26.0.11017</MicrosofttvOSSdknet100_260PackageVersion>
-    <MicrosofttvOSSdknet100_262PackageVersion>26.2.10196</MicrosofttvOSSdknet100_262PackageVersion>
+    <MicrosofttvOSSdknet100_262PackageVersion>26.2.10216</MicrosofttvOSSdknet100_262PackageVersion>
     <!-- dotnet/xharness dependencies -->
     <MicrosoftDotNetXHarnessiOSSharedPackageVersion>10.0.0-prerelease.25516.4</MicrosoftDotNetXHarnessiOSSharedPackageVersion>
   </PropertyGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,21 +43,21 @@
       <Sha>23eb1c2c9465fe76c810c8a69982c1254161f4b0</Sha>
     </Dependency>
     <!-- This is a subscription of the .NET 10/Xcode 26.2 versions of our packages -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.2" Version="26.2.10196">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.2" Version="26.2.10216">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>b364fe57e890ba1d1ca43740c038d1dfb6786576</Sha>
+      <Sha>f5b6c6ff42d49bb79bb2d0e5b5d8382e8feaf3f9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.2" Version="26.2.10196">
+    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.2" Version="26.2.10216">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>b364fe57e890ba1d1ca43740c038d1dfb6786576</Sha>
+      <Sha>f5b6c6ff42d49bb79bb2d0e5b5d8382e8feaf3f9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.2" Version="26.2.10196">
+    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.2" Version="26.2.10216">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>b364fe57e890ba1d1ca43740c038d1dfb6786576</Sha>
+      <Sha>f5b6c6ff42d49bb79bb2d0e5b5d8382e8feaf3f9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.2" Version="26.2.10196">
+    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.2" Version="26.2.10216">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>b364fe57e890ba1d1ca43740c038d1dfb6786576</Sha>
+      <Sha>f5b6c6ff42d49bb79bb2d0e5b5d8382e8feaf3f9</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>


### PR DESCRIPTION
Backport of #24784 

This pull request updates the following dependencies

[marker]: <> (Begin:54e62af8-87ae-460e-96f0-34e0f6ffe51e)
- **Subscription**: [54e62af8-87ae-460e-96f0-34e0f6ffe51e](https://maestro.dot.net/subscriptions?search=54e62af8-87ae-460e-96f0-34e0f6ffe51e)
- **Build**: [20260225.1](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=13393668) ([303328](https://maestro.dot.net/channel/5173/github:dotnet:macios/build/303328))
- **Date Produced**: February 25, 2026 10:19:06 AM UTC
- **Commit**: [f5b6c6ff42d49bb79bb2d0e5b5d8382e8feaf3f9](https://github.com/dotnet/macios/commit/f5b6c6ff42d49bb79bb2d0e5b5d8382e8feaf3f9)
- **Branch**: [release/10.0.1xx](https://github.com/dotnet/macios/tree/release/10.0.1xx)

[DependencyUpdate]: <> (Begin)

- **Dependency Updates**:
  - From [26.2.10196 to 26.2.10216][1] - Microsoft.iOS.Sdk.net10.0_26.2 - Microsoft.MacCatalyst.Sdk.net10.0_26.2 - Microsoft.macOS.Sdk.net10.0_26.2 - Microsoft.tvOS.Sdk.net10.0_26.2

[1]: https://github.com/dotnet/macios/compare/b364fe57e8...f5b6c6ff42

[DependencyUpdate]: <> (End)

[marker]: <> (End:54e62af8-87ae-460e-96f0-34e0f6ffe51e)