### PR TITLE
[release/10.0.1xx] Include .mobile.props for DTB (fix for VS Code)

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<!-- Imports the .mobile.props file if exists and the build is from VS/VSCode -->
-	<Import Project="$(_MobilePropsPath)" Condition="Exists('$(_MobilePropsPath)') And ('$(BuildingInsideVisualStudio)' == 'true' Or '$(BuildingInsideVisualStudioCode)' == 'true')" />
+	<Import Project="$(_MobilePropsPath)" Condition="Exists('$(_MobilePropsPath)') And ('$(BuildingInsideVisualStudio)' == 'true' Or '$(DesignTimeBuild)' == 'true')" />
 	
 	<PropertyGroup>
 		<!-- Set to true when using the Microsoft.<platform>.Sdk NuGet. This is used by pre-existing/shared targets to tweak behavior depending on build system -->


### PR DESCRIPTION
This PR makes a change to improve the Hot Reload experience for .NET MAUI iOS device builds in VS Code:

In VS Code, design-time builds did not receive the correct RuntimeIdentifier for iOS device targets — they defaulted to iossimulator-x64. This caused Roslyn to resolve the wrong baseline assemblies, that broke Hot Reload. The .mobile.props mechanism (already used by VS on Windows) solves this.

As discussed with Mauro and Tomas, the better solution is not to introduce a new parameter, but add "DesignTimeBuild" as one of the triggers for the condition. This is safe for both VS and VS Code and should not cause any side effects.

---------

Co-authored-by: Kirill Ovchinnikov <kovchinnikov@microsoft.com>

Backport of #24801.