### PR TITLE
[QuartzComposer] Replace RSS-related field bindings with manual code that returns null.

### DIFF
--- a/src/QuartzComposer/QCComposition.cs
+++ b/src/QuartzComposer/QCComposition.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel;
+
+using Foundation;
+using ObjCRuntime;
+
+#nullable enable
+
+namespace QuartzComposer;
+
+partial class QCComposition {
+#if !XAMCORE_5_0
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	[Field ("QCCompositionInputRSSArticleDurationKey", "QuartzComposer")]
+	[ObsoletedOSPlatform ("macos10.14", "Use 'Metal' instead.")]
+	[SupportedOSPlatform ("macos")]
+	[EditorBrowsable (EditorBrowsableState.Never)]
+	[Obsolete ("This field is always null.")]
+	public static NSString? InputRSSArticleDurationKey {
+		[ObsoletedOSPlatform ("macos10.14", "Use 'Metal' instead.")]
+		[SupportedOSPlatform ("macos")]
+		get => null;
+	}
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	[Field ("QCCompositionInputRSSFeedURLKey", "QuartzComposer")]
+	[ObsoletedOSPlatform ("macos10.14", "Use 'Metal' instead.")]
+	[SupportedOSPlatform ("macos")]
+	[EditorBrowsable (EditorBrowsableState.Never)]
+	[Obsolete ("This field is always null.")]
+	public static NSString? InputRSSFeedURLKey {
+		[ObsoletedOSPlatform ("macos10.14", "Use 'Metal' instead.")]
+		[SupportedOSPlatform ("macos")]
+		get => null;
+	}
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	[Field ("QCCompositionProtocolRSSVisualizer", "QuartzComposer")]
+	[ObsoletedOSPlatform ("macos10.14", "Use 'Metal' instead.")]
+	[SupportedOSPlatform ("macos")]
+	[EditorBrowsable (EditorBrowsableState.Never)]
+	[Obsolete ("This field is always null.")]
+	public static NSString? ProtocolRSSVisualizer {
+		[ObsoletedOSPlatform ("macos10.14", "Use 'Metal' instead.")]
+		[SupportedOSPlatform ("macos")]
+		get => null;
+	}
+#endif // !XAMCORE_5_0
+}

--- a/src/QuartzComposer/QCComposition.cs
+++ b/src/QuartzComposer/QCComposition.cs
@@ -14,7 +14,6 @@ namespace QuartzComposer;
 partial class QCComposition {
 #if !XAMCORE_5_0
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	[Field ("QCCompositionInputRSSArticleDurationKey", "QuartzComposer")]
 	[ObsoletedOSPlatform ("macos10.14", "Use 'Metal' instead.")]
 	[SupportedOSPlatform ("macos")]
 	[EditorBrowsable (EditorBrowsableState.Never)]
@@ -26,7 +25,6 @@ partial class QCComposition {
 	}
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	[Field ("QCCompositionInputRSSFeedURLKey", "QuartzComposer")]
 	[ObsoletedOSPlatform ("macos10.14", "Use 'Metal' instead.")]
 	[SupportedOSPlatform ("macos")]
 	[EditorBrowsable (EditorBrowsableState.Never)]
@@ -38,7 +36,6 @@ partial class QCComposition {
 	}
 
 	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
-	[Field ("QCCompositionProtocolRSSVisualizer", "QuartzComposer")]
 	[ObsoletedOSPlatform ("macos10.14", "Use 'Metal' instead.")]
 	[SupportedOSPlatform ("macos")]
 	[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1478,6 +1478,11 @@ PRINTCORE_SOURCES = \
 PUSHTOTALK_SOURCES = \
 	PushToTalk/Compat.cs \
 
+# QuartzComposer
+
+QUARTZCOMPOSER_SOURCES = \
+	QuartzComposer/QCComposition.cs \
+
 # QuickLook
 
 QUICKLOOK_SOURCES = \

--- a/src/quartzcomposer.cs
+++ b/src/quartzcomposer.cs
@@ -158,19 +158,10 @@ namespace QuartzComposer {
 		[Field ("QCCompositionInputDestinationImageKey")]
 		NSString InputDestinationImageKey { get; }
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Use 'Metal' instead.")]
-		[Field ("QCCompositionInputRSSFeedURLKey")]
-		NSString InputRSSFeedURLKey { get; }
-
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Use 'Metal' instead.")]
-		[Field ("QCCompositionInputRSSArticleDurationKey")]
-		NSString InputRSSArticleDurationKey { get; }
+#if !XAMCORE_5_0
+		// The 'InputRSSFeedURLKey' property has manual bindings.
+		// The 'InputRSSArticleDurationKey' property has manual bindings.
+#endif
 
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>
@@ -280,12 +271,9 @@ namespace QuartzComposer {
 		[Field ("QCCompositionProtocolScreenSaver")]
 		NSString ProtocolScreenSaver { get; }
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		[Deprecated (PlatformName.MacOSX, 10, 14, message: "Use 'Metal' instead.")]
-		[Field ("QCCompositionProtocolRSSVisualizer")]
-		NSString ProtocolRSSVisualizer { get; }
+#if !XAMCORE_5_0
+		// The 'ProtocolRSSVisualizer' property has manual bindings.
+#endif
 
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>

--- a/tests/introspection/MacApiFieldTest.cs
+++ b/tests/introspection/MacApiFieldTest.cs
@@ -159,12 +159,6 @@ namespace Introspection {
 			// kCLErrorUserInfoAlternateRegionKey also returns null on iOS
 			case "kCLErrorUserInfoAlternateRegionKey":
 				return true;
-			case "QCCompositionInputRSSArticleDurationKey":
-			case "QCCompositionInputRSSFeedURLKey":
-			case "QCCompositionProtocolRSSVisualizer":
-				if (Mac.CheckSystemVersion (10, 14))
-					return true;
-				goto default;
 			default:
 				return base.Skip (constantName, libraryName);
 			}


### PR DESCRIPTION
These fields (QCCompositionInputRSSArticleDurationKey,
QCCompositionInputRSSFeedURLKey, QCCompositionProtocolRSSVisualizer) have not
been available at runtime since macOS 10.13 (which we no longer support), so
remove them with manual code (that returns null) and obsolete them.