### PR TITLE
[Foundation] Add KeepHeadersAfterDecompression app context switch to NSUrlSessionHandler

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -987,6 +987,9 @@ namespace Foundation {
 					// - SocketsHttpHandler:    https://github.com/dotnet/runtime/blob/b2974279efd059efaa17f359ed4b266b1c705721/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/DecompressionHandler.cs#L122-L123
 					// - AndroidMessageHandler: https://github.com/dotnet/android/pull/7785
 					// Ref: https://github.com/dotnet/macios/issues/23958
+					// This behavior can be opted out of by setting the
+					// Foundation.NSUrlSessionHandler.KeepHeadersAfterDecompression switch.
+					var keepHeaders = AppContext.TryGetSwitch ("Foundation.NSUrlSessionHandler.KeepHeadersAfterDecompression", out var keepHeadersEnabled) && keepHeadersEnabled;
 					string? contentEncodingValue = null;
 					string? contentLengthValue = null;
 
@@ -999,11 +1002,11 @@ namespace Foundation {
 						// NSUrlSession tries to be smart with cookies, we will not use the raw value but the ones provided by the cookie storage
 						if (key == SetCookie) continue;
 
-						if (string.Equals (key, ContentEncodingHeaderName, StringComparison.OrdinalIgnoreCase)) {
+						if (!keepHeaders && string.Equals (key, ContentEncodingHeaderName, StringComparison.OrdinalIgnoreCase)) {
 							contentEncodingValue = value;
 							continue;
 						}
-						if (string.Equals (key, ContentLengthHeaderName, StringComparison.OrdinalIgnoreCase)) {
+						if (!keepHeaders && string.Equals (key, ContentLengthHeaderName, StringComparison.OrdinalIgnoreCase)) {
 							contentLengthValue = value;
 							continue;
 						}

--- a/tests/monotouch-test/System.Net.Http/NSUrlSessionHandlerTest.cs
+++ b/tests/monotouch-test/System.Net.Http/NSUrlSessionHandlerTest.cs
@@ -93,6 +93,47 @@ namespace MonoTests.System.Net.Http {
 			Assert.IsTrue (body.Length > 0, "Response body should not be empty");
 		}
 
+		// https://github.com/dotnet/macios/issues/23958
+		[Test]
+		public void KeepHeadersAfterDecompressionSwitch ()
+		{
+			bool hasContentEncoding = false;
+			bool hasContentLength = false;
+			string body = "";
+
+			AppContext.SetSwitch ("Foundation.NSUrlSessionHandler.KeepHeadersAfterDecompression", true);
+			try {
+				var done = TestRuntime.TryRunAsync (TimeSpan.FromSeconds (30), async () => {
+					using var handler = new NSUrlSessionHandler ();
+					using var client = new HttpClient (handler);
+					using var request = new HttpRequestMessage (HttpMethod.Get, $"{NetworkResources.Httpbin.Url}/gzip");
+					request.Headers.TryAddWithoutValidation ("Accept-Encoding", "gzip");
+					var response = await client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead);
+
+					if (!response.IsSuccessStatusCode) {
+						Assert.Inconclusive ($"Request failed with status {response.StatusCode}");
+						return;
+					}
+
+					hasContentEncoding = response.Content.Headers.ContentEncoding.Count > 0;
+					hasContentLength = response.Content.Headers.ContentLength is not null;
+					body = await response.Content.ReadAsStringAsync ();
+				}, out var ex);
+
+				if (!done) {
+					TestRuntime.IgnoreInCI ("Transient network failure - ignore in CI");
+					Assert.Inconclusive ("Request timed out.");
+				}
+				TestRuntime.IgnoreInCIIfBadNetwork (ex);
+				Assert.IsNull (ex, $"Exception: {ex}");
+				Assert.IsTrue (hasContentEncoding, "Content-Encoding header should be preserved when KeepHeadersAfterDecompression is enabled");
+				Assert.IsTrue (hasContentLength, "Content-Length header should be preserved when KeepHeadersAfterDecompression is enabled");
+				Assert.IsTrue (body.Contains ("\"gzipped\"", StringComparison.OrdinalIgnoreCase), "Response body should contain decompressed gzip data");
+			} finally {
+				AppContext.SetSwitch ("Foundation.NSUrlSessionHandler.KeepHeadersAfterDecompression", false);
+			}
+		}
+
 		// https://github.com/dotnet/macios/issues/24376
 		[Test]
 		public void DisposeAndRecreateBackgroundSessionHandler ()


### PR DESCRIPTION
Add an opt-out switch 'Foundation.NSUrlSessionHandler.KeepHeadersAfterDecompression'
that, when enabled, preserves the original Content-Encoding and Content-Length headers
on auto-decompressed responses instead of removing them.

This allows apps that depend on the original headers to restore the previous behavior.