### PR TITLE
[devops] Make the API diff pipeline use a pr: trigger.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,4 +98,3 @@ git-clean-all:
 	@echo "Done"
 
 SUBDIRS += tests
-

--- a/tools/devops/automation/run-pr-api-diff.yml
+++ b/tools/devops/automation/run-pr-api-diff.yml
@@ -1,15 +1,25 @@
 # Pipeline that will calculate the api diff on a pr commit.
 
 trigger: none
-pr: none
 
-resources:
-  pipelines:
-    - pipeline: macios
-      source: \Xamarin\Mac-iOS\pr pipelines\xamarin-macios-pr
-      trigger:
-        stages:
-          - configure_build
+pr:
+  autoCancel: true
+  branches:
+    include:
+      - '*'  # yes, you do need the quote, * has meaning in yamls
+  paths:
+    exclude:
+      - .github
+      - docs
+      - CODEOWNERS
+      - ISSUE_TEMPLATE.md
+      - LICENSE
+      - NOTICE.txt
+      - SECURITY.MD
+      - README.md
+      - src/README.md
+      - tools/mtouch/README.md
+      - msbuild/Xamarin.Localization.MSBuild/README.md
 
 extends:
   template: templates/pipelines/api-diff-pipeline.yml


### PR DESCRIPTION
Unfortunately Azure DevOps doesn't properly report GitHub checks for pipelines
triggered by another pipeline, when that other pipeline was triggered from a
pr trigger.

So go back to triggering the API diff pipeline using a pr: trigger.

This effectively reverts #21880 ("[CI] Make the API diff be triggered as soon as the config of the build is done.")

References:

* https://stackoverflow.com/questions/78443654/reporting-stage-statuses-to-github-for-pipeline-triggered-by-another-pipeline