### PR TITLE
[msbuild/dotnet] Use 'SdkIsSimulator' instead of 'ComputedPlatform'.

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -156,6 +156,7 @@ Common project structure for Apple platform apps:
 2. Run `make` to rebuild affected components
 3. Test changes using appropriate test suite
 4. Verify on both simulator and device when possible
+5. Check if the documentation in the `docs/` directory needs to be updated to reflect the changes (e.g. new MSBuild properties should be documented in `docs/building-apps/build-properties.md`)
 
 ### Code Style
 

--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -1234,6 +1234,19 @@ $ dotnet run -p:StandardInputPath=stdin.txt
 
 Note: this can also be accomplished by passing `--stdin ...` using the [OpenArguments](#openarguments) property.
 
+## SdkIsDevice
+
+This property is a read-only property (setting it will have no effect) that
+specifies whether we're building for a device or not.
+
+This property is only `true` when building for an iOS or tvOS device (i.e.,
+when `SdkIsSimulator` is not `true` and the platform is iOS or tvOS). It is
+not set for macOS or Mac Catalyst builds.
+
+Like `SdkIsSimulator`, this property is only set after [imports and
+properties](/visualstudio/msbuild/build-process-overview#evaluate-imports-and-properties)
+have been evaluated.
+
 ## SdkIsSimulator
 
 This property is a read-only property (setting it will have no effect) that
@@ -1267,19 +1280,6 @@ However, the either of the following works:
 ```
 
 Note: this property will always be `false` on macOS and Mac Catalyst.
-
-## SdkIsDevice
-
-This property is a read-only property (setting it will have no effect) that
-specifies whether we're building for a device or not.
-
-This property is only `true` when building for an iOS or tvOS device (i.e.,
-when `SdkIsSimulator` is not `true` and the platform is iOS or tvOS). It is
-not set for macOS or Mac Catalyst builds.
-
-Like `SdkIsSimulator`, this property is only set after [imports and
-properties](/visualstudio/msbuild/build-process-overview#evaluate-imports-and-properties)
-have been evaluated.
 
 ## StripPath
 

--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -1268,6 +1268,19 @@ However, the either of the following works:
 
 Note: this property will always be `false` on macOS and Mac Catalyst.
 
+## SdkIsDevice
+
+This property is a read-only property (setting it will have no effect) that
+specifies whether we're building for a device or not.
+
+This property is only `true` when building for an iOS or tvOS device (i.e.,
+when `SdkIsSimulator` is not `true` and the platform is iOS or tvOS). It is
+not set for macOS or Mac Catalyst builds.
+
+Like `SdkIsSimulator`, this property is only set after [imports and
+properties](/visualstudio/msbuild/build-process-overview#evaluate-imports-and-properties)
+have been evaluated.
+
 ## StripPath
 
 The full path to the `strip` command-line tool.

--- a/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.DefaultItems.targets
@@ -59,11 +59,6 @@
 		</PropertyGroup>
 	</Target>
 
-	<PropertyGroup Condition="'$(ComputedPlatform)' == '' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS') ">
-		<ComputedPlatform Condition="'$(SdkIsSimulator)' == 'true'">iPhoneSimulator</ComputedPlatform>
-		<ComputedPlatform Condition="'$(ComputedPlatform)' == ''">iPhone</ComputedPlatform>
-	</PropertyGroup>
-
 	<PropertyGroup>
 		<_RuntimeFrameworkVersion>$(BundledNETCorePlatformsPackageVersion)</_RuntimeFrameworkVersion>
 		<_RuntimeFrameworkVersion Condition="'$(CUSTOM_DOTNET_VERSION)' != ''">$(CUSTOM_DOTNET_VERSION)</_RuntimeFrameworkVersion>

--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -152,8 +152,8 @@
 		<SdkIsDevice Condition="'$(SdkIsSimulator)' != 'true' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS')">true</SdkIsDevice>
 
 		<!-- We don't use the 'ComputedPlatform' property anymore, but it seems like there's code out there that depends on it (according to a search on GitHub at least), so define it like we did when we used the property. -->
-		<ComputedPlatform Condition="'$(ComputedPlatform)' == '' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS') And '$(SdkIsSimulator)' == 'true'">iPhoneSimulator</ComputedPlatform>
-		<ComputedPlatform Condition="'$(ComputedPlatform)' == '' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS') And '$(SdkIsSimulator)' != 'true'">iPhone</ComputedPlatform>
+		<ComputedPlatform Condition="'$(ComputedPlatform)' == '' And '$(SdkIsSimulator)' == 'true'">iPhoneSimulator</ComputedPlatform>
+		<ComputedPlatform Condition="'$(ComputedPlatform)' == '' And '$(SdkIsDevice)' == 'true'">iPhone</ComputedPlatform>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -148,9 +148,12 @@
 		<!-- Set a public property that specifies if we're building for the simulator. -->
 		<SdkIsSimulator>$(_SdkIsSimulator)</SdkIsSimulator>
 
+		<!-- SdkIsDevice is true when building for device (which can only happen on iOS and tvOS). -->
+		<SdkIsDevice Condition="'$(SdkIsSimulator)' != 'true' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS')">true</SdkIsDevice>
+
 		<!-- We don't use the 'ComputedPlatform' property anymore, but it seems like there's code out there that depends on it (according to a search on GitHub at least), so define it like we did when we used the property. -->
-		<ComputedPlatform Condition="'$(SdkIsSimulator)' == 'true'">iPhoneSimulator</ComputedPlatform>
-		<ComputedPlatform Condition="'$(ComputedPlatform)' == ''">iPhone</ComputedPlatform>
+		<ComputedPlatform Condition="'$(ComputedPlatform)' == '' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS') And '$(SdkIsSimulator)' == 'true'">iPhoneSimulator</ComputedPlatform>
+		<ComputedPlatform Condition="'$(ComputedPlatform)' == '' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS') And '$(SdkIsSimulator)' != 'true'">iPhone</ComputedPlatform>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -147,6 +147,10 @@
 		<_SdkIsSimulator Condition="'$(_SdkIsSimulator)' == ''">false</_SdkIsSimulator>
 		<!-- Set a public property that specifies if we're building for the simulator. -->
 		<SdkIsSimulator>$(_SdkIsSimulator)</SdkIsSimulator>
+
+		<!-- We don't use the 'ComputedPlatform' property anymore, but it seems like there's code out there that depends on it (according to a search on GitHub at least), so define it like we did when we used the property. -->
+		<ComputedPlatform Condition="'$(SdkIsSimulator)' == 'true'">iPhoneSimulator</ComputedPlatform>
+		<ComputedPlatform Condition="'$(ComputedPlatform)' == ''">iPhone</ComputedPlatform>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1255,14 +1255,14 @@
 
 			<!-- default to 'static' for Mac Catalyst to work around https://github.com/dotnet/macios/issues/14686 -->
 			<_LibMonoLinkMode Condition="'$(_LibMonoLinkMode)' == '' And '$(_PlatformName)' == 'MacCatalyst'">static</_LibMonoLinkMode>
-			<_LibMonoLinkMode Condition="'$(_LibMonoLinkMode)' == '' And ('$(ComputedPlatform)' != 'iPhone' Or '$(_PlatformName)' == 'macOS')">dylib</_LibMonoLinkMode>
+			<_LibMonoLinkMode Condition="'$(_LibMonoLinkMode)' == '' And ('$(SdkIsSimulator)' == 'true' Or '$(_PlatformName)' == 'macOS')">dylib</_LibMonoLinkMode>
 			<_LibMonoLinkMode Condition="'$(_LibMonoLinkMode)' == ''">static</_LibMonoLinkMode>
 			<_LibMonoExtension Condition="'$(_LibMonoLinkMode)' == 'dylib'">dylib</_LibMonoExtension>
 			<_LibMonoExtension Condition="'$(_LibMonoLinkMode)' == 'static'">a</_LibMonoExtension>
 
 			<!-- default to 'static' for Mac Catalyst to work around https://github.com/dotnet/macios/issues/14686 -->
 			<_LibXamarinLinkMode Condition="'$(_LibXamarinLinkMode)' == '' And '$(_PlatformName)' == 'MacCatalyst'">static</_LibXamarinLinkMode>
-			<_LibXamarinLinkMode Condition="'$(_LibXamarinLinkMode)' == '' And '$(ComputedPlatform)' != 'iPhone' And '$(_PlatformName)' != 'macOS'">dylib</_LibXamarinLinkMode>
+			<_LibXamarinLinkMode Condition="'$(_LibXamarinLinkMode)' == '' And '$(SdkIsSimulator)' == 'true' And '$(_PlatformName)' != 'macOS'">dylib</_LibXamarinLinkMode>
 			<_LibXamarinLinkMode Condition="'$(_LibXamarinLinkMode)' == ''">static</_LibXamarinLinkMode>
 			<_LibXamarinExtension Condition="'$(_LibXamarinLinkMode)' == 'dylib'">dylib</_LibXamarinExtension>
 			<_LibXamarinExtension Condition="'$(_LibXamarinLinkMode)' == 'static'">a</_LibXamarinExtension>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -97,10 +97,10 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 
 		<!-- We can archive: -->
 		<!-- macOS and Mac Catalyst: executable projects which aren't app extensions -->
-		<!-- iOS, tvOS and watchOS: executable projects built for device which aren't app extensions nor watch apps -->
+		<!-- iOS, tvOS and watchOS: executable projects built for device which aren't app extensions -->
 		<_CanArchive>false</_CanArchive>
 		<_CanArchive Condition="('$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst') And '$(OutputType)' == 'Exe' And '$(IsAppExtension)' == 'false'">true</_CanArchive>
-		<_CanArchive Condition="('$(_PlatformName)' == 'iOS'  Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS') And '$(OutputType)' == 'Exe' And '$(SdkIsDevice)' == 'true' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'">true</_CanArchive>
+		<_CanArchive Condition="'$(OutputType)' == 'Exe' And '$(SdkIsDevice)' == 'true' And '$(IsAppExtension)' == 'false'">true</_CanArchive>
 
 		<!-- Debug -->
 		<!-- Xamarin.Mac: use MmpDebug -->
@@ -124,7 +124,7 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		<NoSymbolStrip Condition="'$(NoSymbolStrip)' == '' And '$(Configuration)' == 'Debug'">true</NoSymbolStrip>
 		<NoSymbolStrip Condition="'$(NoSymbolStrip)' == '' And ('$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst') And '$(_UseNativeAot)' != 'true'">true</NoSymbolStrip>
 		<!-- Disable stripping for simulator builds by default -->
-		<NoSymbolStrip Condition="'$(NoSymbolStrip)' == '' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS') And '$(SdkIsSimulator)' == 'true'">true</NoSymbolStrip>
+		<NoSymbolStrip Condition="'$(NoSymbolStrip)' == '' And '$(SdkIsSimulator)' == 'true'">true</NoSymbolStrip>
 		<NoSymbolStrip Condition="'$(NoSymbolStrip)' == ''">false</NoSymbolStrip>
 
 		<!-- NoDSymUtil -->
@@ -133,7 +133,7 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		<!-- Disable dsymutil on desktop unless archiving -->
 		<NoDSymUtil Condition="'$(NoDSymUtil)' == '' And ('$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst') And '$(ArchiveOnBuild)' != 'true'">true</NoDSymUtil>
 		<!-- Disable dsymutil for simulator builds by default -->
-		<NoDSymUtil Condition="'$(NoDSymUtil)' == '' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS') And '$(SdkIsSimulator)' == 'true'">true</NoDSymUtil>
+		<NoDSymUtil Condition="'$(NoDSymUtil)' == '' And '$(SdkIsSimulator)' == 'true'">true</NoDSymUtil>
 		<NoDSymUtil Condition="'$(NoDSymUtil)' == ''">false</NoDSymUtil>
 
 		<!-- DeviceSpecificIntermediateOutputPath -->

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -20,26 +20,6 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
 
-	<PropertyGroup>
-		<!--
-		     We don't want to use the Platform variable for conditional logic.
-		     Switching to a new property allows us to potentially switch from
-		     device to simulator builds dynamically based on the user's
-		     selection when starting the project. This allows us to eventually
-		     even (optionally) switch back to AnyCPU platform in the IDE,
-		     therefore fixing a key pain point in managing solution
-		     configurations.
-
-		     Additionally, we cannot use $(Platform) in conditions on props,
-		     because VS interprets them as valid platforms for the current
-		     project and makes them available for solution configurations,
-		     which fails miserably for iOS class library projects. By using
-		     another property name, we "opt out" of this "smart" behavior
-		-->
-		<ComputedPlatform Condition="'$(ComputedPlatform)' == ''">$(Platform)</ComputedPlatform>
-		<ComputedPlatform Condition="'$(_PlatformName)' != 'macOS' And '$(_PlatformName)' != 'MacCatalyst' And '$(ComputedPlatform)' == 'AnyCPU'">iPhone</ComputedPlatform>
-	</PropertyGroup>
-
 	<!-- Sometimes we've used different variable names for the same thing for Xamarin.iOS and Xamarin.Mac projects. Here we try to unify those variables -->
 	<PropertyGroup>
 		<!-- ResourcePrefix -->
@@ -120,7 +100,7 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		<!-- iOS, tvOS and watchOS: executable projects built for device which aren't app extensions nor watch apps -->
 		<_CanArchive>false</_CanArchive>
 		<_CanArchive Condition="('$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst') And '$(OutputType)' == 'Exe' And '$(IsAppExtension)' == 'false'">true</_CanArchive>
-		<_CanArchive Condition="('$(_PlatformName)' == 'iOS'  Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS') And '$(OutputType)' == 'Exe' And '$(ComputedPlatform)' == 'iPhone' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'">true</_CanArchive>
+		<_CanArchive Condition="('$(_PlatformName)' == 'iOS'  Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS') And '$(OutputType)' == 'Exe' And '$(SdkIsSimulator)' != 'true' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'">true</_CanArchive>
 
 		<!-- Debug -->
 		<!-- Xamarin.Mac: use MmpDebug -->
@@ -144,7 +124,7 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		<NoSymbolStrip Condition="'$(NoSymbolStrip)' == '' And '$(Configuration)' == 'Debug'">true</NoSymbolStrip>
 		<NoSymbolStrip Condition="'$(NoSymbolStrip)' == '' And ('$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst') And '$(_UseNativeAot)' != 'true'">true</NoSymbolStrip>
 		<!-- Disable stripping for simulator builds by default -->
-		<NoSymbolStrip Condition="'$(NoSymbolStrip)' == '' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS') And '$(ComputedPlatform)' != 'iPhone'">true</NoSymbolStrip>
+		<NoSymbolStrip Condition="'$(NoSymbolStrip)' == '' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS') And '$(SdkIsSimulator)' == 'true'">true</NoSymbolStrip>
 		<NoSymbolStrip Condition="'$(NoSymbolStrip)' == ''">false</NoSymbolStrip>
 
 		<!-- NoDSymUtil -->
@@ -153,7 +133,7 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		<!-- Disable dsymutil on desktop unless archiving -->
 		<NoDSymUtil Condition="'$(NoDSymUtil)' == '' And ('$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst') And '$(ArchiveOnBuild)' != 'true'">true</NoDSymUtil>
 		<!-- Disable dsymutil for simulator builds by default -->
-		<NoDSymUtil Condition="'$(NoDSymUtil)' == '' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS') And '$(ComputedPlatform)' != 'iPhone'">true</NoDSymUtil>
+		<NoDSymUtil Condition="'$(NoDSymUtil)' == '' And ('$(_PlatformName)' == 'iOS' Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS') And '$(SdkIsSimulator)' == 'true'">true</NoDSymUtil>
 		<NoDSymUtil Condition="'$(NoDSymUtil)' == ''">false</NoDSymUtil>
 
 		<!-- DeviceSpecificIntermediateOutputPath -->

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -100,7 +100,7 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		<!-- iOS, tvOS and watchOS: executable projects built for device which aren't app extensions nor watch apps -->
 		<_CanArchive>false</_CanArchive>
 		<_CanArchive Condition="('$(_PlatformName)' == 'macOS' Or '$(_PlatformName)' == 'MacCatalyst') And '$(OutputType)' == 'Exe' And '$(IsAppExtension)' == 'false'">true</_CanArchive>
-		<_CanArchive Condition="('$(_PlatformName)' == 'iOS'  Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS') And '$(OutputType)' == 'Exe' And '$(SdkIsSimulator)' != 'true' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'">true</_CanArchive>
+		<_CanArchive Condition="('$(_PlatformName)' == 'iOS'  Or '$(_PlatformName)' == 'tvOS' Or '$(_PlatformName)' == 'watchOS') And '$(OutputType)' == 'Exe' And '$(SdkIsDevice)' == 'true' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'">true</_CanArchive>
 
 		<!-- Debug -->
 		<!-- Xamarin.Mac: use MmpDebug -->

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2658,7 +2658,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<Target Name="_PrepareResourceRules" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName">
 		<PrepareResourceRules
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true' And '$(CodesignResourceRules)' != '' And '$(SdkIsSimulator)' != 'true'"
+			Condition="'$(IsMacEnabled)' == 'true' And '$(CodesignResourceRules)' != '' And '$(SdkIsDevice)' == 'true'"
 			AppBundleDir="$(AppBundleDir)"
 			ResourceRules="$(CodesignResourceRules)"
 			SdkVersion="$(_SdkVersion)"

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2658,7 +2658,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<Target Name="_PrepareResourceRules" DependsOnTargets="_DetectSdkLocations;_GenerateBundleName">
 		<PrepareResourceRules
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true' And '$(CodesignResourceRules)' != '' And '$(ComputedPlatform)' == 'iPhone'"
+			Condition="'$(IsMacEnabled)' == 'true' And '$(CodesignResourceRules)' != '' And '$(SdkIsSimulator)' != 'true'"
 			AppBundleDir="$(AppBundleDir)"
 			ResourceRules="$(CodesignResourceRules)"
 			SdkVersion="$(_SdkVersion)"

--- a/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
@@ -109,7 +109,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</_CompileITunesMetadataDependsOn>
 	</PropertyGroup>
 
-	<Target Name="_CompileITunesMetadata" Condition="'$(SdkIsSimulator)' != 'true' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'"
+	<Target Name="_CompileITunesMetadata" Condition="'$(SdkIsDevice)' == 'true' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'"
 		DependsOnTargets="$(_CompileITunesMetadataDependsOn)"
 		Inputs="@(ITunesMetadata)"
 		Outputs="$(DeviceSpecificOutputPath)iTunesMetadata.plist" >
@@ -124,7 +124,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		/>
 	</Target>
 
-	<Target Name="_CollectITunesArtwork" Condition="'$(SdkIsSimulator)' != 'true' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'">
+	<Target Name="_CollectITunesArtwork" Condition="'$(SdkIsDevice)' == 'true' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'">
 		<CollectITunesArtwork
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
@@ -134,7 +134,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</CollectITunesArtwork>
 	</Target>
 
-	<Target Name="_CopyITunesArtwork" Condition="'$(SdkIsSimulator)' != 'true' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'"
+	<Target Name="_CopyITunesArtwork" Condition="'$(SdkIsDevice)' == 'true' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'"
 		DependsOnTargets="_CollectITunesArtwork"
 		Inputs="@(_ITunesArtworkWithLogicalName)" Outputs="$(DeviceSpecificOutputPath)%(_ITunesArtworkWithLogicalName.LogicalName)">
 		<Copy

--- a/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
@@ -109,7 +109,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</_CompileITunesMetadataDependsOn>
 	</PropertyGroup>
 
-	<Target Name="_CompileITunesMetadata" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'"
+	<Target Name="_CompileITunesMetadata" Condition="'$(SdkIsSimulator)' != 'true' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'"
 		DependsOnTargets="$(_CompileITunesMetadataDependsOn)"
 		Inputs="@(ITunesMetadata)"
 		Outputs="$(DeviceSpecificOutputPath)iTunesMetadata.plist" >
@@ -124,7 +124,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		/>
 	</Target>
 
-	<Target Name="_CollectITunesArtwork" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'">
+	<Target Name="_CollectITunesArtwork" Condition="'$(SdkIsSimulator)' != 'true' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'">
 		<CollectITunesArtwork
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
@@ -134,7 +134,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</CollectITunesArtwork>
 	</Target>
 
-	<Target Name="_CopyITunesArtwork" Condition="'$(ComputedPlatform)' == 'iPhone' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'"
+	<Target Name="_CopyITunesArtwork" Condition="'$(SdkIsSimulator)' != 'true' And '$(IsAppExtension)' == 'false' And '$(IsWatchApp)' == 'false'"
 		DependsOnTargets="_CollectITunesArtwork"
 		Inputs="@(_ITunesArtworkWithLogicalName)" Outputs="$(DeviceSpecificOutputPath)%(_ITunesArtworkWithLogicalName.LogicalName)">
 		<Copy

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
@@ -103,7 +103,7 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 		<Delete Condition="'$(MtouchTargetsEnabled)' And '$(IsMacEnabled)' == 'true' And Exists('$(DeviceSpecificOutputPath)AppBundle\$(_AppBundleName).zip')" SessionId="$(BuildSessionId)" Files="$(DeviceSpecificOutputPath)AppBundle\$(_AppBundleName).zip" />
 	</Target>
 	
-	<Target Name="CopyIpaFromMac" Condition="'$(OutputType)' == 'Exe' And '$(ComputedPlatform)' == 'iPhone' And '$(BuildIpa)' == 'true'">
+	<Target Name="CopyIpaFromMac" Condition="'$(OutputType)' == 'Exe' And '$(SdkIsSimulator)' != 'true' And '$(BuildIpa)' == 'true'">
 		<CopyFileFromBuildServer Condition="'$(IsAppDistribution)' == 'True'" SessionId="$(BuildSessionId)" File="$(IpaPackagePath)" TargetFile="$(DistributionPath)" />
 		<CopyFileFromBuildServer Condition="'$(IsAppDistribution)' != 'True'" SessionId="$(BuildSessionId)" File="$(IpaPackagePath)" />
 		<CopyFileFromBuildServer Condition="('$(_DistributionType)' == 'AppStore' Or '$(_DistributionType)' == 'AdHoc') And '$(EmbedOnDemandResources)' == 'false'" SessionId="$(BuildSessionId)" File="$(IpaPackageDir)\OnDemandResources\%(_AssetPack.DirectoryName)" />
@@ -178,7 +178,7 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 		</CopyLongPaths>
 	</Target>
 	
-	<Target Name="CopyDSYMFromMac" DependsOnTargets="_SayHello" Condition="'$(IsMacEnabled)' == 'true' And '$(IsAppExtension)' == 'false' And '$(ComputedPlatform)' == 'iPhone' And '$(CopyDSYM)' == 'true' And ('$(BuildIpa)' == 'true' Or '$(CopyAppBundle)' == 'true')" BeforeTargets="BeforeDisconnect">
+	<Target Name="CopyDSYMFromMac" DependsOnTargets="_SayHello" Condition="'$(IsMacEnabled)' == 'true' And '$(IsAppExtension)' == 'false' And '$(SdkIsSimulator)' != 'true' And '$(CopyDSYM)' == 'true' And ('$(BuildIpa)' == 'true' Or '$(CopyAppBundle)' == 'true')" BeforeTargets="BeforeDisconnect">
 		<!--Copy watchOS Dsym folders from Mac-->
 		<MSBuild Projects="@(_WatchAppReferenceWithConfigurationExistent)" Targets="CopyDSYMFromMac" Properties="%(_WatchAppReferenceWithConfigurationExistent.SetConfiguration);      %(_WatchAppReferenceWithConfigurationExistent.SetPlatform);      BuildIpa=true" Condition="'$(IsWatchApp)' == 'false' And '@(_WatchAppReferenceWithConfigurationExistent)' != '' And '$(_BuildReferencedExtensionProjects)' != 'true'"></MSBuild>
 		<!--Look for all *.dsym folders int the output path of the main app -->

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
@@ -103,7 +103,7 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 		<Delete Condition="'$(MtouchTargetsEnabled)' And '$(IsMacEnabled)' == 'true' And Exists('$(DeviceSpecificOutputPath)AppBundle\$(_AppBundleName).zip')" SessionId="$(BuildSessionId)" Files="$(DeviceSpecificOutputPath)AppBundle\$(_AppBundleName).zip" />
 	</Target>
 	
-	<Target Name="CopyIpaFromMac" Condition="'$(OutputType)' == 'Exe' And '$(SdkIsSimulator)' != 'true' And '$(BuildIpa)' == 'true'">
+	<Target Name="CopyIpaFromMac" Condition="'$(OutputType)' == 'Exe' And '$(SdkIsDevice)' == 'true' And '$(BuildIpa)' == 'true'">
 		<CopyFileFromBuildServer Condition="'$(IsAppDistribution)' == 'True'" SessionId="$(BuildSessionId)" File="$(IpaPackagePath)" TargetFile="$(DistributionPath)" />
 		<CopyFileFromBuildServer Condition="'$(IsAppDistribution)' != 'True'" SessionId="$(BuildSessionId)" File="$(IpaPackagePath)" />
 		<CopyFileFromBuildServer Condition="('$(_DistributionType)' == 'AppStore' Or '$(_DistributionType)' == 'AdHoc') And '$(EmbedOnDemandResources)' == 'false'" SessionId="$(BuildSessionId)" File="$(IpaPackageDir)\OnDemandResources\%(_AssetPack.DirectoryName)" />
@@ -178,7 +178,7 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 		</CopyLongPaths>
 	</Target>
 	
-	<Target Name="CopyDSYMFromMac" DependsOnTargets="_SayHello" Condition="'$(IsMacEnabled)' == 'true' And '$(IsAppExtension)' == 'false' And '$(SdkIsSimulator)' != 'true' And '$(CopyDSYM)' == 'true' And ('$(BuildIpa)' == 'true' Or '$(CopyAppBundle)' == 'true')" BeforeTargets="BeforeDisconnect">
+	<Target Name="CopyDSYMFromMac" DependsOnTargets="_SayHello" Condition="'$(IsMacEnabled)' == 'true' And '$(IsAppExtension)' == 'false' And '$(SdkIsDevice)' == 'true' And '$(CopyDSYM)' == 'true' And ('$(BuildIpa)' == 'true' Or '$(CopyAppBundle)' == 'true')" BeforeTargets="BeforeDisconnect">
 		<!--Copy watchOS Dsym folders from Mac-->
 		<MSBuild Projects="@(_WatchAppReferenceWithConfigurationExistent)" Targets="CopyDSYMFromMac" Properties="%(_WatchAppReferenceWithConfigurationExistent.SetConfiguration);      %(_WatchAppReferenceWithConfigurationExistent.SetPlatform);      BuildIpa=true" Condition="'$(IsWatchApp)' == 'false' And '@(_WatchAppReferenceWithConfigurationExistent)' != '' And '$(_BuildReferencedExtensionProjects)' != 'true'"></MSBuild>
 		<!--Look for all *.dsym folders int the output path of the main app -->

--- a/tests/ComputeRegistrarConstant.targets
+++ b/tests/ComputeRegistrarConstant.targets
@@ -2,7 +2,7 @@
 <Project>
 	<Target Name="ComputeRegistrarConstant" BeforeTargets="BeforeBuild">
 		<PropertyGroup Condition="('$(_PlatformName)' == 'iOS' Or $(TargetFramework.EndsWith('-ios')) Or '$(_PlatformName)' == 'tvOS' Or $(TargetFramework.EndsWith('-tvos'))) And '$(_UseNativeAot)' != 'true'">
-			<IsDynamicRegistrar Condition="'$(ComputedPlatform)' == 'iPhoneSimulator' And '$(Registrar)' == ''">true</IsDynamicRegistrar>
+			<IsDynamicRegistrar Condition="'$(SdkIsSimulator)' == 'true' And '$(Registrar)' == ''">true</IsDynamicRegistrar>
 			<IsDynamicRegistrar Condition="'$(Registrar)' == 'dynamic'">true</IsDynamicRegistrar>
 		</PropertyGroup>
 

--- a/tests/monotouch-test/dotnet/shared.csproj
+++ b/tests/monotouch-test/dotnet/shared.csproj
@@ -267,7 +267,7 @@
 
   <Target Name="ComputeDefineConstants" BeforeTargets="BeforeBuild">
     <PropertyGroup>
-      <DefineConstants Condition="'$(ComputedPlatform)' == 'iPhone'">$(DefineConstants);AOT</DefineConstants>
+      <DefineConstants Condition="'$(SdkIsSimulator)' != 'true'">$(DefineConstants);AOT</DefineConstants>
       <DefineConstants Condition="'$(RuntimeIdentifier)' == 'iossimulator-arm64'">$(DefineConstants);AOT</DefineConstants>
       <DefineConstants Condition="'$(RuntimeIdentifier)' == 'tvossimulator-arm64'">$(DefineConstants);AOT</DefineConstants>
     </PropertyGroup>

--- a/tests/monotouch-test/dotnet/shared.csproj
+++ b/tests/monotouch-test/dotnet/shared.csproj
@@ -267,7 +267,7 @@
 
   <Target Name="ComputeDefineConstants" BeforeTargets="BeforeBuild">
     <PropertyGroup>
-      <DefineConstants Condition="'$(SdkIsSimulator)' != 'true'">$(DefineConstants);AOT</DefineConstants>
+      <DefineConstants Condition="'$(SdkIsDevice)' == 'true'">$(DefineConstants);AOT</DefineConstants>
       <DefineConstants Condition="'$(RuntimeIdentifier)' == 'iossimulator-arm64'">$(DefineConstants);AOT</DefineConstants>
       <DefineConstants Condition="'$(RuntimeIdentifier)' == 'tvossimulator-arm64'">$(DefineConstants);AOT</DefineConstants>
     </PropertyGroup>


### PR DESCRIPTION
This simplifies the code, since we only have a single property as the source
of truth whether we're building for the simulator or not.