### PR TITLE
[Foundation] Remove Content-Encoding and Content-Length headers for auto-decompressed responses in NSUrlSessionHandler. Fixes #23958.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -871,6 +871,15 @@ namespace Foundation {
 			}
 		}
 
+		static bool HasCompressedEncoding (string headerValue)
+		{
+			foreach (var encoding in headerValue.Split (',')) {
+				if (IsCompressedEncoding (encoding.Trim ()))
+					return true;
+			}
+			return false;
+		}
+
 		static bool IsCompressedEncoding (string encoding)
 		{
 			return string.Equals (encoding, "gzip", StringComparison.OrdinalIgnoreCase)
@@ -1003,7 +1012,7 @@ namespace Foundation {
 						httpResponse.Content.Headers.TryAddWithoutValidation (key, value);
 					}
 
-					var contentWasDecompressed = contentEncodingValue is not null && IsCompressedEncoding (contentEncodingValue);
+					var contentWasDecompressed = contentEncodingValue is not null && HasCompressedEncoding (contentEncodingValue);
 					if (!contentWasDecompressed) {
 						if (contentEncodingValue is not null) {
 							httpResponse.Headers.TryAddWithoutValidation (ContentEncodingHeaderName, contentEncodingValue);

--- a/tests/monotouch-test/System.Net.Http/NSUrlSessionHandlerTest.cs
+++ b/tests/monotouch-test/System.Net.Http/NSUrlSessionHandlerTest.cs
@@ -25,9 +25,12 @@ namespace MonoTests.System.Net.Http {
 			var done = TestRuntime.TryRunAsync (TimeSpan.FromSeconds (30), async () => {
 				using var handler = new NSUrlSessionHandler ();
 				using var client = new HttpClient (handler);
+				// Explicitly request gzip to ensure the server compresses the response.
+				using var request = new HttpRequestMessage (HttpMethod.Get, $"{NetworkResources.Httpbin.Url}/gzip");
+				request.Headers.TryAddWithoutValidation ("Accept-Encoding", "gzip");
 				// Use ResponseHeadersRead so that the response content is not buffered,
 				// which would cause HttpContent to compute Content-Length from the buffer.
-				var response = await client.GetAsync ($"{NetworkResources.Httpbin.Url}/gzip", HttpCompletionOption.ResponseHeadersRead);
+				var response = await client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead);
 
 				if (!response.IsSuccessStatusCode) {
 					Assert.Inconclusive ($"Request failed with status {response.StatusCode}");
@@ -54,21 +57,26 @@ namespace MonoTests.System.Net.Http {
 		[Test]
 		public void NonCompressedResponseHasContentLength ()
 		{
+			bool noContentEncoding = false;
 			long? contentLength = null;
 			string body = "";
 
 			var done = TestRuntime.TryRunAsync (TimeSpan.FromSeconds (30), async () => {
 				using var handler = new NSUrlSessionHandler ();
 				using var client = new HttpClient (handler);
+				// Request identity encoding to ensure no compression is applied.
+				using var request = new HttpRequestMessage (HttpMethod.Get, $"{NetworkResources.Httpbin.Url}/html");
+				request.Headers.TryAddWithoutValidation ("Accept-Encoding", "identity");
 				// Use ResponseHeadersRead so that the response content is not buffered,
 				// which would cause HttpContent to compute Content-Length from the buffer.
-				var response = await client.GetAsync ($"{NetworkResources.Httpbin.Url}/html", HttpCompletionOption.ResponseHeadersRead);
+				var response = await client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead);
 
 				if (!response.IsSuccessStatusCode) {
 					Assert.Inconclusive ($"Request failed with status {response.StatusCode}");
 					return;
 				}
 
+				noContentEncoding = response.Content.Headers.ContentEncoding.Count == 0;
 				contentLength = response.Content.Headers.ContentLength;
 				body = await response.Content.ReadAsStringAsync ();
 			}, out var ex);
@@ -79,6 +87,7 @@ namespace MonoTests.System.Net.Http {
 			}
 			TestRuntime.IgnoreInCIIfBadNetwork (ex);
 			Assert.IsNull (ex, $"Exception: {ex}");
+			Assert.IsTrue (noContentEncoding, "Content-Encoding should not be present for non-compressed content");
 			Assert.IsNotNull (contentLength, "Content-Length header should be present for non-compressed content");
 			Assert.IsTrue (contentLength > 0, "Content-Length should be greater than zero");
 			Assert.IsTrue (body.Length > 0, "Response body should not be empty");


### PR DESCRIPTION
NSURLSession automatically decompresses content for supported encodings (gzip,
deflate, br, zstd, etc.) but leaves the original Content-Encoding and
Content-Length headers in the response. This causes a mismatch where
Content-Length refers to the compressed size while the body is decompressed.

All other HTTP handlers (SocketsHttpHandler, WinHttpHandler, Android's
handler) remove these headers after automatic decompression. This change makes
NSUrlSessionHandler consistent with them.

Fixes https://github.com/dotnet/macios/issues/23958

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>