### PR TITLE
[msbuild] Put all the tasks in the same assembly (Xamarin.MacDev.Tasks.dll).

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/MessagingTasks.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/MessagingTasks.cs
@@ -1,0 +1,27 @@
+namespace Xamarin.MacDev.Tasks.Messaging;
+
+// We subclass the Xamarin.Messaging.Build.Client tasks so that we have all our tasks in the same
+// assembly; otherwise we run into problems with task isolation in .NET, where the tasks in one
+// assembly can't access shared state from tasks in another assembly (for instance, all remoted tasks
+// need to access shared state from the SayHello task).
+
+public class GenerateBuildSessionId : Xamarin.Messaging.Build.Client.Tasks.GenerateBuildSessionId {
+}
+
+public class SayHello : Xamarin.Messaging.Build.Client.Tasks.SayHello {
+}
+
+public class CopyFileFromBuildServer : Xamarin.Messaging.Build.Client.Tasks.CopyFileFromBuildServer {
+}
+
+public class CopyFilesToBuildServer : Xamarin.Messaging.Build.Client.Tasks.CopyFilesToBuildServer {
+}
+
+public class CopyLongPaths : Xamarin.Messaging.Build.Client.Tasks.CopyLongPaths {
+}
+
+public class VerifyBuildSignature : Xamarin.Messaging.Build.Client.Tasks.VerifyBuildSignature {
+}
+
+public class SayGoodbye : Xamarin.Messaging.Build.Client.Tasks.SayGoodbye {
+}

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.Messaging.Apple.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.Messaging.Apple.targets
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">	
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Messaging.Build.targets" Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Messaging.Build.targets') And '$(MessagingBuildTargetsImported)' != 'true'" />
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Messaging.targets" Condition="'$(MessagingBuildTargetsImported)' != 'true'" />
 
 	<PropertyGroup>
 		<RebuildDependsOn>

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.Messaging.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.Messaging.targets
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build"	xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.Messaging.GenerateBuildSessionId" AssemblyFile="$(_TaskAssemblyName)" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.Messaging.SayHello" AssemblyFile="$(_TaskAssemblyName)" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.Messaging.CopyFileFromBuildServer" AssemblyFile="$(_TaskAssemblyName)" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.Messaging.CopyFilesToBuildServer" AssemblyFile="$(_TaskAssemblyName)" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.Messaging.CopyLongPaths" AssemblyFile="$(_TaskAssemblyName)" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.Messaging.VerifyBuildSignature" AssemblyFile="$(_TaskAssemblyName)" />
+	<UsingTask TaskName="Xamarin.MacDev.Tasks.Messaging.SayGoodbye" AssemblyFile="$(_TaskAssemblyName)" />
+
+	<PropertyGroup>
+		<IsRemoteBuild Condition="'$(IsRemoteBuild)' == ''">true</IsRemoteBuild>
+		<ShouldDisconnect Condition="'$(ShouldDisconnect)' == ''">true</ShouldDisconnect>
+		<IsRebuild>false</IsRebuild>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<RebuildDependsOn>
+			_SetIsRebuild;
+			_SetShouldDisconnect;
+			_GenerateBuildSessionId;
+			_SayHello;
+			$(RebuildDependsOn);
+			_SayGoodbye;
+		</RebuildDependsOn>
+		<!-- If the Clean executes as part of a Rebuild, the _GenerateBuildSessionId and _SayHello will not run because they've already run -->
+		<CleanDependsOn>
+			_GenerateBuildSessionId;
+			_SayHello;
+			$(CleanDependsOn);
+			_DisconnectAfterClean;
+		</CleanDependsOn>
+		<!-- If the Build executes as part of a Rebuild, the _GenerateBuildSessionId and _SayHello will not run because they've already run -->
+		<BuildDependsOn>
+			_GenerateBuildSessionId;
+			_SayHello;
+			_VerifyBuildSignature;
+			AfterConnect;
+			$(BuildDependsOn);
+			BeforeDisconnect;
+			_DisconnectAfterBuild;
+		</BuildDependsOn>
+		<BuildSignatureDirectory Condition="'$(BuildSignatureDirectory)' == ''">$(IntermediateOutputPath)build-signature\</BuildSignatureDirectory>
+		<BuildSignatureDirectory Condition="!HasTrailingSlash('$(BuildSignatureDirectory)')">$(BuildSignatureDirectory)\</BuildSignatureDirectory>
+		<BuildSignatureFile>$(BuildSignatureDirectory)signature</BuildSignatureFile>
+		<!-- By default, we don't want to warn about offline builds for class libraries, which typically don't require a connection -->
+		<WarnOfflineBuild Condition="'$(WarnOfflineBuild)' == '' and '$(OutputType)' == 'Library' and '$(XamarinOutputType)' != 'Binding'">false</WarnOfflineBuild>
+		<WarnOfflineBuild Condition="'$(WarnOfflineBuild)' == ''">true</WarnOfflineBuild>
+		<NoWarn Condition="'$(WarnOfflineBuild)' == 'false'">$(NoWarn);VSX1000</NoWarn>
+	</PropertyGroup>
+
+	<!-- AfterConnect: Redefine this target in your project in order to run tasks just after the XMA connection is performed -->
+	<Target Name="AfterConnect" Condition="'$(IsRemoteBuild)' == 'true'" />
+
+	<!-- BeforeDisconnect: Redefine this target in your project in order to run tasks just before the XMA disconnection happens -->
+	<Target Name="BeforeDisconnect" Condition="'$(IsRemoteBuild)' == 'true'" />
+
+	<Target Name="_SetShouldDisconnect">
+		<PropertyGroup>
+			<ShouldDisconnect>false</ShouldDisconnect>
+		</PropertyGroup>
+	</Target>
+
+	<Target Name="_SetIsRebuild">
+		<PropertyGroup>
+			<IsRebuild>true</IsRebuild>
+		</PropertyGroup>
+	</Target>
+
+	<Target Name="_DisconnectAfterClean" Condition="'$(ShouldDisconnect)' == 'true' Or ('$(ShouldDisconnect)' == 'if-connection-established' And '$(_DidEstablishConnection)' == 'true')" DependsOnTargets="_SayGoodbye" />
+
+	<Target Name="_DisconnectAfterBuild" Condition="'$(ShouldDisconnect)' == 'true' Or ('$(ShouldDisconnect)' == 'if-connection-established' And '$(_DidEstablishConnection)' == 'true')" DependsOnTargets="_SayGoodbye" />
+
+	<Target Name="_GenerateBuildSessionId" Condition="'$(IsRemoteBuild)' == 'true'">
+		<GenerateBuildSessionId MessagingVersion="$(MessagingVersion)" 
+			TargetFramework="$(TargetFramework)" 
+			ProjectFullPath="$(MSBuildProjectFullPath)" 
+			ProjectName="$(MSBuildProjectName)"
+			VisualStudioProcessId="$(VisualStudioProcessId)">
+			<Output TaskParameter="BuildSessionId" PropertyName="BuildSessionId" />
+			<Output TaskParameter="BuildAppName" PropertyName="BuildAppName" />
+		</GenerateBuildSessionId>
+	</Target>
+
+	<Target Name="_SayHello" Condition="'$(IsRemoteBuild)' == 'true'" DependsOnTargets="_GenerateBuildSessionId">
+		<PropertyGroup>
+			<!-- Explicitly using defauly SSH port if not specified -->
+			<ServerSshPort Condition="'$(ServerSshPort)' == ''">22</ServerSshPort>
+			<!-- Maintaining backwards compatibility if using the deprecated ServerPort property -->
+			<ServerTcpPort Condition="'$(ServerPort)' != ''">$(ServerPort)</ServerTcpPort>
+			<GenerateCache Condition=" '$(GenerateCache)' == '' And '$(BuildingInsideVisualStudio)' == 'true' ">true</GenerateCache>
+			<GenerateCache Condition=" '$(GenerateCache)' == '' And '$(BuildingInsideVisualStudio)' != 'true' ">false</GenerateCache>
+			<ContinueOnDisconnected Condition="'$(ContinueOnDisconnected)' == ''">true</ContinueOnDisconnected>
+		</PropertyGroup>
+
+		<Warning Condition="'$(ServerPort)' != ''" Text="The 'ServerPort' property has been deprecated. Please consider using 'ServerSshPort' or 'ServerTcpPort' instead." />
+
+		<Message Importance="high" Condition="'$(ServerAddress)' != ''" Text="Executing SayHello Task to establish a connection to a Remote Server. 
+			Properties: 
+				SessionId=$(BuildSessionId), 
+				Addresss=$(ServerAddress), 
+				SshPort=$(ServerSshPort), 
+				TcpPort=$(ServerTcpPort), 
+				User=$(ServerUser), 
+				AppName=$(BuildAppName),
+				VisualStudioProcessId=$(VisualStudioProcessId),
+				DotNetRuntimePath=$(DotNetRuntimePath),
+				DotNetSdkPath=$(_DotNetRootRemoteDirectory),
+				ContinueOnDisconnected=$(ContinueOnDisconnected)" />
+
+		<SayHello Condition="'$(ServerAddress)' != ''" 
+				  SessionId="$(BuildSessionId)"
+				  LocalBasePath="$(LocalBasePath)"
+				  LocalSettingsPath="$(LocalSettingsPath)"
+				  BasePath="$(BasePath)"
+				  BuildsPath="$(BuildsPath)"
+				  LogsPath="$(LogsPath)"
+				  IntermediateDir="$(IntermediateOutputPath)build_package\"
+				  DotNetRuntimePath="$(DotNetRuntimePath)"
+				  DotNetSdkPath="$(_DotNetRootRemoteDirectory)"
+				  ServerAddress="$(ServerAddress)"
+				  ServerSshPort="$(ServerSshPort)"
+				  ServerTcpPort="$(ServerTcpPort)"
+				  ServerUser="$(ServerUser)"
+				  ServerPassword="$(ServerPassword)"
+				  SSHKey="$(SSHKey)"
+				  SSHPassPhrase="$(SSHPassPhrase)"
+				  AppName="$(BuildAppName)"
+				  GenerateCache="$(GenerateCache)"
+				  ProjectDirectory="$(MSBuildProjectDirectory)"
+				  ContinueOnDisconnected="$(ContinueOnDisconnected)"
+				  VisualStudioProcessId="$(VisualStudioProcessId)"
+				  NoWarn="$(NoWarn)"
+				  AgentsDirectory="$(MessagingAgentsDirectory)">
+			<Output TaskParameter="DidEstablishConnection" PropertyName="_DidEstablishConnection" />
+			<Output TaskParameter="IsBuildServerAvailable" PropertyName="MtouchTargetsEnabled" />
+			<Output TaskParameter="IsBuildServerAvailable" PropertyName="IsMacEnabled" />
+			<Output TaskParameter="MacBuildPath" PropertyName="MacBuildPath" />
+		</SayHello>
+	</Target>
+
+	<!-- We don't want to execute _VerifyBuildSignature on Rebuild since the Rebuild implies a Clean before Build -->
+	<!-- so we don't need to Clean again if the signature does not exist -->
+	<!-- Also, if there is no Mac available and the signature file does not exist, we ignore this check because offline builds never produce a signature file and this would end up always rebuilding the project -->
+	<Target Name="_VerifyBuildSignature" Condition="'$(IsRemoteBuild)' == 'true'  And '$(IsRebuild)' != 'true' And ('$(IsMacEnabled)' == 'true' Or ('$(IsMacEnabled)' != 'true' And Exists('$(BuildSignatureFile)')))">
+		<VerifyBuildSignature SessionId="$(BuildSessionId)" SignatureDirectory="$(BuildSignatureDirectory)">
+			<Output TaskParameter="IsValidSignature" PropertyName="IsValidSignature" />
+		</VerifyBuildSignature>
+		<MSBuild Condition="'$(IsValidSignature)' != 'true'" Projects="$(MSBuildProjectFile)" Targets="Clean" Properties="Configuration=$(Configuration); Platform=$(Platform); ShouldDisconnect=if-connection-established; BuildProjectReferences=false"></MSBuild>
+	</Target>
+
+	<Target Name="_SayGoodbye" Condition="'$(IsRemoteBuild)' == 'true'">
+		<SayGoodbye Condition="'$(IsMacEnabled)' == 'true'" SessionId="$(BuildSessionId)" SignatureFile="$(BuildSignatureFile)" />
+		<ItemGroup>
+			<FileWrites Include="$(BuildSignatureFile)" />
+		</ItemGroup>
+	</Target>
+
+	<PropertyGroup>
+		<MessagingBuildTargetsImported>True</MessagingBuildTargetsImported>
+	</PropertyGroup>
+</Project>

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
@@ -21,7 +21,7 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 	<UsingTask TaskName="Xamarin.iOS.Tasks.Windows.CreateArchiveDirectory" AssemblyFile="$(_TaskAssemblyFileNameWindows)" />
 	<UsingTask TaskName="Xamarin.iOS.Tasks.Windows.ResolveUniversalTypeIdentifiers" AssemblyFile="$(_TaskAssemblyFileNameWindows)" />
 
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Messaging.Build.targets" Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Messaging.Build.targets') And '$(MessagingBuildTargetsImported)' != 'true'" />
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Messaging.targets" Condition="'$(MessagingBuildTargetsImported)' != 'true'" />
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.iOS.Windows.After.targets" Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.iOS.Windows.After.targets')" />
 
 	<PropertyGroup>

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.WatchApp.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.WatchApp.Common.After.targets
@@ -13,7 +13,7 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.iOS.Windows.props" Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.iOS.Windows.props')" />
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Messaging.Build.targets" Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Messaging.Build.targets') And '$(MessagingBuildTargetsImported)' != 'true'" />
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Messaging.targets" Condition="'$(MessagingBuildTargetsImported)' != 'true'" />
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Messaging.Apple.targets" Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Messaging.Apple.targets') And '$(MessagingAppleTargetsImported)' != 'true'" />
 	
 	<PropertyGroup>

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Windows.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Windows.After.targets
@@ -15,7 +15,7 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.CalculateAssembliesReport" AssemblyFile="$(CoreiOSSdkDirectory)$(_TaskAssemblyFileName)" />
 	<UsingTask TaskName="Xamarin.MacDev.Tasks.AnalyzeFileChanges" AssemblyFile="$(CoreiOSSdkDirectory)$(_TaskAssemblyFileName)" />
 	
-	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Messaging.Build.targets" Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Messaging.Build.targets') And '$(MessagingBuildTargetsImported)' != 'true'" />
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Messaging.targets" Condition="'$(MessagingBuildTargetsImported)' != 'true'" />
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Messaging.Apple.targets" Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Messaging.Apple.targets') And '$(MessagingAppleTargetsImported)' != 'true'" />
 
 	<PropertyGroup>

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Windows.props
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Windows.props
@@ -13,8 +13,6 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<!-- Property originally defined in Xamarin.Messaging.Build.targets, from Xamarin.Messaging.Build.Client package -->
-		<MessagingBuildClientAssemblyFile>$(CoreiOSSdkDirectory)Xamarin.MacDev.Tasks.dll</MessagingBuildClientAssemblyFile>
 		<MessagingAgentsDirectory>$(MSBuildThisFileDirectory)</MessagingAgentsDirectory>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
We want to build our task assembly for .NET 10, but there's a breaking change
when loading .NET assemblies in MSBuild: they're isolated from eachother.

However, we need all our tasks to be able to talk to eachother when building
remotely (because the remote connection is stored in static state) - so the
solution is to put all the tasks in the same assembly.

The quickest and easiest way to do this is to just create an empty subclass of
the actual task class in the assembly where we have all the other tasks, so
this pull request does that.

To simplify iterating on the MSBuild logic, I've also included the `Xamarin.Messaging.targets` file.