### PR TITLE
Fix typo in src/Simd/README.md: "43-bit" → "32-bit" for NVector3i

### DIFF
--- a/src/Simd/README.md
+++ b/src/Simd/README.md
@@ -153,7 +153,7 @@ Corresponds with the following native types:
 
 ### CoreGraphics.NVector3i
 
-A vector of 3 43-bit ints.
+A vector of 3 32-bit ints.
 
 For memory alignment purposes, this vector has a length of 4 ints, which
 means that the size of this struct is 16 bytes (and not 12 bytes).


### PR DESCRIPTION
Line 156 of `src/Simd/README.md` described `NVector3i` as "A vector of 3 43-bit ints.", which is a factual error.

`NVector3i` wraps the native `simd_int3` / `vector_int3` type, which is a vector of three **32-bit** signed integers. The sibling types `NVector2i` and `NVector4i` already correctly say "32-bit" in the same file.

**Change:** `43-bit` → `32-bit` on line 156 — documentation only, no code changes.