### PR TITLE
[dotnet] Disable trimming when using CoreCLR in the simulator.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.Trimming.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.Trimming.props
@@ -50,8 +50,11 @@
 		<!-- Linking is always on for all assemblies when using NativeAOT - this is because we need to modify all assemblies in the linker for them to be compatible with NativeAOT -->
 		<_DefaultLinkMode Condition="'$(_DefaultLinkMode)' == '' And '$(_UseNativeAot)' == 'true'">Full</_DefaultLinkMode>
 
-		<!-- Linking is off by default when using CoreCLR -->
-		<_DefaultLinkMode Condition="'$(_DefaultLinkMode)' == '' And '$(UseMonoRuntime)' != 'true'">None</_DefaultLinkMode>
+		<!-- Linking is off by default when using CoreCLR on macOS -->
+		<_DefaultLinkMode Condition="'$(_DefaultLinkMode)' == '' And '$(UseMonoRuntime)' != 'true' And '$(_PlatformName)' == 'macOS'">None</_DefaultLinkMode>
+
+		<!-- Default linking is off when using CoreCLR in the simulator -->
+		<_DefaultLinkMode Condition="'$(_DefaultLinkMode)' == '' And '$(UseMonoRuntime)' != 'true' And '$(_SdkIsSimulator)' == 'true'">None</_DefaultLinkMode>
 
 		<!-- Default linking is on for release builds for Mac Catalyst apps -->
 		<_DefaultLinkMode Condition="'$(_DefaultLinkMode)' == '' And '$(_PlatformName)' == 'MacCatalyst' And '$(Configuration)' == 'Release'">SdkOnly</_DefaultLinkMode>
@@ -62,10 +65,10 @@
 		<!-- Otherwise, default linking is off for Mac Catalyst (this is just a safety net, because all possible scenarios should be handled already) -->
 		<_DefaultLinkMode Condition="'$(_DefaultLinkMode)' == '' And '$(_PlatformName)' == 'MacCatalyst'">None</_DefaultLinkMode>
 
-		<!-- Linking is on by default in the simulator when building for arm64, as long as the interpreter is not enabled -->
-		<_DefaultLinkMode Condition="'$(_DefaultLinkMode)' == '' And '$(_SdkIsSimulator)' == 'true' And $(RuntimeIdentifier.Contains('arm64')) And '$(MtouchInterpreter)' == ''">SdkOnly</_DefaultLinkMode>
-		<!-- Linking is off by default in the simulator when not building for arm64 -->
-		<_DefaultLinkMode Condition="'$(_DefaultLinkMode)' == '' And '$(_SdkIsSimulator)' == 'true' And (!$(RuntimeIdentifier.Contains('arm64')) Or '$(MtouchInterpreter)' != '')">None</_DefaultLinkMode>
+		<!-- Linking is on by default in the simulator when building for arm64, as long as the interpreter is not enabled and using MonoVM -->
+		<_DefaultLinkMode Condition="'$(_DefaultLinkMode)' == '' And '$(_SdkIsSimulator)' == 'true' And '$(UseMonoRuntime)' == 'true' And $(RuntimeIdentifier.Contains('arm64')) And '$(MtouchInterpreter)' == ''">SdkOnly</_DefaultLinkMode>
+		<!-- Linking is off by default in the simulator when not building for arm64 and using MonOVM -->
+		<_DefaultLinkMode Condition="'$(_DefaultLinkMode)' == '' And '$(_SdkIsSimulator)' == 'true' And '$(UseMonoRuntime)' == 'true' And (!$(RuntimeIdentifier.Contains('arm64')) Or '$(MtouchInterpreter)' != '')">None</_DefaultLinkMode>
 		<!-- Otherwise, default linking is SdkOnly for iOS/tvOS apps -->
 		<_DefaultLinkMode Condition="'$(_DefaultLinkMode)' == ''">SdkOnly</_DefaultLinkMode>
 

--- a/dotnet/targets/Xamarin.Shared.Sdk.Trimming.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.Trimming.props
@@ -67,7 +67,7 @@
 
 		<!-- Linking is on by default in the simulator when building for arm64, as long as the interpreter is not enabled and using MonoVM -->
 		<_DefaultLinkMode Condition="'$(_DefaultLinkMode)' == '' And '$(_SdkIsSimulator)' == 'true' And '$(UseMonoRuntime)' == 'true' And $(RuntimeIdentifier.Contains('arm64')) And '$(MtouchInterpreter)' == ''">SdkOnly</_DefaultLinkMode>
-		<!-- Linking is off by default in the simulator when not building for arm64 and using MonOVM -->
+		<!-- Linking is off by default in the simulator when not building for arm64 and using MonoVM -->
 		<_DefaultLinkMode Condition="'$(_DefaultLinkMode)' == '' And '$(_SdkIsSimulator)' == 'true' And '$(UseMonoRuntime)' == 'true' And (!$(RuntimeIdentifier.Contains('arm64')) Or '$(MtouchInterpreter)' != '')">None</_DefaultLinkMode>
 		<!-- Otherwise, default linking is SdkOnly for iOS/tvOS apps -->
 		<_DefaultLinkMode Condition="'$(_DefaultLinkMode)' == ''">SdkOnly</_DefaultLinkMode>


### PR DESCRIPTION
Fixes #25295.