### PR TITLE
[Foundation] Enable HTTP digest auth in NSUrlSessionHandler

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -1289,9 +1289,10 @@ namespace Foundation {
 					authenticationType = "NTLM";
 				} else if (protectionSpace.AuthenticationMethod == NSUrlProtectionSpace.AuthenticationMethodHTTPBasic) {
 					authenticationType = "basic";
+				} else if (protectionSpace.AuthenticationMethod == NSUrlProtectionSpace.AuthenticationMethodHTTPDigest) {
+					authenticationType = "digest";
 				} else if (protectionSpace.AuthenticationMethod == NSUrlProtectionSpace.AuthenticationMethodNegotiate ||
-					protectionSpace.AuthenticationMethod == NSUrlProtectionSpace.AuthenticationMethodHTMLForm ||
-					protectionSpace.AuthenticationMethod == NSUrlProtectionSpace.AuthenticationMethodHTTPDigest) {
+					protectionSpace.AuthenticationMethod == NSUrlProtectionSpace.AuthenticationMethodHTMLForm) {
 					// Want to reject this authentication type to allow the next authentication method in the request to
 					// be used.
 					authenticationType = RejectProtectionSpaceAuthType;

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -909,6 +909,32 @@ namespace MonoTests.System.Net.Http {
 			}
 		}
 
+		[TestCase (HttpStatusCode.OK, "mandel", "12345678", "mandel", "12345678")]
+		[TestCase (HttpStatusCode.Unauthorized, "mandel", "12345678", "mandel", "87654321")]
+		[TestCase (HttpStatusCode.Unauthorized, "mandel", "12345678", "", "")]
+		public void SupportsDigestAuthentication (HttpStatusCode expectedStatus, string validUsername, string validPassword, string username, string password)
+		{
+			var handler = new NSUrlSessionHandler () {
+				Credentials = new NetworkCredential (username, password, "")
+			};
+
+			var client = new HttpClient (handler);
+
+			HttpStatusCode httpStatus = HttpStatusCode.NotFound;
+			var done = TestRuntime.TryRunAsync (TimeSpan.FromSeconds (30), async () => {
+				var result = await client.GetAsync (NetworkResources.Httpbin.GetDigestAuthUrl (validUsername, validPassword));
+				httpStatus = result.StatusCode;
+			}, out var ex);
+
+			if (!done) {
+				Assert.Inconclusive ("Request timedout.");
+			} else {
+				TestRuntime.IgnoreInCIIfBadNetwork (httpStatus);
+				Assert.IsNull (ex, "Exception not null");
+				Assert.AreEqual (expectedStatus, httpStatus, "Status not ok");
+			}
+		}
+
 		[TestCase]
 		public void GHIssue8344 ()
 		{

--- a/tests/monotouch-test/System.Net.Http/NetworkResources.cs
+++ b/tests/monotouch-test/System.Net.Http/NetworkResources.cs
@@ -102,6 +102,7 @@ namespace MonoTests.System.Net.Http {
 			public static string GetStatusCodeUrl (HttpStatusCode status) => $"{HttpUrl}/status/{(int) status}";
 			public static string GetSetCookieUrl (string cookie, string value) => $"{Url}/cookies/set?{cookie}={value}";
 			public static string GetBasicAuthUrl (string username, string password) => $"{Url}/basic-auth/{username}/{password}";
+			public static string GetDigestAuthUrl (string username, string password) => $"{Url}/digest-auth/auth/{username}/{password}";
 
 		}
 	}


### PR DESCRIPTION
NSUrlSessionHandler was explicitly rejecting HTTP digest challenges by mapping NSURLAuthenticationMethodHTTPDigest to the internal reject sentinel. That meant iOS never answered digest auth challenges with configured credentials, while other supported auth schemes did.

Handle digest challenges like other credential-backed auth methods so Credentials.GetCredential can return a NetworkCredential and the handler can respond with an NSUrlCredential.

Add a System.Net.Http regression test covering successful and failed digest authentication, and add a shared httpbin helper for the digest auth endpoint.

Local monotouch-test build validation was attempted, but this checkout is currently blocked by the expected Xcode installation and local build environment configuration.