### PR TITLE
[tests] Improve the AppSizeTest a bit.

### DIFF
--- a/tests/dotnet/UnitTests/AppSizeTest.cs
+++ b/tests/dotnet/UnitTests/AppSizeTest.cs
@@ -120,7 +120,9 @@ namespace Xamarin.Tests {
 			var expectedAppBundleSize = 0L;
 			if (File.Exists (expectedSizeReportPath)) {
 				expectedSizeReport = File.ReadAllText (expectedSizeReportPath);
-				expectedAppBundleSize = long.Parse (expectedSizeReport.SplitLines ().First ().Replace ("AppBundleSize: ", "").Replace (",", "").Replace (".", "").RemoveAfterFirstSpace ());
+				if (!long.TryParse (expectedSizeReport.SplitLines ().First ().Replace ("AppBundleSize: ", "").Replace (",", "").Replace (".", "").RemoveAfterFirstSpace (), out expectedAppBundleSize)) {
+					expectedSizeReport = "";
+				}
 			}
 
 			var appSizeDifference = appBundleSize - expectedAppBundleSize;
@@ -155,10 +157,12 @@ namespace Xamarin.Tests {
 			foreach (var key in allKeys) {
 				if (!expectedLines.TryGetValue (key, out var expectedLine)) {
 					Console.WriteLine ($"        File '{key}' was added to app bundle: {actualLines [key]}");
-					Assert.Fail ($"The file '{key}' was added to the app bundle.");
+					if (!updated)
+						Assert.Fail ($"The file '{key}' was added to the app bundle.");
 				} else if (!actualLines.TryGetValue (key, out var actualLine)) {
 					Console.WriteLine ($"        File '{key}' was removed from app bundle: {expectedLine}");
-					Assert.Fail ($"The file '{key}' was removed from the app bundle.");
+					if (!updated)
+						Assert.Fail ($"The file '{key}' was removed from the app bundle.");
 				} else if (expectedLine != actualLine) {
 					Console.WriteLine ($"        File '{key}' changed in app bundle:");
 					Console.WriteLine ($"            -{expectedLine}");


### PR DESCRIPTION
* Don't fail immediately if the file with the expected sizes can't be parsed,
  treat it like the file didn't exist (this allows it to be easily
  re-generated even if it's invalid - which is common with merge conflicts,
  with this change the test will just overwrite any expected files that have
  merge conflict markers).
* Don't fail if the set of files has changed and the test is updating the
  expected sizes (instead just write out the expected sizes instead).