### PR TITLE
[msbuild] Add com.apple.developer.payment-pass-provisioning to known entitlements

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileEntitlements.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileEntitlements.cs
@@ -789,6 +789,7 @@ namespace Xamarin.MacDev.Tasks {
 					new EntitlementData ("com.apple.developer.on-demand-install-capable", iOS, EntitlementType.Boolean ),
 					new EntitlementData ("com.apple.developer.parent-application-identifiers", iOS, EntitlementType.ArrayOfStrings ),
 					new EntitlementData ("com.apple.developer.pass-type-identifiers", iOS, EntitlementType.ArrayOfStrings ),
+					new EntitlementData ("com.apple.developer.payment-pass-provisioning", iOS, EntitlementType.Boolean ),
 					new EntitlementData ("com.apple.developer.persistent-content-capture", desktop, EntitlementType.Boolean ),
 					new EntitlementData ("com.apple.developer.playable-content", iOS, EntitlementType.Boolean ),
 					new EntitlementData ("com.apple.developer.proximity-reader.identity.display", iOS, EntitlementType.Boolean ),

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileEntitlementsTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileEntitlementsTaskTests.cs
@@ -573,6 +573,38 @@ namespace Xamarin.MacDev.Tasks {
 			ValidateEntitlementsImpl (platform, "error", [], mode, entitlement, "String", "InvalidValue", mobileProvision: "Apple_Signin_Test_Profile.mobileprovision");
 		}
 
+		// Test case inspired by https://github.com/dotnet/macios/issues/25306
+		// A wallet extension requests com.apple.developer.payment-pass-provisioning,
+		// but the provisioning profile doesn't grant it. This should produce a
+		// warning/error so the developer knows why installation fails on device.
+		[Test]
+		[TestCase (EntitlementsMode.InCustomEntitlements)]
+		[TestCase (EntitlementsMode.InFile)]
+		public void ValidateEntitlements_PaymentPassProvisioningNotInProfile (EntitlementsMode mode)
+		{
+			ValidateEntitlementsImpl (ApplePlatform.iOS, "error", [
+				"MT7140:The app requests the entitlement 'com.apple.developer.payment-pass-provisioning', but the provisioning profile 'iOS Team Provisioning Profile: *' doesn't contain this entitlement."
+			], mode, "com.apple.developer.payment-pass-provisioning", "Boolean", "true");
+		}
+
+		[Test]
+		[TestCase (EntitlementsMode.InCustomEntitlements)]
+		[TestCase (EntitlementsMode.InFile)]
+		public void ValidateEntitlements_PaymentPassProvisioningNotInProfile_Warning (EntitlementsMode mode)
+		{
+			ValidateEntitlementsImpl (ApplePlatform.iOS, "warn", [
+				"MT7140:The app requests the entitlement 'com.apple.developer.payment-pass-provisioning', but the provisioning profile 'iOS Team Provisioning Profile: *' doesn't contain this entitlement."
+			], mode, "com.apple.developer.payment-pass-provisioning", "Boolean", "true");
+		}
+
+		[Test]
+		[TestCase (EntitlementsMode.InCustomEntitlements)]
+		[TestCase (EntitlementsMode.InFile)]
+		public void ValidateEntitlements_PaymentPassProvisioningNotInProfile_Disable (EntitlementsMode mode)
+		{
+			ValidateEntitlementsImpl (ApplePlatform.iOS, "disable", [], mode, "com.apple.developer.payment-pass-provisioning", "Boolean", "true");
+		}
+
 		public enum EntitlementsMode {
 			None,
 			InFile,


### PR DESCRIPTION
Add the com.apple.developer.payment-pass-provisioning entitlement to the
known entitlements list so that validation properly reports a warning/error
when an app requests this entitlement but the provisioning profile doesn't
grant it. Previously this was an unknown entitlement that only logged a
low-importance message, causing silent install failures on device.

Also add tests verifying the error, warning, and disable modes for this
entitlement validation scenario.

Fixes https://github.com/dotnet/macios/issues/25306