### PR TITLE
[sharpie] Add the sharpie nupkg version to 'make show-versions'.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ show-versions:
 	@echo "Building:"
 	@echo "    The .NET NuGet(s):"
 	@$(foreach platform,$(DOTNET_PLATFORMS),echo "        Microsoft.$(platform) $($(shell echo $(platform) | tr 'a-z' 'A-Z')_NUGET_VERSION_FULL)";)
+	@$(MAKE) -C tools/sharpie show-version
 
 all-local:: global.json
 

--- a/tools/common/create-makefile-fragment.sh
+++ b/tools/common/create-makefile-fragment.sh
@@ -40,13 +40,17 @@ if test -z "$FRAGMENT_PATH"; then
 	FRAGMENT_PATH=$PROJECT_FILE.inc
 fi
 
-if test -z "$BUILD_EXECUTABLE"; then
-	if test -z "$DOTNET"; then
-		echo "The DOTNET environment variable isn't set to the location of the 'dotnet' executable"
-		exit 1
-	fi
-	BUILD_EXECUTABLE="$DOTNET build"
+if test -z "$DOTNET"; then
+	echo "The DOTNET environment variable isn't set to the location of the 'dotnet' executable"
+	exit 1
 fi
+
+# Our local 'dotnet' executable might not be available yet, in which case don't do anything.
+if ! test -f "$DOTNET"; then
+	exit 0
+fi
+
+BUILD_EXECUTABLE="$DOTNET build"
 
 if test -z "$BUILD_VERBOSITY"; then
 	BUILD_VERBOSITY=/verbosity:diag

--- a/tools/dotnet-linker/Makefile
+++ b/tools/dotnet-linker/Makefile
@@ -15,7 +15,6 @@ DOTNET_DIRECTORIES += \
 	$(foreach platform,$(DOTNET_PLATFORMS),$(DOTNET_DESTDIR)/$($(platform)_NUGET_SDK_NAME)/tools/dotnet-linker) \
 
 # dotnet-linker.csproj.inc contains the dotnet_linker_dependencies variable used to determine if mtouch needs to be rebuilt or not.
-dotnet-linker.csproj.inc: export BUILD_EXECUTABLE=$(DOTNET) build
 dotnet-linker.csproj.inc: export BUILD_VERBOSITY=$(DOTNET_BUILD_VERBOSITY)
 dotnet-linker.csproj.inc: dotnet-linker.csproj
 -include dotnet-linker.csproj.inc

--- a/tools/sharpie/Makefile
+++ b/tools/sharpie/Makefile
@@ -34,3 +34,6 @@ run-tests: $(Sharpie.Bind_dependencies)
 	$(Q_BUILD) $(DOTNET) test $(TOP)/tests/sharpie/Sharpie.Bind.Tests/Sharpie.Bind.Tests.csproj --logger "console;verbosity=detailed" $(DOTNET_BUILD_VERBOSITY) -bl:$@.binlog
 
 generated-files: $(abspath ../common/SdkVersions.cs) $(abspath ../common/ProductConstants.cs)
+
+show-version:
+	@echo "        Sharpie.Bind.Tool $(SHARPIE_BIND_TOOL_NUGET_VERSION)"


### PR DESCRIPTION
This required a few simplifications to the 'create-makefile-fragment.sh'
script to avoid trying to create a makefile fragment if we don't have .NET
downloaded yet, because 'make show-versions' should succeed without a
downloaded .NET.