### PR TITLE
Add eng/Signing.props to sign cab files inside MSI workload packs

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,0 +1,16 @@
+<Project>
+  <PropertyGroup>
+    <UseDotNetCertificate>true</UseDotNetCertificate>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Sign cab files embedded inside MSI containers with Authenticode -->
+    <FileExtensionSignInfo Include=".cab" CertificateName="Microsoft400" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ItemsToSign Include="$(ArtifactsShippingPackagesDir)\**\*.msi" Condition="'$(PostBuildSign)' != 'true'" />
+    <ItemsToSign Include="$(ArtifactsShippingPackagesDir)\**\*.wixpack.zip" Condition="'$(PostBuildSign)' != 'true'" />
+    <ItemsToSignPostBuild Include="$(ArtifactsShippingPackagesDir)\**\*.msi" Condition="'$(PostBuildSign)' == 'true'" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The VS signing scan flags 42 unsigned cab1.cab files inside macOS SDK and Templates workload pack MSI payloads. The Arcade SDK's default Sign.props does not include a FileExtensionSignInfo for .cab, so the SignTool skips signing them even though .cab is in SignableExtensions.

Add eng/Signing.props with:
- FileExtensionSignInfo for .cab -> Microsoft400
- UseDotNetCertificate = true (standard for dotnet/* repos)
- ItemsToSign entries for *.msi and *.wixpack.zip so the SignTool opens MSI containers and signs embedded cabs

This is recreating #25184 from origin since we can't build from forks.