### PR TITLE
[tools] Enable xml doc generation for dotnet-linker.

### DIFF
--- a/src/Foundation/ExportAttribute.cs
+++ b/src/Foundation/ExportAttribute.cs
@@ -36,6 +36,7 @@ using Registrar;
 
 namespace Foundation {
 
+#if !BUNDLER
 	/// <summary>Exports a method or property to the Objective-C world.</summary>
 	///     <remarks>
 	///       <para>
@@ -52,6 +53,7 @@ namespace Foundation {
 	///   ]]></code>
 	///       </example>
 	///     </remarks>
+#endif
 	[AttributeUsage (AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Property)]
 	public class ExportAttribute : Attribute {
 		string? selector;

--- a/tools/common/StringUtils.cs
+++ b/tools/common/StringUtils.cs
@@ -247,7 +247,7 @@ namespace Xamarin.Utils {
 		/// <param name="code">The code of the message.</param>
 		/// <param name="message">The message text.</param>
 		/// <returns></returns>
-		/// <see cref="https://learn.microsoft.com/visualstudio/msbuild/msbuild-diagnostic-format-for-tasks"/>
+		/// <see href="https://learn.microsoft.com/visualstudio/msbuild/msbuild-diagnostic-format-for-tasks"/>
 		public static string FormatMessage (string? fileName, long? lineNumber, bool isError, string prefix, int code, string message)
 		{
 			var sb = new StringBuilder ();

--- a/tools/dotnet-linker/dotnet-linker.csproj
+++ b/tools/dotnet-linker/dotnet-linker.csproj
@@ -4,9 +4,11 @@
     <RootNamespace>dotnet_linker</RootNamespace>
     <DefineConstants>$(DefineConstants);BUNDLER</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn> <!-- Missing XML comment for publicly visible type or member: don't care, the APIs aren't for public consumption -->
   </PropertyGroup>
 
   <Import Project="..\..\eng\Versions.props" />


### PR DESCRIPTION
This way we get validation of any xml docs in dotnet-linker.

Also make all warnings errors, since we're now warning-free.