### PR TITLE
[msbuild] Revamp finding a simulator to use when running an app in the simulator. Fixes #25112.

### DIFF
--- a/dotnet/targets/Microsoft.Sdk.Mobile.targets
+++ b/dotnet/targets/Microsoft.Sdk.Mobile.targets
@@ -26,6 +26,7 @@
 
 		<GetMlaunchArguments
 			AppManifestPath="$(_AppBundleManifestPath)"
+			DiscardedDevices="@(DiscardedDevices)"
 			Devices="@(Devices)"
 			Help="true"
 			MlaunchPath="$(MlaunchPath)"
@@ -54,6 +55,7 @@
 		<GetMlaunchArguments
 			SessionId="$(BuildSessionId)"
 			AppManifestPath="$(_AppBundleManifestPath)"
+			DiscardedDevices="@(DiscardedDevices)"
 			Devices="@(Devices)"
 			DeviceName="$(Device)"
 			InstallApp="$(_AppBundlePath)"
@@ -107,6 +109,7 @@
 			AdditionalArguments="@(MlaunchAdditionalArguments)"
 			AppManifestPath="$(_AppBundleManifestPath)"
 			CaptureOutput="$(_MlaunchCaptureOutput)"
+			DiscardedDevices="@(DiscardedDevices)"
 			Devices="@(Devices)"
 			DeviceName="$(Device)"
 			EnvironmentVariables="@(MlaunchEnvironmentVariables)"

--- a/dotnet/targets/Microsoft.Sdk.Mobile.targets
+++ b/dotnet/targets/Microsoft.Sdk.Mobile.targets
@@ -20,12 +20,13 @@
 
 	<Target
 		Name="ShowRunHelp"
-		DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_DetectAppManifest">
+		DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_DetectAppManifest;ComputeAvailableDevices">
 		<Error Condition="$([MSBuild]::IsOSPlatform('windows'))" Text="It's currently not supported to launch an app from the command line on Windows." />
 		<Error Condition="!Exists('$(_AppBundleManifestPath)')" Text="The app must be built before showing how to launch it." />
 
 		<GetMlaunchArguments
 			AppManifestPath="$(_AppBundleManifestPath)"
+			Devices="@(Devices)"
 			Help="true"
 			MlaunchPath="$(MlaunchPath)"
 			SdkDevPath="$(_SdkDevPath)"
@@ -44,7 +45,7 @@
 	</Target>
 	<Target Name="_ShowRunHelpConditioned" Condition="'$(Help)' == 'true'" DependsOnTargets="ShowRunHelp" />
 
-	<Target Name="ComputeMlaunchInstallArguments" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_DetectAppManifest;_ShowRunHelpConditioned;_ComputeMlaunchInstallArguments" />
+	<Target Name="ComputeMlaunchInstallArguments" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_DetectAppManifest;ComputeAvailableDevices;_ShowRunHelpConditioned;_ComputeMlaunchInstallArguments" />
 	<Target Name="_ComputeMlaunchInstallArguments" Condition="'$(_SdkIsSimulator)' == 'false' And '$(Help)' != 'true'">
 		<!-- Launching from the command line on windows hasn't been implemented: https://github.com/dotnet/macios/issues/16609 -->
 		<Error Condition="$([MSBuild]::IsOSPlatform('windows'))" Text="It's currently not supported to launch an app from the command line on Windows." />
@@ -53,6 +54,7 @@
 		<GetMlaunchArguments
 			SessionId="$(BuildSessionId)"
 			AppManifestPath="$(_AppBundleManifestPath)"
+			Devices="@(Devices)"
 			DeviceName="$(Device)"
 			InstallApp="$(_AppBundlePath)"
 			MlaunchPath="$(MlaunchPath)"
@@ -77,7 +79,7 @@
 		<Exec SessionId="$(BuildSessionId)" Command="'$(MlaunchPath)' $(MlaunchInstallArguments)" />
 	</Target>
 
-	<Target Name="ComputeMlaunchRunArguments" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_DetectAppManifest;_ShowRunHelpConditioned;_ComputeMlaunchRunArguments" Condition="'$(_PlatformName)' != 'macOS' And '$(_PlatformName)' != 'MacCatalyst'" />
+	<Target Name="ComputeMlaunchRunArguments" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName;_DetectAppManifest;ComputeAvailableDevices;_ShowRunHelpConditioned;_ComputeMlaunchRunArguments" Condition="'$(_PlatformName)' != 'macOS' And '$(_PlatformName)' != 'MacCatalyst'" />
 
 	<Target Name="_ComputeMlaunchRunArguments" Condition="'$(Help)' != 'true'">
 		<!-- Launching from the command line on windows hasn't been implemented: https://github.com/dotnet/macios/issues/16609 -->
@@ -105,6 +107,7 @@
 			AdditionalArguments="@(MlaunchAdditionalArguments)"
 			AppManifestPath="$(_AppBundleManifestPath)"
 			CaptureOutput="$(_MlaunchCaptureOutput)"
+			Devices="@(Devices)"
 			DeviceName="$(Device)"
 			EnvironmentVariables="@(MlaunchEnvironmentVariables)"
 			LaunchApp="$(_AppBundlePath)"

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
@@ -455,7 +455,7 @@ namespace Xamarin.MacDev.Tasks {
 			}
 
 			if (Devices.Length == 0) {
-				Log.LogError ("The 'Devices' item group is empty.");
+				Log.LogError ("No applicable and available devices found.");
 				return false;
 			}
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
@@ -236,20 +236,13 @@ namespace Xamarin.MacDev.Tasks {
 
 		string SelectSimulatorDevice ()
 		{
-			if (Devices.Length > 0) {
-				var simulator = Devices.FirstOrDefault (v => string.Equals (v.GetMetadata ("Type"), "Simulator", StringComparison.OrdinalIgnoreCase));
-				if (simulator is not null)
-					return string.IsNullOrEmpty (simulator.GetMetadata ("UDID")) ? simulator.ItemSpec : simulator.GetMetadata ("UDID");
+			var simulator = Devices.FirstOrDefault (v => string.Equals (v.GetMetadata ("Type"), "Simulator", StringComparison.OrdinalIgnoreCase));
+			if (simulator is null) {
+				Log.LogError ("The 'Devices' item group does not contain any simulators.");
+				return string.Empty;
 			}
 
-			return GetSimulatorDevices ()
-				.Where (v => v.IsCompatible && string.IsNullOrEmpty (v.NotApplicableBecause))
-				.OrderByDescending (v => v.RuntimeVersion)
-				.ThenByDescending (v => v.DeviceTypeOrder)
-				.ThenBy (v => v.Name, StringComparer.Ordinal)
-				.ThenBy (v => v.Identifier, StringComparer.Ordinal)
-				.Select (v => v.Identifier)
-				.FirstOrDefault () ?? string.Empty;
+			return string.IsNullOrEmpty (simulator.GetMetadata ("UDID")) ? simulator.ItemSpec : simulator.GetMetadata ("UDID");
 		}
 
 		List<(string Identifier, string Name, string? NotApplicableBecause)> GetDeviceListForSimulator ()
@@ -459,6 +452,11 @@ namespace Xamarin.MacDev.Tasks {
 			if (!string.IsNullOrEmpty (Help)) {
 				ShowHelp ();
 				return !Log.HasLoggedErrors;
+			}
+
+			if (Devices.Length == 0) {
+				Log.LogError ("The 'Devices' item group is empty.");
+				return false;
 			}
 
 			MlaunchArguments = GenerateCommandLineCommands ();

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
@@ -540,13 +540,12 @@ namespace Xamarin.MacDev.Tasks {
 			if (ShouldExecuteRemotely ())
 				return ExecuteRemotely ();
 
-			FilterTaskItemInputs ();
-
 			if (!string.IsNullOrEmpty (Help)) {
 				ShowHelp ();
 				return !Log.HasLoggedErrors;
 			}
 
+			FilterTaskItemInputs ();
 			if (Devices.Length == 0) {
 				LogNoAvailableDevicesError ();
 				return false;

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
@@ -58,10 +58,19 @@ namespace Xamarin.MacDev.Tasks {
 			}
 		}
 
-		List<string>? GetDeviceTypes (bool onlyExact)
+		sealed class SimulatorDeviceInfo {
+			public string Identifier { get; set; } = string.Empty;
+			public string Name { get; set; } = string.Empty;
+			public long RuntimeVersion { get; set; }
+			public int DeviceTypeOrder { get; set; } = int.MinValue;
+			public bool IsCompatible { get; set; }
+			public string? NotApplicableBecause { get; set; }
+		}
+
+		List<(long Min, long Max, string Identifier)>? GetDeviceTypes ()
 		{
 			var output = GetSimulatorList ();
-			if (output is null)
+			if (string.IsNullOrEmpty (output))
 				return null;
 
 			// Which product family are we looking for?
@@ -100,55 +109,31 @@ namespace Xamarin.MacDev.Tasks {
 					continue;
 				deviceTypes.Add ((minRuntimeVersion, maxRuntimeVersion, identifier));
 			}
-			// Sort by minRuntimeVersion, this is a rudimentary way of sorting so that the last device is at the end.
-			deviceTypes.Sort ((a, b) => a.Min.CompareTo (b.Min));
-			// Return the sorted list
-			return deviceTypes.Select (v => v.Identifier).ToList ();
-		}
 
-		List<(long Version, string Identifier)>? GetSimulatorRuntimes ()
-		{
-			var output = GetSimulatorList ();
-			if (string.IsNullOrEmpty (output))
-				return null;
-
-			var xml = new XmlDocument ();
-			xml.LoadXml (output);
-
-			var runtimePrefix = $"com.apple.CoreSimulator.SimRuntime.{PlatformName}-";
-			var nodes = xml.SelectNodes ("/MTouch/Simulator/SupportedRuntimes/SimRuntime")?.Cast<XmlNode> () ?? Array.Empty<XmlNode> ();
-			var runtimes = new List<(long Version, string Identifier)> ();
-			foreach (var node in nodes) {
-				var identifier = node.SelectSingleNode ("Identifier")?.InnerText ?? string.Empty;
-				if (!identifier.StartsWith (runtimePrefix, StringComparison.Ordinal))
-					continue;
-
-				var versionValue = node.SelectSingleNode ("Version")?.InnerText ?? string.Empty;
-				if (!long.TryParse (versionValue, out var version))
-					version = 0;
-
-				runtimes.Add ((version, identifier));
-			}
-
-			runtimes.Sort ((a, b) => {
-				var rv = a.Version.CompareTo (b.Version);
+			deviceTypes.Sort ((a, b) => {
+				var rv = a.Min.CompareTo (b.Min);
+				if (rv != 0)
+					return rv;
+				rv = a.Max.CompareTo (b.Max);
 				if (rv != 0)
 					return rv;
 				return StringComparer.Ordinal.Compare (a.Identifier, b.Identifier);
 			});
-			return runtimes;
+
+			return deviceTypes;
 		}
 
-		string GetDefaultSimulatorRuntime ()
+		static bool TryGetSimulatorVersion (long versionValue, out Version? version)
 		{
-			var requestedRuntime = $"com.apple.CoreSimulator.SimRuntime.{PlatformName}-{SdkVersion.Replace ('.', '-')}";
-			var simulatorRuntimes = GetSimulatorRuntimes ();
-			if (simulatorRuntimes?.Count > 0) {
-				if (simulatorRuntimes.Any (v => v.Identifier == requestedRuntime))
-					return requestedRuntime;
-				return simulatorRuntimes [simulatorRuntimes.Count - 1].Identifier;
+			if (versionValue <= 0) {
+				version = null;
+				return false;
 			}
-			return requestedRuntime;
+
+			var major = (int) ((versionValue >> 16) & 0xFF);
+			var minor = (int) ((versionValue >> 8) & 0xFF);
+			version = new Version (major, minor);
+			return true;
 		}
 
 		string? simulator_list;
@@ -187,45 +172,88 @@ namespace Xamarin.MacDev.Tasks {
 			return device_list;
 		}
 
-		List<(string Identifier, string Name, string? NotApplicableBecause)> GetDeviceListForSimulator ()
+		List<SimulatorDeviceInfo> GetSimulatorDevices ()
 		{
-			var rv = new List<(string Identifier, string Name, string? NotApplicableBecause)> ();
+			var rv = new List<SimulatorDeviceInfo> ();
 
 			var output = GetSimulatorList ();
 			if (string.IsNullOrEmpty (output))
 				return rv;
 
-			var deviceTypes = GetDeviceTypes (false);
+			var deviceTypes = GetDeviceTypes ();
 			if (deviceTypes is null)
 				return rv;
 
-			// Load mlaunch's output
+			var deviceTypeOrders = deviceTypes
+				.Select ((v, index) => (v.Identifier, Index: index))
+				.ToDictionary (v => v.Identifier, v => v.Index, StringComparer.Ordinal);
+
 			var xml = new XmlDocument ();
 			xml.LoadXml (output);
-			// Get the device types for the product family we're looking for
+
+			var runtimePrefix = $"com.apple.CoreSimulator.SimRuntime.{PlatformName}-";
+			var runtimeVersions = new Dictionary<string, long> (StringComparer.Ordinal);
+			var runtimeNodes = xml.SelectNodes ("/MTouch/Simulator/SupportedRuntimes/SimRuntime")?.Cast<XmlNode> () ?? Array.Empty<XmlNode> ();
+			foreach (var node in runtimeNodes) {
+				var identifier = node.SelectSingleNode ("Identifier")?.InnerText ?? string.Empty;
+				var versionValue = node.SelectSingleNode ("Version")?.InnerText ?? string.Empty;
+				if (long.TryParse (versionValue, out var version))
+					runtimeVersions [identifier] = version;
+			}
+
 			var nodes = xml.SelectNodes ($"/MTouch/Simulator/AvailableDevices/SimDevice")?.Cast<XmlNode> () ?? Array.Empty<XmlNode> ();
 			foreach (var node in nodes) {
-				var simDeviceType = node.SelectSingleNode ("SimDeviceType")?.InnerText ?? string.Empty;
-				if (!deviceTypes.Contains (simDeviceType))
-					continue;
-				var udid = node.Attributes? ["UDID"]?.Value ?? string.Empty;
-				var name = node.Attributes? ["Name"]?.Value ?? string.Empty;
-				string? notApplicableBecause = null;
+				var device = new SimulatorDeviceInfo {
+					Identifier = node.Attributes? ["UDID"]?.Value ?? string.Empty,
+					Name = node.Attributes? ["Name"]?.Value ?? string.Empty,
+				};
 
-				var simRuntime = node.SelectSingleNode ("SimRuntime")?.InnerText;
-				if (!string.IsNullOrEmpty (simRuntime)) {
-					var simRuntimeVersionString = xml.SelectSingleNode ($"/MTouch/Simulator/SupportedRuntimes/SimRuntime[Identifier='{simRuntime}']/Version")?.InnerText;
-					if (int.TryParse (simRuntimeVersionString, out var simRuntimeVersionNumber)) {
-						var simRuntimeVersionMajor = (simRuntimeVersionNumber >> 16) & 0xFF;
-						var simRuntimeVersionMinor = (simRuntimeVersionNumber >> 8) & 0xFF;
-						var simRuntimeVersion = new Version (simRuntimeVersionMajor, simRuntimeVersionMinor);
-						if (Version.TryParse (SupportedOSPlatformVersion, out var supportedOSPlatformVersion) && simRuntimeVersion < supportedOSPlatformVersion)
-							notApplicableBecause = $" [OS version ({simRuntimeVersion}) lower than minimum supported platform version ({SupportedOSPlatformVersion}) for this app]";
-					}
+				var simDeviceType = node.SelectSingleNode ("SimDeviceType")?.InnerText ?? string.Empty;
+				var simRuntime = node.SelectSingleNode ("SimRuntime")?.InnerText ?? string.Empty;
+				runtimeVersions.TryGetValue (simRuntime, out var simRuntimeVersion);
+				device.RuntimeVersion = simRuntimeVersion;
+
+				string? notApplicableBecause = null;
+				if (!simRuntime.StartsWith (runtimePrefix, StringComparison.Ordinal)) {
+					notApplicableBecause = $" [Simulator runtime ({simRuntime}) does not match the requested platform ({PlatformName}) for this app]";
+				} else if (!deviceTypeOrders.TryGetValue (simDeviceType, out var deviceTypeOrder)) {
+					notApplicableBecause = $" [Simulator device type ({simDeviceType}) is not applicable for this app]";
+				} else {
+					device.IsCompatible = true;
+					device.DeviceTypeOrder = deviceTypeOrder;
+					if (Version.TryParse (SupportedOSPlatformVersion, out var supportedOSPlatformVersion) && TryGetSimulatorVersion (simRuntimeVersion, out var simRuntimeVersionValue) && simRuntimeVersionValue is not null && simRuntimeVersionValue < supportedOSPlatformVersion)
+						notApplicableBecause = $" [OS version ({simRuntimeVersionValue}) lower than minimum supported platform version ({SupportedOSPlatformVersion}) for this app]";
 				}
-				rv.Add ((udid, name, notApplicableBecause));
+
+				device.NotApplicableBecause = notApplicableBecause;
+				rv.Add (device);
 			}
+
 			return rv;
+		}
+
+		string SelectSimulatorDevice ()
+		{
+			return GetSimulatorDevices ()
+				.Where (v => v.IsCompatible && string.IsNullOrEmpty (v.NotApplicableBecause))
+				.OrderByDescending (v => v.RuntimeVersion)
+				.ThenByDescending (v => v.DeviceTypeOrder)
+				.ThenBy (v => v.Name, StringComparer.Ordinal)
+				.ThenBy (v => v.Identifier, StringComparer.Ordinal)
+				.Select (v => v.Identifier)
+				.FirstOrDefault () ?? string.Empty;
+		}
+
+		List<(string Identifier, string Name, string? NotApplicableBecause)> GetDeviceListForSimulator ()
+		{
+			return GetSimulatorDevices ()
+				.Where (v => v.IsCompatible)
+				.OrderByDescending (v => v.RuntimeVersion)
+				.ThenByDescending (v => v.DeviceTypeOrder)
+				.ThenBy (v => v.Name, StringComparer.Ordinal)
+				.ThenBy (v => v.Identifier, StringComparer.Ordinal)
+				.Select (v => (v.Identifier, v.Name, v.NotApplicableBecause))
+				.ToList ();
 		}
 
 		List<(string Identifier, string Name, string? NotApplicableBecause)> GetDeviceListForDevice ()
@@ -274,6 +302,8 @@ namespace Xamarin.MacDev.Tasks {
 		protected string GenerateCommandLineCommands ()
 		{
 			var sb = new List<string> ();
+			string? selectedSimulator = null;
+			var deviceName = DeviceName;
 
 			if (!string.IsNullOrEmpty (LaunchApp)) {
 				sb.Add (SdkIsSimulator ? "--launchsim" : "--launchdev");
@@ -285,58 +315,38 @@ namespace Xamarin.MacDev.Tasks {
 				sb.Add (InstallApp);
 			}
 
-			if (SdkIsSimulator && string.IsNullOrEmpty (DeviceName)) {
-				var simruntime = GetDefaultSimulatorRuntime ();
-				var simdevicetypes = GetDeviceTypes (true);
-				string simdevicetype;
-
-				if (simdevicetypes?.Count > 0) {
-					// Use the latest device type we can find. This seems to be what Xcode does by default.
-					simdevicetype = simdevicetypes.Last ();
-				} else {
-					// We couldn't find any device types, so pick one.
-					switch (Platform) {
-					case ApplePlatform.iOS:
-						// Don't try to launch an iPad-only app on an iPhone
-						if (DeviceType == IPhoneDeviceType.IPad) {
-							simdevicetype = "com.apple.CoreSimulator.SimDeviceType.iPad--7th-generation-";
-						} else {
-							simdevicetype = "com.apple.CoreSimulator.SimDeviceType.iPhone-11";
-						}
-						break;
-					case ApplePlatform.TVOS:
-						simdevicetype = "com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K-1080p";
-						break;
-					default:
-						throw new InvalidOperationException (string.Format (MSBStrings.InvalidPlatform, Platform));
-					}
-				}
-				DeviceName = $":v2:runtime={simruntime},devicetype={simdevicetype}";
+			if (SdkIsSimulator && string.IsNullOrEmpty (deviceName)) {
+				selectedSimulator = SelectSimulatorDevice ();
+				deviceName = selectedSimulator;
 			}
 
-			if (!string.IsNullOrEmpty (DeviceName)) {
+			if (!string.IsNullOrEmpty (deviceName)) {
 				if (SdkIsSimulator) {
 					sb.Add ("--device");
 
-					// Figure out whether we got the exact name of a simulator, in which case construct the corresponding argument.
-					string? simulator = null;
-					var deviceList = GetDeviceListForSimulator ();
-					var simulatorsByIdentifier = deviceList.Where (v => v.Identifier == DeviceName).ToArray ();
-					if (simulatorsByIdentifier.Length == 1) {
-						simulator = simulatorsByIdentifier [0].Identifier;
+					if (!string.IsNullOrEmpty (selectedSimulator)) {
+						sb.Add ($":v2:udid={selectedSimulator}");
 					} else {
-						var simulatorsByName = deviceList.Where (v => v.Name == DeviceName).ToArray ();
-						if (simulatorsByName.Length == 1)
-							simulator = simulatorsByName [0].Identifier;
-					}
-					if (!string.IsNullOrEmpty (simulator)) {
-						sb.Add ($":v2:udid={simulator}");
-					} else {
-						sb.Add (DeviceName);
+						// Figure out whether we got the exact name of a simulator, in which case construct the corresponding argument.
+						string? simulator = null;
+						var deviceList = GetDeviceListForSimulator ();
+						var simulatorsByIdentifier = deviceList.Where (v => v.Identifier == deviceName).ToArray ();
+						if (simulatorsByIdentifier.Length == 1) {
+							simulator = simulatorsByIdentifier [0].Identifier;
+						} else {
+							var simulatorsByName = deviceList.Where (v => v.Name == deviceName).ToArray ();
+							if (simulatorsByName.Length == 1)
+								simulator = simulatorsByName [0].Identifier;
+						}
+						if (!string.IsNullOrEmpty (simulator)) {
+							sb.Add ($":v2:udid={simulator}");
+						} else {
+							sb.Add (deviceName);
+						}
 					}
 				} else {
 					sb.Add ("--devname");
-					sb.Add (DeviceName);
+					sb.Add (deviceName);
 				}
 			}
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
@@ -42,6 +42,8 @@ namespace Xamarin.MacDev.Tasks {
 		[Required]
 		public string MlaunchPath { get; set; } = string.Empty;
 
+		public ITaskItem [] Devices { get; set; } = Array.Empty<ITaskItem> ();
+
 		[Output]
 		public string MlaunchArguments { get; set; } = string.Empty;
 
@@ -234,6 +236,12 @@ namespace Xamarin.MacDev.Tasks {
 
 		string SelectSimulatorDevice ()
 		{
+			if (Devices.Length > 0) {
+				var simulator = Devices.FirstOrDefault (v => string.Equals (v.GetMetadata ("Type"), "Simulator", StringComparison.OrdinalIgnoreCase));
+				if (simulator is not null)
+					return string.IsNullOrEmpty (simulator.GetMetadata ("UDID")) ? simulator.ItemSpec : simulator.GetMetadata ("UDID");
+			}
+
 			return GetSimulatorDevices ()
 				.Where (v => v.IsCompatible && string.IsNullOrEmpty (v.NotApplicableBecause))
 				.OrderByDescending (v => v.RuntimeVersion)

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
@@ -237,7 +237,7 @@ namespace Xamarin.MacDev.Tasks {
 
 		string SelectSimulatorDevice ()
 		{
-			var simulator = Devices.FirstOrDefault (v => string.Equals (v.GetMetadata ("Type"), "Simulator", StringComparison.OrdinalIgnoreCase));
+			var simulator = GetTaskItemsOfType (Devices, "Simulator").FirstOrDefault ();
 			if (simulator is null) {
 				var sb = new StringBuilder ();
 				sb.AppendLine ("The 'Devices' item group does not contain any simulators.");
@@ -331,6 +331,25 @@ namespace Xamarin.MacDev.Tasks {
 			return name == identifier ? identifier : $"{name} ({identifier})";
 		}
 
+		static ITaskItem [] GetTaskItemsOfType (ITaskItem [] items, string type)
+		{
+			return items
+				.Where (v => string.Equals (v.GetMetadata ("Type"), type, StringComparison.OrdinalIgnoreCase))
+				.ToArray ();
+		}
+
+		string GetApplicableDeviceType ()
+		{
+			return SdkIsSimulator ? "Simulator" : "Device";
+		}
+
+		void FilterTaskItemInputs ()
+		{
+			var type = GetApplicableDeviceType ();
+			Devices = GetTaskItemsOfType (Devices, type);
+			DiscardedDevices = GetTaskItemsOfType (DiscardedDevices, type);
+		}
+
 		static List<(string Identifier, string Name, string? NotApplicableBecause)> GetDevicesFromTaskItems (string type, ITaskItem [] items)
 		{
 			return items
@@ -366,7 +385,7 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			var sb = new StringBuilder ();
 			sb.AppendLine ("No applicable and available devices found.");
-			AppendDiscardedDevices (sb, "");
+			AppendDiscardedDevices (sb, "", GetApplicableDeviceType ());
 			Log.LogError (sb.ToString ().TrimEnd ());
 		}
 
@@ -520,6 +539,8 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			if (ShouldExecuteRemotely ())
 				return ExecuteRemotely ();
+
+			FilterTaskItemInputs ();
 
 			if (!string.IsNullOrEmpty (Help)) {
 				ShowHelp ();

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
@@ -80,7 +80,7 @@ namespace Xamarin.MacDev.Tasks {
 			string [] productFamilies;
 			switch (DeviceType) {
 			case IPhoneDeviceType.IPhone: // if we're looking for an iPhone, an iPad also works
-				productFamilies = onlyExact ? ["iPhone"] : ["iPhone", "iPad"];
+				productFamilies = ["iPhone", "iPad"];
 				break;
 			case IPhoneDeviceType.IPad:
 				productFamilies = ["iPad"];

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
@@ -499,7 +499,6 @@ namespace Xamarin.MacDev.Tasks {
 			var devices = GetDeviceListForDevice ();
 			if (devices.Count == 0) {
 				sb.AppendLine ($"        There are no devices connected to this Mac that can be used to run this app.");
-				AppendDiscardedDevices (sb, "        ", "Device");
 			} else {
 				sb.AppendLine ($"        There are {devices.Count} device(s) connected to this Mac that can be used to run this app:");
 				foreach (var d in devices)
@@ -510,6 +509,7 @@ namespace Xamarin.MacDev.Tasks {
 				var sampleDevice = firstDevice.Name == StringUtils.Quote (firstDevice.Name) ? firstDevice.Name : firstDevice.Identifier;
 				sb.AppendLine ($"        dotnet run -f {f} -r {rid} -p:DeviceName={sampleDevice}");
 			}
+			AppendDiscardedDevices (sb, "        ", "Device");
 
 			sb.AppendLine ($"");
 			sb.AppendLine ($"To run in a simulator:");
@@ -518,7 +518,6 @@ namespace Xamarin.MacDev.Tasks {
 			var simulators = GetDeviceListForSimulator ();
 			if (simulators.Count == 0) {
 				sb.AppendLine ($"        There are no simulators available that can be used to run this app. Please open Xcode, then the menu Window -> Devices and Simulators, select Simulators on the top left, and create a new simulator clicking on the plus sign on the bottom left.");
-				AppendDiscardedDevices (sb, "        ", "Simulator");
 			} else {
 				sb.AppendLine ($"        There are {simulators.Count} simulators(s) on this Mac that can be used to run this app:");
 				foreach (var s in simulators)
@@ -529,6 +528,7 @@ namespace Xamarin.MacDev.Tasks {
 				var sampleDevice = firstSim.Name == StringUtils.Quote (firstSim.Name) ? firstSim.Name : firstSim.Identifier;
 				sb.AppendLine ($"        dotnet run -f {f} -p:DeviceName={sampleDevice}");
 			}
+			AppendDiscardedDevices (sb, "        ", "Simulator");
 			sb.AppendLine ();
 
 			// Sadly the only way to have the help show up in the terminal reliably is to make it a warning

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
@@ -106,6 +106,51 @@ namespace Xamarin.MacDev.Tasks {
 			return deviceTypes.Select (v => v.Identifier).ToList ();
 		}
 
+		List<(long Version, string Identifier)>? GetSimulatorRuntimes ()
+		{
+			var output = GetSimulatorList ();
+			if (string.IsNullOrEmpty (output))
+				return null;
+
+			var xml = new XmlDocument ();
+			xml.LoadXml (output);
+
+			var runtimePrefix = $"com.apple.CoreSimulator.SimRuntime.{PlatformName}-";
+			var nodes = xml.SelectNodes ("/MTouch/Simulator/SupportedRuntimes/SimRuntime")?.Cast<XmlNode> () ?? Array.Empty<XmlNode> ();
+			var runtimes = new List<(long Version, string Identifier)> ();
+			foreach (var node in nodes) {
+				var identifier = node.SelectSingleNode ("Identifier")?.InnerText ?? string.Empty;
+				if (!identifier.StartsWith (runtimePrefix, StringComparison.Ordinal))
+					continue;
+
+				var versionValue = node.SelectSingleNode ("Version")?.InnerText ?? string.Empty;
+				if (!long.TryParse (versionValue, out var version))
+					version = 0;
+
+				runtimes.Add ((version, identifier));
+			}
+
+			runtimes.Sort ((a, b) => {
+				var rv = a.Version.CompareTo (b.Version);
+				if (rv != 0)
+					return rv;
+				return StringComparer.Ordinal.Compare (a.Identifier, b.Identifier);
+			});
+			return runtimes;
+		}
+
+		string GetDefaultSimulatorRuntime ()
+		{
+			var requestedRuntime = $"com.apple.CoreSimulator.SimRuntime.{PlatformName}-{SdkVersion.Replace ('.', '-')}";
+			var simulatorRuntimes = GetSimulatorRuntimes ();
+			if (simulatorRuntimes?.Count > 0) {
+				if (simulatorRuntimes.Any (v => v.Identifier == requestedRuntime))
+					return requestedRuntime;
+				return simulatorRuntimes [simulatorRuntimes.Count - 1].Identifier;
+			}
+			return requestedRuntime;
+		}
+
 		string? simulator_list;
 		string? GetSimulatorList ()
 		{
@@ -241,7 +286,7 @@ namespace Xamarin.MacDev.Tasks {
 			}
 
 			if (SdkIsSimulator && string.IsNullOrEmpty (DeviceName)) {
-				var simruntime = $"com.apple.CoreSimulator.SimRuntime.{PlatformName}-{SdkVersion.Replace ('.', '-')}";
+				var simruntime = GetDefaultSimulatorRuntime ();
 				var simdevicetypes = GetDeviceTypes (true);
 				string simdevicetype;
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetMlaunchArguments.cs
@@ -43,6 +43,7 @@ namespace Xamarin.MacDev.Tasks {
 		public string MlaunchPath { get; set; } = string.Empty;
 
 		public ITaskItem [] Devices { get; set; } = Array.Empty<ITaskItem> ();
+		public ITaskItem [] DiscardedDevices { get; set; } = Array.Empty<ITaskItem> ();
 
 		[Output]
 		public string MlaunchArguments { get; set; } = string.Empty;
@@ -238,15 +239,21 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			var simulator = Devices.FirstOrDefault (v => string.Equals (v.GetMetadata ("Type"), "Simulator", StringComparison.OrdinalIgnoreCase));
 			if (simulator is null) {
-				Log.LogError ("The 'Devices' item group does not contain any simulators.");
-				return string.Empty;
+				var sb = new StringBuilder ();
+				sb.AppendLine ("The 'Devices' item group does not contain any simulators.");
+				AppendDiscardedDevices (sb, "", "Simulator");
+				Log.LogError (sb.ToString ().TrimEnd ());
+				return "";
 			}
 
-			return string.IsNullOrEmpty (simulator.GetMetadata ("UDID")) ? simulator.ItemSpec : simulator.GetMetadata ("UDID");
+			return GetDeviceIdentifier (simulator);
 		}
 
 		List<(string Identifier, string Name, string? NotApplicableBecause)> GetDeviceListForSimulator ()
 		{
+			if (Devices.Length > 0 || DiscardedDevices.Length > 0)
+				return GetDevicesFromTaskItems ("Simulator", Devices);
+
 			return GetSimulatorDevices ()
 				.Where (v => v.IsCompatible)
 				.OrderByDescending (v => v.RuntimeVersion)
@@ -259,6 +266,9 @@ namespace Xamarin.MacDev.Tasks {
 
 		List<(string Identifier, string Name, string? NotApplicableBecause)> GetDeviceListForDevice ()
 		{
+			if (Devices.Length > 0 || DiscardedDevices.Length > 0)
+				return GetDevicesFromTaskItems ("Device", Devices);
+
 			var rv = new List<(string Identifier, string Name, string? NotApplicableBecause)> ();
 
 			var output = GetDeviceList ();
@@ -298,6 +308,66 @@ namespace Xamarin.MacDev.Tasks {
 				rv.Add ((deviceIdentifier, name, notApplicableBecause));
 			}
 			return rv;
+		}
+
+		static string GetDeviceIdentifier (ITaskItem device)
+		{
+			var udid = device.GetMetadata ("UDID");
+			return string.IsNullOrEmpty (udid) ? device.ItemSpec : udid;
+		}
+
+		static string GetDeviceName (ITaskItem device)
+		{
+			var name = device.GetMetadata ("Name");
+			if (string.IsNullOrEmpty (name))
+				name = device.GetMetadata ("Description");
+			return string.IsNullOrEmpty (name) ? GetDeviceIdentifier (device) : name;
+		}
+
+		static string FormatDevice (ITaskItem device)
+		{
+			var identifier = GetDeviceIdentifier (device);
+			var name = GetDeviceName (device);
+			return name == identifier ? identifier : $"{name} ({identifier})";
+		}
+
+		static List<(string Identifier, string Name, string? NotApplicableBecause)> GetDevicesFromTaskItems (string type, ITaskItem [] items)
+		{
+			return items
+				.Where (v => string.Equals (v.GetMetadata ("Type"), type, StringComparison.OrdinalIgnoreCase))
+				.Select (v => {
+					var reason = v.GetMetadata ("DiscardedReason");
+					return (GetDeviceIdentifier (v), GetDeviceName (v), string.IsNullOrEmpty (reason) ? null : reason);
+				})
+				.ToList ();
+		}
+
+		void AppendDiscardedDevices (StringBuilder sb, string indent, string? type = null)
+		{
+			var discardedDevices = DiscardedDevices
+				.Where (v => type is null || string.Equals (v.GetMetadata ("Type"), type, StringComparison.OrdinalIgnoreCase))
+				.ToArray ();
+
+			if (discardedDevices.Length == 0)
+				return;
+
+			sb.AppendLine ($"{indent}The following devices were discarded:");
+			foreach (var device in discardedDevices) {
+				var reason = device.GetMetadata ("DiscardedReason");
+				if (string.IsNullOrEmpty (reason)) {
+					sb.AppendLine ($"{indent}    {FormatDevice (device)}");
+				} else {
+					sb.AppendLine ($"{indent}    {FormatDevice (device)}: {reason}");
+				}
+			}
+		}
+
+		void LogNoAvailableDevicesError ()
+		{
+			var sb = new StringBuilder ();
+			sb.AppendLine ("No applicable and available devices found.");
+			AppendDiscardedDevices (sb, "");
+			Log.LogError (sb.ToString ().TrimEnd ());
 		}
 
 		protected string GenerateCommandLineCommands ()
@@ -410,6 +480,7 @@ namespace Xamarin.MacDev.Tasks {
 			var devices = GetDeviceListForDevice ();
 			if (devices.Count == 0) {
 				sb.AppendLine ($"        There are no devices connected to this Mac that can be used to run this app.");
+				AppendDiscardedDevices (sb, "        ", "Device");
 			} else {
 				sb.AppendLine ($"        There are {devices.Count} device(s) connected to this Mac that can be used to run this app:");
 				foreach (var d in devices)
@@ -428,6 +499,7 @@ namespace Xamarin.MacDev.Tasks {
 			var simulators = GetDeviceListForSimulator ();
 			if (simulators.Count == 0) {
 				sb.AppendLine ($"        There are no simulators available that can be used to run this app. Please open Xcode, then the menu Window -> Devices and Simulators, select Simulators on the top left, and create a new simulator clicking on the plus sign on the bottom left.");
+				AppendDiscardedDevices (sb, "        ", "Simulator");
 			} else {
 				sb.AppendLine ($"        There are {simulators.Count} simulators(s) on this Mac that can be used to run this app:");
 				foreach (var s in simulators)
@@ -455,7 +527,7 @@ namespace Xamarin.MacDev.Tasks {
 			}
 
 			if (Devices.Length == 0) {
-				Log.LogError ("No applicable and available devices found.");
+				LogNoAvailableDevicesError ();
 				return false;
 			}
 

--- a/tests/dotnet/UnitTests/MlaunchTest.cs
+++ b/tests/dotnet/UnitTests/MlaunchTest.cs
@@ -52,9 +52,9 @@ namespace Xamarin.Tests {
 		public static object [] GetMlaunchRunArgumentsTestCases ()
 		{
 			return new object [] {
-				new object [] {ApplePlatform.iOS, "iossimulator-x64;iossimulator-arm64", @":v2:runtime=com.apple.CoreSimulator.SimRuntime.iOS-[^,]+,devicetype=com.apple.CoreSimulator.SimDeviceType.iPhone-.*" },
+				new object [] {ApplePlatform.iOS, "iossimulator-x64;iossimulator-arm64", @":v2:udid=[A-F0-9-]+" },
 				new object [] {ApplePlatform.iOS, "ios-arm64", "" },
-				new object [] {ApplePlatform.TVOS, "tvossimulator-arm64", @":v2:runtime=com.apple.CoreSimulator.SimRuntime.tvOS-[^,]+,devicetype=com.apple.CoreSimulator.SimDeviceType.Apple-TV-.*" },
+				new object [] {ApplePlatform.TVOS, "tvossimulator-arm64", @":v2:udid=[A-F0-9-]+" },
 			};
 		}
 

--- a/tests/dotnet/UnitTests/MlaunchTest.cs
+++ b/tests/dotnet/UnitTests/MlaunchTest.cs
@@ -52,9 +52,9 @@ namespace Xamarin.Tests {
 		public static object [] GetMlaunchRunArgumentsTestCases ()
 		{
 			return new object [] {
-				new object [] {ApplePlatform.iOS, "iossimulator-x64;iossimulator-arm64", $":v2:runtime=com.apple.CoreSimulator.SimRuntime.iOS-{SdkVersions.iOS.Replace('.', '-')},devicetype=com.apple.CoreSimulator.SimDeviceType.iPhone-.*" },
+				new object [] {ApplePlatform.iOS, "iossimulator-x64;iossimulator-arm64", @":v2:runtime=com.apple.CoreSimulator.SimRuntime.iOS-[^,]+,devicetype=com.apple.CoreSimulator.SimDeviceType.iPhone-.*" },
 				new object [] {ApplePlatform.iOS, "ios-arm64", "" },
-				new object [] {ApplePlatform.TVOS, "tvossimulator-arm64", $":v2:runtime=com.apple.CoreSimulator.SimRuntime.tvOS-{SdkVersions.TVOS.Replace('.', '-')},devicetype=com.apple.CoreSimulator.SimDeviceType.Apple-TV-.*" },
+				new object [] {ApplePlatform.TVOS, "tvossimulator-arm64", @":v2:runtime=com.apple.CoreSimulator.SimRuntime.tvOS-[^,]+,devicetype=com.apple.CoreSimulator.SimDeviceType.Apple-TV-.*" },
 			};
 		}
 

--- a/tests/dotnet/UnitTests/MlaunchTest.cs
+++ b/tests/dotnet/UnitTests/MlaunchTest.cs
@@ -29,7 +29,13 @@ namespace Xamarin.Tests {
 			DotNet.Execute ("build", project_path, properties, target: "_DetectSdkLocations;_DetectAppManifest;_CompileAppManifest;_WriteAppManifest");
 
 			properties ["MlaunchInstallScript"] = outputPath;
-			var rv = DotNet.Execute ("build", project_path, properties, target: "ComputeMlaunchInstallArguments");
+			var rv = DotNet.Execute ("build", project_path, properties, assert_success: false, target: "ComputeMlaunchInstallArguments");
+
+			if (rv.ExitCode != 0) {
+				var errors = BinLog.GetBuildLogErrors (rv.BinLogPath).Select (v => v.Message).OfType<string> ().ToArray ();
+				Assert.That (string.Join ("\n", errors), Does.Contain ("No applicable and available devices found."));
+				return;
+			}
 
 			if (!BinLog.TryFindPropertyValue (rv.BinLogPath, "MlaunchInstallArguments", out var mlaunchInstallArguments))
 				Assert.Fail ("Could not find the property 'MlaunchInstallArguments' in the binlog.");
@@ -75,7 +81,13 @@ namespace Xamarin.Tests {
 			DotNet.Execute ("build", project_path, properties, target: "_DetectSdkLocations;_DetectAppManifest;_CompileAppManifest;_WriteAppManifest");
 
 			properties ["MlaunchRunScript"] = outputPath;
-			var rv = DotNet.Execute ("build", project_path, properties, target: "ComputeMlaunchRunArguments");
+			var rv = DotNet.Execute ("build", project_path, properties, assert_success: false, target: "ComputeMlaunchRunArguments");
+
+			if (rv.ExitCode != 0) {
+				var errors = BinLog.GetBuildLogErrors (rv.BinLogPath).Select (v => v.Message).OfType<string> ().ToArray ();
+				Assert.That (string.Join ("\n", errors), Does.Contain ("No applicable and available devices found."));
+				return;
+			}
 
 			if (!BinLog.TryFindPropertyValue (rv.BinLogPath, "MlaunchRunArguments", out var mlaunchRunArguments))
 				Assert.Fail ("Could not find the property 'MlaunchRunArguments' in the binlog.");

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetMlaunchArgumentsTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetMlaunchArgumentsTaskTests.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.IO;
+using System.Text;
+
+using NUnit.Framework;
+
+using Xamarin.Tests;
+using Xamarin.Utils;
+
+#nullable enable
+
+namespace Xamarin.MacDev.Tasks {
+	[TestFixture]
+	public class GetMlaunchArgumentsTaskTests : TestBase {
+
+		[Test]
+		public void SimulatorRuntimeSelection ()
+		{
+			AssertSimulatorRuntime (
+				CreateSimulatorXml (
+					("com.apple.CoreSimulator.SimRuntime.iOS-26-2", 1704448),
+					("com.apple.CoreSimulator.SimRuntime.iOS-26-3", 1704705)
+				),
+				"com.apple.CoreSimulator.SimRuntime.iOS-26-2");
+
+			AssertSimulatorRuntime (
+				CreateSimulatorXml (
+					("com.apple.CoreSimulator.SimRuntime.iOS-26-1", 1704192),
+					("com.apple.CoreSimulator.SimRuntime.iOS-26-3", 1704705)
+				),
+				"com.apple.CoreSimulator.SimRuntime.iOS-26-3");
+		}
+
+		void AssertSimulatorRuntime (string simulatorXml, string expectedRuntime)
+		{
+			var task = CreateTask<GetMlaunchArguments> ();
+			task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (ApplePlatform.iOS).ToString ();
+			task.AppManifestPath = CreateAppManifest ();
+			task.LaunchApp = "MySimpleApp.app";
+			task.MlaunchPath = CreateMlaunch (simulatorXml);
+			task.SdkIsSimulator = true;
+			task.SdkVersion = "26.2";
+			task.WaitForExit = true;
+
+			ExecuteTask (task);
+
+			Assert.That (task.MlaunchArguments, Does.Contain ($"--device :v2:runtime={expectedRuntime},devicetype=com.apple.CoreSimulator.SimDeviceType.iPhone-17"));
+		}
+
+		string CreateAppManifest ()
+		{
+			var appManifestPath = Path.Combine (Cache.CreateTemporaryDirectory ("msbuild-tests"), "Info.plist");
+			File.WriteAllText (appManifestPath, @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<!DOCTYPE plist PUBLIC ""-//Apple//DTD PLIST 1.0//EN"" ""http://www.apple.com/DTDs/PropertyList-1.0.dtd"">
+<plist version=""1.0"">
+<dict>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+	</array>
+</dict>
+</plist>
+");
+			return appManifestPath;
+		}
+
+		string CreateMlaunch (string simulatorXml)
+		{
+			var mlaunchPath = Path.Combine (Cache.CreateTemporaryDirectory ("msbuild-tests"), "mlaunch");
+			var script = new StringBuilder ();
+			script.AppendLine ("#!/bin/sh");
+			script.AppendLine ("if [ \"$1\" = \"--listsim\" ]; then");
+			script.AppendLine ("cat <<'EOF' > \"$2\"");
+			script.AppendLine (simulatorXml);
+			script.AppendLine ("EOF");
+			script.AppendLine ("exit 0");
+			script.AppendLine ("fi");
+			script.AppendLine ("exit 1");
+			File.WriteAllText (mlaunchPath, script.ToString ());
+			if (OperatingSystem.IsMacOS ())
+				File.SetUnixFileMode (mlaunchPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute | UnixFileMode.GroupRead | UnixFileMode.GroupExecute | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+			return mlaunchPath;
+		}
+
+		string CreateSimulatorXml (params (string Identifier, long Version) [] runtimes)
+		{
+			var xml = new StringBuilder ();
+			xml.AppendLine ("<MTouch>");
+			xml.AppendLine ("  <Simulator>");
+			xml.AppendLine ("    <SupportedRuntimes>");
+			foreach (var runtime in runtimes) {
+				xml.AppendLine ("      <SimRuntime>");
+				xml.AppendLine ($"        <Identifier>{runtime.Identifier}</Identifier>");
+				xml.AppendLine ($"        <Version>{runtime.Version}</Version>");
+				xml.AppendLine ("      </SimRuntime>");
+			}
+			xml.AppendLine ("    </SupportedRuntimes>");
+			xml.AppendLine ("    <SupportedDeviceTypes>");
+			xml.AppendLine ("      <SimDeviceType>");
+			xml.AppendLine ("        <Identifier>com.apple.CoreSimulator.SimDeviceType.iPhone-16</Identifier>");
+			xml.AppendLine ("        <ProductFamilyId>iPhone</ProductFamilyId>");
+			xml.AppendLine ("        <MinRuntimeVersion>1704448</MinRuntimeVersion>");
+			xml.AppendLine ("        <MaxRuntimeVersion>4294967295</MaxRuntimeVersion>");
+			xml.AppendLine ("      </SimDeviceType>");
+			xml.AppendLine ("      <SimDeviceType>");
+			xml.AppendLine ("        <Identifier>com.apple.CoreSimulator.SimDeviceType.iPhone-17</Identifier>");
+			xml.AppendLine ("        <ProductFamilyId>iPhone</ProductFamilyId>");
+			xml.AppendLine ("        <MinRuntimeVersion>1704705</MinRuntimeVersion>");
+			xml.AppendLine ("        <MaxRuntimeVersion>4294967295</MaxRuntimeVersion>");
+			xml.AppendLine ("      </SimDeviceType>");
+			xml.AppendLine ("    </SupportedDeviceTypes>");
+			xml.AppendLine ("  </Simulator>");
+			xml.AppendLine ("</MTouch>");
+			return xml.ToString ();
+		}
+	}
+}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetMlaunchArgumentsTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetMlaunchArgumentsTaskTests.cs
@@ -2,7 +2,10 @@
 // Licensed under the MIT License.
 
 using System.IO;
+using System.Linq;
 using System.Text;
+
+using Microsoft.Build.Utilities;
 
 using NUnit.Framework;
 
@@ -16,72 +19,40 @@ namespace Xamarin.MacDev.Tasks {
 	public class GetMlaunchArgumentsTaskTests : TestBase {
 
 		[Test]
-		public void SelectSimulatorDeviceSortsByRuntimeDeviceTypeNameAndUdid ()
-		{
-			AssertSelectedSimulator (
-				CreateSimulatorXml (
-					runtimes: [
-						("com.apple.CoreSimulator.SimRuntime.iOS-26-2", 1704448),
-						("com.apple.CoreSimulator.SimRuntime.iOS-26-3", 1704705),
-					],
-					deviceTypes: [
-						("com.apple.CoreSimulator.SimDeviceType.iPhone-16", "iPhone", 1704448, 4294967295),
-						("com.apple.CoreSimulator.SimDeviceType.iPhone-17", "iPhone", 1704705, 4294967295),
-					],
-					availableDevices: [
-						("UDID-5", "A Older Runtime", "com.apple.CoreSimulator.SimRuntime.iOS-26-2", "com.apple.CoreSimulator.SimDeviceType.iPhone-17"),
-						("UDID-4", "A Older Device Type", "com.apple.CoreSimulator.SimRuntime.iOS-26-3", "com.apple.CoreSimulator.SimDeviceType.iPhone-16"),
-						("UDID-3", "B Name", "com.apple.CoreSimulator.SimRuntime.iOS-26-3", "com.apple.CoreSimulator.SimDeviceType.iPhone-17"),
-						("UDID-2", "A Name", "com.apple.CoreSimulator.SimRuntime.iOS-26-3", "com.apple.CoreSimulator.SimDeviceType.iPhone-17"),
-						("UDID-1", "A Name", "com.apple.CoreSimulator.SimRuntime.iOS-26-3", "com.apple.CoreSimulator.SimDeviceType.iPhone-17"),
-					]
-				),
-				"UDID-1",
-				[1, 2]);
-		}
-
-		[Test]
-		public void SelectSimulatorDeviceFiltersNonApplicableDevices ()
-		{
-			AssertSelectedSimulator (
-				CreateSimulatorXml (
-					runtimes: [
-						("com.apple.CoreSimulator.SimRuntime.iOS-26-2", 1704448),
-						("com.apple.CoreSimulator.SimRuntime.iOS-26-3", 1704705),
-						("com.apple.CoreSimulator.SimRuntime.tvOS-26-2", 1704448),
-					],
-					deviceTypes: [
-						("com.apple.CoreSimulator.SimDeviceType.iPhone-17", "iPhone", 1704705, 4294967295),
-						("com.apple.CoreSimulator.SimDeviceType.iPad-Pro", "iPad", 1704448, 4294967295),
-						("com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K", "Apple TV", 1704448, 4294967295),
-					],
-					availableDevices: [
-						("UDID-IPHONE", "Newest iPhone", "com.apple.CoreSimulator.SimRuntime.iOS-26-3", "com.apple.CoreSimulator.SimDeviceType.iPhone-17"),
-						("UDID-TV", "Apple TV", "com.apple.CoreSimulator.SimRuntime.tvOS-26-2", "com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K"),
-						("UDID-IPAD", "Newest iPad", "com.apple.CoreSimulator.SimRuntime.iOS-26-2", "com.apple.CoreSimulator.SimDeviceType.iPad-Pro"),
-					]
-				),
-				"UDID-IPAD",
-				[2]);
-		}
-
-		void AssertSelectedSimulator (string simulatorXml, string expectedUdid, int [] deviceFamilies)
+		public void SelectSimulatorDeviceUsesFirstAvailableSimulator ()
 		{
 			var task = CreateTask<GetMlaunchArguments> ();
 			task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (ApplePlatform.iOS).ToString ();
-			task.AppManifestPath = CreateAppManifest (deviceFamilies);
+			task.AppManifestPath = CreateAppManifest (1, 2);
+			task.Devices = CreateDevices (
+				("DEVICE-1", "Connected iPhone", "Device"),
+				("SIM-2", "Preferred Simulator", "Simulator"),
+				("SIM-1", "Another Simulator", "Simulator")
+			);
 			task.LaunchApp = "MySimpleApp.app";
-			task.MlaunchPath = CreateMlaunch (simulatorXml);
+			task.MlaunchPath = "/usr/bin/false";
 			task.SdkIsSimulator = true;
 			task.SdkVersion = "26.2";
 			task.WaitForExit = true;
 
 			ExecuteTask (task);
 
-			Assert.That (task.MlaunchArguments, Does.Contain ($"--device :v2:udid={expectedUdid}"));
+			Assert.That (task.MlaunchArguments, Does.Contain ("--device :v2:udid=SIM-2"));
 		}
 
-		string CreateAppManifest (int [] deviceFamilies)
+		static TaskItem [] CreateDevices (params (string Udid, string Name, string Type) [] devices)
+		{
+			return devices.Select (v => {
+				var item = new TaskItem (v.Udid);
+				item.SetMetadata ("Description", v.Name);
+				item.SetMetadata ("Name", v.Name);
+				item.SetMetadata ("Type", v.Type);
+				item.SetMetadata ("UDID", v.Udid);
+				return item;
+			}).ToArray ();
+		}
+
+		static string CreateAppManifest (params int [] deviceFamilies)
 		{
 			var appManifestPath = Path.Combine (Cache.CreateTemporaryDirectory ("msbuild-tests"), "Info.plist");
 			var plist = new StringBuilder ();
@@ -98,63 +69,6 @@ namespace Xamarin.MacDev.Tasks {
 			plist.AppendLine ("</plist>");
 			File.WriteAllText (appManifestPath, plist.ToString ());
 			return appManifestPath;
-		}
-
-		string CreateMlaunch (string simulatorXml)
-		{
-			var mlaunchPath = Path.Combine (Cache.CreateTemporaryDirectory ("msbuild-tests"), "mlaunch");
-			var script = new StringBuilder ();
-			script.AppendLine ("#!/bin/sh");
-			script.AppendLine ("if [ \"$1\" = \"--listsim\" ]; then");
-			script.AppendLine ("cat <<'EOF' > \"$2\"");
-			script.AppendLine (simulatorXml);
-			script.AppendLine ("EOF");
-			script.AppendLine ("exit 0");
-			script.AppendLine ("fi");
-			script.AppendLine ("exit 1");
-			File.WriteAllText (mlaunchPath, script.ToString ());
-			if (OperatingSystem.IsMacOS ())
-				File.SetUnixFileMode (mlaunchPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute | UnixFileMode.GroupRead | UnixFileMode.GroupExecute | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
-			return mlaunchPath;
-		}
-
-		string CreateSimulatorXml (
-			(string Identifier, long Version) [] runtimes,
-			(string Identifier, string ProductFamilyId, long MinRuntimeVersion, long MaxRuntimeVersion) [] deviceTypes,
-			(string Udid, string Name, string Runtime, string DeviceType) [] availableDevices)
-		{
-			var xml = new StringBuilder ();
-			xml.AppendLine ("<MTouch>");
-			xml.AppendLine ("  <Simulator>");
-			xml.AppendLine ("    <SupportedRuntimes>");
-			foreach (var runtime in runtimes) {
-				xml.AppendLine ("      <SimRuntime>");
-				xml.AppendLine ($"        <Identifier>{runtime.Identifier}</Identifier>");
-				xml.AppendLine ($"        <Version>{runtime.Version}</Version>");
-				xml.AppendLine ("      </SimRuntime>");
-			}
-			xml.AppendLine ("    </SupportedRuntimes>");
-			xml.AppendLine ("    <SupportedDeviceTypes>");
-			foreach (var deviceType in deviceTypes) {
-				xml.AppendLine ("      <SimDeviceType>");
-				xml.AppendLine ($"        <Identifier>{deviceType.Identifier}</Identifier>");
-				xml.AppendLine ($"        <ProductFamilyId>{deviceType.ProductFamilyId}</ProductFamilyId>");
-				xml.AppendLine ($"        <MinRuntimeVersion>{deviceType.MinRuntimeVersion}</MinRuntimeVersion>");
-				xml.AppendLine ($"        <MaxRuntimeVersion>{deviceType.MaxRuntimeVersion}</MaxRuntimeVersion>");
-				xml.AppendLine ("      </SimDeviceType>");
-			}
-			xml.AppendLine ("    </SupportedDeviceTypes>");
-			xml.AppendLine ("    <AvailableDevices>");
-			foreach (var device in availableDevices) {
-				xml.AppendLine ($"      <SimDevice UDID=\"{device.Udid}\" Name=\"{device.Name}\">");
-				xml.AppendLine ($"        <SimRuntime>{device.Runtime}</SimRuntime>");
-				xml.AppendLine ($"        <SimDeviceType>{device.DeviceType}</SimDeviceType>");
-				xml.AppendLine ("      </SimDevice>");
-			}
-			xml.AppendLine ("    </AvailableDevices>");
-			xml.AppendLine ("  </Simulator>");
-			xml.AppendLine ("</MTouch>");
-			return xml.ToString ();
 		}
 	}
 }

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetMlaunchArgumentsTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetMlaunchArgumentsTaskTests.cs
@@ -46,6 +46,9 @@ namespace Xamarin.MacDev.Tasks {
 			var task = CreateTask<GetMlaunchArguments> ();
 			task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (ApplePlatform.iOS).ToString ();
 			task.AppManifestPath = CreateAppManifest (1, 2);
+			task.Devices = CreateDevices (
+				("DEVICE-2", "Connected iPhone", "Device")
+			);
 			task.DiscardedDevices = CreateDiscardedDevices (
 				("SIM-1", "Unsupported Simulator", "Simulator", "Device is not an iPad, but the app only supports iPads"),
 				("DEVICE-1", "Old Phone", "Device", "Device OS version '17.0' is lower than the app's minimum OS version '18.0'")
@@ -60,7 +63,8 @@ namespace Xamarin.MacDev.Tasks {
 
 			Assert.That (Engine.Logger.ErrorEvents [0].Message, Does.Contain ("No applicable and available devices found."));
 			Assert.That (Engine.Logger.ErrorEvents [0].Message, Does.Contain ("Unsupported Simulator (SIM-1): Device is not an iPad, but the app only supports iPads"));
-			Assert.That (Engine.Logger.ErrorEvents [0].Message, Does.Contain ("Old Phone (DEVICE-1): Device OS version '17.0' is lower than the app's minimum OS version '18.0'"));
+			Assert.That (Engine.Logger.ErrorEvents [0].Message, Does.Not.Contain ("Connected iPhone"));
+			Assert.That (Engine.Logger.ErrorEvents [0].Message, Does.Not.Contain ("Old Phone"));
 		}
 
 		[Test]
@@ -69,6 +73,9 @@ namespace Xamarin.MacDev.Tasks {
 			var task = CreateTask<GetMlaunchArguments> ();
 			task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (ApplePlatform.iOS).ToString ();
 			task.AppManifestPath = CreateAppManifest (1, 2);
+			task.Devices = CreateDevices (
+				("DEVICE-2", "Connected iPhone", "Device")
+			);
 			task.DiscardedDevices = CreateDiscardedDevices (
 				("SIM-1", "Unsupported Simulator", "Simulator", "Device is not an iPad, but the app only supports iPads"),
 				("DEVICE-1", "Old Phone", "Device", "Device OS version '17.0' is lower than the app's minimum OS version '18.0'")
@@ -82,7 +89,8 @@ namespace Xamarin.MacDev.Tasks {
 
 			Assert.That (Engine.Logger.WarningsEvents [0].Message, Does.Contain ("The following devices were discarded:"));
 			Assert.That (Engine.Logger.WarningsEvents [0].Message, Does.Contain ("Unsupported Simulator (SIM-1): Device is not an iPad, but the app only supports iPads"));
-			Assert.That (Engine.Logger.WarningsEvents [0].Message, Does.Contain ("Old Phone (DEVICE-1): Device OS version '17.0' is lower than the app's minimum OS version '18.0'"));
+			Assert.That (Engine.Logger.WarningsEvents [0].Message, Does.Not.Contain ("Connected iPhone"));
+			Assert.That (Engine.Logger.WarningsEvents [0].Message, Does.Not.Contain ("Old Phone"));
 		}
 
 		static TaskItem [] CreateDevices (params (string Udid, string Name, string Type) [] devices)

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetMlaunchArgumentsTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetMlaunchArgumentsTaskTests.cs
@@ -89,8 +89,8 @@ namespace Xamarin.MacDev.Tasks {
 
 			Assert.That (Engine.Logger.WarningsEvents [0].Message, Does.Contain ("The following devices were discarded:"));
 			Assert.That (Engine.Logger.WarningsEvents [0].Message, Does.Contain ("Unsupported Simulator (SIM-1): Device is not an iPad, but the app only supports iPads"));
-			Assert.That (Engine.Logger.WarningsEvents [0].Message, Does.Not.Contain ("Connected iPhone"));
-			Assert.That (Engine.Logger.WarningsEvents [0].Message, Does.Not.Contain ("Old Phone"));
+			Assert.That (Engine.Logger.WarningsEvents [0].Message, Does.Contain ("Connected iPhone"));
+			Assert.That (Engine.Logger.WarningsEvents [0].Message, Does.Contain ("Old Phone (DEVICE-1): Device OS version '17.0' is lower than the app's minimum OS version '18.0'"));
 		}
 
 		static TaskItem [] CreateDevices (params (string Udid, string Name, string Type) [] devices)

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetMlaunchArgumentsTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetMlaunchArgumentsTaskTests.cs
@@ -16,28 +16,60 @@ namespace Xamarin.MacDev.Tasks {
 	public class GetMlaunchArgumentsTaskTests : TestBase {
 
 		[Test]
-		public void SimulatorRuntimeSelection ()
+		public void SelectSimulatorDeviceSortsByRuntimeDeviceTypeNameAndUdid ()
 		{
-			AssertSimulatorRuntime (
+			AssertSelectedSimulator (
 				CreateSimulatorXml (
-					("com.apple.CoreSimulator.SimRuntime.iOS-26-2", 1704448),
-					("com.apple.CoreSimulator.SimRuntime.iOS-26-3", 1704705)
+					runtimes: [
+						("com.apple.CoreSimulator.SimRuntime.iOS-26-2", 1704448),
+						("com.apple.CoreSimulator.SimRuntime.iOS-26-3", 1704705),
+					],
+					deviceTypes: [
+						("com.apple.CoreSimulator.SimDeviceType.iPhone-16", "iPhone", 1704448, 4294967295),
+						("com.apple.CoreSimulator.SimDeviceType.iPhone-17", "iPhone", 1704705, 4294967295),
+					],
+					availableDevices: [
+						("UDID-5", "A Older Runtime", "com.apple.CoreSimulator.SimRuntime.iOS-26-2", "com.apple.CoreSimulator.SimDeviceType.iPhone-17"),
+						("UDID-4", "A Older Device Type", "com.apple.CoreSimulator.SimRuntime.iOS-26-3", "com.apple.CoreSimulator.SimDeviceType.iPhone-16"),
+						("UDID-3", "B Name", "com.apple.CoreSimulator.SimRuntime.iOS-26-3", "com.apple.CoreSimulator.SimDeviceType.iPhone-17"),
+						("UDID-2", "A Name", "com.apple.CoreSimulator.SimRuntime.iOS-26-3", "com.apple.CoreSimulator.SimDeviceType.iPhone-17"),
+						("UDID-1", "A Name", "com.apple.CoreSimulator.SimRuntime.iOS-26-3", "com.apple.CoreSimulator.SimDeviceType.iPhone-17"),
+					]
 				),
-				"com.apple.CoreSimulator.SimRuntime.iOS-26-2");
-
-			AssertSimulatorRuntime (
-				CreateSimulatorXml (
-					("com.apple.CoreSimulator.SimRuntime.iOS-26-1", 1704192),
-					("com.apple.CoreSimulator.SimRuntime.iOS-26-3", 1704705)
-				),
-				"com.apple.CoreSimulator.SimRuntime.iOS-26-3");
+				"UDID-1",
+				[1, 2]);
 		}
 
-		void AssertSimulatorRuntime (string simulatorXml, string expectedRuntime)
+		[Test]
+		public void SelectSimulatorDeviceFiltersNonApplicableDevices ()
+		{
+			AssertSelectedSimulator (
+				CreateSimulatorXml (
+					runtimes: [
+						("com.apple.CoreSimulator.SimRuntime.iOS-26-2", 1704448),
+						("com.apple.CoreSimulator.SimRuntime.iOS-26-3", 1704705),
+						("com.apple.CoreSimulator.SimRuntime.tvOS-26-2", 1704448),
+					],
+					deviceTypes: [
+						("com.apple.CoreSimulator.SimDeviceType.iPhone-17", "iPhone", 1704705, 4294967295),
+						("com.apple.CoreSimulator.SimDeviceType.iPad-Pro", "iPad", 1704448, 4294967295),
+						("com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K", "Apple TV", 1704448, 4294967295),
+					],
+					availableDevices: [
+						("UDID-IPHONE", "Newest iPhone", "com.apple.CoreSimulator.SimRuntime.iOS-26-3", "com.apple.CoreSimulator.SimDeviceType.iPhone-17"),
+						("UDID-TV", "Apple TV", "com.apple.CoreSimulator.SimRuntime.tvOS-26-2", "com.apple.CoreSimulator.SimDeviceType.Apple-TV-4K"),
+						("UDID-IPAD", "Newest iPad", "com.apple.CoreSimulator.SimRuntime.iOS-26-2", "com.apple.CoreSimulator.SimDeviceType.iPad-Pro"),
+					]
+				),
+				"UDID-IPAD",
+				[2]);
+		}
+
+		void AssertSelectedSimulator (string simulatorXml, string expectedUdid, int [] deviceFamilies)
 		{
 			var task = CreateTask<GetMlaunchArguments> ();
 			task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (ApplePlatform.iOS).ToString ();
-			task.AppManifestPath = CreateAppManifest ();
+			task.AppManifestPath = CreateAppManifest (deviceFamilies);
 			task.LaunchApp = "MySimpleApp.app";
 			task.MlaunchPath = CreateMlaunch (simulatorXml);
 			task.SdkIsSimulator = true;
@@ -46,23 +78,25 @@ namespace Xamarin.MacDev.Tasks {
 
 			ExecuteTask (task);
 
-			Assert.That (task.MlaunchArguments, Does.Contain ($"--device :v2:runtime={expectedRuntime},devicetype=com.apple.CoreSimulator.SimDeviceType.iPhone-17"));
+			Assert.That (task.MlaunchArguments, Does.Contain ($"--device :v2:udid={expectedUdid}"));
 		}
 
-		string CreateAppManifest ()
+		string CreateAppManifest (int [] deviceFamilies)
 		{
 			var appManifestPath = Path.Combine (Cache.CreateTemporaryDirectory ("msbuild-tests"), "Info.plist");
-			File.WriteAllText (appManifestPath, @"<?xml version=""1.0"" encoding=""UTF-8""?>
-<!DOCTYPE plist PUBLIC ""-//Apple//DTD PLIST 1.0//EN"" ""http://www.apple.com/DTDs/PropertyList-1.0.dtd"">
-<plist version=""1.0"">
-<dict>
-	<key>UIDeviceFamily</key>
-	<array>
-		<integer>1</integer>
-	</array>
-</dict>
-</plist>
-");
+			var plist = new StringBuilder ();
+			plist.AppendLine (@"<?xml version=""1.0"" encoding=""UTF-8""?>");
+			plist.AppendLine (@"<!DOCTYPE plist PUBLIC ""-//Apple//DTD PLIST 1.0//EN"" ""http://www.apple.com/DTDs/PropertyList-1.0.dtd"">");
+			plist.AppendLine (@"<plist version=""1.0"">");
+			plist.AppendLine ("<dict>");
+			plist.AppendLine ("\t<key>UIDeviceFamily</key>");
+			plist.AppendLine ("\t<array>");
+			foreach (var family in deviceFamilies)
+				plist.AppendLine ($"\t\t<integer>{family}</integer>");
+			plist.AppendLine ("\t</array>");
+			plist.AppendLine ("</dict>");
+			plist.AppendLine ("</plist>");
+			File.WriteAllText (appManifestPath, plist.ToString ());
 			return appManifestPath;
 		}
 
@@ -84,7 +118,10 @@ namespace Xamarin.MacDev.Tasks {
 			return mlaunchPath;
 		}
 
-		string CreateSimulatorXml (params (string Identifier, long Version) [] runtimes)
+		string CreateSimulatorXml (
+			(string Identifier, long Version) [] runtimes,
+			(string Identifier, string ProductFamilyId, long MinRuntimeVersion, long MaxRuntimeVersion) [] deviceTypes,
+			(string Udid, string Name, string Runtime, string DeviceType) [] availableDevices)
 		{
 			var xml = new StringBuilder ();
 			xml.AppendLine ("<MTouch>");
@@ -98,19 +135,23 @@ namespace Xamarin.MacDev.Tasks {
 			}
 			xml.AppendLine ("    </SupportedRuntimes>");
 			xml.AppendLine ("    <SupportedDeviceTypes>");
-			xml.AppendLine ("      <SimDeviceType>");
-			xml.AppendLine ("        <Identifier>com.apple.CoreSimulator.SimDeviceType.iPhone-16</Identifier>");
-			xml.AppendLine ("        <ProductFamilyId>iPhone</ProductFamilyId>");
-			xml.AppendLine ("        <MinRuntimeVersion>1704448</MinRuntimeVersion>");
-			xml.AppendLine ("        <MaxRuntimeVersion>4294967295</MaxRuntimeVersion>");
-			xml.AppendLine ("      </SimDeviceType>");
-			xml.AppendLine ("      <SimDeviceType>");
-			xml.AppendLine ("        <Identifier>com.apple.CoreSimulator.SimDeviceType.iPhone-17</Identifier>");
-			xml.AppendLine ("        <ProductFamilyId>iPhone</ProductFamilyId>");
-			xml.AppendLine ("        <MinRuntimeVersion>1704705</MinRuntimeVersion>");
-			xml.AppendLine ("        <MaxRuntimeVersion>4294967295</MaxRuntimeVersion>");
-			xml.AppendLine ("      </SimDeviceType>");
+			foreach (var deviceType in deviceTypes) {
+				xml.AppendLine ("      <SimDeviceType>");
+				xml.AppendLine ($"        <Identifier>{deviceType.Identifier}</Identifier>");
+				xml.AppendLine ($"        <ProductFamilyId>{deviceType.ProductFamilyId}</ProductFamilyId>");
+				xml.AppendLine ($"        <MinRuntimeVersion>{deviceType.MinRuntimeVersion}</MinRuntimeVersion>");
+				xml.AppendLine ($"        <MaxRuntimeVersion>{deviceType.MaxRuntimeVersion}</MaxRuntimeVersion>");
+				xml.AppendLine ("      </SimDeviceType>");
+			}
 			xml.AppendLine ("    </SupportedDeviceTypes>");
+			xml.AppendLine ("    <AvailableDevices>");
+			foreach (var device in availableDevices) {
+				xml.AppendLine ($"      <SimDevice UDID=\"{device.Udid}\" Name=\"{device.Name}\">");
+				xml.AppendLine ($"        <SimRuntime>{device.Runtime}</SimRuntime>");
+				xml.AppendLine ($"        <SimDeviceType>{device.DeviceType}</SimDeviceType>");
+				xml.AppendLine ("      </SimDevice>");
+			}
+			xml.AppendLine ("    </AvailableDevices>");
 			xml.AppendLine ("  </Simulator>");
 			xml.AppendLine ("</MTouch>");
 			return xml.ToString ();

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetMlaunchArgumentsTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetMlaunchArgumentsTaskTests.cs
@@ -46,6 +46,10 @@ namespace Xamarin.MacDev.Tasks {
 			var task = CreateTask<GetMlaunchArguments> ();
 			task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (ApplePlatform.iOS).ToString ();
 			task.AppManifestPath = CreateAppManifest (1, 2);
+			task.DiscardedDevices = CreateDiscardedDevices (
+				("SIM-1", "Unsupported Simulator", "Simulator", "Device is not an iPad, but the app only supports iPads"),
+				("DEVICE-1", "Old Phone", "Device", "Device OS version '17.0' is lower than the app's minimum OS version '18.0'")
+			);
 			task.LaunchApp = "MySimpleApp.app";
 			task.MlaunchPath = "/usr/bin/false";
 			task.SdkIsSimulator = true;
@@ -54,19 +58,55 @@ namespace Xamarin.MacDev.Tasks {
 
 			ExecuteTask (task, expectedErrorCount: 1);
 
-			Assert.That (Engine.Logger.ErrorEvents [0].Message, Does.Contain ("The 'Devices' item group is empty."));
+			Assert.That (Engine.Logger.ErrorEvents [0].Message, Does.Contain ("No applicable and available devices found."));
+			Assert.That (Engine.Logger.ErrorEvents [0].Message, Does.Contain ("Unsupported Simulator (SIM-1): Device is not an iPad, but the app only supports iPads"));
+			Assert.That (Engine.Logger.ErrorEvents [0].Message, Does.Contain ("Old Phone (DEVICE-1): Device OS version '17.0' is lower than the app's minimum OS version '18.0'"));
+		}
+
+		[Test]
+		public void HelpListsDiscardedDevicesWhenNoDevicesAreAvailable ()
+		{
+			var task = CreateTask<GetMlaunchArguments> ();
+			task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (ApplePlatform.iOS).ToString ();
+			task.AppManifestPath = CreateAppManifest (1, 2);
+			task.DiscardedDevices = CreateDiscardedDevices (
+				("SIM-1", "Unsupported Simulator", "Simulator", "Device is not an iPad, but the app only supports iPads"),
+				("DEVICE-1", "Old Phone", "Device", "Device OS version '17.0' is lower than the app's minimum OS version '18.0'")
+			);
+			task.Help = "true";
+			task.MlaunchPath = "/usr/bin/false";
+			task.SdkIsSimulator = true;
+			task.SdkVersion = "26.2";
+
+			ExecuteTask (task);
+
+			Assert.That (Engine.Logger.WarningsEvents [0].Message, Does.Contain ("The following devices were discarded:"));
+			Assert.That (Engine.Logger.WarningsEvents [0].Message, Does.Contain ("Unsupported Simulator (SIM-1): Device is not an iPad, but the app only supports iPads"));
+			Assert.That (Engine.Logger.WarningsEvents [0].Message, Does.Contain ("Old Phone (DEVICE-1): Device OS version '17.0' is lower than the app's minimum OS version '18.0'"));
 		}
 
 		static TaskItem [] CreateDevices (params (string Udid, string Name, string Type) [] devices)
 		{
 			return devices.Select (v => {
-				var item = new TaskItem (v.Udid);
-				item.SetMetadata ("Description", v.Name);
-				item.SetMetadata ("Name", v.Name);
-				item.SetMetadata ("Type", v.Type);
-				item.SetMetadata ("UDID", v.Udid);
-				return item;
+				return CreateDevice (v.Udid, v.Name, v.Type);
 			}).ToArray ();
+		}
+
+		static TaskItem [] CreateDiscardedDevices (params (string Udid, string Name, string Type, string DiscardedReason) [] devices)
+		{
+			return devices.Select (v => CreateDevice (v.Udid, v.Name, v.Type, v.DiscardedReason)).ToArray ();
+		}
+
+		static TaskItem CreateDevice (string udid, string name, string type, string? discardedReason = null)
+		{
+			var item = new TaskItem (udid);
+			item.SetMetadata ("Description", name);
+			item.SetMetadata ("Name", name);
+			item.SetMetadata ("Type", type);
+			item.SetMetadata ("UDID", udid);
+			if (!string.IsNullOrEmpty (discardedReason))
+				item.SetMetadata ("DiscardedReason", discardedReason);
+			return item;
 		}
 
 		static string CreateAppManifest (params int [] deviceFamilies)

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetMlaunchArgumentsTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetMlaunchArgumentsTaskTests.cs
@@ -40,6 +40,23 @@ namespace Xamarin.MacDev.Tasks {
 			Assert.That (task.MlaunchArguments, Does.Contain ("--device :v2:udid=SIM-2"));
 		}
 
+		[Test]
+		public void ErrorsIfDevicesItemGroupIsEmpty ()
+		{
+			var task = CreateTask<GetMlaunchArguments> ();
+			task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (ApplePlatform.iOS).ToString ();
+			task.AppManifestPath = CreateAppManifest (1, 2);
+			task.LaunchApp = "MySimpleApp.app";
+			task.MlaunchPath = "/usr/bin/false";
+			task.SdkIsSimulator = true;
+			task.SdkVersion = "26.2";
+			task.WaitForExit = true;
+
+			ExecuteTask (task, expectedErrorCount: 1);
+
+			Assert.That (Engine.Logger.ErrorEvents [0].Message, Does.Contain ("The 'Devices' item group is empty."));
+		}
+
 		static TaskItem [] CreateDevices (params (string Udid, string Name, string Type) [] devices)
 		{
 			return devices.Select (v => {


### PR DESCRIPTION
In the GetMlaunchArguments task, instead of repeating what the GetAvailableDevices task does, just run the GetAvailableDevices task and pass the resulting devices to the GetMlaunchArguments task. Then GetMlaunchArguments can just pick the first applicable one, which should work fine.

Fixes https://github.com/dotnet/macios/issues/25112.