### PR TITLE
[copilot] Tell copilot to not report potential compiler errors.

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ Ignore comments from the user 'vs-mobiletools-engineering-service2' when process
 
 ## Pull request review instructions
 
-- Don't report about C# code you don't think will compile.
+- Don't report potential C# compilation errors (the compiler will report those).
 
 ## Repository Overview
 


### PR DESCRIPTION
If copilot is right, the compiler will also tell us, so copilot's comment will
be unnecessary noise. Which it will also be if copilot is wrong.