### PR TITLE
Fix flaky UrlProtocolTest.RegistrarTest race condition. Fixes #25223

### DIFF
--- a/tests/monotouch-test/Foundation/UrlProtocolTest.cs
+++ b/tests/monotouch-test/Foundation/UrlProtocolTest.cs
@@ -67,6 +67,7 @@ namespace MonoTouchFixtures.Foundation {
 			// Networking seems broken on our macOS 10.9 bot, so skip this test.
 			TestRuntime.AssertSystemVersion (ApplePlatform.MacOSX, 10, 10, throwIfOtherPlatform: false);
 
+			CustomUrlProtocol.State = 0;
 			var success = false;
 
 			var task = Task.Run (async () => {
@@ -79,7 +80,10 @@ namespace MonoTouchFixtures.Foundation {
 				}
 			});
 
-			Assert.IsTrue (TestRuntime.RunAsync (TimeSpan.FromSeconds (10), task), "Timed out");
+			// Use the completion check overload so RunAsync also waits for
+			// StopLoading to fire (State reaches 5) instead of returning as
+			// soon as the download task completes (State may still be 4).
+			Assert.IsTrue (TestRuntime.RunAsync (TimeSpan.FromSeconds (10), task, () => CustomUrlProtocol.State >= 5), "Timed out");
 			Assert.That (CustomUrlProtocol.State, Is.EqualTo (5), "State");
 			Assert.IsTrue (success, "Success");
 		}


### PR DESCRIPTION
StopLoading is called asynchronously by the URL loading system after the download task completes. The test was asserting `State==5` immediately when the task finished, but `StopLoading` (which increments State from 4 to 5) hadn't fired yet.

Fix by:
- Using the `RunAsync(timeout, task, check_completed)` overload that polls until `State>=5` instead of returning as soon as the task completes.
- Resetting `State=0` at test start to prevent cross-test interference.

Fixes https://github.com/dotnet/macios/issues/25223