### PR TITLE
[release/11.0.1xx-preview4] [net11.0] Fix PublishBuildAssets.proj path for newer Arcade SDK

### DIFF
--- a/dotnet/package/common.csproj
+++ b/dotnet/package/common.csproj
@@ -159,12 +159,12 @@
 
     <MSBuild
         Targets="Restore"
-        Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
+        Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\toolset\PublishBuildAssets.proj"
         Properties="Configuration=$(Configuration);RepoRoot=$(_RepositoryPath);VersionPrefix=$(_PackageVersion);NuGetPackageRoot=$(_RepositoryPath)\packages\"
     />
 
     <MSBuild
-        Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
+        Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\toolset\PublishBuildAssets.proj"
         Properties="Configuration=$(Configuration);RepoRoot=$(_RepositoryPath);VersionPrefix=$(_PackageVersion);ManifestsPath=$(ArtifactsLogDir)AssetManifest;MaestroApiEndpoint=https://maestro.dot.net;NuGetPackageRoot=$(_RepositoryPath)\packages\"
     />
   </Target>


### PR DESCRIPTION
Arcade SDK `11.0.0-beta.26215.121` moved `PublishBuildAssets.proj` from
`tools/SdkTasks/` to `toolset/` (see dotnet/arcade#16753). This caused
the "generate and publish BAR manifest" CI step to fail with:

```
error MSB3202: The project file "...\packages\microsoft.dotnet.arcade.sdk\11.0.0-beta.26215.121\tools\SdkTasks\PublishBuildAssets.proj" was not found.
```

Fixes:
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=13945090

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Backport of #25260.