### PR TITLE
[dotnet] Fix CoreCLR framework signing with correct Info.plist tracking. Fixes #25248.

### DIFF
--- a/dotnet/targets/Microsoft.Sdk.R2R.targets
+++ b/dotnet/targets/Microsoft.Sdk.R2R.targets
@@ -468,6 +468,8 @@
 			<_ComputeFrameworksToCreateAppManifestInputs Include="$(SupportedOSPlatformVersion)" />
 			<_ComputeFrameworksToCreateAppManifestInputs Include="$(TargetArchitectures)" />
 			<_ComputeFrameworksToCreateAppManifestInputs Include="$(_ComputedTargetFrameworkMoniker)" />
+			<!-- The bundle identifier is used to compute the framework's CFBundleIdentifier -->
+			<_ComputeFrameworksToCreateAppManifestInputs Include="$(_BundleIdentifier)" />
 		</ItemGroup>
 
 		<Hash
@@ -485,7 +487,7 @@
 
 	<Target
 		Name="_CreateInfoPlistForFrameworks"
-		Inputs="@(_CreatedFrameworksFromDylibs->'%(OriginatingDylib)');$(_ComputeFrameworksToCreateAppManifestHashedInputs)"
+		Inputs="@(_CreatedFrameworksFromDylibs->'%(OriginatingDylib)');$(_ComputeFrameworksToCreateAppManifestHashedInputsPath)"
 		Outputs="@(_CreatedFrameworksFromDylibs->'%(AppManifestPath)')"
 		>
 

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1022,6 +1022,9 @@
 				<SourceDirectory>%(_DirectoriesToPublish.SourceDirectory)</SourceDirectory>
 				<TargetDirectory>%(_DirectoriesToPublish.TargetDirectory)</TargetDirectory>
 			</_StampFilesToDelete>
+
+			<!-- Also collect Info.plist files from converted dylib frameworks as additional inputs for the copy target -->
+			<_DirectoriesToPublishInfoPlist Include="@(_DirectoriesToPublish->'%(AppManifestPath)')" Condition="'%(_DirectoriesToPublish.AppManifestPath)' != ''" />
 		</ItemGroup>
 
 		<Delete
@@ -1032,7 +1035,7 @@
 
 	<Target Name="_CopyDirectoriesToBundle"
 		DependsOnTargets="_CollectDecompressedPlugins;_ComputeFrameworkFilesToPublish;_CollectDecompressedXpcServices;_CreateStampLocationForCopyDirectoriesToBundle"
-		Inputs="@(_DirectoriesToPublish)"
+		Inputs="@(_DirectoriesToPublish);@(_DirectoriesToPublishInfoPlist)"
 		Outputs="@(_DirectoriesToPublish -> '%(StampLocation)')"
 		>
 

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1023,8 +1023,8 @@
 				<TargetDirectory>%(_DirectoriesToPublish.TargetDirectory)</TargetDirectory>
 			</_StampFilesToDelete>
 
-			<!-- Also collect Info.plist files from converted dylib frameworks as additional inputs for the copy target -->
-			<_DirectoriesToPublishInfoPlist Include="@(_DirectoriesToPublish->'%(AppManifestPath)')" Condition="'%(_DirectoriesToPublish.AppManifestPath)' != ''" />
+			<!-- Also collect Info.plist files from framework directories as additional inputs for the copy target -->
+			<_DirectoriesToPublishInfoPlist Include="@(_DirectoriesToPublish->'%(SourceDirectory)/Info.plist')" Condition="Exists('%(_DirectoriesToPublish.SourceDirectory)/Info.plist')" />
 		</ItemGroup>
 
 		<Delete

--- a/tests/dotnet/UnitTests/PostBuildTest.cs
+++ b/tests/dotnet/UnitTests/PostBuildTest.cs
@@ -96,16 +96,20 @@ namespace Xamarin.Tests {
 			// Read the main app's bundle identifier
 			var appInfoPlistPath = Path.Combine (appPath, "Info.plist");
 			Assert.That (appInfoPlistPath, Does.Exist, "App Info.plist should exist");
-			var appPlist = PDictionary.FromFile (appInfoPlistPath)!;
-			var bundleIdentifier = appPlist.GetString ("CFBundleIdentifier")!.Value;
+			var appPlist = PDictionary.FromFile (appInfoPlistPath);
+			Assert.That (appPlist, Is.Not.Null, $"Failed to parse Info.plist at '{appInfoPlistPath}'");
+			var bundleIdentifierValue = appPlist!.GetString ("CFBundleIdentifier");
+			Assert.That (bundleIdentifierValue, Is.Not.Null, $"CFBundleIdentifier should exist in '{appInfoPlistPath}'");
+			var bundleIdentifier = bundleIdentifierValue!.Value;
 
 			foreach (var fwDir in frameworkDirs) {
 				var fwName = Path.GetFileNameWithoutExtension (fwDir);
 				var infoPlistPath = Path.Combine (fwDir, "Info.plist");
 				Assert.That (infoPlistPath, Does.Exist, $"Info.plist should exist in {fwName}.framework");
 
-				var plist = PDictionary.FromFile (infoPlistPath)!;
-				var fwBundleId = plist.GetString ("CFBundleIdentifier")?.Value;
+				var plist = PDictionary.FromFile (infoPlistPath);
+				Assert.That (plist, Is.Not.Null, $"Failed to parse Info.plist at '{infoPlistPath}'");
+				var fwBundleId = plist!.GetString ("CFBundleIdentifier")?.Value;
 				Assert.That (fwBundleId, Does.StartWith (bundleIdentifier + "."), $"CFBundleIdentifier for {fwName}.framework should start with the app bundle identifier");
 
 				var bundleExe = plist.GetString ("CFBundleExecutable")?.Value;
@@ -123,6 +127,7 @@ namespace Xamarin.Tests {
 				if (Directory.Exists (codeSignatureDir)) {
 					var exitCode = ExecutionHelper.Execute ("/usr/bin/codesign", new string [] { "-dvvv", fwDir }, out var codesignOutput);
 					var output = codesignOutput.ToString ();
+					Assert.That (exitCode, Is.EqualTo (0), $"codesign failed for framework {fwName}. Codesign output:\n{output}");
 					Assert.That (output, Does.Contain ("Format=bundle with Mach-O"), $"Framework {fwName} should be signed as a bundle, not a bare Mach-O. Codesign output:\n{output}");
 					Assert.That (output, Does.Contain ($"Identifier={fwBundleId}"), $"Framework {fwName} codesign identifier should match its Info.plist CFBundleIdentifier. Codesign output:\n{output}");
 				}

--- a/tests/dotnet/UnitTests/PostBuildTest.cs
+++ b/tests/dotnet/UnitTests/PostBuildTest.cs
@@ -64,6 +64,71 @@ namespace Xamarin.Tests {
 			BuildIpaTestImpl (platform, runtimeIdentifiers, useMonoRuntime: false);
 		}
 
+		[Test]
+		[TestCase (ApplePlatform.iOS, "ios-arm64")]
+		[TestCase (ApplePlatform.TVOS, "tvos-arm64")]
+		public void CoreCLR_ConvertedFrameworks_HaveInfoPlist (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			// Ref: https://github.com/dotnet/macios/issues/25248
+			// Verify that converted CoreCLR dylib frameworks have a valid Info.plist
+			// with the correct CFBundleIdentifier, so that codesign signs them as
+			// framework bundles and uses the plist bundle identifier.
+			var project = "MySimpleApp";
+			var configuration = "Release";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath, configuration: configuration);
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["BuildIpa"] = "true";
+			properties ["Configuration"] = configuration;
+			properties ["UseMonoRuntime"] = "false";
+
+			DotNet.AssertBuild (project_path, properties);
+
+			var frameworksDir = Path.Combine (appPath, "Frameworks");
+			Assert.That (frameworksDir, Does.Exist, "Frameworks directory should exist for CoreCLR device builds");
+
+			var frameworkDirs = Directory.GetDirectories (frameworksDir, "*.framework");
+			Assert.That (frameworkDirs.Length, Is.GreaterThan (0), "Expected at least one .framework directory");
+
+			// Read the main app's bundle identifier
+			var appInfoPlistPath = Path.Combine (appPath, "Info.plist");
+			Assert.That (appInfoPlistPath, Does.Exist, "App Info.plist should exist");
+			var appPlist = PDictionary.FromFile (appInfoPlistPath)!;
+			var bundleIdentifier = appPlist.GetString ("CFBundleIdentifier")!.Value;
+
+			foreach (var fwDir in frameworkDirs) {
+				var fwName = Path.GetFileNameWithoutExtension (fwDir);
+				var infoPlistPath = Path.Combine (fwDir, "Info.plist");
+				Assert.That (infoPlistPath, Does.Exist, $"Info.plist should exist in {fwName}.framework");
+
+				var plist = PDictionary.FromFile (infoPlistPath)!;
+				var actualId = plist.GetString ("CFBundleIdentifier")?.Value;
+				var expectedId = $"{bundleIdentifier}.{fwName}";
+				Assert.That (actualId, Is.EqualTo (expectedId), $"CFBundleIdentifier for {fwName}.framework");
+
+				var bundleExe = plist.GetString ("CFBundleExecutable")?.Value;
+				Assert.That (bundleExe, Is.EqualTo (fwName), $"CFBundleExecutable for {fwName}.framework");
+
+				var packageType = plist.GetString ("CFBundlePackageType")?.Value;
+				Assert.That (packageType, Is.EqualTo ("FMWK"), $"CFBundlePackageType for {fwName}.framework");
+
+				// Verify the executable binary actually exists
+				Assert.That (Path.Combine (fwDir, fwName), Does.Exist, $"Executable should exist in {fwName}.framework");
+
+				// If the framework was signed, verify it was signed as a bundle (not a bare Mach-O)
+				var codeSignatureDir = Path.Combine (fwDir, "_CodeSignature");
+				if (Directory.Exists (codeSignatureDir)) {
+					var exitCode = ExecutionHelper.Execute ("/usr/bin/codesign", new string [] { "-dvvv", fwDir }, out var codesignOutput);
+					var output = codesignOutput.ToString ();
+					Assert.That (output, Does.Contain ("Format=bundle with Mach-O"), $"Framework {fwName} should be signed as a bundle, not a bare Mach-O. Codesign output:\n{output}");
+					Assert.That (output, Does.Contain ($"Identifier={expectedId}"), $"Framework {fwName} should be signed with the correct identifier. Codesign output:\n{output}");
+				}
+			}
+		}
+
 		void BuildIpaTestImpl (ApplePlatform platform, string runtimeIdentifiers, bool useMonoRuntime)
 		{
 			var project = "MySimpleApp";

--- a/tests/dotnet/UnitTests/PostBuildTest.cs
+++ b/tests/dotnet/UnitTests/PostBuildTest.cs
@@ -105,9 +105,8 @@ namespace Xamarin.Tests {
 				Assert.That (infoPlistPath, Does.Exist, $"Info.plist should exist in {fwName}.framework");
 
 				var plist = PDictionary.FromFile (infoPlistPath)!;
-				var actualId = plist.GetString ("CFBundleIdentifier")?.Value;
-				var expectedId = $"{bundleIdentifier}.{fwName}";
-				Assert.That (actualId, Is.EqualTo (expectedId), $"CFBundleIdentifier for {fwName}.framework");
+				var fwBundleId = plist.GetString ("CFBundleIdentifier")?.Value;
+				Assert.That (fwBundleId, Does.StartWith (bundleIdentifier + "."), $"CFBundleIdentifier for {fwName}.framework should start with the app bundle identifier");
 
 				var bundleExe = plist.GetString ("CFBundleExecutable")?.Value;
 				Assert.That (bundleExe, Is.EqualTo (fwName), $"CFBundleExecutable for {fwName}.framework");
@@ -119,12 +118,13 @@ namespace Xamarin.Tests {
 				Assert.That (Path.Combine (fwDir, fwName), Does.Exist, $"Executable should exist in {fwName}.framework");
 
 				// If the framework was signed, verify it was signed as a bundle (not a bare Mach-O)
+				// and that the codesign identifier matches the Info.plist CFBundleIdentifier
 				var codeSignatureDir = Path.Combine (fwDir, "_CodeSignature");
 				if (Directory.Exists (codeSignatureDir)) {
 					var exitCode = ExecutionHelper.Execute ("/usr/bin/codesign", new string [] { "-dvvv", fwDir }, out var codesignOutput);
 					var output = codesignOutput.ToString ();
 					Assert.That (output, Does.Contain ("Format=bundle with Mach-O"), $"Framework {fwName} should be signed as a bundle, not a bare Mach-O. Codesign output:\n{output}");
-					Assert.That (output, Does.Contain ($"Identifier={expectedId}"), $"Framework {fwName} should be signed with the correct identifier. Codesign output:\n{output}");
+					Assert.That (output, Does.Contain ($"Identifier={fwBundleId}"), $"Framework {fwName} codesign identifier should match its Info.plist CFBundleIdentifier. Codesign output:\n{output}");
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Fix incremental-build bugs that could cause CoreCLR framework bundles (converted from dylibs) to be missing or have stale Info.plist files, leading to codesign signing them as bare Mach-O binaries instead of framework bundles. This results in a mismatched bundle ID / signing identifier, which causes iOS device installs to fail with `MismatchedBundleIDSigningIdentifier`.

## Changes

### MSBuild targets fixes (`Microsoft.Sdk.R2R.targets`)

1. **Fixed `_CreateInfoPlistForFrameworks` Inputs**: Changed from using the hash string (`$(_ComputeFrameworksToCreateAppManifestHashedInputs)`) to the hash file path (`$(_ComputeFrameworksToCreateAppManifestHashedInputsPath)`). The hash string is computed at evaluation time and always changes, defeating incremental build skipping.

2. **Added `$(_BundleIdentifier)` to hash inputs**: The bundle identifier flows into the generated Info.plist's `CFBundleIdentifier`, so changes to it must trigger regeneration.

### MSBuild targets fixes (`Xamarin.Shared.Sdk.targets`)

3. **Added Info.plist tracking to `_CopyDirectoriesToBundle`**: The target's Inputs only tracked framework binary timestamps (via `_DirectoriesToPublish`), not their Info.plist files. If the Info.plist was regenerated but the binary wasn't, the copy step would be skipped and the app bundle would have a stale or missing Info.plist.

### Unit test (`PostBuildTest.cs`)

Added `CoreCLR_ConvertedFrameworks_HaveInfoPlist` test (iOS + tvOS) that verifies:
- Every `.framework` directory contains an Info.plist
- CFBundleIdentifier starts with the app's bundle identifier
- CFBundleExecutable and CFBundlePackageType are correct
- Codesign identifies the framework as a bundle (not bare Mach-O)
- Codesign identifier matches the Info.plist CFBundleIdentifier

Fixes https://github.com/dotnet/macios/issues/25248

🤖 Pull request created by Copilot