### PR TITLE
[msbuild] Copy some ILLink output back to Windows when building remotely.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ILLink.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ILLink.cs
@@ -132,7 +132,7 @@ namespace Xamarin.MacDev.Tasks {
 					Log.LogMessage (MessageImportance.Low, "Not creating output file '{0}' because the entire file will be copied to Windows", item.ItemSpec);
 					return false;
 				}
-				Log.LogMessage (MessageImportance.Low, $"Checking LinkerCacheItemsToCopyToWindows with {LinkerCacheItemsToCopyToWindows.Length} items for {item.ItemSpec}");
+
 				if (Array.IndexOf (LinkerCacheItemsToCopyToWindows, item) >= 0) {
 					Log.LogMessage (MessageImportance.Low, "Not creating output file '{0}' because the entire file will be copied to Windows (because it's not native code)", item.ItemSpec);
 					return false;

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ILLink.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ILLink.cs
@@ -32,10 +32,20 @@ namespace Xamarin.MacDev.Tasks {
 		[Output]
 		public ITaskItem [] LinkedItems { get; set; } = Array.Empty<ITaskItem> ();
 
+		// if the linked output should be copied to windows (as opposed to only creating empty output files)
+		public bool CopyToWindows { get; set; }
+
 		public override bool Execute ()
 		{
-			if (this.ShouldExecuteRemotely (SessionId))
-				return XamarinTask.ExecuteRemotely (this);
+			if (this.ShouldExecuteRemotely (SessionId)) {
+				if (XamarinTask.ExecuteRemotely (this, out var taskRunner)) {
+					if (CopyToWindows)
+						XamarinTask.CopyFilesToWindowsAsync (this, taskRunner, LinkedItems).Wait ();
+					return true;
+				}
+
+				return false;
+			}
 
 			// Capture execution start time for Mac-side detection
 			var executionStartTime = DateTime.UtcNow;
@@ -86,6 +96,11 @@ namespace Xamarin.MacDev.Tasks {
 
 		public bool ShouldCreateOutputFile (ITaskItem item)
 		{
+			if (CopyToWindows && Array.IndexOf (LinkedItems, item) >= 0) {
+				Log.LogMessage (MessageImportance.Low, "Not creating output file '{0}' because the entire file will be copied to Windows", item.ItemSpec);
+				return false;
+			}
+
 			var modifiedMetadata = item.GetMetadata ("Modified");
 			var wasModified = bool.TryParse (modifiedMetadata, out var modified) && modified;
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ILLink.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ILLink.cs
@@ -35,12 +35,43 @@ namespace Xamarin.MacDev.Tasks {
 		// if the linked output should be copied to windows (as opposed to only creating empty output files)
 		public bool CopyToWindows { get; set; }
 
+		ITaskItem []? linkerCacheItemsToCopyToWindows;
+		ITaskItem [] LinkerCacheItemsToCopyToWindows {
+			get {
+				if (!CopyToWindows)
+					return [];
+
+				// We might get called before LinkerCacheItems has been populated, in which case we don't want to cache any results.
+				if (LinkerCacheItems.Length == 0)
+					return [];
+
+				if (linkerCacheItemsToCopyToWindows is null) {
+					linkerCacheItemsToCopyToWindows = LinkerCacheItems.Where (item => {
+						var extension = item.GetMetadata ("Extension");
+						switch (extension.ToLowerInvariant ()) {
+						case ".h":
+						case ".m":
+						case ".mm":
+							return false; // we don't need any native code on Windows.
+						default:
+							return true; // copy the rest of the files to Windows
+						}
+					}).ToArray ();
+				}
+				return linkerCacheItemsToCopyToWindows;
+			}
+		}
+
 		public override bool Execute ()
 		{
 			if (this.ShouldExecuteRemotely (SessionId)) {
 				if (XamarinTask.ExecuteRemotely (this, out var taskRunner)) {
-					if (CopyToWindows)
-						XamarinTask.CopyFilesToWindowsAsync (this, taskRunner, LinkedItems).Wait ();
+					if (CopyToWindows) {
+						var filesToCopy = new List<ITaskItem> ();
+						filesToCopy.AddRange (LinkedItems);
+						filesToCopy.AddRange (LinkerCacheItemsToCopyToWindows);
+						XamarinTask.CopyFilesToWindowsAsync (this, taskRunner, filesToCopy).Wait ();
+					}
 					return true;
 				}
 
@@ -96,9 +127,16 @@ namespace Xamarin.MacDev.Tasks {
 
 		public bool ShouldCreateOutputFile (ITaskItem item)
 		{
-			if (CopyToWindows && Array.IndexOf (LinkedItems, item) >= 0) {
-				Log.LogMessage (MessageImportance.Low, "Not creating output file '{0}' because the entire file will be copied to Windows", item.ItemSpec);
-				return false;
+			if (CopyToWindows) {
+				if (Array.IndexOf (LinkedItems, item) >= 0) {
+					Log.LogMessage (MessageImportance.Low, "Not creating output file '{0}' because the entire file will be copied to Windows", item.ItemSpec);
+					return false;
+				}
+				Log.LogMessage (MessageImportance.Low, $"Checking LinkerCacheItemsToCopyToWindows with {LinkerCacheItemsToCopyToWindows.Length} items for {item.ItemSpec}");
+				if (Array.IndexOf (LinkerCacheItemsToCopyToWindows, item) >= 0) {
+					Log.LogMessage (MessageImportance.Low, "Not creating output file '{0}' because the entire file will be copied to Windows (because it's not native code)", item.ItemSpec);
+					return false;
+				}
 			}
 
 			var modifiedMetadata = item.GetMetadata ("Modified");

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/XamarinTask.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/XamarinTask.cs
@@ -317,12 +317,17 @@ namespace Xamarin.MacDev.Tasks {
 			return CreateItemsForAllFilesRecursively (directories?.Select (v => v.ItemSpec));
 		}
 
-		internal async global::System.Threading.Tasks.Task CopyFilesToWindowsAsync (TaskRunner runner, IEnumerable<ITaskItem> items)
+		internal static async global::System.Threading.Tasks.Task CopyFilesToWindowsAsync (Task task, TaskRunner runner, IEnumerable<ITaskItem> items)
 		{
 			foreach (var item in items) {
-				Log.LogMessage (MessageImportance.Low, $"Copying {item.ItemSpec} from the remote Mac to Windows");
-				await runner.GetFileAsync (this, item.ItemSpec).ConfigureAwait (false);
+				task.Log.LogMessage (MessageImportance.Low, $"Copying {item.ItemSpec} from the remote Mac to Windows");
+				await runner.GetFileAsync (task, item.ItemSpec).ConfigureAwait (false);
 			}
+		}
+
+		internal global::System.Threading.Tasks.Task CopyFilesToWindowsAsync (TaskRunner runner, IEnumerable<ITaskItem> items)
+		{
+			return CopyFilesToWindowsAsync (this, runner, items);
 		}
 
 		/// <summary>

--- a/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
+++ b/msbuild/Xamarin.iOS.Tasks.Windows/Xamarin.iOS.Common.After.targets
@@ -375,6 +375,8 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 			<TrimmerDefaultAction Condition="'$(TrimmerDefaultAction)' == ''">$(_TrimmerDefaultAction)</TrimmerDefaultAction>
 
 			<_RemoteExtraTrimmerArgs Condition="'$(_ExtraTrimmerArgs)' != ''">$(_ExtraTrimmerArgs.Replace('$(NetCoreRoot)', '$(_DotNetRootRemoteDirectory)'))</_RemoteExtraTrimmerArgs>
+
+			<_CopyLinkerOutputToWindows Condition="'$(UseMonoRuntime)' == 'false'">true</_CopyLinkerOutputToWindows>
 		</PropertyGroup>
 
 		<!-- Include Debug symbols as input so those are copied to the server -->
@@ -387,6 +389,8 @@ Copyright (C) 2011-2013 Xamarin. All rights reserved.
 		<Delete SessionId="$(BuildSessionId)" Files="@(_LinkedResolvedFileToPublishCandidate)" />
 		<Xamarin.MacDev.Tasks.ILLink
 				SessionId="$(BuildSessionId)"
+				CopyToWindows="$(_CopyLinkerOutputToWindows)"
+
 				AssemblyPaths="@(ManagedAssemblyToLink)"
 				ReferenceAssemblyPaths="@(ReferencePath)"
 				RootAssemblyNames="@(TrimmerRootAssembly)"


### PR DESCRIPTION
This is needed when building iOS apps using CoreCLR or NativeAOT remotely (in
the .NET 11 branch), and I'm adding these changes into main to ease upcoming
changes to these files in main.

No tests here, but the net11.0 branch already contains tests that will verify this.

Ref: #24521