### PR TITLE
[devops] Disable implicit CI triggers on xamarin-macios-pr pipeline

### DIFF
--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -48,6 +48,8 @@ variables:
 - name: Packaging.EnableSBOMSigning
   value: false
 
+trigger: none
+
 pr:
   autoCancel: true
   branches:


### PR DESCRIPTION
Without an explicit `trigger:` section, Azure DevOps defaults to enabling CI triggers on all branches. This caused duplicate builds when a branch (e.g. `dev/*`) had an open PR — one `individualCI` build from the implicit CI trigger and one `pullRequest` build from the PR trigger.

Adding `trigger: none` ensures only PR-triggered builds run, eliminating the duplicate.

Fixes the duplicate build issue reported in session 4eff85aa (PR #25209 triggered two CI builds).

🤖 Pull request created by Copilot