### PR TITLE
[CoreBluetooth] Remove CBUUIDValidRangeString.

### DIFF
--- a/src/corebluetooth.cs
+++ b/src/corebluetooth.cs
@@ -1284,15 +1284,6 @@ namespace CoreBluetooth {
 		[Field ("CBUUIDCharacteristicAggregateFormatString")]
 		NSString CharacteristicAggregateFormatString { get; }
 
-		[Internal]
-		[Field ("CBUUIDValidRangeString")]
-		[Deprecated (PlatformName.MacOSX, 10, 13)]
-		[Obsoleted (PlatformName.MacOSX, 10, 13)]
-		[NoiOS]
-		[NoTV]
-		[NoMacCatalyst]
-		NSString CBUUIDValidRangeString { get; }
-
 		/// <summary>Represents the value associated with the constant CBUUIDCharacteristicValidRangeString</summary>
 		///         <value>To be added.</value>
 		///         <remarks>To be added.</remarks>

--- a/tests/introspection/MacApiFieldTest.cs
+++ b/tests/introspection/MacApiFieldTest.cs
@@ -133,10 +133,6 @@ namespace Introspection {
 			// MonoMac.CoreServices.CFHTTPMessage - document in 10.9 but returns null
 			case "_AuthenticationSchemeOAuth1":
 				return true;
-			case "CBUUIDValidRangeString":
-				if (Mac.CheckSystemVersion (10, 13)) // radar 32858911
-					return true;
-				goto default;
 			default:
 				return base.Skip (p);
 			}
@@ -145,10 +141,6 @@ namespace Introspection {
 		protected override bool Skip (string constantName, string? libraryName)
 		{
 			switch (constantName) {
-			case "CBUUIDValidRangeString":
-				if (Mac.CheckSystemVersion (10, 13)) // radar 32858911
-					return true;
-				goto default;
 			// Only there for API compat
 			case "kSecUseNoAuthenticationUI":
 			case "kSecUseOperationPrompt":

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreBluetooth.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreBluetooth.ignore
@@ -1,6 +1,3 @@
-## old and different name for CBUUIDCharacteristicValidRangeString, removed in Xcode9 headers (27160443)
-!unknown-field! CBUUIDValidRangeString bound
-
 # not to be added since it is not needed in any API on macOS as of xcode13 beta 3.
 !missing-enum! CBCentralManagerFeature not bound
 


### PR DESCRIPTION
It's not available, and it's not in any public API, so we don't have to worry
about API compatibility either.