### PR TITLE
[msbuild] Include iPads when looking for devices for apps built for iPhones.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
@@ -58,7 +58,7 @@ namespace Xamarin.MacDev.Tasks {
 			}
 		}
 
-		List<string>? GetDeviceTypes ()
+		List<string>? GetDeviceTypes (bool onlyExact)
 		{
 			var output = GetSimulatorList ();
 			if (output is null)
@@ -67,10 +67,12 @@ namespace Xamarin.MacDev.Tasks {
 			// Which product family are we looking for?
 			string [] productFamilies;
 			switch (DeviceType) {
+			case IPhoneDeviceType.IPhone: // if we're looking for an iPhone, an iPad also works
+				productFamilies = onlyExact ? ["iPhone"] : ["iPhone", "iPad"];
+				break;
 			case IPhoneDeviceType.IPad:
 				productFamilies = ["iPad"];
 				break;
-			case IPhoneDeviceType.IPhone: // if we're looking for an iPhone, an iPad also works
 			case IPhoneDeviceType.IPhoneAndIPad:
 				productFamilies = ["iPhone", "iPad"];
 				break;
@@ -148,7 +150,7 @@ namespace Xamarin.MacDev.Tasks {
 			if (string.IsNullOrEmpty (output))
 				return rv;
 
-			var deviceTypes = GetDeviceTypes ();
+			var deviceTypes = GetDeviceTypes (false);
 			if (deviceTypes is null)
 				return rv;
 
@@ -240,7 +242,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			if (SdkIsSimulator && string.IsNullOrEmpty (DeviceName)) {
 				var simruntime = $"com.apple.CoreSimulator.SimRuntime.{PlatformName}-{SdkVersion.Replace ('.', '-')}";
-				var simdevicetypes = GetDeviceTypes ();
+				var simdevicetypes = GetDeviceTypes (true);
 				string simdevicetype;
 
 				if (simdevicetypes?.Count > 0) {


### PR DESCRIPTION
This fixes an issue where passing `--device=<ipad-udid>` wouldn't work,
because the UDID wouldn't be found in the list of applicable devices, because
iPads weren't listed as applicable devices.