### PR TITLE
[devops] Remove empty directories and extract archive-html-report template

### DIFF
--- a/tools/devops/automation/templates/common/archive-html-report.yml
+++ b/tools/devops/automation/templates/common/archive-html-report.yml
@@ -1,0 +1,47 @@
+# Remove empty directories, archive the Html Report, and publish it as a pipeline artifact.
+parameters:
+
+- name: rootFolder
+  type: string
+
+- name: artifactName
+  type: string
+
+steps:
+
+# Remove empty directories before archiving.
+- pwsh: |
+    $root = "${{ parameters.rootFolder }}"
+    if (Test-Path $root) {
+      Get-ChildItem $root -Recurse -Force -Directory |
+        Sort-Object -Property FullName -Descending |
+        Where-Object { ($_ | Get-ChildItem -Force | Select-Object -First 1).Count -eq 0 } |
+        ForEach-Object {
+          Write-Host "Removing empty directory: $($_.FullName)"
+          Remove-Item -Force $_
+        }
+    }
+  displayName: 'Remove empty directories from HtmlReport'
+  continueOnError: true
+  condition: succeededOrFailed()
+
+# Archive files for the Html Report so that the report can be easily uploaded as artifacts of the build.
+- task: ArchiveFiles@1
+  displayName: 'Archive HtmlReport'
+  inputs:
+    rootFolder: '${{ parameters.rootFolder }}'
+    includeRootFolder: false
+    archiveFile: '$(Build.ArtifactStagingDirectory)/HtmlReport.zip'
+  continueOnError: true
+  condition: succeededOrFailed()
+
+# Create HtmlReport artifact. This serves two purposes:
+# 1. It is the way we are going to share the HtmlReport with the publish_html job that is executed on a Windows machine.
+# 2. Users can download this if they want.
+- task: PublishPipelineArtifact@1
+  displayName: 'Publish Artifact: HtmlReport'
+  inputs:
+    targetPath: '$(Build.ArtifactStagingDirectory)/HtmlReport.zip'
+    artifactName: '${{ parameters.artifactName }}'
+  continueOnError: true
+  condition: succeededOrFailed()

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -223,6 +223,14 @@ steps:
   continueOnError: true
   condition: succeededOrFailed()
 
+# Remove empty directories before archiving.
+- bash: |
+    set -x
+    find "$(BUILD_REPOSITORY_TITLE)/jenkins-results" -type d -empty -delete || true
+  displayName: 'Remove empty directories from HtmlReport'
+  continueOnError: true
+  condition: succeededOrFailed()
+
 # Archive files for the Html Report so that the report can be easily uploaded as artifacts of the build.
 - task: ArchiveFiles@1
   displayName: 'Archive HtmlReport'

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -223,30 +223,9 @@ steps:
   continueOnError: true
   condition: succeededOrFailed()
 
-# Remove empty directories before archiving.
-- bash: |
-    set -x
-    find "$(BUILD_REPOSITORY_TITLE)/jenkins-results" -type d -empty -delete || true
-  displayName: 'Remove empty directories from HtmlReport'
-  continueOnError: true
-  condition: succeededOrFailed()
-
-# Archive files for the Html Report so that the report can be easily uploaded as artifacts of the build.
-- task: ArchiveFiles@1
-  displayName: 'Archive HtmlReport'
-  inputs:
+- template: ../common/archive-html-report.yml
+  parameters:
     rootFolder: '$(BUILD_REPOSITORY_TITLE)/jenkins-results'
-    includeRootFolder: false
-    archiveFile: '$(Build.ArtifactStagingDirectory)/HtmlReport.zip'
-  continueOnError: true
-  condition: succeededOrFailed()
-
-- task: PublishPipelineArtifact@1
-  displayName: 'Publish Artifact: HtmlReport'
-  inputs:
-    targetPath: '$(Build.ArtifactStagingDirectory)/HtmlReport.zip'
     artifactName: '${{ parameters.uploadPrefix }}HtmlReport-${{ parameters.stageName }}${{ parameters.label }}-$(System.JobAttempt)'
-  continueOnError: true
-  condition: succeededOrFailed()
 
 

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -217,34 +217,10 @@ steps:
   continueOnError: true
   condition: and(ne(variables['VSTS_XML_FILES'], 0), succeededOrFailed())
 
-# Remove empty directories before archiving.
-- bash: |
-    set -x
-    find "$(BUILD_REPOSITORY_TITLE)/jenkins-results" -type d -empty -delete || true
-  displayName: 'Remove empty directories from HtmlReport'
-  continueOnError: true
-  condition: succeededOrFailed()
-
-# Archive files for the Html Report so that the report can be easily uploaded as artifacts of the build.
-- task: ArchiveFiles@1
-  displayName: 'Archive HtmlReport'
-  inputs:
+- template: ../common/archive-html-report.yml
+  parameters:
     rootFolder: '$(BUILD_REPOSITORY_TITLE)/jenkins-results'
-    includeRootFolder: false
-    archiveFile: '$(Build.ArtifactStagingDirectory)/HtmlReport.zip'
-  continueOnError: true
-  condition: succeededOrFailed()
-
-# Create HtmlReport artifact. This serves two purposes:
-# 1. It is the way we are going to share the HtmlReport with the publish_html job that is executed on a Windows machine.
-# 2. Users can download this if they want.
-- task: PublishPipelineArtifact@1
-  displayName: 'Publish Artifact: HtmlReport'
-  inputs:
-    targetPath: '$(Build.ArtifactStagingDirectory)/HtmlReport.zip'
     artifactName: '${{ parameters.uploadPrefix }}HtmlReport-${{ parameters.testPrefix }}-$(System.JobAttempt)'
-  continueOnError: true
-  condition: succeededOrFailed()
 
 # Upload all the binlogs
 # Copy all the binlogs to a separate directory, keeping directory structure.

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -217,6 +217,14 @@ steps:
   continueOnError: true
   condition: and(ne(variables['VSTS_XML_FILES'], 0), succeededOrFailed())
 
+# Remove empty directories before archiving.
+- bash: |
+    set -x
+    find "$(BUILD_REPOSITORY_TITLE)/jenkins-results" -type d -empty -delete || true
+  displayName: 'Remove empty directories from HtmlReport'
+  continueOnError: true
+  condition: succeededOrFailed()
+
 # Archive files for the Html Report so that the report can be easily uploaded as artifacts of the build.
 - task: ArchiveFiles@1
   displayName: 'Archive HtmlReport'

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -357,6 +357,22 @@ steps:
   continueOnError: true
   condition: succeededOrFailed()
 
+# Remove empty directories before archiving.
+- pwsh: |
+    $root = "$(Build.SourcesDirectory)/$(BUILD_REPOSITORY_TITLE)/jenkins-results"
+    if (Test-Path $root) {
+      Get-ChildItem $root -Recurse -Force -Directory |
+        Sort-Object -Property FullName -Descending |
+        Where-Object { ($_ | Get-ChildItem -Force | Select-Object -First 1).Count -eq 0 } |
+        ForEach-Object {
+          Write-Host "Removing empty directory: $($_.FullName)"
+          Remove-Item -Force $_
+        }
+    }
+  displayName: 'Remove empty directories from HtmlReport'
+  continueOnError: true
+  condition: succeededOrFailed()
+
 # Archive files for the Html Report so that the report can be easily uploaded as artifacts of the build.
 - task: ArchiveFiles@1
   displayName: 'Archive HtmlReport'

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -357,42 +357,10 @@ steps:
   continueOnError: true
   condition: succeededOrFailed()
 
-# Remove empty directories before archiving.
-- pwsh: |
-    $root = "$(Build.SourcesDirectory)/$(BUILD_REPOSITORY_TITLE)/jenkins-results"
-    if (Test-Path $root) {
-      Get-ChildItem $root -Recurse -Force -Directory |
-        Sort-Object -Property FullName -Descending |
-        Where-Object { ($_ | Get-ChildItem -Force | Select-Object -First 1).Count -eq 0 } |
-        ForEach-Object {
-          Write-Host "Removing empty directory: $($_.FullName)"
-          Remove-Item -Force $_
-        }
-    }
-  displayName: 'Remove empty directories from HtmlReport'
-  continueOnError: true
-  condition: succeededOrFailed()
-
-# Archive files for the Html Report so that the report can be easily uploaded as artifacts of the build.
-- task: ArchiveFiles@1
-  displayName: 'Archive HtmlReport'
-  inputs:
+- template: ../common/archive-html-report.yml
+  parameters:
     rootFolder: '$(Build.SourcesDirectory)/$(BUILD_REPOSITORY_TITLE)/jenkins-results'
-    includeRootFolder: false
-    archiveFile: '$(Build.ArtifactStagingDirectory)/HtmlReport.zip'
-  continueOnError: true
-  condition: succeededOrFailed()
-
-# Create HtmlReport artifact. This serves two purposes:
-# 1. It is the way we are going to share the HtmlReport with the publish_html job that is executed on a Windows machine.
-# 2. Users can download this if they want.
-- task: PublishPipelineArtifact@1
-  displayName: 'Publish Artifact: HtmlReport'
-  inputs:
-    targetPath: '$(Build.ArtifactStagingDirectory)/HtmlReport.zip'
     artifactName: '${{ parameters.uploadPrefix }}HtmlReport-windows_integrationwindows-$(System.JobAttempt)'
-  continueOnError: true
-  condition: succeededOrFailed()
 
 - pwsh: |
     Write-Host "Run windows tests."


### PR DESCRIPTION
Extract the duplicated HTML report archiving steps (remove empty dirs → archive → publish artifact) into a shared template `common/archive-html-report.yml`.

### Changes

- **New**: `templates/common/archive-html-report.yml` — shared template with `rootFolder` and `artifactName` parameters. Uses cross-platform `pwsh` to remove empty directories before archiving.
- **Updated**: `tests/run-tests.yml`, `mac/build.yml`, `windows/build.yml` — replaced ~25 lines each with a 4-line template reference.