### PR TITLE
[build] Fix PublishBuildAssets.proj path for Arcade SDK 11.x

### DIFF
--- a/dotnet/package/common.csproj
+++ b/dotnet/package/common.csproj
@@ -159,12 +159,12 @@
 
     <MSBuild
         Targets="Restore"
-        Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
+        Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\toolset\PublishBuildAssets.proj"
         Properties="Configuration=$(Configuration);RepoRoot=$(_RepositoryPath);VersionPrefix=$(_PackageVersion);NuGetPackageRoot=$(_RepositoryPath)\packages\"
     />
 
     <MSBuild
-        Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
+        Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\toolset\PublishBuildAssets.proj"
         Properties="Configuration=$(Configuration);RepoRoot=$(_RepositoryPath);VersionPrefix=$(_PackageVersion);ManifestsPath=$(ArtifactsLogDir)AssetManifest;MaestroApiEndpoint=https://maestro.dot.net;NuGetPackageRoot=$(_RepositoryPath)\packages\"
     />
   </Target>


### PR DESCRIPTION
The Arcade SDK 11.x moved `PublishBuildAssets.proj` from `tools/SdkTasks/` to `toolset/`. This caused the "generate and publish BAR manifest" step to fail with:

```
error MSB3202: The project file "...\packages\microsoft.dotnet.arcade.sdk\11.0.0-beta.26215.121\tools\SdkTasks\PublishBuildAssets.proj" was not found.
```

This PR updates the path references in `common.csproj` to use the new `toolset/` location.