### PR TITLE
CoreSpotlight: fix 'occured' -> 'occurred' in CSEnums XML doc comment

### DIFF
--- a/src/CoreSpotlight/CSEnums.cs
+++ b/src/CoreSpotlight/CSEnums.cs
@@ -17,7 +17,7 @@ namespace CoreSpotlight {
 	[Native]
 	[ErrorDomain ("CSIndexErrorDomain")]
 	public enum CSIndexErrorCode : long {
-		/// <summary>An unknown error occured.</summary>
+		/// <summary>An unknown error occurred.</summary>
 		UnknownError = -1,
 		/// <summary>The index was not available.</summary>
 		IndexUnavailableError = -1000,


### PR DESCRIPTION
XML doc comment in `src/CoreSpotlight/CSEnums.cs` line 20 reads `An unknown error occured`. Fixed to `occurred`. Comment-only change.