### PR TITLE
[msbuild] Fix incremental build for Metal shaders. Fixes #24816.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1308,6 +1308,9 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<!-- scntool output caches -->
 			<_SceneKitCache>$(DeviceSpecificIntermediateOutputPath)copySceneKitAssets\_BundleResourceWithLogicalName.items</_SceneKitCache>
 
+			<!-- metal output caches -->
+			<_SmeltedMetalCache>$(DeviceSpecificIntermediateOutputPath)metal\_SmeltedMetal.items</_SmeltedMetalCache>
+
 			<!-- TextureAtlas output caches -->
 			<_TextureAtlasCache>$(DeviceSpecificIntermediateOutputPath)atlas\_BundleResourceWithLogicalName.items</_TextureAtlasCache>
 
@@ -1584,10 +1587,28 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			_ComputeTargetFrameworkMoniker;
 			_ReadAppManifest;
 			_SetResourceMetadata;
+			_BeforeSmeltMetal;
+			_ReadSmeltedMetal;
 		</_SmeltMetalDependsOn>
 	</PropertyGroup>
 
-	<Target Name="_SmeltMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(Metal)' != ''" DependsOnTargets="$(_SmeltMetalDependsOn)">
+	<Target Name="_BeforeSmeltMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(Metal)' != ''"
+		Inputs="@(Metal)"
+		Outputs="$(_SmeltedMetalCache)">
+		<!-- If any Metal file is newer than the cached items list, delete the cache so that the _SmeltMetal target runs again -->
+		<Delete Files="$(_SmeltedMetalCache)" />
+	</Target>
+
+	<Target Name="_ReadSmeltedMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(Metal)' != ''" DependsOnTargets="_BeforeSmeltMetal">
+		<!-- If _BeforeSmeltMetal did not delete the cache, read the cached _SmeltedMetal items -->
+		<ReadItemsFromFile File="$(_SmeltedMetalCache)" Condition="Exists('$(_SmeltedMetalCache)')">
+			<Output TaskParameter="Items" ItemName="_SmeltedMetal" />
+		</ReadItemsFromFile>
+	</Target>
+
+	<Target Name="_SmeltMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(Metal)' != ''" DependsOnTargets="$(_SmeltMetalDependsOn)"
+		Inputs="@(Metal)"
+		Outputs="$(_SmeltedMetalCache)">
 		<Metal
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true' and '%(Metal.Identity)' != ''"
@@ -1604,6 +1625,11 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			SourceFile="@(Metal)">
 			<Output TaskParameter="OutputFile" ItemName="_SmeltedMetal" />
 		</Metal>
+
+		<WriteItemsToFile Items="@(_SmeltedMetal)" ItemName="_SmeltedMetal" File="$(_SmeltedMetalCache)" Overwrite="true" IncludeMetadata="true" />
+		<ItemGroup>
+			<FileWrites Include="$(_SmeltedMetalCache)" />
+		</ItemGroup>
 	</Target>
 
 	<Target Name="_TemperMetal" Condition="'$(_CanOutputAppBundle)' == 'true' And '@(_SmeltedMetal)' != ''" DependsOnTargets="_GenerateBundleName"

--- a/tests/dotnet/UnitTests/IncrementalBuildTest.cs
+++ b/tests/dotnet/UnitTests/IncrementalBuildTest.cs
@@ -205,6 +205,57 @@ class MainClass {
 			CodeChangeSkipsTargetsImpl (platform, runtimeIdentifiers, interpreterEnabled);
 		}
 
+		[Test]
+		[TestCase (ApplePlatform.iOS, "iossimulator-arm64")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
+		public void MetalShadersNotRecompiled (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var project_path = GenerateProject (platform, name: nameof (MetalShadersNotRecompiled), runtimeIdentifiers: runtimeIdentifiers, out var appPath);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["UseInterpreter"] = "true"; // this makes the test faster
+
+			var projectDir = Path.GetDirectoryName (project_path)!;
+
+			// Add a Main.cs so the project compiles
+			File.WriteAllText (Path.Combine (projectDir, "Main.cs"), @"
+class MainClass {
+	static int Main ()
+	{
+		return 0;
+	}
+}
+");
+
+			// Add a Metal shader file to the project
+			File.WriteAllText (Path.Combine (projectDir, "Shaders.metal"), @"
+#include <metal_stdlib>
+using namespace metal;
+
+kernel void myKernel (texture2d<half, access::read> inTexture [[texture(0)]],
+                      texture2d<half, access::write> outTexture [[texture(1)]],
+                      uint2 gid [[thread_position_in_grid]])
+{
+}
+");
+
+			// Build the first time
+			var rv = DotNet.AssertBuild (project_path, properties);
+			var allTargets = BinLog.GetAllTargets (rv.BinLogPath);
+			AssertTargetExecuted (allTargets, "_SmeltMetal", "First build");
+			AssertTargetExecuted (allTargets, "_TemperMetal", "First build");
+
+			// Build again without any changes
+			rv = DotNet.AssertBuild (project_path, properties);
+			allTargets = BinLog.GetAllTargets (rv.BinLogPath);
+
+			// _SmeltMetal should NOT execute on the second build since nothing changed
+			AssertTargetNotExecuted (allTargets, "_SmeltMetal", "Second build");
+			AssertTargetNotExecuted (allTargets, "_TemperMetal", "Second build");
+		}
+
 		void CodeChangeSkipsTargetsImpl (ApplePlatform platform, string runtimeIdentifiers, bool interpreterEnabled)
 		{
 			var project = "IncrementalTestApp";


### PR DESCRIPTION
The _SmeltMetal target lacked Inputs/Outputs attributes, causing Metal
shaders to always be recompiled even when unchanged. This follows the
same cache/stamp file pattern used by _CoreCompileInterfaceDefinitions:

- _BeforeSmeltMetal: deletes cache when any Metal file is newer
- _ReadSmeltedMetal: reads cached _SmeltedMetal items for incremental builds
- _SmeltMetal: now has Inputs/Outputs and writes cache after compilation

Also adds a unit test (MetalShadersNotRecompiled) that verifies
_SmeltMetal and _TemperMetal are skipped on the second build when
no Metal files have changed.

Fixes https://github.com/dotnet/macios/issues/24816