### PR TITLE
[devops] Add a timeout to the 'Publish to Artifact Services Drop' step.

### DIFF
--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -219,6 +219,7 @@ steps:
     sourcePath: '$(BUILD_REPOSITORY_TITLE)/jenkins-results'
     detailedLog: true
     usePat: true
+  timeoutInMinutes: 30
   continueOnError: true
   condition: succeededOrFailed()
 

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -191,6 +191,7 @@ steps:
     sourcePath: '$(BUILD_REPOSITORY_TITLE)/jenkins-results'
     detailedLog: true
     usePat: true
+  timeoutInMinutes: 30
   continueOnError: true
   condition: succeededOrFailed()
 

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -353,6 +353,7 @@ steps:
     sourcePath: '$(BUILD_REPOSITORY_TITLE)/jenkins-results'
     detailedLog: true
     usePat: true
+  timeoutInMinutes: 30
   continueOnError: true
   condition: succeededOrFailed()
 


### PR DESCRIPTION
This step has taken to hanging recently, and it'll hang until the job's
timeout of 3 hours is hit, at which point it'll mark the entire job as failed.

So add a timeout just for this step, so that it can timeout by itself, and
then the job can finish successfully.