### PR TITLE
[ios-clr] Always include libmscordaccore and libmscordbi in app bundles

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ProcessRuntimeLibraries.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ProcessRuntimeLibraries.cs
@@ -127,14 +127,6 @@ public class ProcessRuntimeLibraries : XamarinTask, ICancelableTask {
 					continue;
 				}
 
-				if (Platform != Utils.ApplePlatform.MacOSX && !DebuggerSupport) {
-					// libmscordaccore and libmscordbi are debug-only libraries, don't include them when debugger support is disabled on mobile platforms
-					if (string.Equals (kvp.Key, "libmscordaccore", StringComparison.OrdinalIgnoreCase) ||
-						string.Equals (kvp.Key, "libmscordbi", StringComparison.OrdinalIgnoreCase)) {
-						continue;
-					}
-				}
-
 				switch (RuntimeLibLinkMode.ToLowerInvariant ()) {
 				case "static":
 					// if we only have a single .a, we need to link with it, but not copy to the app bundle


### PR DESCRIPTION
## Description

This PR fixes a crash when running CoreCLR apps on simulators with DebuggerSupport disabled.

When `DebuggerSupport=false`, the build was skipping `libmscordaccore.dylib` and `libmscordbi.dylib` because they are debug-only libraries. However, `libcoreclr.dylib` has load-time dependencies on these libraries in its MachO header. When dyld loads the app, it attempts to resolve all dependencies regardless of whether the debug is actually used, resulting in `DYLD 1 Library missing Library not loaded: @rpath/libmscordaccore.dylib`.

Tracking issue: https://github.com/dotnet/macios/issues/24849
