### PR TITLE
[sharpie] Bump ClangSharp to v21.1.8.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,7 @@
 		<!-- Fix transient dependency issue found by component governance 4.7.0 -> 4.7.1 brought by Microsoft.Build.Tasks.Core package -->
 		<SystemSecurityCryptographyXmlPackageVersion>8.0.0</SystemSecurityCryptographyXmlPackageVersion>
 
-		<ClangSharpPackageVersion>21.1.8.2</ClangSharpPackageVersion>
+		<ClangSharpPackageVersion>21.1.8.3</ClangSharpPackageVersion>
 		<ICSharpCodeNRefactoryPackageVersion>5.5.1</ICSharpCodeNRefactoryPackageVersion>
 		<libclangPackageVersion>21.1.8</libclangPackageVersion>
 		<MicrosoftNETTestSdkPackageVersion>17.14.0</MicrosoftNETTestSdkPackageVersion>


### PR DESCRIPTION
In order to get dotnet/ClangSharp#690