### PR TITLE
[devops] Remove the branch-based trigger for pull requests.

### DIFF
--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -48,20 +48,6 @@ variables:
 - name: Packaging.EnableSBOMSigning
   value: false
 
-
-# only allow triggers from specific branches
-trigger:
-  branches:
-    include:
-    - refs/heads/dev/*
-    - refs/heads/darc-*
-    - refs/heads/backport-pr-*
-    - refs/heads/lego/*
-    - refs/heads/locfiles/*
-    - refs/heads/copilot/*
-    - refs/heads/dependabot/*
-    - refs/heads/merge/*
-
 pr:
   autoCancel: true
   branches:


### PR DESCRIPTION
The pull request https://github.com/dotnet/macios/pull/25177 ran the PR pipeline twice:

* https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=13868591&view=results
* https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=13868592&view=results

when it should only have been done once.

So I asked Copilot, which said:

    It was triggered twice because two different Azure triggers fired for the same change.

     - 13868591 was queued as individualCI for refs/heads/dev/rolf/nsurlsession-cleanup on commit b3223c4.
     - 13868592 was queued seconds later as pullRequest for refs/pull/25177/merge on the synthetic merge commit 7fccb8c.

    That matches the repo’s PR pipeline config in tools/devops/automation/build-pull-request.yml, which has both a branch trigger: for refs/heads/dev/* and a pr: trigger for '*'. So opening/updating PR #25177 caused one normal branch CI run and one PR-validation run.

So disable the branched-based trigger.