### PR TITLE
Update MessagingVersion to 18.3.99-g08330b37ad

### DIFF
--- a/msbuild/Directory.Build.props
+++ b/msbuild/Directory.Build.props
@@ -15,7 +15,7 @@
 			https://dev.azure.com/azure-public/vside/_artifacts/feed/xamarin-impl/NuGet/Xamarin.Messaging.Client/
 
 		-->
-		<MessagingVersion Condition="'$(MessagingVersion)' == ''">[18.3.92-g254217267d]</MessagingVersion>
+		<MessagingVersion Condition="'$(MessagingVersion)' == ''">[18.3.99-g08330b37ad]</MessagingVersion>
 	</PropertyGroup>
 	<Import Project="$(MSBuildThisFileDirectory)../Directory.Build.props" />
 </Project>


### PR DESCRIPTION
Brings fixes for building from Windows targeting a .NET version lower than the used to build (i.e., building with .NET 11 a project targeting net10.0-ios).