### PR TITLE
[msbuild] Don't pass symbol file to strip when _ExportSymbolsExplicitly=false. Fixes #24582.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2941,7 +2941,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 				<DSymName>%(Filename).dSYM</DSymName>
 			</_PostProcessingItem>
 			<_PostProcessingItem Include="$([System.IO.Path]::GetFileName('$(AppBundleDir)'))/$(_NativeExecutableRelativePath)" Condition="'$(IsWatchApp)' != 'true'">
-				<SymbolFile>$(_SymbolsListFullPath)</SymbolFile>
+				<SymbolFile Condition="'$(_ExportSymbolsExplicitly)' == 'true'">$(_SymbolsListFullPath)</SymbolFile>
 				<DSymName>$(_AppBundleName)$(AppBundleExtension).dSYM</DSymName>
 				<IsXPCService>$(IsXpcService)</IsXPCService>
 				<IsAppExtension>$(IsAppExtension)</IsAppExtension>

--- a/tests/dotnet/UnitTests/WindowsTest.cs
+++ b/tests/dotnet/UnitTests/WindowsTest.cs
@@ -273,6 +273,27 @@ namespace Xamarin.Tests {
 		}
 
 		[Category ("RemoteWindows")]
+		[TestCase (ApplePlatform.iOS, "ios-arm64", "Release")]
+		public void StripTest (ApplePlatform platform, string runtimeIdentifiers, string configuration)
+		{
+			var project = "MySimpleApp";
+
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+			Configuration.IgnoreIfNotOnWindows ();
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
+			var project_dir = Path.GetDirectoryName (project_path)!;
+			Clean (project_path);
+
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["Configuration"] = configuration;
+			properties ["_ExportSymbolsExplicitly"] = "false";
+
+			DotNet.AssertBuild (project_path, properties, timeout: TimeSpan.FromMinutes (15));
+		}
+
+		[Category ("RemoteWindows")]
 		[TestCase (ApplePlatform.iOS, "ios-arm64")]
 		public void RemoteTest (ApplePlatform platform, string runtimeIdentifiers)
 		{


### PR DESCRIPTION
When _ExportSymbolsExplicitly is false, the linker uses -u flags instead of
-exported_symbols_list, so mtouch-symbols.list is not transferred to the
remote Mac. Don't pass it to strip either, since the file won't exist.

Fixes https://github.com/dotnet/macios/issues/24582.