### PR TITLE
[release/11.0.1xx-preview2] Update dependencies from dotnet/macios

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -10,7 +10,7 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-macios -->
-    <add key="darc-pub-dotnet-macios-f5b6c6f" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-f5b6c6ff/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-macios-f97742b" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-f97742bf/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-macios -->
     <!--  Begin: Package sources from xamarin-xamarin-macios -->
     <!--  End: Package sources from xamarin-xamarin-macios -->

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -18,13 +18,13 @@ This file should be imported by eng/Versions.props
     <MicrosoftTemplateEngineAuthoringTasksPackageVersion>11.0.100-preview.2.26122.107</MicrosoftTemplateEngineAuthoringTasksPackageVersion>
     <!-- dotnet/macios dependencies -->
     <MicrosoftiOSSdknet100_260PackageVersion>26.0.11017</MicrosoftiOSSdknet100_260PackageVersion>
-    <MicrosoftiOSSdknet100_262PackageVersion>26.2.10216</MicrosoftiOSSdknet100_262PackageVersion>
+    <MicrosoftiOSSdknet100_262PackageVersion>26.2.10217</MicrosoftiOSSdknet100_262PackageVersion>
     <MicrosoftMacCatalystSdknet100_260PackageVersion>26.0.11017</MicrosoftMacCatalystSdknet100_260PackageVersion>
-    <MicrosoftMacCatalystSdknet100_262PackageVersion>26.2.10216</MicrosoftMacCatalystSdknet100_262PackageVersion>
+    <MicrosoftMacCatalystSdknet100_262PackageVersion>26.2.10217</MicrosoftMacCatalystSdknet100_262PackageVersion>
     <MicrosoftmacOSSdknet100_260PackageVersion>26.0.11017</MicrosoftmacOSSdknet100_260PackageVersion>
-    <MicrosoftmacOSSdknet100_262PackageVersion>26.2.10216</MicrosoftmacOSSdknet100_262PackageVersion>
+    <MicrosoftmacOSSdknet100_262PackageVersion>26.2.10217</MicrosoftmacOSSdknet100_262PackageVersion>
     <MicrosofttvOSSdknet100_260PackageVersion>26.0.11017</MicrosofttvOSSdknet100_260PackageVersion>
-    <MicrosofttvOSSdknet100_262PackageVersion>26.2.10216</MicrosofttvOSSdknet100_262PackageVersion>
+    <MicrosofttvOSSdknet100_262PackageVersion>26.2.10217</MicrosofttvOSSdknet100_262PackageVersion>
     <!-- dotnet/xharness dependencies -->
     <MicrosoftDotNetXHarnessiOSSharedPackageVersion>10.0.0-prerelease.25516.4</MicrosoftDotNetXHarnessiOSSharedPackageVersion>
   </PropertyGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,21 +43,21 @@
       <Sha>23eb1c2c9465fe76c810c8a69982c1254161f4b0</Sha>
     </Dependency>
     <!-- This is a subscription of the .NET 10/Xcode 26.2 versions of our packages -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.2" Version="26.2.10216">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.2" Version="26.2.10217">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>f5b6c6ff42d49bb79bb2d0e5b5d8382e8feaf3f9</Sha>
+      <Sha>f97742bfb9145a25a2372f93b4efd2ef9c95f84c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.2" Version="26.2.10216">
+    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.2" Version="26.2.10217">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>f5b6c6ff42d49bb79bb2d0e5b5d8382e8feaf3f9</Sha>
+      <Sha>f97742bfb9145a25a2372f93b4efd2ef9c95f84c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.2" Version="26.2.10216">
+    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.2" Version="26.2.10217">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>f5b6c6ff42d49bb79bb2d0e5b5d8382e8feaf3f9</Sha>
+      <Sha>f97742bfb9145a25a2372f93b4efd2ef9c95f84c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.2" Version="26.2.10216">
+    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.2" Version="26.2.10217">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>f5b6c6ff42d49bb79bb2d0e5b5d8382e8feaf3f9</Sha>
+      <Sha>f97742bfb9145a25a2372f93b4efd2ef9c95f84c</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>


### PR DESCRIPTION
Backport of #24789

This pull request updates the following dependencies

[marker]: <> (Begin:54e62af8-87ae-460e-96f0-34e0f6ffe51e)
## From https://github.com/dotnet/macios
- **Subscription**: [54e62af8-87ae-460e-96f0-34e0f6ffe51e](https://maestro.dot.net/subscriptions?search=54e62af8-87ae-460e-96f0-34e0f6ffe51e)
- **Build**: [20260225.9](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=13395476) ([303383](https://maestro.dot.net/channel/5173/github:dotnet:macios/build/303383))
- **Date Produced**: February 25, 2026 5:17:28 PM UTC
- **Commit**: [f97742bfb9145a25a2372f93b4efd2ef9c95f84c](https://github.com/dotnet/macios/commit/f97742bfb9145a25a2372f93b4efd2ef9c95f84c)
- **Branch**: [release/10.0.1xx](https://github.com/dotnet/macios/tree/release/10.0.1xx)

[DependencyUpdate]: <> (Begin)

- **Dependency Updates**:
  - From [26.2.10216 to 26.2.10217][1]
     - Microsoft.iOS.Sdk.net10.0_26.2
     - Microsoft.MacCatalyst.Sdk.net10.0_26.2
     - Microsoft.macOS.Sdk.net10.0_26.2
     - Microsoft.tvOS.Sdk.net10.0_26.2

[1]: https://github.com/dotnet/macios/compare/f5b6c6ff42...f97742bfb9

[DependencyUpdate]: <> (End)


[marker]: <> (End:54e62af8-87ae-460e-96f0-34e0f6ffe51e)

