### PR TITLE
[dotnet] Add net10.0 msbuild tool DLLs to SignList.xml

### DIFF
--- a/dotnet/Workloads/SignList.xml
+++ b/dotnet/Workloads/SignList.xml
@@ -42,7 +42,6 @@
     <Skip Include="Microsoft.Win32.SystemEvents.dll" />
     <Skip Include="MonoTargetsTasks.dll" />
     <Skip Include="MQTTnet.dll" />
-    <Skip Include="Renci.SshNet.dll" />
     <Skip Include="System.CodeDom.dll" />
     <Skip Include="System.ComponentModel.Composition.dll" />
     <Skip Include="System.Configuration.ConfigurationManager.dll" />
@@ -58,6 +57,7 @@
 
   <ItemGroup>
     <ThirdParty Include="BouncyCastle.Crypto.dll" />
+    <ThirdParty Include="Renci.SshNet.dll" />
     <!-- Build.zip -->
     <ThirdParty Include="Mono.Cecil*.dll" />
 


### PR DESCRIPTION
The dotnet/dotnet dependency update (#24989) introduced new DLLs in the tools/msbuild/net10.0/ directory of the SDK NuGet packages. These DLLs were not listed in SignList.xml, causing the 'Sign Package Contents' task to fail in the xamarin-macios-ci pipeline (build 13640795).

Add 18 DLLs as Skip entries since they come pre-signed from the dotnet/dotnet unified build.