### PR TITLE
[tests] Fix flaky TestNSUrlSessionHandlerSendClientCertificate. Fixes #25240

### DIFF
--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -703,6 +703,7 @@ namespace MonoTests.System.Net.Http {
 			if (!done) { // timeouts happen in the bots due to dns issues, connection issues etc.. we do not want to fail
 				Assert.Inconclusive ("Request timedout.");
 			} else {
+				TestRuntime.IgnoreInCIIfBadNetwork (ex);
 				Assert.IsNull (ex, "Exception wasn't expected.");
 				X509Certificate2 certificate2 = X509CertificateLoader.LoadCertificate (global::System.Convert.FromBase64String (content));
 				Assert.AreEqual (certificate.Thumbprint, certificate2.Thumbprint);

--- a/tests/monotouch-test/System.Net.Http/NetworkResources.cs
+++ b/tests/monotouch-test/System.Net.Http/NetworkResources.cs
@@ -13,7 +13,7 @@ namespace MonoTests.System.Net.Http {
 		public static string XamarinHttpUrl => AssertNetworkConnection ("http://dotnet.microsoft.com/apps/xamarin");
 		public static Uri XamarinUri => new Uri (XamarinUrl);
 		public static string StatsUrl => AssertNetworkConnection ("https://api.imgur.com/2/stats");
-		public static string EchoClientCertificateUrl = "https://corefx-net-tls.azurewebsites.net/EchoClientCertificate.ashx";
+		public static string EchoClientCertificateUrl => AssertNetworkConnection ("https://corefx-net-tls.azurewebsites.net/EchoClientCertificate.ashx");
 
 		public static string [] HttpsUrls => new [] {
 			MicrosoftUrl,


### PR DESCRIPTION
The test `TestNSUrlSessionHandlerSendClientCertificate` was flaky due to two issues:

1. **Missing upfront network check**: `EchoClientCertificateUrl` was a plain field without `AssertNetworkConnection()`, unlike all other URLs in `NetworkResources`. When the external Azure server was unreachable, the test would attempt the request anyway instead of being skipped.

2. **Missing network error handling**: When the request completed with a non-timeout network error (connection reset, HTTP 502, etc.), the test hard-failed on `Assert.IsNull(ex)` instead of being marked inconclusive. Other network-dependent tests in the file use `IgnoreInCIIfBadNetwork(ex)` for this purpose.

**Fix**:
- Change `EchoClientCertificateUrl` to use `AssertNetworkConnection()` (consistent with other URLs)
- Add `IgnoreInCIIfBadNetwork(ex)` before the assertion (consistent with other tests)

Fixes https://github.com/dotnet/macios/issues/25240