### PR TITLE
[devops] Match Tahoe bots on 'Tahoe'.

### DIFF
--- a/tools/devops/automation/templates/tests-stage.yml
+++ b/tools/devops/automation/templates/tests-stage.yml
@@ -102,7 +102,7 @@ parameters:
       statusContext: 'arm64 - Mac Tahoe (26)',
       demands: [
         "Agent.OS -equals Darwin",
-        "Agent.OSVersion -equals 26.0",
+        "Agent.Name -equals Tahoe",
         "macOS.Architecture -equals arm64",
         "Agent.HasDevices -equals False",
         "Agent.IsPaired -equals False"


### PR DESCRIPTION
That way we don't limit ourselves to bots with Version=26.0 (but we can also
run on bots with minor OS updates, such as Version=26.3).