### PR TITLE
Fix unclosed markdown code block in scripts/README.md

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,6 +16,7 @@ The harder way is to copy an existing script directory, and:
 
   ```make
   $(eval $(call TemplateScript,MY_SCRIPT,my-script))
+  ```
 
 To use the new script:
 


### PR DESCRIPTION
scripts/README.md has an unclosed code fence (opens with ```make but never closes), causing the rest of the README to render as code on GitHub.

**Changes:**
- Added the missing closing ``` after the TemplateScript example
- All 4 code blocks now have balanced open/close fences

🤖 Pull request created by Copilot