### PR TITLE
[HomeKit] Ignore HMError.QuotaExceeded removed by Apple in Xcode 26.4

### DIFF
--- a/src/HomeKit/HMEnums.cs
+++ b/src/HomeKit/HMEnums.cs
@@ -212,8 +212,10 @@ namespace HomeKit {
 		PartialCommunicationFailure = 104,
 		// iOS 18.4
 		HomeUpgradeRequired = 105,
-		// iOS 26.1
+#if !XAMCORE_5_0
+		// iOS 26.1 - Apple removed this enum value from native headers in Xcode 26.4
 		QuotaExceeded = 106,
+#endif
 	}
 
 

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-HomeKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-HomeKit.ignore
@@ -1,1 +1,2 @@
+# Apple removed this enum value from native headers in Xcode 26.4
 !extra-enum-value! Managed value 106 for HMError.QuotaExceeded not found in native headers

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-HomeKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-HomeKit.ignore
@@ -1,3 +1,6 @@
 # CHIP is not bound yet and will be only when is stable
 !missing-selector! HMAccessorySetupRequest::matterPayload not bound
 !missing-selector! HMAccessorySetupRequest::setMatterPayload: not bound
+
+# Apple removed this enum value from native headers in Xcode 26.4
+!extra-enum-value! Managed value 106 for HMError.QuotaExceeded not found in native headers

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-HomeKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-HomeKit.ignore
@@ -1,1 +1,2 @@
+# Apple removed this enum value from native headers in Xcode 26.4
 !extra-enum-value! Managed value 106 for HMError.QuotaExceeded not found in native headers

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-HomeKit.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-HomeKit.todo
@@ -1,1 +1,0 @@
-!extra-enum-value! Managed value 106 for HMError.QuotaExceeded not found in native headers


### PR DESCRIPTION
Apple removed the QuotaExceeded (106) enum value from native HomeKit headers in Xcode 26.4. Since error enum members cannot have availability attributes (enforced by cecil NoAvailabilityOnError test), keep the value for backward compatibility and add platform-specific xtro ignore entries.