### PR TITLE
[AppKit] Implement manual bindings for notification event args properties that use literal strings.

### DIFF
--- a/src/AppKit/NSControlTextEditingEventArgs.cs
+++ b/src/AppKit/NSControlTextEditingEventArgs.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if !__MACCATALYST__
+namespace AppKit;
+
+partial class NSControlTextEditingEventArgs : NSNotificationEventArgs {
+	// This property needs a manual binding, because it's not using a constant string value,
+	// it's using a literal string value (as per Apple's documentation).
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public NSTextView? FieldEditor {
+		get {
+			var userinfo = Notification.UserInfo;
+			if (userinfo is null)
+				return null;
+
+			using var key = new TransientCFString ("NSFieldEditor");
+			var value = userinfo.LowlevelObjectForKey (key);
+			return Runtime.GetNSObject<NSTextView> (value);
+		}
+	}
+}
+#endif // !__MACCATALYST__

--- a/src/AppKit/NSMenuItemEventArgs.cs
+++ b/src/AppKit/NSMenuItemEventArgs.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if !__MACCATALYST__
+namespace AppKit;
+
+partial class NSMenuItemEventArgs : NSNotificationEventArgs {
+	// This property needs a manual binding, because it's not using a constant string value,
+	// it's using a literal string value (as per Apple's documentation).
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public NSMenu? MenuItem {
+		get {
+			var userinfo = Notification.UserInfo;
+			if (userinfo is null)
+				return null;
+
+			using var key = new TransientCFString ("MenuItem");
+			var value = userinfo.LowlevelObjectForKey (key);
+			return Runtime.GetNSObject<NSMenu> (value);
+		}
+	}
+}
+#endif // !__MACCATALYST__

--- a/src/AppKit/NSMenuItemIndexEventArgs.cs
+++ b/src/AppKit/NSMenuItemIndexEventArgs.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if !__MACCATALYST__
+namespace AppKit;
+
+partial class NSMenuItemIndexEventArgs : NSNotificationEventArgs {
+	// This property needs a manual binding, because it's not using a constant string value,
+	// it's using a literal string value (as per Apple's documentation).
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public nint MenuItemIndex {
+		get {
+			var userinfo = Notification.UserInfo;
+			if (userinfo is null)
+				return 0;
+
+			using var key = new TransientCFString ("NSMenuItemIndex");
+			var value = userinfo.LowlevelObjectForKey (key);
+			return Runtime.GetNSObject<Foundation.NSNumber> (value)?.NIntValue ?? 0;
+		}
+	}
+}
+#endif // !__MACCATALYST__

--- a/src/AppKit/NSOutlineViewItemEventArgs.cs
+++ b/src/AppKit/NSOutlineViewItemEventArgs.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if !__MACCATALYST__
+namespace AppKit;
+
+partial class NSOutlineViewItemEventArgs : NSNotificationEventArgs {
+	// This property needs a manual binding, because it's not using a constant string value,
+	// it's using a literal string value (as per Apple's documentation).
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public Foundation.NSObject? Item {
+		get {
+			var userinfo = Notification.UserInfo;
+			if (userinfo is null)
+				return null;
+
+			using var key = new TransientCFString ("NSObject");
+			var value = userinfo.LowlevelObjectForKey (key);
+			return Runtime.GetNSObject<Foundation.NSObject> (value);
+		}
+	}
+}
+#endif // !__MACCATALYST__

--- a/src/AppKit/NSTextAlternativesSelectedAlternativeStringEventArgs.cs
+++ b/src/AppKit/NSTextAlternativesSelectedAlternativeStringEventArgs.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if !__MACCATALYST__
+namespace AppKit;
+
+partial class NSTextAlternativesSelectedAlternativeStringEventArgs : NSNotificationEventArgs {
+	// This property needs a manual binding, because it's not using a constant string value,
+	// it's using a literal string value (as per Apple's documentation).
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public string? AlternativeString {
+		get {
+			var userinfo = Notification.UserInfo;
+			if (userinfo is null)
+				return null;
+
+			using var key = new TransientCFString ("NSAlternativeString");
+			var value = userinfo.LowlevelObjectForKey (key);
+			return CoreFoundation.CFString.FromHandle (value);
+		}
+	}
+}
+#endif // !__MACCATALYST__

--- a/src/AppKit/NSTextDidEndEditingEventArgs.cs
+++ b/src/AppKit/NSTextDidEndEditingEventArgs.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if !__MACCATALYST__
+namespace AppKit;
+
+partial class NSTextDidEndEditingEventArgs : NSNotificationEventArgs {
+	// This property needs a manual binding, because it's not using a constant string value,
+	// it's using a literal string value (as per Apple's documentation).
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public nint Movement {
+		get {
+			var userinfo = Notification.UserInfo;
+			if (userinfo is null)
+				return 0;
+
+			using var key = new TransientCFString ("NSTextMovement");
+			var value = userinfo.LowlevelObjectForKey (key);
+			return Runtime.GetNSObject<Foundation.NSNumber> (value)?.NIntValue ?? 0;
+		}
+	}
+}
+#endif // !__MACCATALYST__

--- a/src/AppKit/NSTextViewDidChangeSelectionEventArgs.cs
+++ b/src/AppKit/NSTextViewDidChangeSelectionEventArgs.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if !__MACCATALYST__
+namespace AppKit;
+
+partial class NSTextViewDidChangeSelectionEventArgs : NSNotificationEventArgs {
+	// This property needs a manual binding, because it's not using a constant string value,
+	// it's using a literal string value (as per Apple's documentation).
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public Foundation.NSValue? OldSelectedCharacterRange {
+		get {
+			var userinfo = Notification.UserInfo;
+			if (userinfo is null)
+				return null;
+
+			using var key = new TransientCFString ("NSOldSelectedCharacterRange");
+			var value = userinfo.LowlevelObjectForKey (key);
+			return Runtime.GetNSObject<Foundation.NSValue> (value);
+		}
+	}
+}
+#endif // !__MACCATALYST__

--- a/src/AppKit/NSTextViewWillChangeNotifyingTextViewEventArgs.cs
+++ b/src/AppKit/NSTextViewWillChangeNotifyingTextViewEventArgs.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if !__MACCATALYST__
+namespace AppKit;
+
+partial class NSTextViewWillChangeNotifyingTextViewEventArgs : NSNotificationEventArgs {
+	// These properties need manual bindings, because they're not using constant string values,
+	// they're using literal string values (as per Apple's documentation).
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public NSTextView? OldView {
+		get {
+			var userinfo = Notification.UserInfo;
+			if (userinfo is null)
+				return null;
+
+			using var key = new TransientCFString ("NSOldNotifyingTextView");
+			var value = userinfo.LowlevelObjectForKey (key);
+			return Runtime.GetNSObject<NSTextView> (value);
+		}
+	}
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public NSTextView? NewView {
+		get {
+			var userinfo = Notification.UserInfo;
+			if (userinfo is null)
+				return null;
+
+			using var key = new TransientCFString ("NSNewNotifyingTextView");
+			var value = userinfo.LowlevelObjectForKey (key);
+			return Runtime.GetNSObject<NSTextView> (value);
+		}
+	}
+}
+#endif // !__MACCATALYST__

--- a/src/AppKit/NSViewColumnMoveEventArgs.cs
+++ b/src/AppKit/NSViewColumnMoveEventArgs.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if !__MACCATALYST__
+namespace AppKit;
+
+partial class NSViewColumnMoveEventArgs : NSNotificationEventArgs {
+	// These properties need manual bindings, because they're not using constant string values,
+	// they're using literal string values (as per Apple's documentation).
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public nint OldColumn {
+		get {
+			var userinfo = Notification.UserInfo;
+			if (userinfo is null)
+				return 0;
+
+			using var key = new TransientCFString ("NSOldColumn");
+			var value = userinfo.LowlevelObjectForKey (key);
+			return Runtime.GetNSObject<Foundation.NSNumber> (value)?.NIntValue ?? 0;
+		}
+	}
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public nint NewColumn {
+		get {
+			var userinfo = Notification.UserInfo;
+			if (userinfo is null)
+				return 0;
+
+			using var key = new TransientCFString ("NSNewColumn");
+			var value = userinfo.LowlevelObjectForKey (key);
+			return Runtime.GetNSObject<Foundation.NSNumber> (value)?.NIntValue ?? 0;
+		}
+	}
+}
+#endif // !__MACCATALYST__

--- a/src/AppKit/NSViewColumnResizeEventArgs.cs
+++ b/src/AppKit/NSViewColumnResizeEventArgs.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if !__MACCATALYST__
+namespace AppKit;
+
+partial class NSViewColumnResizeEventArgs : NSNotificationEventArgs {
+	// These properties need manual bindings, because they're not using constant string values,
+	// they're using literal string values (as per Apple's documentation).
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public NSTableColumn? Column {
+		get {
+			var userinfo = Notification.UserInfo;
+			if (userinfo is null)
+				return null;
+
+			using var key = new TransientCFString ("NSTableColumn");
+			var value = userinfo.LowlevelObjectForKey (key);
+			return Runtime.GetNSObject<NSTableColumn> (value);
+		}
+	}
+
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public nint OldWidth {
+		get {
+			var userinfo = Notification.UserInfo;
+			if (userinfo is null)
+				return 0;
+
+			using var key = new TransientCFString ("NSOldWidth");
+			var value = userinfo.LowlevelObjectForKey (key);
+			return Runtime.GetNSObject<Foundation.NSNumber> (value)?.NIntValue ?? 0;
+		}
+	}
+}
+#endif // !__MACCATALYST__

--- a/src/AppKit/NSWorkspaceFileOperationEventArgs.cs
+++ b/src/AppKit/NSWorkspaceFileOperationEventArgs.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if !__MACCATALYST__
+namespace AppKit;
+
+partial class NSWorkspaceFileOperationEventArgs : NSNotificationEventArgs {
+	// This property needs a manual binding, because it's not using a constant string value,
+	// it's using a literal string value (as per Apple's documentation).
+	[BindingImpl (BindingImplOptions.GeneratedCode | BindingImplOptions.Optimizable)]
+	public nint FileType {
+		get {
+			var userinfo = Notification.UserInfo;
+			if (userinfo is null)
+				return 0;
+
+			using var key = new TransientCFString ("NSOperationNumber");
+			var value = userinfo.LowlevelObjectForKey (key);
+			return Runtime.GetNSObject<Foundation.NSNumber> (value)?.NIntValue ?? 0;
+		}
+	}
+}
+#endif // !__MACCATALYST__

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -26805,11 +26805,7 @@ namespace AppKit {
 
 	[NoMacCatalyst]
 	interface NSWorkspaceFileOperationEventArgs {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		[Export ("NSOperationNumber")]
-		nint FileType { get; }
+		// The 'FileType' property has manual bindings.
 	}
 
 	delegate void NSWorkspaceUrlHandler (NSDictionary newUrls, NSError error);
@@ -28279,39 +28275,15 @@ namespace AppKit {
 	}
 
 	partial interface NSViewColumnMoveEventArgs {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		[Export ("NSOldColumn")]
-		nint OldColumn { get; }
-
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		[Export ("NSNewColumn")]
-		nint NewColumn { get; }
+		// The 'OldColumn' and 'NewColumn' properties have manual bindings.
 	}
 
 	partial interface NSViewColumnResizeEventArgs {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		[Export ("NSTableColumn")]
-		NSTableColumn Column { get; }
-
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		[Export ("NSOldWidth")]
-		nint OldWidth { get; }
+		// The 'Column' and 'OldWidth' properties have manual bindings.
 	}
 
 	partial interface NSOutlineViewItemEventArgs {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		[Export ("NSObject")]
-		NSObject Item { get; }
+		// The 'Item' property has manual bindings.
 	}
 
 	partial interface NSOutlineView : NSAccessibilityOutline {
@@ -28704,26 +28676,11 @@ namespace AppKit {
 	}
 
 	partial interface NSTextViewDidChangeSelectionEventArgs {
-		// FIXME: verify property type "NSValue object containing an NSRange structure"
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		[Export ("NSOldSelectedCharacterRange")]
-		NSValue OldSelectedCharacterRange { get; }
+		// The 'OldSelectedCharacterRange' property has manual bindings.
 	}
 
 	partial interface NSTextViewWillChangeNotifyingTextViewEventArgs {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		[Export ("NSOldNotifyingTextView")]
-		NSTextView OldView { get; }
-
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		[Export ("NSNewNotifyingTextView")]
-		NSTextView NewView { get; }
+		// The 'OldView' and 'NewView' properties have manual bindings.
 	}
 
 	partial interface NSTextView : NSTextLayoutOrientationProvider {
@@ -28785,11 +28742,7 @@ namespace AppKit {
 	}
 
 	partial interface NSControlTextEditingEventArgs {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		[Export ("NSFieldEditor")]
-		NSTextView FieldEditor { get; }
+		// The 'FieldEditor' property has manual bindings.
 	}
 
 	partial interface NSControl {
@@ -29083,11 +29036,7 @@ namespace AppKit {
 	}*/
 
 	interface NSTextAlternativesSelectedAlternativeStringEventArgs {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		[Export ("NSAlternativeString")]
-		string AlternativeString { get; }
+		// The 'AlternativeString' property has manual bindings.
 	}
 
 	[NoMacCatalyst]
@@ -29218,19 +29167,11 @@ namespace AppKit {
 	}
 
 	partial interface NSMenuItemIndexEventArgs {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		[Export ("NSMenuItemIndex")]
-		nint MenuItemIndex { get; }
+		// The 'MenuItemIndex' property has manual bindings.
 	}
 
 	partial interface NSMenuItemEventArgs {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		[Export ("MenuItem")]
-		NSMenu MenuItem { get; }
+		// The 'MenuItem' property has manual bindings.
 	}
 
 	partial interface NSMenu {
@@ -29299,14 +29240,7 @@ namespace AppKit {
 
 	[NoMacCatalyst]
 	partial interface NSTextDidEndEditingEventArgs {
-		// FIXME: I think this is essentially a flags value
-		// of movements and characters. The docs are a bit
-		// confusing.
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
-		[Export ("NSTextMovement")]
-		nint Movement { get; }
+		// The 'Movement' property has manual bindings.
 	}
 
 	partial interface NSText {

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -152,6 +152,17 @@ APPKIT_SOURCES = \
 	AppKit/NSCollectionView.cs \
 	AppKit/NSCollectionViewLayout.cs \
 	AppKit/NSColorPickerTouchBarItem.cs \
+	AppKit/NSControlTextEditingEventArgs.cs \
+	AppKit/NSMenuItemEventArgs.cs \
+	AppKit/NSMenuItemIndexEventArgs.cs \
+	AppKit/NSOutlineViewItemEventArgs.cs \
+	AppKit/NSTextAlternativesSelectedAlternativeStringEventArgs.cs \
+	AppKit/NSTextViewDidChangeSelectionEventArgs.cs \
+	AppKit/NSTextViewWillChangeNotifyingTextViewEventArgs.cs \
+	AppKit/NSTextDidEndEditingEventArgs.cs \
+	AppKit/NSViewColumnMoveEventArgs.cs \
+	AppKit/NSViewColumnResizeEventArgs.cs \
+	AppKit/NSWorkspaceFileOperationEventArgs.cs \
 	AppKit/NSSliderTouchBarItem.cs \
 	AppKit/NSView.cs \
 	AppKit/NSCollectionLayoutAnchor.cs \

--- a/tests/monotouch-test/AppKit/NSNotificationEventArgsTest.cs
+++ b/tests/monotouch-test/AppKit/NSNotificationEventArgsTest.cs
@@ -1,0 +1,268 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if __MACOS__
+
+using AppKit;
+using Foundation;
+
+namespace Xamarin.Mac.Tests {
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class NSNotificationEventArgsTest {
+		[Test]
+		public void NSViewColumnMoveEventArgs_Properties ()
+		{
+			using var userInfo = new NSMutableDictionary ();
+			userInfo ["NSOldColumn"] = NSNumber.FromNInt (3);
+			userInfo ["NSNewColumn"] = NSNumber.FromNInt (7);
+
+			using var notification = NSNotification.FromName ("test", null, userInfo);
+			var args = new NSViewColumnMoveEventArgs (notification);
+
+			Assert.That (args.OldColumn, Is.EqualTo ((nint) 3), "OldColumn");
+			Assert.That (args.NewColumn, Is.EqualTo ((nint) 7), "NewColumn");
+		}
+
+		[Test]
+		public void NSViewColumnMoveEventArgs_NullUserInfo ()
+		{
+			using var notification = NSNotification.FromName ("test", null);
+			var args = new NSViewColumnMoveEventArgs (notification);
+
+			Assert.That (args.OldColumn, Is.EqualTo ((nint) 0), "OldColumn");
+			Assert.That (args.NewColumn, Is.EqualTo ((nint) 0), "NewColumn");
+		}
+
+		[Test]
+		public void NSViewColumnResizeEventArgs_Properties ()
+		{
+			using var column = new NSTableColumn ("testCol");
+			using var userInfo = new NSMutableDictionary ();
+			userInfo ["NSTableColumn"] = column;
+			userInfo ["NSOldWidth"] = NSNumber.FromNInt (42);
+
+			using var notification = NSNotification.FromName ("test", null, userInfo);
+			var args = new NSViewColumnResizeEventArgs (notification);
+
+			Assert.That (args.Column, Is.Not.Null, "Column not null");
+			Assert.That (args.Column!.Handle, Is.EqualTo (column.Handle), "Column");
+			Assert.That (args.OldWidth, Is.EqualTo ((nint) 42), "OldWidth");
+		}
+
+		[Test]
+		public void NSViewColumnResizeEventArgs_NullUserInfo ()
+		{
+			using var notification = NSNotification.FromName ("test", null);
+			var args = new NSViewColumnResizeEventArgs (notification);
+
+			Assert.That (args.Column, Is.Null, "Column");
+			Assert.That (args.OldWidth, Is.EqualTo ((nint) 0), "OldWidth");
+		}
+
+		[Test]
+		public void NSOutlineViewItemEventArgs_Properties ()
+		{
+			using var item = new NSObject ();
+			using var userInfo = new NSMutableDictionary ();
+			userInfo ["NSObject"] = item;
+
+			using var notification = NSNotification.FromName ("test", null, userInfo);
+			var args = new NSOutlineViewItemEventArgs (notification);
+
+			Assert.That (args.Item, Is.Not.Null, "Item not null");
+			Assert.That (args.Item!.Handle, Is.EqualTo (item.Handle), "Item");
+		}
+
+		[Test]
+		public void NSOutlineViewItemEventArgs_NullUserInfo ()
+		{
+			using var notification = NSNotification.FromName ("test", null);
+			var args = new NSOutlineViewItemEventArgs (notification);
+
+			Assert.That (args.Item, Is.Null, "Item");
+		}
+
+		[Test]
+		public void NSTextViewDidChangeSelectionEventArgs_Properties ()
+		{
+			using var value = NSValue.FromRange (new NSRange (5, 10));
+			using var userInfo = new NSMutableDictionary ();
+			userInfo ["NSOldSelectedCharacterRange"] = value;
+
+			using var notification = NSNotification.FromName ("test", null, userInfo);
+			var args = new NSTextViewDidChangeSelectionEventArgs (notification);
+
+			Assert.That (args.OldSelectedCharacterRange, Is.Not.Null, "OldSelectedCharacterRange not null");
+			Assert.That (args.OldSelectedCharacterRange!.Handle, Is.EqualTo (value.Handle), "OldSelectedCharacterRange");
+		}
+
+		[Test]
+		public void NSTextViewDidChangeSelectionEventArgs_NullUserInfo ()
+		{
+			using var notification = NSNotification.FromName ("test", null);
+			var args = new NSTextViewDidChangeSelectionEventArgs (notification);
+
+			Assert.That (args.OldSelectedCharacterRange, Is.Null, "OldSelectedCharacterRange");
+		}
+
+		[Test]
+		public void NSTextViewWillChangeNotifyingTextViewEventArgs_Properties ()
+		{
+			using var oldView = new NSTextView ();
+			using var newView = new NSTextView ();
+			using var userInfo = new NSMutableDictionary ();
+			userInfo ["NSOldNotifyingTextView"] = oldView;
+			userInfo ["NSNewNotifyingTextView"] = newView;
+
+			using var notification = NSNotification.FromName ("test", null, userInfo);
+			var args = new NSTextViewWillChangeNotifyingTextViewEventArgs (notification);
+
+			Assert.That (args.OldView, Is.Not.Null, "OldView not null");
+			Assert.That (args.OldView!.Handle, Is.EqualTo (oldView.Handle), "OldView");
+			Assert.That (args.NewView, Is.Not.Null, "NewView not null");
+			Assert.That (args.NewView!.Handle, Is.EqualTo (newView.Handle), "NewView");
+		}
+
+		[Test]
+		public void NSTextViewWillChangeNotifyingTextViewEventArgs_NullUserInfo ()
+		{
+			using var notification = NSNotification.FromName ("test", null);
+			var args = new NSTextViewWillChangeNotifyingTextViewEventArgs (notification);
+
+			Assert.That (args.OldView, Is.Null, "OldView");
+			Assert.That (args.NewView, Is.Null, "NewView");
+		}
+
+		[Test]
+		public void NSControlTextEditingEventArgs_Properties ()
+		{
+			using var textView = new NSTextView ();
+			using var userInfo = new NSMutableDictionary ();
+			userInfo ["NSFieldEditor"] = textView;
+
+			using var notification = NSNotification.FromName ("test", null, userInfo);
+			var args = new NSControlTextEditingEventArgs (notification);
+
+			Assert.That (args.FieldEditor, Is.Not.Null, "FieldEditor not null");
+			Assert.That (args.FieldEditor!.Handle, Is.EqualTo (textView.Handle), "FieldEditor");
+		}
+
+		[Test]
+		public void NSControlTextEditingEventArgs_NullUserInfo ()
+		{
+			using var notification = NSNotification.FromName ("test", null);
+			var args = new NSControlTextEditingEventArgs (notification);
+
+			Assert.That (args.FieldEditor, Is.Null, "FieldEditor");
+		}
+
+		[Test]
+		public void NSTextAlternativesSelectedAlternativeStringEventArgs_Properties ()
+		{
+			using var userInfo = new NSMutableDictionary ();
+			userInfo ["NSAlternativeString"] = new NSString ("hello");
+
+			using var notification = NSNotification.FromName ("test", null, userInfo);
+			var args = new NSTextAlternativesSelectedAlternativeStringEventArgs (notification);
+
+			Assert.That (args.AlternativeString, Is.EqualTo ("hello"), "AlternativeString");
+		}
+
+		[Test]
+		public void NSTextAlternativesSelectedAlternativeStringEventArgs_NullUserInfo ()
+		{
+			using var notification = NSNotification.FromName ("test", null);
+			var args = new NSTextAlternativesSelectedAlternativeStringEventArgs (notification);
+
+			Assert.That (args.AlternativeString, Is.Null, "AlternativeString");
+		}
+
+		[Test]
+		public void NSMenuItemIndexEventArgs_Properties ()
+		{
+			using var userInfo = new NSMutableDictionary ();
+			userInfo ["NSMenuItemIndex"] = NSNumber.FromNInt (5);
+
+			using var notification = NSNotification.FromName ("test", null, userInfo);
+			var args = new NSMenuItemIndexEventArgs (notification);
+
+			Assert.That (args.MenuItemIndex, Is.EqualTo ((nint) 5), "MenuItemIndex");
+		}
+
+		[Test]
+		public void NSMenuItemIndexEventArgs_NullUserInfo ()
+		{
+			using var notification = NSNotification.FromName ("test", null);
+			var args = new NSMenuItemIndexEventArgs (notification);
+
+			Assert.That (args.MenuItemIndex, Is.EqualTo ((nint) 0), "MenuItemIndex");
+		}
+
+		[Test]
+		public void NSMenuItemEventArgs_Properties ()
+		{
+			using var menu = new NSMenu ("testMenu");
+			using var userInfo = new NSMutableDictionary ();
+			userInfo ["MenuItem"] = menu;
+
+			using var notification = NSNotification.FromName ("test", null, userInfo);
+			var args = new NSMenuItemEventArgs (notification);
+
+			Assert.That (args.MenuItem, Is.Not.Null, "MenuItem not null");
+			Assert.That (args.MenuItem!.Handle, Is.EqualTo (menu.Handle), "MenuItem");
+		}
+
+		[Test]
+		public void NSMenuItemEventArgs_NullUserInfo ()
+		{
+			using var notification = NSNotification.FromName ("test", null);
+			var args = new NSMenuItemEventArgs (notification);
+
+			Assert.That (args.MenuItem, Is.Null, "MenuItem");
+		}
+
+		[Test]
+		public void NSWorkspaceFileOperationEventArgs_Properties ()
+		{
+			using var userInfo = new NSMutableDictionary ();
+			userInfo ["NSOperationNumber"] = NSNumber.FromNInt (99);
+
+			using var notification = NSNotification.FromName ("test", null, userInfo);
+			var args = new NSWorkspaceFileOperationEventArgs (notification);
+
+			Assert.That (args.FileType, Is.EqualTo ((nint) 99), "FileType");
+		}
+
+		[Test]
+		public void NSWorkspaceFileOperationEventArgs_NullUserInfo ()
+		{
+			using var notification = NSNotification.FromName ("test", null);
+			var args = new NSWorkspaceFileOperationEventArgs (notification);
+
+			Assert.That (args.FileType, Is.EqualTo ((nint) 0), "FileType");
+		}
+
+		[Test]
+		public void NSTextDidEndEditingEventArgs_Properties ()
+		{
+			using var userInfo = new NSMutableDictionary ();
+			userInfo ["NSTextMovement"] = NSNumber.FromNInt (1);
+
+			using var notification = NSNotification.FromName ("test", null, userInfo);
+			var args = new NSTextDidEndEditingEventArgs (notification);
+
+			Assert.That (args.Movement, Is.EqualTo ((nint) 1), "Movement");
+		}
+
+		[Test]
+		public void NSTextDidEndEditingEventArgs_NullUserInfo ()
+		{
+			using var notification = NSNotification.FromName ("test", null);
+			var args = new NSTextDidEndEditingEventArgs (notification);
+
+			Assert.That (args.Movement, Is.EqualTo ((nint) 0), "Movement");
+		}
+	}
+}
+#endif // __MACOS__

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
@@ -151,20 +151,6 @@
 !missing-selector! NSTextStorage::setWords: not bound
 !missing-selector! NSTextStorage::words not bound
 !missing-selector! NSWindow::anchorAttributeForOrientation: not bound
-!unknown-field! MenuItem bound
-!unknown-field! NSAlternativeString bound
-!unknown-field! NSFieldEditor bound
-!unknown-field! NSMenuItemIndex bound
-!unknown-field! NSNewColumn bound
-!unknown-field! NSNewNotifyingTextView bound
-!unknown-field! NSObject bound
-!unknown-field! NSOldColumn bound
-!unknown-field! NSOldNotifyingTextView bound
-!unknown-field! NSOldSelectedCharacterRange bound
-!unknown-field! NSOldWidth bound
-!unknown-field! NSOperationNumber bound
-!unknown-field! NSTableColumn bound
-!unknown-field! NSTextMovement bound
 !unknown-native-enum! NSAlertButtonReturn bound
 !unknown-native-enum! NSBackingStore bound
 !unknown-native-enum! NSCellHit bound


### PR DESCRIPTION
Implement manual bindings for the following properties, because they use
literal string keys instead of constant strings:

- NSViewColumnMoveEventArgs.OldColumn / NewColumn
- NSViewColumnResizeEventArgs.Column / OldWidth
- NSOutlineViewItemEventArgs.Item
- NSTextViewDidChangeSelectionEventArgs.OldSelectedCharacterRange
- NSTextViewWillChangeNotifyingTextViewEventArgs.OldView / NewView
- NSControlTextEditingEventArgs.FieldEditor
- NSTextAlternativesSelectedAlternativeStringEventArgs.AlternativeString
- NSMenuItemIndexEventArgs.MenuItemIndex
- NSMenuItemEventArgs.MenuItem
- NSWorkspaceFileOperationEventArgs.FileType
- NSTextDidEndEditingEventArgs.Movement

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>