### PR TITLE
[net11.0] [tests] Re-enable CoreCLR test variations on x64

### DIFF
--- a/tests/xharness/Jenkins/TestVariationsFactory.cs
+++ b/tests/xharness/Jenkins/TestVariationsFactory.cs
@@ -38,8 +38,7 @@ namespace Xharness.Jenkins {
 			var x64_sim_runtime_identifier = string.Empty;
 			var supports_mono = test.Platform != TestPlatform.Mac;
 			var supports_coreclr = true;
-			var coreclr_works = Harness.CanRunArm64 || test.Platform == TestPlatform.Mac; // ignore tests on x64 until https://github.com/dotnet/runtime/issues/122563
-			var ignore_coreclr = coreclr_works ? ignore : true;
+			var ignore_coreclr = ignore;
 
 			switch (test.Platform) {
 			case TestPlatform.Mac:

--- a/tests/xharness/Jenkins/TestVariationsFactory.cs
+++ b/tests/xharness/Jenkins/TestVariationsFactory.cs
@@ -80,7 +80,10 @@ namespace Xharness.Jenkins {
 			case "monotouch-test":
 				if (supports_coreclr && supports_mono) { // we only need specific coreclr test if we *also* support mono (otherwise the default test will be coreclr)
 					yield return new TestData { Variation = "Debug (CoreCLR)", TestVariation = "debug|coreclr", Ignored = ignore_coreclr, Debug = true };
-					yield return new TestData { Variation = "Release (CoreCLR)", TestVariation = "release|coreclr", Ignored = ignore_coreclr, Debug = false };
+					if (mac_supports_arm64)
+						yield return new TestData { Variation = "Release (CoreCLR, ARM64)", TestVariation = "release|coreclr", Ignored = ignore_coreclr, Debug = false, RuntimeIdentifier = arm64_sim_runtime_identifier };
+					yield return new TestData { Variation = "Release (CoreCLR, x64)", TestVariation = "release|coreclr", Ignored = ignore_coreclr, Debug = false, RuntimeIdentifier = x64_sim_runtime_identifier };
+					yield return new TestData { Variation = "Release (CoreCLR, Universal)", TestVariation = "release|coreclr", Ignored = ignore_coreclr, Debug = false };
 				}
 				break;
 			}


### PR DESCRIPTION
Remove the workaround that disabled CoreCLR test variations on x64 to verify if dotnet/runtime#122563 has been fixed.

The original issue was a CoreCLR interpreter crash on x64 (stack overflow in `InterpreterStubRetI8`). This PR re-enables the tests so CI can confirm whether the fix has landed in the runtime.

Also add a specific x64 test variation to make sure the tests aren't just passing because we happen to run on an arm64 bot.