### PR TITLE
[tests] Fix flaky SecureTransportTest.Tls12 by ignoring network timeouts in CI

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -1664,6 +1664,11 @@ partial class TestRuntime {
 				IgnoreInCI ($"Ignored due to network error: {wex}");
 			}
 		}
+
+		var se = FindInner<System.Net.Sockets.SocketException> (ex);
+		if (se is not null && se.SocketErrorCode == System.Net.Sockets.SocketError.TimedOut) {
+			IgnoreInCI ($"Ignored due to socket timeout: {se.Message}");
+		}
 	}
 
 	public static void IgnoreInCIIfForbidden (Exception ex)

--- a/tests/monotouch-test/Security/SecureTransportTest.cs
+++ b/tests/monotouch-test/Security/SecureTransportTest.cs
@@ -140,9 +140,11 @@ namespace MonoTouchFixtures.Security {
 
 					ssl.Connection = new SslStreamConnection (ns);
 
+					var deadline = DateTime.UtcNow.AddSeconds (30);
 					var result = ssl.Handshake ();
-					while (result == SslStatus.WouldBlock || result == (SslStatus) (-108)) {
-						// we need to ask again - but if we're too fast we'll get -108 (errSecAllocate)
+					while (result == SslStatus.WouldBlock || result == (SslStatus) errSecAllocate) {
+						Assert.That (DateTime.UtcNow, Is.LessThan (deadline), "Handshake/timeout");
+						// we need to ask again - but if we're too fast we'll get errSecAllocate
 						Thread.Sleep (100);
 						// during the above call SessionState is Handshake
 						Assert.That (ssl.SessionState, Is.EqualTo (SslSessionState.Handshake), "Handshake/in progress");
@@ -161,9 +163,12 @@ namespace MonoTouchFixtures.Security {
 					Assert.That (result, Is.EqualTo (SslStatus.Success), "Write");
 
 					data = new byte [1024];
+					deadline = DateTime.UtcNow.AddSeconds (30);
 					result = ssl.Read (data, out processed);
-					while (result == SslStatus.WouldBlock)
+					while (result == SslStatus.WouldBlock) {
+						Assert.That (DateTime.UtcNow, Is.LessThan (deadline), "Read/timeout");
 						result = ssl.Read (data, out processed);
+					}
 					Assert.That (result, Is.EqualTo (SslStatus.Success), "Read");
 
 					string s = Encoding.UTF8.GetString (data, 0, (int) processed);

--- a/tests/monotouch-test/Security/SecureTransportTest.cs
+++ b/tests/monotouch-test/Security/SecureTransportTest.cs
@@ -130,45 +130,50 @@ namespace MonoTouchFixtures.Security {
 		[Test]
 		public void Tls12 ()
 		{
-			var client = new TcpClient ("google.ca", 443);
-			using (NetworkStream ns = client.GetStream ())
-			using (var ssl = new SslContext (SslProtocolSide.Client, SslConnectionType.Stream)) {
+			try {
+				var client = new TcpClient ("google.ca", 443);
+				using (NetworkStream ns = client.GetStream ())
+				using (var ssl = new SslContext (SslProtocolSide.Client, SslConnectionType.Stream)) {
 
-				ssl.MinProtocol = SslProtocol.Tls_1_2;
-				Assert.That (ssl.MinProtocol, Is.EqualTo (SslProtocol.Tls_1_2), "MinProtocol");
+					ssl.MinProtocol = SslProtocol.Tls_1_2;
+					Assert.That (ssl.MinProtocol, Is.EqualTo (SslProtocol.Tls_1_2), "MinProtocol");
 
-				ssl.Connection = new SslStreamConnection (ns);
+					ssl.Connection = new SslStreamConnection (ns);
 
-				var result = ssl.Handshake ();
-				while (result == SslStatus.WouldBlock || result == (SslStatus) (-108)) {
-					// we need to ask again - but if we're too fast we'll get -108 (errSecAllocate)
-					Thread.Sleep (100);
-					// during the above call SessionState is Handshake
-					Assert.That (ssl.SessionState, Is.EqualTo (SslSessionState.Handshake), "Handshake/in progress");
-					result = ssl.Handshake ();
-				}
-				Assert.That (result, Is.EqualTo (SslStatus.Success), "Handshake/done");
+					var result = ssl.Handshake ();
+					while (result == SslStatus.WouldBlock || result == (SslStatus) (-108)) {
+						// we need to ask again - but if we're too fast we'll get -108 (errSecAllocate)
+						Thread.Sleep (100);
+						// during the above call SessionState is Handshake
+						Assert.That (ssl.SessionState, Is.EqualTo (SslSessionState.Handshake), "Handshake/in progress");
+						result = ssl.Handshake ();
+					}
+					Assert.That (result, Is.EqualTo (SslStatus.Success), "Handshake/done");
 
-				// FIXME: iOS 8 beta 1 bug ?!? the state is not updated (maybe delayed?) but the code still works
-				//Assert.That (ssl.SessionState, Is.EqualTo (SslSessionState.Connected), "Connected");
-				Assert.That (ssl.NegotiatedProtocol, Is.EqualTo (SslProtocol.Tls_1_2), "NegotiatedProtocol");
+					// FIXME: iOS 8 beta 1 bug ?!? the state is not updated (maybe delayed?) but the code still works
+					//Assert.That (ssl.SessionState, Is.EqualTo (SslSessionState.Connected), "Connected");
+					Assert.That (ssl.NegotiatedProtocol, Is.EqualTo (SslProtocol.Tls_1_2), "NegotiatedProtocol");
 
-				nint processed;
-				var data = Encoding.UTF8.GetBytes ("GET / HTTP/1.0" + Environment.NewLine + Environment.NewLine);
-				result = ssl.Write (data, out processed);
-				Assert.That (processed, Is.EqualTo ((nint) data.Length), "small buffer");
-				Assert.That (result, Is.EqualTo (SslStatus.Success), "Write");
+					nint processed;
+					var data = Encoding.UTF8.GetBytes ("GET / HTTP/1.0" + Environment.NewLine + Environment.NewLine);
+					result = ssl.Write (data, out processed);
+					Assert.That (processed, Is.EqualTo ((nint) data.Length), "small buffer");
+					Assert.That (result, Is.EqualTo (SslStatus.Success), "Write");
 
-				data = new byte [1024];
-				result = ssl.Read (data, out processed);
-				while (result == SslStatus.WouldBlock)
+					data = new byte [1024];
 					result = ssl.Read (data, out processed);
-				Assert.That (result, Is.EqualTo (SslStatus.Success), "Read");
+					while (result == SslStatus.WouldBlock)
+						result = ssl.Read (data, out processed);
+					Assert.That (result, Is.EqualTo (SslStatus.Success), "Read");
 
-				string s = Encoding.UTF8.GetString (data, 0, (int) processed);
-				// The result apparently depends on where you are: I get a 302, the bots get a 200.
-				// Also sometimes it fails with 502 Bad Gateway on the bots
-				Assert.That (s, Does.StartWith ("HTTP/1.0 302 Found").Or.StartWith ("HTTP/1.0 200 OK").Or.StartWith ("HTTP/1.0 502 Bad Gateway"), "response");
+					string s = Encoding.UTF8.GetString (data, 0, (int) processed);
+					// The result apparently depends on where you are: I get a 302, the bots get a 200.
+					// Also sometimes it fails with 502 Bad Gateway on the bots
+					Assert.That (s, Does.StartWith ("HTTP/1.0 302 Found").Or.StartWith ("HTTP/1.0 200 OK").Or.StartWith ("HTTP/1.0 502 Bad Gateway"), "response");
+				}
+			} catch (Exception ex) {
+				TestRuntime.IgnoreInCIIfBadNetwork (ex);
+				throw;
 			}
 		}
 	}


### PR DESCRIPTION
Wrap the Tls12 test body in a try/catch that calls TestRuntime.IgnoreInCIIfBadNetwork to mark the test as ignored (rather than failed) when transient network issues occur in CI.

Also extend IgnoreInCIIfTimedOut to handle SocketException timeouts, not just WebException timeouts, so that the SocketException thrown by TcpClient is properly recognized.

Fixes https://github.com/dotnet/macios/issues/25241