### PR TITLE
[sharpie] Add support for visionos_app_extension availability platform. Fixes #18098.

### DIFF
--- a/tests/sharpie/Tests/AvailabilityAppExtension.h
+++ b/tests/sharpie/Tests/AvailabilityAppExtension.h
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// RUN iphoneos: -x objective-c -sdk iphoneos
+
+__attribute__((availability(ios_app_extension,unavailable)))
+@interface UnavailableiOSAppExtension
+@end
+
+__attribute__((availability(macosx_app_extension,unavailable)))
+@interface UnavailableMacOSXAppExtension
+@end
+
+__attribute__((availability(tvos_app_extension,unavailable)))
+@interface UnavailableTvOSAppExtension
+@end
+
+__attribute__((availability(watchos_app_extension,unavailable)))
+@interface UnavailableWatchOSAppExtension
+@end
+
+__attribute__((availability(maccatalyst_app_extension,unavailable)))
+@interface UnavailableMacCatalystAppExtension
+@end
+
+__attribute__((availability(visionos_app_extension,unavailable)))
+@interface UnavailableVisionOSAppExtension
+@end

--- a/tests/sharpie/Tests/AvailabilityAppExtension.iphoneos.cs
+++ b/tests/sharpie/Tests/AvailabilityAppExtension.iphoneos.cs
@@ -1,0 +1,31 @@
+using ObjCRuntime;
+
+// @interface UnavailableiOSAppExtension
+[Unavailable (PlatformName.iOSAppExtension)]
+interface UnavailableiOSAppExtension {
+}
+
+// @interface UnavailableMacOSXAppExtension
+[Unavailable (PlatformName.MacOSXAppExtension)]
+interface UnavailableMacOSXAppExtension {
+}
+
+// @interface UnavailableTvOSAppExtension
+[Unavailable (PlatformName.TvOSAppExtension)]
+interface UnavailableTvOSAppExtension {
+}
+
+// @interface UnavailableWatchOSAppExtension
+[Unavailable (PlatformName.WatchOSAppExtension)]
+interface UnavailableWatchOSAppExtension {
+}
+
+// @interface UnavailableMacCatalystAppExtension
+[Unavailable (PlatformName.MacCatalystAppExtension)]
+interface UnavailableMacCatalystAppExtension {
+}
+
+// @interface UnavailableVisionOSAppExtension
+[Unavailable (PlatformName.VisionOSAppExtension)]
+interface UnavailableVisionOSAppExtension {
+}

--- a/tools/sharpie/Sharpie.Bind/Attributes/AvailabilityBaseAttribute.cs
+++ b/tools/sharpie/Sharpie.Bind/Attributes/AvailabilityBaseAttribute.cs
@@ -20,6 +20,7 @@ enum PlatformName : byte {
 	MacCatalyst,
 	DriverKit,
 	VisionOS,
+	VisionOSAppExtension,
 	MacCatalystAppExtension,
 }
 
@@ -155,6 +156,9 @@ class AvailabilityBaseAttribute : ICSharpCode.NRefactory.CSharp.Attribute {
 		case "visionOS":
 		case "visionos":
 			return PlatformName.VisionOS;
+		case "xros_app_extension":
+		case "visionos_app_extension":
+			return PlatformName.VisionOSAppExtension;
 		case "maccatalyst_app_extension":
 			return PlatformName.MacCatalystAppExtension;
 		default:


### PR DESCRIPTION
Sharpie's clang reports visionOS app extension availability as 'xros_app_extension', which was not handled in the GetPlatform() switch statement, causing an 'Unsupported clang availability platform' exception. This is the same class of bug as #18098.

Add:
- VisionOSAppExtension to the PlatformName enum
- Handle 'xros_app_extension' and 'visionos_app_extension' strings in GetPlatform()
- Test with all app extension availability platforms

Fixes https://github.com/dotnet/macios/issues/18098.