### PR TITLE
[msbuild] Fix race condition when generating MSBStrings.Designer.cs

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/Xamarin.Localization.MSBuild.csproj
+++ b/msbuild/Xamarin.Localization.MSBuild/Xamarin.Localization.MSBuild.csproj
@@ -18,7 +18,7 @@
       <Type>Resx</Type>
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>MSBStrings.Designer.cs</LastGenOutput>
-      <StronglyTypedFileName>MSBStrings.Designer.cs</StronglyTypedFileName>
+      <StronglyTypedFileName>$(IntermediateOutputPath)MSBStrings.Designer.cs</StronglyTypedFileName>
       <StronglyTypedLanguage>CSharp</StronglyTypedLanguage>
       <StronglyTypedNamespace>Xamarin.Localization.MSBuild</StronglyTypedNamespace>
       <StronglyTypedClassName>MSBStrings</StronglyTypedClassName>


### PR DESCRIPTION
When the Xamarin.Localization.MSBuild project was changed to multi-target (netstandard2.0 + net10.0), both inner builds run in parallel and both try to generate MSBStrings.Designer.cs to the same path. One build may write the file while the other is compiling it, causing:

    CSC : error CS1504: Source file 'MSBStrings.Designer.cs' could not be opened -- Attempted to read past the end of the stream.

Fix by directing StronglyTypedFileName to $(IntermediateOutputPath), which is per-TFM (obj/Debug/netstandard2.0/ vs obj/Debug/net10.0/), so each inner build generates its own copy without interfering with the other.