### PR TITLE
[devops] Disable implicit CI triggers on xamarin-macios-pr pipeline

### DIFF
--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -48,6 +48,8 @@ variables:
 - name: Packaging.EnableSBOMSigning
   value: false
 
+trigger: none
+
 pr:
   autoCancel: true
   branches:


### PR DESCRIPTION
Without an explicit trigger section, Azure DevOps defaults to enabling
CI triggers on all branches. This causes duplicate builds when a branch
(e.g. darc-main-*) has an open PR — one from the implicit CI trigger
and one from the PR trigger.

Adding 'trigger: none' ensures only PR-triggered builds run.