### PR TITLE
Copy final user assemblies to output directory for CoreCLR debugger

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -268,6 +268,7 @@
 			_CopyDirectoriesToBundle;
 			_CopyAppExtensionsToBundle;
 			_PostProcessAppBundle;
+			_CopyDebuggerAssetsToOutput;
 		</CreateAppBundleDependsOn>
 
 		<!-- not inner build for multi-rid build (single-rid build or outer build for multi-rid build) -->
@@ -283,6 +284,7 @@
 			$(CreateAppBundleDependsOn);
 			_CreateMergedAppBundle;
 			_PostProcessAppBundle;
+			_CopyDebuggerAssetsToOutput;
 		</CreateAppBundleDependsOn>
 	</PropertyGroup>
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -3045,6 +3045,36 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 	<Target Name="_PostProcessAppBundle" DependsOnTargets="$(_PostProcessAppBundleDependsOn)" />
 
+	<Target Name="_CopyDebuggerAssetsToOutput"
+		Condition="'$(_CanOutputAppBundle)' == 'true' and '$(DebuggerSupport)' == 'true' and '$(_XamarinRuntime)' == 'CoreCLR'"
+		DependsOnTargets="_GenerateBundleName;_ComputeVariables">
+		<PropertyGroup>
+			<_DebuggerAssetsDir>$([MSBuild]::NormalizeDirectory('$(DeviceSpecificOutputPath)', 'debugger-assets'))</_DebuggerAssetsDir>
+			<_CoreCLRRuntimePackPath>%(_MonoFrameworkReference.RuntimePackPath)</_CoreCLRRuntimePackPath>
+		</PropertyGroup>
+		<MakeDir Directories="$(_DebuggerAssetsDir)" />
+		<ItemGroup>
+			<_FinalAppBundleAssembly Include="@(_UserAssemblies -> '$(_AppBundlePath)$(_AppContentsRelativePath)%(Filename).dll')" />
+			<_FinalAppBundleAssembly Include="@(_UserAssemblies -> '$(_AppBundlePath)$(_AppContentsRelativePath)%(Filename).pdb')" />
+			<_FinalAppBundleAssembly Remove="@(_FinalAppBundleAssembly)" Condition="!Exists('%(Identity)')" />
+
+			<_HostDebugComponent Include="$(_CoreCLRRuntimePackPath)/tools/osx-*/libmscordaccore.dylib" />
+			<_HostDebugComponent Include="$(_CoreCLRRuntimePackPath)/tools/osx-*/libmscordbi.dylib" />
+		</ItemGroup>
+		<Copy
+			SourceFiles="@(_FinalAppBundleAssembly)"
+			DestinationFolder="$(_DebuggerAssetsDir)"
+			SkipUnchangedFiles="true"
+			Condition="'@(_FinalAppBundleAssembly)' != ''"
+		/>
+		<Copy
+			SourceFiles="@(_HostDebugComponent)"
+			DestinationFolder="$(_DebuggerAssetsDir)"
+			SkipUnchangedFiles="true"
+			Condition="'@(_HostDebugComponent)' != ''"
+		/>
+	</Target>
+
 	<Target Name="_PreparePostProcessing" DependsOnTargets="_CollectItemsForPostProcessing">
 		<ItemGroup>
 			<_PostProcessingItem>


### PR DESCRIPTION
## Summary

After the app bundle is created (post-link, post-strip), this change copies the final `.dll` and `.pdb` files for user assemblies back to the output directory (`DeviceSpecificOutputPath`). This is the directory that vsdbg uses as `assetsPath` to resolve assembly metadata and PDB symbols.

Fixes https://github.com/dotnet/runtime/issues/125974