### PR TITLE
[net11.0] [dotnet] Sign net11.0 workload msbuild task DLLs

### DIFF
--- a/dotnet/Workloads/SignList.xml
+++ b/dotnet/Workloads/SignList.xml
@@ -35,12 +35,12 @@
     <Skip Include="Build\System.Text.Json.dll" />
     <Skip Include="Build\System.Threading.Tasks.Dataflow.dll" />
     <Skip Include="Build\System.Threading.Tasks.Extensions.dll" />
-    <!-- net10.0 msbuild tools content -->
-    <Skip Include="AssemblyStripper.dll" />
+    <!-- Pre-signed msbuild tools content -->
+    <Skip Include="tools\msbuild\net10.0\AssemblyStripper.dll" />
     <Skip Include="BouncyCastle.Cryptography.dll" />
-    <Skip Include="ILLink.Tasks.dll" />
+    <Skip Include="tools\msbuild\net10.0\ILLink.Tasks.dll" />
     <Skip Include="Microsoft.Win32.SystemEvents.dll" />
-    <Skip Include="MonoTargetsTasks.dll" />
+    <Skip Include="tools\msbuild\net10.0\MonoTargetsTasks.dll" />
     <Skip Include="MQTTnet.dll" />
     <Skip Include="System.CodeDom.dll" />
     <Skip Include="System.ComponentModel.Composition.dll" />
@@ -138,6 +138,10 @@
     <FirstParty Include="Broker.resources.dll" />
     <!-- Build.zip -->
     <FirstParty Include="Build.dll" />
+    <!-- The net11.0 SDK packs ship these task assemblies unsigned, so we sign them here. -->
+    <FirstParty Include="tools\msbuild\net11.0\AssemblyStripper.dll" />
+    <FirstParty Include="tools\msbuild\net11.0\ILLink.Tasks.dll" />
+    <FirstParty Include="tools\msbuild\net11.0\MonoTargetsTasks.dll" />
     <FirstParty Include="Microsoft.Build*.dll" />
     <FirstParty Include="Microsoft.NET.StringTools.dll" />
     <FirstParty Include="System.IO.Abstractions.dll" />


### PR DESCRIPTION
The verify signed msi content step on net11.0 started failing because three task assemblies in tools/msbuild/net11.0 were still covered by the older Skip entries that were added for the pre-signed net10.0 copies.

Scope the Skip entries to the net10.0 paths and sign the net11.0 copies as first-party so they do not remain unsigned in the MSI payload.
