### PR TITLE
Re-enable CoreCLR test variations on x64

### DIFF
--- a/tests/xharness/Jenkins/TestVariationsFactory.cs
+++ b/tests/xharness/Jenkins/TestVariationsFactory.cs
@@ -38,8 +38,7 @@ namespace Xharness.Jenkins {
 			var x64_sim_runtime_identifier = string.Empty;
 			var supports_mono = test.Platform != TestPlatform.Mac;
 			var supports_coreclr = true;
-			var coreclr_works = Harness.CanRunArm64 || test.Platform == TestPlatform.Mac; // ignore tests on x64 until https://github.com/dotnet/runtime/issues/122563
-			var ignore_coreclr = coreclr_works ? ignore : true;
+			var ignore_coreclr = ignore;
 
 			switch (test.Platform) {
 			case TestPlatform.Mac:


### PR DESCRIPTION
Remove the workaround that disabled CoreCLR test variations on x64 to verify if dotnet/runtime#122563 has been fixed.

The original issue was a CoreCLR interpreter crash on x64 (stack overflow in `InterpreterStubRetI8`). This PR re-enables the tests so CI can confirm whether the fix has landed in the runtime.