### PR TITLE
[net11.0] Fix R2R --instruction-set computation for iOS/tvOS device builds

### DIFF
--- a/dotnet/targets/Microsoft.Sdk.R2R.targets
+++ b/dotnet/targets/Microsoft.Sdk.R2R.targets
@@ -29,7 +29,7 @@
 			RuntimeIdentifier="$(RuntimeIdentifier)"
 			SdkDevPath="$(_SdkDevPath)"
 			SupportedOSPlatformVersion="$(SupportedOSPlatformVersion)"
-			TargetFrameworkMoniker="$(TargetFramework)"
+			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 			>
 			<Output TaskParameter="InstructionSet" PropertyName="_ComputedInstructionSet" />
 		</ComputeInstructionSet>


### PR DESCRIPTION
## Summary

`_ComputeInstructionSetForCrossgen2` was passing `$(TargetFramework)` (the short form like `net11.0-ios`) as `TargetFrameworkMoniker`. The base task calls `TargetFramework.Parse`, which only handles the long comma-delimited form (`.NETCoreApp,Version=v11.0,Profile=ios`); the short form silently parses to an empty `TargetFramework` whose `Platform` getter falls through to `ApplePlatform.MacOSX`.

For an `ios-arm64` build the platform was therefore reported as macOS, so `ComputeMinimumInstructionSet` routed to `ComputeMacInstructionSet`, which returns `apple-m1` for any arm64 RID. crossgen2 was then invoked with `--instruction-set:apple-m1` even on iOS device builds.

## Impact

`apple-m1` requires ARMv8.5 features. Pre-A14 iOS devices (iPhone XR/A12, iPhone 11/A13, etc.) do not implement them, so the runtime rejects the R2R image at load time and falls back to the interpreter — defeating R2R on a wide range of supported devices and visibly regressing cold-start.

## Fix

The other call sites in the same file already use `$(_ComputedTargetFrameworkMoniker)` (the long form expanded by the shared targets). Align this one with them — one-line change.

## Verification

After the fix, `ios-arm64` device builds pick the oldest-supported-device ISA via the existing device table walk in `ComputeInstructionSet` — `armv8-a` for `SupportedOSPlatformVersion` 15.0–17.x, `armv8.3-a` for iOS 18.0+, etc. iPhone 13 (A15) cold-start was unchanged within noise (~228 ms median); pre-A14 devices should now actually use R2R instead of falling back to the interpreter.

Note: The instruction set was silently ignored before https://github.com/dotnet/macios/pull/25176
