### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 14411: Build ID 14005610

### DIFF
--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.cs.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.cs.resx
@@ -1216,6 +1216,9 @@
   <data name="MT4190" xml:space="preserve">
 		<value>The class '{0}' will not be registered because the {1} framework has been deprecated from the {2} SDK.</value>
 	</data>
+  <data name="MX4191" xml:space="preserve">
+		<value>Could not find the trampoline for the category method {0}.</value>
+	</data>
   <data name="MT5101" xml:space="preserve">
 		<value>Missing '{0}' compiler. Please install Xcode 'Command-Line Tools' component</value>
 	</data>
@@ -1458,5 +1461,11 @@
 	</data>
   <data name="MX8060" xml:space="preserve">
 		<value>Invalid DelegateProxyAttribute for the return value for the method {0}.{1}: No 'Invoke' method found. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8061" xml:space="preserve">
+		<value>Unable to find the managed function with id {0} ({1}, {2}). Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8062" xml:space="preserve">
+		<value>Type '{0}' is expected to have a ProtocolProxyAttribute. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
 	</data>
 </root>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.de.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.de.resx
@@ -1216,6 +1216,9 @@
   <data name="MT4190" xml:space="preserve">
 		<value>The class '{0}' will not be registered because the {1} framework has been deprecated from the {2} SDK.</value>
 	</data>
+  <data name="MX4191" xml:space="preserve">
+		<value>Could not find the trampoline for the category method {0}.</value>
+	</data>
   <data name="MT5101" xml:space="preserve">
 		<value>Missing '{0}' compiler. Please install Xcode 'Command-Line Tools' component</value>
 	</data>
@@ -1458,5 +1461,11 @@
 	</data>
   <data name="MX8060" xml:space="preserve">
 		<value>Invalid DelegateProxyAttribute for the return value for the method {0}.{1}: No 'Invoke' method found. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8061" xml:space="preserve">
+		<value>Unable to find the managed function with id {0} ({1}, {2}). Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8062" xml:space="preserve">
+		<value>Type '{0}' is expected to have a ProtocolProxyAttribute. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
 	</data>
 </root>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.es.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.es.resx
@@ -1216,6 +1216,9 @@
   <data name="MT4190" xml:space="preserve">
 		<value>The class '{0}' will not be registered because the {1} framework has been deprecated from the {2} SDK.</value>
 	</data>
+  <data name="MX4191" xml:space="preserve">
+		<value>Could not find the trampoline for the category method {0}.</value>
+	</data>
   <data name="MT5101" xml:space="preserve">
 		<value>Missing '{0}' compiler. Please install Xcode 'Command-Line Tools' component</value>
 	</data>
@@ -1458,5 +1461,11 @@
 	</data>
   <data name="MX8060" xml:space="preserve">
 		<value>Invalid DelegateProxyAttribute for the return value for the method {0}.{1}: No 'Invoke' method found. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8061" xml:space="preserve">
+		<value>Unable to find the managed function with id {0} ({1}, {2}). Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8062" xml:space="preserve">
+		<value>Type '{0}' is expected to have a ProtocolProxyAttribute. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
 	</data>
 </root>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.fr.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.fr.resx
@@ -1216,6 +1216,9 @@
   <data name="MT4190" xml:space="preserve">
 		<value>The class '{0}' will not be registered because the {1} framework has been deprecated from the {2} SDK.</value>
 	</data>
+  <data name="MX4191" xml:space="preserve">
+		<value>Could not find the trampoline for the category method {0}.</value>
+	</data>
   <data name="MT5101" xml:space="preserve">
 		<value>Missing '{0}' compiler. Please install Xcode 'Command-Line Tools' component</value>
 	</data>
@@ -1458,5 +1461,11 @@
 	</data>
   <data name="MX8060" xml:space="preserve">
 		<value>Invalid DelegateProxyAttribute for the return value for the method {0}.{1}: No 'Invoke' method found. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8061" xml:space="preserve">
+		<value>Unable to find the managed function with id {0} ({1}, {2}). Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8062" xml:space="preserve">
+		<value>Type '{0}' is expected to have a ProtocolProxyAttribute. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
 	</data>
 </root>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.it.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.it.resx
@@ -1216,6 +1216,9 @@
   <data name="MT4190" xml:space="preserve">
 		<value>The class '{0}' will not be registered because the {1} framework has been deprecated from the {2} SDK.</value>
 	</data>
+  <data name="MX4191" xml:space="preserve">
+		<value>Could not find the trampoline for the category method {0}.</value>
+	</data>
   <data name="MT5101" xml:space="preserve">
 		<value>Missing '{0}' compiler. Please install Xcode 'Command-Line Tools' component</value>
 	</data>
@@ -1458,5 +1461,11 @@
 	</data>
   <data name="MX8060" xml:space="preserve">
 		<value>Invalid DelegateProxyAttribute for the return value for the method {0}.{1}: No 'Invoke' method found. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8061" xml:space="preserve">
+		<value>Unable to find the managed function with id {0} ({1}, {2}). Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8062" xml:space="preserve">
+		<value>Type '{0}' is expected to have a ProtocolProxyAttribute. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
 	</data>
 </root>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.ja.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.ja.resx
@@ -1216,6 +1216,9 @@
   <data name="MT4190" xml:space="preserve">
 		<value>The class '{0}' will not be registered because the {1} framework has been deprecated from the {2} SDK.</value>
 	</data>
+  <data name="MX4191" xml:space="preserve">
+		<value>Could not find the trampoline for the category method {0}.</value>
+	</data>
   <data name="MT5101" xml:space="preserve">
 		<value>Missing '{0}' compiler. Please install Xcode 'Command-Line Tools' component</value>
 	</data>
@@ -1458,5 +1461,11 @@
 	</data>
   <data name="MX8060" xml:space="preserve">
 		<value>Invalid DelegateProxyAttribute for the return value for the method {0}.{1}: No 'Invoke' method found. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8061" xml:space="preserve">
+		<value>Unable to find the managed function with id {0} ({1}, {2}). Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8062" xml:space="preserve">
+		<value>Type '{0}' is expected to have a ProtocolProxyAttribute. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
 	</data>
 </root>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.ko.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.ko.resx
@@ -1216,6 +1216,9 @@
   <data name="MT4190" xml:space="preserve">
 		<value>The class '{0}' will not be registered because the {1} framework has been deprecated from the {2} SDK.</value>
 	</data>
+  <data name="MX4191" xml:space="preserve">
+		<value>Could not find the trampoline for the category method {0}.</value>
+	</data>
   <data name="MT5101" xml:space="preserve">
 		<value>Missing '{0}' compiler. Please install Xcode 'Command-Line Tools' component</value>
 	</data>
@@ -1458,5 +1461,11 @@
 	</data>
   <data name="MX8060" xml:space="preserve">
 		<value>Invalid DelegateProxyAttribute for the return value for the method {0}.{1}: No 'Invoke' method found. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8061" xml:space="preserve">
+		<value>Unable to find the managed function with id {0} ({1}, {2}). Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8062" xml:space="preserve">
+		<value>Type '{0}' is expected to have a ProtocolProxyAttribute. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
 	</data>
 </root>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.pl.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.pl.resx
@@ -1216,6 +1216,9 @@
   <data name="MT4190" xml:space="preserve">
 		<value>The class '{0}' will not be registered because the {1} framework has been deprecated from the {2} SDK.</value>
 	</data>
+  <data name="MX4191" xml:space="preserve">
+		<value>Could not find the trampoline for the category method {0}.</value>
+	</data>
   <data name="MT5101" xml:space="preserve">
 		<value>Missing '{0}' compiler. Please install Xcode 'Command-Line Tools' component</value>
 	</data>
@@ -1458,5 +1461,11 @@
 	</data>
   <data name="MX8060" xml:space="preserve">
 		<value>Invalid DelegateProxyAttribute for the return value for the method {0}.{1}: No 'Invoke' method found. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8061" xml:space="preserve">
+		<value>Unable to find the managed function with id {0} ({1}, {2}). Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8062" xml:space="preserve">
+		<value>Type '{0}' is expected to have a ProtocolProxyAttribute. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
 	</data>
 </root>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.pt-BR.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.pt-BR.resx
@@ -1216,6 +1216,9 @@
   <data name="MT4190" xml:space="preserve">
 		<value>The class '{0}' will not be registered because the {1} framework has been deprecated from the {2} SDK.</value>
 	</data>
+  <data name="MX4191" xml:space="preserve">
+		<value>Could not find the trampoline for the category method {0}.</value>
+	</data>
   <data name="MT5101" xml:space="preserve">
 		<value>Missing '{0}' compiler. Please install Xcode 'Command-Line Tools' component</value>
 	</data>
@@ -1458,5 +1461,11 @@
 	</data>
   <data name="MX8060" xml:space="preserve">
 		<value>Invalid DelegateProxyAttribute for the return value for the method {0}.{1}: No 'Invoke' method found. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8061" xml:space="preserve">
+		<value>Unable to find the managed function with id {0} ({1}, {2}). Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8062" xml:space="preserve">
+		<value>Type '{0}' is expected to have a ProtocolProxyAttribute. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
 	</data>
 </root>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.ru.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.ru.resx
@@ -1216,6 +1216,9 @@
   <data name="MT4190" xml:space="preserve">
 		<value>The class '{0}' will not be registered because the {1} framework has been deprecated from the {2} SDK.</value>
 	</data>
+  <data name="MX4191" xml:space="preserve">
+		<value>Could not find the trampoline for the category method {0}.</value>
+	</data>
   <data name="MT5101" xml:space="preserve">
 		<value>Missing '{0}' compiler. Please install Xcode 'Command-Line Tools' component</value>
 	</data>
@@ -1458,5 +1461,11 @@
 	</data>
   <data name="MX8060" xml:space="preserve">
 		<value>Invalid DelegateProxyAttribute for the return value for the method {0}.{1}: No 'Invoke' method found. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8061" xml:space="preserve">
+		<value>Unable to find the managed function with id {0} ({1}, {2}). Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8062" xml:space="preserve">
+		<value>Type '{0}' is expected to have a ProtocolProxyAttribute. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
 	</data>
 </root>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.tr.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.tr.resx
@@ -1216,6 +1216,9 @@
   <data name="MT4190" xml:space="preserve">
 		<value>The class '{0}' will not be registered because the {1} framework has been deprecated from the {2} SDK.</value>
 	</data>
+  <data name="MX4191" xml:space="preserve">
+		<value>Could not find the trampoline for the category method {0}.</value>
+	</data>
   <data name="MT5101" xml:space="preserve">
 		<value>Missing '{0}' compiler. Please install Xcode 'Command-Line Tools' component</value>
 	</data>
@@ -1458,5 +1461,11 @@
 	</data>
   <data name="MX8060" xml:space="preserve">
 		<value>Invalid DelegateProxyAttribute for the return value for the method {0}.{1}: No 'Invoke' method found. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8061" xml:space="preserve">
+		<value>Unable to find the managed function with id {0} ({1}, {2}). Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8062" xml:space="preserve">
+		<value>Type '{0}' is expected to have a ProtocolProxyAttribute. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
 	</data>
 </root>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.zh-Hans.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.zh-Hans.resx
@@ -1216,6 +1216,9 @@
   <data name="MT4190" xml:space="preserve">
 		<value>The class '{0}' will not be registered because the {1} framework has been deprecated from the {2} SDK.</value>
 	</data>
+  <data name="MX4191" xml:space="preserve">
+		<value>Could not find the trampoline for the category method {0}.</value>
+	</data>
   <data name="MT5101" xml:space="preserve">
 		<value>Missing '{0}' compiler. Please install Xcode 'Command-Line Tools' component</value>
 	</data>
@@ -1458,5 +1461,11 @@
 	</data>
   <data name="MX8060" xml:space="preserve">
 		<value>Invalid DelegateProxyAttribute for the return value for the method {0}.{1}: No 'Invoke' method found. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8061" xml:space="preserve">
+		<value>Unable to find the managed function with id {0} ({1}, {2}). Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8062" xml:space="preserve">
+		<value>Type '{0}' is expected to have a ProtocolProxyAttribute. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
 	</data>
 </root>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.zh-Hant.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.zh-Hant.resx
@@ -1216,6 +1216,9 @@
   <data name="MT4190" xml:space="preserve">
 		<value>The class '{0}' will not be registered because the {1} framework has been deprecated from the {2} SDK.</value>
 	</data>
+  <data name="MX4191" xml:space="preserve">
+		<value>Could not find the trampoline for the category method {0}.</value>
+	</data>
   <data name="MT5101" xml:space="preserve">
 		<value>Missing '{0}' compiler. Please install Xcode 'Command-Line Tools' component</value>
 	</data>
@@ -1458,5 +1461,11 @@
 	</data>
   <data name="MX8060" xml:space="preserve">
 		<value>Invalid DelegateProxyAttribute for the return value for the method {0}.{1}: No 'Invoke' method found. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8061" xml:space="preserve">
+		<value>Unable to find the managed function with id {0} ({1}, {2}). Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
+	</data>
+  <data name="MX8062" xml:space="preserve">
+		<value>Type '{0}' is expected to have a ProtocolProxyAttribute. Please file a bug report with a test case (https://github.com/dotnet/macios/issues/new).</value>
 	</data>
 </root>


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.