### PR TITLE
[sharpie/xtro] VersionTuple.IsEmpty is incorrect, so use an extension property with the correct implementation.

### DIFF
--- a/tests/xtro-sharpie/.vscode/launch.json
+++ b/tests/xtro-sharpie/.vscode/launch.json
@@ -13,7 +13,36 @@
             "args": [
                 "@xtro-sharpie-iOS.rsp",
             ],
+        },
+        {
+            "name": "xtro-sharpie: tvOS",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "dotnet: build",
+            "program": "${workspaceFolder}/xtro-sharpie/bin/Debug/xtro-sharpie.dll",
+            "args": [
+                "@xtro-sharpie-tvOS.rsp",
+            ],
+        },
+        {
+            "name": "xtro-sharpie: Mac Catalyst",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "dotnet: build",
+            "program": "${workspaceFolder}/xtro-sharpie/bin/Debug/xtro-sharpie.dll",
+            "args": [
+                "@xtro-sharpie-MacCatalyst.rsp",
+            ],
+        },
+        {
+            "name": "xtro-sharpie: macOS",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "dotnet: build",
+            "program": "${workspaceFolder}/xtro-sharpie/bin/Debug/xtro-sharpie.dll",
+            "args": [
+                "@xtro-sharpie-macOS.rsp",
+            ],
         }
-
     ]
 }

--- a/tests/xtro-sharpie/xtro-sharpie/AttributeHelpers.cs
+++ b/tests/xtro-sharpie/xtro-sharpie/AttributeHelpers.cs
@@ -93,7 +93,7 @@ namespace Extrospection {
 
 		public static bool FindObjcDeprecated (IEnumerable<Attr> attrs, out VersionTuple version)
 		{
-			var attr = attrs.GetAvailabilityAttributes ().FirstOrDefault (x => x.AvailabilityAttributeDeprecated.HasValue && !x.AvailabilityAttributeDeprecated.Value.IsEmpty && x.AvailabilityAttributePlatformIdentifierName == Helpers.ClangPlatformName);
+			var attr = attrs.GetAvailabilityAttributes ().FirstOrDefault (x => x.AvailabilityAttributeDeprecated.HasValue && !x.AvailabilityAttributeDeprecated.Value.IsEmptyVersionTuple && x.AvailabilityAttributePlatformIdentifierName == Helpers.ClangPlatformName);
 			if (attr is not null) {
 				version = attr.AvailabilityAttributeDeprecated.Value;
 				return true;

--- a/tests/xtro-sharpie/xtro-sharpie/Helpers.cs
+++ b/tests/xtro-sharpie/xtro-sharpie/Helpers.cs
@@ -160,10 +160,10 @@ namespace Extrospection {
 				if (attr.AvailabilityAttributeUnavailable && (availName == platform))
 					return false;
 				// for iOS we won't report missing members that were deprecated before 5.0
-				if (!attr.Deprecated.IsEmpty && availName == "ios" && attr.Deprecated.Major < 5)
+				if (!attr.Deprecated.IsEmptyVersionTuple && availName == "ios" && attr.Deprecated.Major < 5)
 					return false;
 				// can't return true right away as it can be deprecated too
-				if (!attr.Introduced.IsEmpty && (availName == platform))
+				if (!attr.Introduced.IsEmptyVersionTuple && availName == platform)
 					result = true;
 			}
 			return result;
@@ -205,7 +205,7 @@ namespace Extrospection {
 				var availName = attr.AvailabilityAttributePlatformIdentifierName.ToLowerInvariant ();
 				if (availName != platform)
 					continue;
-				if (!attr.Deprecated.IsEmpty)
+				if (!attr.Deprecated.IsEmptyVersionTuple)
 					return true;
 			}
 			// then check for introduced - there may be both, so we must check *all* attributes for deprecation before checking for introduced
@@ -213,7 +213,7 @@ namespace Extrospection {
 				var availName = attr.AvailabilityAttributePlatformIdentifierName.ToLowerInvariant ();
 				if (availName != platform)
 					continue;
-				if (!attr.Introduced.IsEmpty)
+				if (!attr.Introduced.IsEmptyVersionTuple)
 					return false;
 			}
 

--- a/tools/sharpie/Sharpie.Bind/Attributes/AvailabilityBaseAttribute.cs
+++ b/tools/sharpie/Sharpie.Bind/Attributes/AvailabilityBaseAttribute.cs
@@ -81,7 +81,7 @@ class AvailabilityBaseAttribute : ICSharpCode.NRefactory.CSharp.Attribute {
 			));
 		}
 
-		if (!version.IsEmpty) {
+		if (!version.IsEmptyVersionTuple) {
 			Arguments.Add (new PrimitiveExpression (version.Major));
 			Arguments.Add (new PrimitiveExpression (version.Minor.GetValueOrDefault ()));
 			if (version.Subminor is not null)
@@ -104,15 +104,15 @@ class AvailabilityBaseAttribute : ICSharpCode.NRefactory.CSharp.Attribute {
 			yield break;
 		}
 
-		if (attr.AvailabilityAttributeIntroduced.HasValue && !attr.AvailabilityAttributeIntroduced.Value.IsEmpty)
+		if (attr.AvailabilityAttributeIntroduced.HasValue && !attr.AvailabilityAttributeIntroduced.Value.IsEmptyVersionTuple)
 			yield return new AvailabilityBaseAttribute (
 				AvailabilityKind.Introduced, platform, attr.AvailabilityAttributeIntroduced ?? default, attr.AvailabilityAttributeMessage);
 
-		if (attr.AvailabilityAttributeDeprecated.HasValue && !attr.AvailabilityAttributeDeprecated.Value.IsEmpty)
+		if (attr.AvailabilityAttributeDeprecated.HasValue && !attr.AvailabilityAttributeDeprecated.Value.IsEmptyVersionTuple)
 			yield return new AvailabilityBaseAttribute (
 				AvailabilityKind.Deprecated, platform, attr.AvailabilityAttributeDeprecated.Value, attr.AvailabilityAttributeMessage);
 
-		if (attr.AvailabilityAttributeObsoleted.HasValue && !attr.AvailabilityAttributeObsoleted.Value.IsEmpty)
+		if (attr.AvailabilityAttributeObsoleted.HasValue && !attr.AvailabilityAttributeObsoleted.Value.IsEmptyVersionTuple)
 			yield return new AvailabilityBaseAttribute (
 				AvailabilityKind.Obsoleted, platform, attr.AvailabilityAttributeObsoleted.Value, attr.AvailabilityAttributeMessage);
 
@@ -170,9 +170,9 @@ class AvailabilityBaseAttribute : ICSharpCode.NRefactory.CSharp.Attribute {
 	{
 		// shorthand attributes are only returned iff there
 		// is one attribute of any kind for the platform
-		var hasIntroduced = attr.AvailabilityAttributeIntroduced.HasValue && !attr.AvailabilityAttributeIntroduced.Value.IsEmpty;
-		var hasDeprecated = attr.AvailabilityAttributeDeprecated.HasValue && !attr.AvailabilityAttributeDeprecated.Value.IsEmpty;
-		var hasObsoleted = attr.AvailabilityAttributeObsoleted.HasValue && !attr.AvailabilityAttributeObsoleted.Value.IsEmpty;
+		var hasIntroduced = attr.AvailabilityAttributeIntroduced.HasValue && !attr.AvailabilityAttributeIntroduced.Value.IsEmptyVersionTuple;
+		var hasDeprecated = attr.AvailabilityAttributeDeprecated.HasValue && !attr.AvailabilityAttributeDeprecated.Value.IsEmptyVersionTuple;
+		var hasObsoleted = attr.AvailabilityAttributeObsoleted.HasValue && !attr.AvailabilityAttributeObsoleted.Value.IsEmptyVersionTuple;
 		var hasUnavailable = attr.AvailabilityAttributeUnavailable;
 
 		if (hasIntroduced && !hasDeprecated && !hasObsoleted && !hasUnavailable)

--- a/tools/sharpie/Sharpie.Bind/ClangExtensions.cs
+++ b/tools/sharpie/Sharpie.Bind/ClangExtensions.cs
@@ -443,5 +443,10 @@ public static class ClangExtensions {
 		public VersionTuple Deprecated => self.AvailabilityAttributeDeprecated ?? default;
 		public VersionTuple Obsoleted => self.AvailabilityAttributeObsoleted ?? default;
 	}
+
+	extension(VersionTuple self) {
+		// An extension property for IsEmpty until we get the actual IsEmpty fix: https://github.com/dotnet/ClangSharp/pull/693
+		public bool IsEmptyVersionTuple => self.Major == 0 && (self.Minor ?? 0) == 0 && (self.Subminor ?? 0) == 0 && (self.Build ?? 0) == 0;
+	}
 }
 


### PR DESCRIPTION
VersionTuple.IsEmpty is incorrect, so use an extension property with the
correct implementation until we get the fixed version from ClangSharp.