### PR TITLE
[release/10.0.1xx] Backport a number of CI changes to make PRs work.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,4 +98,3 @@ git-clean-all:
 	@echo "Done"
 
 SUBDIRS += tests
-

--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -48,6 +48,8 @@ variables:
 - name: Packaging.EnableSBOMSigning
   value: false
 
+trigger: none
+
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/build-pull-request.yml
+++ b/tools/devops/automation/build-pull-request.yml
@@ -48,20 +48,6 @@ variables:
 - name: Packaging.EnableSBOMSigning
   value: false
 
-
-# only allow triggers from specific branches
-trigger:
-  branches:
-    include:
-    - refs/heads/dev/*
-    - refs/heads/darc-*
-    - refs/heads/backport-pr-*
-    - refs/heads/lego/*
-    - refs/heads/locfiles/*
-    - refs/heads/copilot/*
-    - refs/heads/dependabot/*
-    - refs/heads/merge/*
-
 pr:
   autoCancel: true
   branches:

--- a/tools/devops/automation/run-post-pr-build-tests.yml
+++ b/tools/devops/automation/run-post-pr-build-tests.yml
@@ -1,19 +1,29 @@
-# YAML pipeline for post build operations. 
-# This pipeline will execute the tests for the CI on PR as soon as the workloads have been complited.
+# YAML pipeline for post build operations.
+# This pipeline will build the workloads and then execute the tests for the CI on a PR.
 
 trigger: none
-pr: none
 
-# we cannot use a template in a pipeline context
-resources:
-  pipelines:
-    - pipeline: macios
-      source: \Xamarin\Mac-iOS\pr pipelines\xamarin-macios-pr
-      trigger:
-        stages:
-          - build_packages
+pr:
+  autoCancel: true
+  branches:
+    include:
+      - '*'  # yes, you do need the quote, * has meaning in yamls
+  paths:
+    exclude:
+      - .github
+      - docs
+      - CODEOWNERS
+      - ISSUE_TEMPLATE.md
+      - LICENSE
+      - NOTICE.txt
+      - SECURITY.MD
+      - README.md
+      - src/README.md
+      - tools/mtouch/README.md
+      - msbuild/Xamarin.Localization.MSBuild/README.md
 
 extends:
   template: templates/pipelines/run-tests-pipeline.yml
   parameters:
     isPR: true
+    buildPackages: true

--- a/tools/devops/automation/run-pr-api-diff.yml
+++ b/tools/devops/automation/run-pr-api-diff.yml
@@ -1,15 +1,25 @@
 # Pipeline that will calculate the api diff on a pr commit.
 
 trigger: none
-pr: none
 
-resources:
-  pipelines:
-    - pipeline: macios
-      source: \Xamarin\Mac-iOS\pr pipelines\xamarin-macios-pr
-      trigger:
-        stages:
-          - configure_build
+pr:
+  autoCancel: true
+  branches:
+    include:
+      - '*'  # yes, you do need the quote, * has meaning in yamls
+  paths:
+    exclude:
+      - .github
+      - docs
+      - CODEOWNERS
+      - ISSUE_TEMPLATE.md
+      - LICENSE
+      - NOTICE.txt
+      - SECURITY.MD
+      - README.md
+      - src/README.md
+      - tools/mtouch/README.md
+      - msbuild/Xamarin.Localization.MSBuild/README.md
 
 extends:
   template: templates/pipelines/api-diff-pipeline.yml

--- a/tools/devops/automation/scripts/GitHub.Tests.ps1
+++ b/tools/devops/automation/scripts/GitHub.Tests.ps1
@@ -257,7 +257,16 @@ Describe 'IsCurrentCommitLatestInPR' {
                     "head" = @{
                         "sha" = "different123hash"
                     }
+                    "base" = @{
+                        "ref" = "main"
+                    }
                 }
+            } -ModuleName 'GitHub'
+            Mock Test-GitIsAncestor {
+                return $false
+            } -ModuleName 'GitHub'
+            Mock Get-GitCommitParents {
+                return @("basebranch123")
             } -ModuleName 'GitHub'
 
             $result = Get-IsCurrentCommitLatestInPR -Org "testorg" -Repo "testrepo" -Token "test-token" -Hash "abc123def456" -PrIDs @("123")
@@ -276,5 +285,87 @@ Describe 'IsCurrentCommitLatestInPR' {
             $result = Get-IsCurrentCommitLatestInPR -Org "testorg" -Repo "testrepo" -Token "test-token" -Hash "abc123def456" -PrIDs @() # Empty array means not in PR
             $result | Should -Be $true
         }
+
+        It 'returns true when the current commit is a synthetic merge commit for the latest PR head' {
+            Mock Invoke-Request {
+                return @{
+                    "head" = @{
+                        "sha" = "abc123def456"
+                    }
+                    "base" = @{
+                        "ref" = "main"
+                    }
+                }
+            } -ModuleName 'GitHub'
+            Mock Test-GitIsAncestor {
+                return $false
+            } -ModuleName 'GitHub'
+            Mock Get-GitCommitParents {
+                return @("basebranch123", "abc123def456")
+            } -ModuleName 'GitHub'
+
+            $result = Get-IsCurrentCommitLatestInPR -Org "testorg" -Repo "testrepo" -Token "test-token" -Hash "merge123456" -PrIDs @("123")
+            $result | Should -Be $true
+        }
+
+        It 'returns false when commit is in the base branch despite having the PR head as a parent' {
+            Mock Invoke-Request {
+                return @{
+                    "head" = @{
+                        "sha" = "prhead123"
+                    }
+                    "base" = @{
+                        "ref" = "main"
+                    }
+                }
+            } -ModuleName 'GitHub'
+            Mock Test-GitIsAncestor {
+                param ($Commit, $Branch)
+                # The commit is in the base branch
+                return $Branch -eq "origin/main"
+            } -ModuleName 'GitHub'
+            Mock Get-GitCommitParents {
+                return @("prhead123", "someothercommit")
+            } -ModuleName 'GitHub'
+
+            $result = Get-IsCurrentCommitLatestInPR -Org "testorg" -Repo "testrepo" -Token "test-token" -Hash "mergecommit456" -PrIDs @("123")
+            $result | Should -Be $false
+        }
+
+        It 'returns false when commit is in the PR branch despite having the PR head as a parent' {
+            Mock Invoke-Request {
+                return @{
+                    "head" = @{
+                        "sha" = "prhead123"
+                    }
+                    "base" = @{
+                        "ref" = "main"
+                    }
+                }
+            } -ModuleName 'GitHub'
+            Mock Test-GitIsAncestor {
+                param ($Commit, $Branch)
+                # The commit is in the PR branch (ancestor of PR head)
+                return $Branch -eq "prhead123"
+            } -ModuleName 'GitHub'
+            Mock Get-GitCommitParents {
+                return @("prhead123", "someothercommit")
+            } -ModuleName 'GitHub'
+
+            $result = Get-IsCurrentCommitLatestInPR -Org "testorg" -Repo "testrepo" -Token "test-token" -Hash "mergecommit456" -PrIDs @("123")
+            $result | Should -Be $false
+        }
+    }
+}
+
+Describe 'IsPR' {
+    It 'returns true for manual builds that use a PR merge ref' {
+        Set-Item -Path "Env:BUILD_REASON" -Value "Manual"
+        Set-Item -Path "Env:BUILD_SOURCEBRANCH" -Value "refs/pull/123/merge"
+
+        $githubComments = New-GitHubCommentsObject -Org "testorg" -Repo "testrepo" -Token "test-token"
+
+        $githubComments.IsPR() | Should -Be $true
+        $githubComments.PRIds | Should -Contain "123"
     }
 }

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -41,6 +41,45 @@ function Invoke-Request {
     } while ($true)
 }
 
+function Get-GitCommitParents {
+    param (
+        [ValidateNotNullOrEmpty ()]
+        [string]
+        $Commit
+    )
+
+    $output = & git rev-list --parents -n 1 -- $Commit 2>$null
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($output)) {
+        throw [System.InvalidOperationException]::new("Failed to get parent commits for '$Commit'.")
+    }
+
+    $commits = $output.Trim() -split '\s+'
+    if ($commits.Length -le 1) {
+        return @()
+    }
+
+    return @($commits[1..($commits.Length - 1)])
+}
+
+function Test-GitIsAncestor {
+    param (
+        [ValidateNotNullOrEmpty ()]
+        [string]
+        $Commit,
+
+        [ValidateNotNullOrEmpty ()]
+        [string]
+        $Branch
+    )
+
+    & git merge-base --is-ancestor -- $Commit $Branch 2>$null
+    switch ($LASTEXITCODE) {
+        0 { return $true }
+        1 { return $false }
+        default { throw [System.InvalidOperationException]::new("Failed to determine whether '$Commit' is an ancestor of '$Branch'.") }
+    }
+}
+
 class GitHubStatus {
     [ValidateNotNullOrEmpty ()] [string] $Status
     [ValidateNotNullOrEmpty ()] [string] $Description
@@ -228,6 +267,8 @@ class GitHubComments {
     [ValidateNotNullOrEmpty ()][string] $Token
     [string] $Hash
     [string[]] $PRIds
+    [bool] $CurrentCommitIsLatestInPR
+    [bool] $CurrentCommitIsLatestInPRCalculated
     hidden static [string] $GitHubGraphQLEndpoint = "https://api.github.com/graphql"
 
     GitHubComments (
@@ -240,6 +281,8 @@ class GitHubComments {
         $this.Token = $githubToken
         $this.Hash = $null
         $this.PRIds = [string[]]@()
+        $this.CurrentCommitIsLatestInPR = $false
+        $this.CurrentCommitIsLatestInPRCalculated = $false
     }
 
     GitHubComments (
@@ -253,6 +296,8 @@ class GitHubComments {
         $this.Token = $githubToken
         $this.Hash = $hash
         $this.PRIds = Get-GitHubPRsForHash -Org $githubOrg -Repo $githubRepo -Token $githubToken -Hash $hash
+        $this.CurrentCommitIsLatestInPR = $false
+        $this.CurrentCommitIsLatestInPRCalculated = $false
     }
 
     [bool] IsPR() {
@@ -268,13 +313,12 @@ class GitHubComments {
                 return $true;
             }
 
-            if (($Env:BUILD_REASON -eq "ResourceTrigger")) {
-                $sourceBranch = $Env:BUILD_SOURCEBRANCH
-                if ($sourceBranch.StartsWith("refs/pull/") -and $sourceBranch.EndsWith("/merge")) {
-                    # Set the PRs parsing the source branch
-                    $this.PRIds = @($sourceBranch.Replace("refs/pull/", "").Replace("/merge", ""))
-                    return $true
-                }
+            $sourceBranch = $Env:BUILD_SOURCEBRANCH
+            if ($sourceBranch -and $sourceBranch.StartsWith("refs/pull/") -and $sourceBranch.EndsWith("/merge")) {
+                # Some builds (such as pipeline-completion/manual follow-up jobs) still use PR merge refs
+                # even when BUILD_REASON is not "PullRequest".
+                $this.PRIds = @($sourceBranch.Replace("refs/pull/", "").Replace("/merge", ""))
+                return $true
             }
 
             return $false
@@ -725,13 +769,21 @@ mutation {
                Also returns true if not in a PR context or if hash comparison cannot be performed.
     #>
     [bool] IsCurrentCommitLatestInPR() {
+        if ($this.CurrentCommitIsLatestInPRCalculated) {
+            return $this.CurrentCommitIsLatestInPR
+        }
+
         # If we're not in a PR context, we can't determine this
         if (-not $this.IsPR()) {
+            $this.CurrentCommitIsLatestInPR = $true
+            $this.CurrentCommitIsLatestInPRCalculated = $true
             return $true
         }
 
         # If we don't have a hash to compare, assume it's latest
         if (-not $this.Hash) {
+            $this.CurrentCommitIsLatestInPR = $true
+            $this.CurrentCommitIsLatestInPRCalculated = $true
             return $true
         }
 
@@ -747,14 +799,65 @@ mutation {
             
             $prInfo = Invoke-Request -Request { Invoke-RestMethod -Uri $url -Headers $headers -Method "GET" -ContentType 'application/json' }
             $latestCommit = $prInfo.head.sha
-            
+
             Write-Host "Current commit: $($this.Hash)"
             Write-Host "Latest commit in PR #${prId}: $latestCommit"
-            
-            return $this.Hash -eq $latestCommit
+
+            $hashesToCompare = [System.Collections.Generic.List[string]]::new()
+            $hashesToCompare.Add($this.Hash)
+            if ($Env:SYSTEM_PULLREQUEST_SOURCECOMMITID) {
+                $hashesToCompare.Add($Env:SYSTEM_PULLREQUEST_SOURCECOMMITID)
+            }
+            if ($Env:BUILD_SOURCEVERSION) {
+                $hashesToCompare.Add($Env:BUILD_SOURCEVERSION)
+            }
+
+            foreach ($hash in ($hashesToCompare | Select-Object -Unique)) {
+                if ($hash -eq $latestCommit) {
+                    Write-Host "Detected latest PR commit via hash comparison: $hash"
+                    $this.CurrentCommitIsLatestInPR = $true
+                    $this.CurrentCommitIsLatestInPRCalculated = $true
+                    return $true
+                }
+            }
+
+            # PR validation builds typically use a synthetic merge commit. If that's the hash we were
+            # given, accept it when one of its local git parents is the current PR head commit.
+            # However, skip this check if the commit is already in the base or PR branch - a commit
+            # that's in either branch is not a synthetic merge commit, and checking its parents could
+            # produce a false positive (e.g. a merge from the base branch into the PR branch).
+            $baseBranch = $prInfo.base.ref
+            $isInKnownBranch = $false
+
+            if ($baseBranch -and (Test-GitIsAncestor -Commit $this.Hash -Branch "origin/$baseBranch")) {
+                Write-Host "Commit $($this.Hash) is in the base branch ($baseBranch), skipping synthetic merge check."
+                $isInKnownBranch = $true
+            }
+
+            if (-not $isInKnownBranch -and (Test-GitIsAncestor -Commit $this.Hash -Branch $latestCommit)) {
+                Write-Host "Commit $($this.Hash) is in the PR branch, skipping synthetic merge check."
+                $isInKnownBranch = $true
+            }
+
+            if (-not $isInKnownBranch) {
+                foreach ($parent in (Get-GitCommitParents -Commit $this.Hash)) {
+                    if ($parent -eq $latestCommit) {
+                        Write-Host "Detected latest PR commit via merge parent: $parent"
+                        $this.CurrentCommitIsLatestInPR = $true
+                        $this.CurrentCommitIsLatestInPRCalculated = $true
+                        return $true
+                    }
+                }
+            }
+
+            $this.CurrentCommitIsLatestInPR = $false
+            $this.CurrentCommitIsLatestInPRCalculated = $true
+            return $false
         } catch {
             Write-Host "Error checking if current commit is latest in PR: $_"
             # On error, assume it's the latest to avoid hiding valid comments
+            $this.CurrentCommitIsLatestInPR = $true
+            $this.CurrentCommitIsLatestInPRCalculated = $true
             return $true
         }
     }

--- a/tools/devops/automation/templates/common/checkout.yml
+++ b/tools/devops/automation/templates/common/checkout.yml
@@ -55,7 +55,7 @@ steps:
   workingDirectory: $(System.DefaultWorkingDirectory)/$(BUILD_REPOSITORY_TITLE)/tools/devops/automation/scripts
   timeoutInMinutes: 15
   env:
-    IS_PR: and(eq(parameters.isPR, 'true'), not(startsWith(variables['Build.SourceBranch'], 'refs/pull')))
+    IS_PR: ${{ parameters.isPR }}
 
 - checkout: yaml-templates
   clean: true

--- a/tools/devops/automation/templates/common/configure.yml
+++ b/tools/devops/automation/templates/common/configure.yml
@@ -232,7 +232,19 @@ steps:
     $testMatrix = $testMatrix | ConvertFrom-Json | ConvertTo-Json -Compress
     # update the config file so that we do not recalculate the matrix in other pipelines
     Edit-BuildConfiguration -ConfigKey TEST_MATRIX -ConfigValue $testMatrix -ConfigFile $Env:CONFIG_PATH
-    #CONFIG_PATH
+    Write-Host "##vso[task.setvariable variable=TEST_MATRIX;isOutput=true]$testMatrix"
+
+    # also compute the simulator test matrix and set it as output variable so that
+    # dependent stages in post-build test pipelines can consume it
+    $simulatorTestMatrix = Get-TestConfiguration `
+      -TestConfigurations "$Env:TEST_CONFIGURATIONS" `
+      -SupportedPlatforms "$Env:SUPPORTED_PLATFORMS" `
+      -EnabledPlatforms "$Env:CONFIGURE_PLATFORMS_DOTNET_PLATFORMS" `
+      -TestsLabels "${{ parameters.testsLabels }}" `
+      -StatusContext "${{ parameters.statusContext }}" `
+      -StageFilter "simulator_tests"
+    $simulatorTestMatrix = $simulatorTestMatrix | ConvertFrom-Json | ConvertTo-Json -Compress
+    Write-Host "##vso[task.setvariable variable=SIMULATOR_TEST_MATRIX;isOutput=true]$simulatorTestMatrix"
   name: test_matrix
   displayName: 'Create tests strategy matrix'
   env:

--- a/tools/devops/automation/templates/mac/build.yml
+++ b/tools/devops/automation/templates/mac/build.yml
@@ -219,6 +219,7 @@ steps:
     sourcePath: '$(BUILD_REPOSITORY_TITLE)/jenkins-results'
     detailedLog: true
     usePat: true
+  timeoutInMinutes: 30
   continueOnError: true
   condition: succeededOrFailed()
 

--- a/tools/devops/automation/templates/pipelines/run-tests-pipeline.yml
+++ b/tools/devops/automation/templates/pipelines/run-tests-pipeline.yml
@@ -31,6 +31,11 @@ parameters:
     type: boolean
     default: true
 
+  - name: buildPackages
+    displayName: Build packages as part of this pipeline (instead of downloading from a pipeline resource)
+    type: boolean
+    default: false
+
 resources:
   repositories:
     - repository: self
@@ -56,3 +61,4 @@ stages:
       provisionatorChannel: ${{ parameters.provisionatorChannel }}
       runTests: ${{ parameters.runTests }}
       runWindowsIntegration: ${{ parameters.runWindowsIntegration }}
+      buildPackages: ${{ parameters.buildPackages }}

--- a/tools/devops/automation/templates/tests-stage.yml
+++ b/tools/devops/automation/templates/tests-stage.yml
@@ -121,6 +121,10 @@ parameters:
   type: string
   default: ''
 
+- name: buildPackages
+  type: boolean
+  default: false
+
 stages:
 
 - template: ./build/linux-build-verification.yml
@@ -148,13 +152,69 @@ stages:
       BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
 
     steps:
-    - template: common/load_configuration.yml
-      parameters: 
-        repositoryAlias: ${{ parameters.repositoryAlias }}
-        commit: ${{ parameters.commit }}
-        statusContext: 'VSTS: simulator tests' 
-        uploadArtifacts: true
-        use1ES: false
+    - ${{ if eq(parameters.buildPackages, true) }}:
+      # When building packages in this pipeline, generate configuration from scratch
+      - template: common/configure.yml
+        parameters:
+          repositoryAlias: ${{ parameters.repositoryAlias }}
+          commit: ${{ parameters.commit }}
+          statusContext: 'VSTS: simulator tests'
+          uploadArtifacts: true
+          use1ES: false
+          isPR: ${{ parameters.isPR }}
+    - ${{ else }}:
+      # When using pre-built packages from a pipeline resource, load existing configuration
+      - template: common/load_configuration.yml
+        parameters: 
+          repositoryAlias: ${{ parameters.repositoryAlias }}
+          commit: ${{ parameters.commit }}
+          statusContext: 'VSTS: simulator tests' 
+          uploadArtifacts: true
+          use1ES: false
+
+# When buildPackages is true, build packages as part of this pipeline
+- ${{ if eq(parameters.buildPackages, true) }}:
+  - stage: build_packages
+    displayName: '${{ parameters.stageDisplayNamePrefix }}Build'
+    dependsOn: [configure_build]
+    jobs:
+    - job: build
+      displayName: 'Build packages'
+      timeoutInMinutes: 1000
+      variables:
+        DOTNET_PLATFORMS: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.DOTNET_PLATFORMS'] ]
+        INCLUDE_DOTNET_IOS: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_DOTNET_IOS'] ]
+        INCLUDE_DOTNET_MACCATALYST: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_DOTNET_MACCATALYST'] ]
+        INCLUDE_DOTNET_MACOS: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_DOTNET_MACOS'] ]
+        INCLUDE_DOTNET_TVOS: $[ stageDependencies.configure_build.configure.outputs['configure_platforms.INCLUDE_DOTNET_TVOS'] ]
+        BuildPackage: $[ stageDependencies.configure_build.configure.outputs['labels.build_package'] ]
+        SkipPackages: $[ stageDependencies.configure_build.configure.outputs['labels.skip_packages'] ]
+        SkipNugets: $[ stageDependencies.configure_build.configure.outputs['labels.skip_nugets'] ]
+        SkipSigning: $[ stageDependencies.configure_build.configure.outputs['labels.skip_signing'] ]
+        SkipApiComparison: $[ stageDependencies.configure_build.configure.outputs['labels.skip_api_comparison'] ]
+        PR_ID: $[ stageDependencies.configure_build.configure.outputs['labels.pr_number'] ]
+        BRANCH_NAME: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
+        XHARNESS_LABELS: $[ stageDependencies.configure_build.configure.outputs['labels.xharness_labels'] ]
+        RUN_MAC_TESTS: $[ stageDependencies.configure_build.configure.outputs['decisions.RUN_MAC_TESTS'] ]
+      pool:
+        name: $(PRBuildPool)
+        demands:
+        - Agent.OS -equals Darwin
+        - Agent.OSVersion -gtVersion $(minimumMacOSVersion)
+        - macOS.Name -equals ${{ parameters.macOSName }}
+        - XcodeChannel -equals ${{ parameters.xcodeChannel }}
+      steps:
+      - template: build/build-pkgs.yml
+        parameters:
+          isPR: ${{ parameters.isPR }}
+          repositoryAlias: ${{ parameters.repositoryAlias }}
+          commit: ${{ parameters.commit }}
+          vsdropsPrefix: ${{ variables.vsdropsPrefix }}
+          keyringPass: $(pass--lab--mac--builder--keychain)
+          gitHubToken: $(Github.Token)
+          xqaCertPass: $(xqa--certificates--password)
+          use1ES: false
+          xcodeChannel: ${{ parameters.xcodeChannel }}
 
 # always run simulator tests
 - template: ./tests/stage.yml
@@ -173,7 +233,7 @@ stages:
     gitHubToken: $(Github.Token)
     xqaCertPass: $(xqa--certificates--password)
     condition: ${{ parameters.runTests }}
-    postPipeline: true
+    postPipeline: ${{ not(parameters.buildPackages) }}
 
 - template: ./tests/publish-results.yml
   parameters:
@@ -185,7 +245,7 @@ stages:
     isPR: ${{ parameters.isPR }}
     repositoryAlias: ${{ parameters.repositoryAlias }}
     commit: ${{ parameters.commit }}
-    postPipeline: true
+    postPipeline: ${{ not(parameters.buildPackages) }}
     macTestsConfigurations: ${{ parameters.macTestsConfigurations }}
 
 - ${{ if eq(parameters.runWindowsIntegration, true) }}:
@@ -200,11 +260,14 @@ stages:
       statusContext: 'Windows Integration Tests'
       gitHubToken: $(Github.Token)
       xqaCertPass: $(xqa--certificates--password)
-      postPipeline: true
+      postPipeline: ${{ not(parameters.buildPackages) }}
 
 - stage: build_macos_tests
   displayName: '${{ parameters.stageDisplayNamePrefix }}Build macOS tests'
-  dependsOn: [configure_build]
+  dependsOn:
+  - configure_build
+  - ${{ if eq(parameters.buildPackages, true) }}:
+    - build_packages
   condition: and(succeeded(), ne(dependencies.configure_build.outputs['configure.configure_platforms.DOTNET_PLATFORMS'], ''))
   jobs:
   - template: ./build/build-mac-tests-stage.yml
@@ -234,5 +297,5 @@ stages:
       keyringPass: $(pass--lab--mac--builder--keychain)
       demands: ${{ config.demands }}
       xqaCertPass: $(xqa--certificates--password)
-      postPipeline: true
+      postPipeline: ${{ not(parameters.buildPackages) }}
       label: ${{ config.label }}

--- a/tools/devops/automation/templates/tests/run-tests.yml
+++ b/tools/devops/automation/templates/tests/run-tests.yml
@@ -191,6 +191,7 @@ steps:
     sourcePath: '$(BUILD_REPOSITORY_TITLE)/jenkins-results'
     detailedLog: true
     usePat: true
+  timeoutInMinutes: 30
   continueOnError: true
   condition: succeededOrFailed()
 

--- a/tools/devops/automation/templates/windows/build.yml
+++ b/tools/devops/automation/templates/windows/build.yml
@@ -353,6 +353,7 @@ steps:
     sourcePath: '$(BUILD_REPOSITORY_TITLE)/jenkins-results'
     detailedLog: true
     usePat: true
+  timeoutInMinutes: 30
   continueOnError: true
   condition: succeededOrFailed()
 

--- a/tools/devops/automation/templates/windows/stage.yml
+++ b/tools/devops/automation/templates/windows/stage.yml
@@ -47,6 +47,8 @@ stages:
   displayName: ${{ parameters.displayName }}
   dependsOn:
   - configure_build
+  - ${{ if not(parameters.postPipeline) }}:
+    - build_packages
   condition: and(succeeded(), eq(dependencies.configure_build.outputs['configure.decisions.RUN_WINDOWS_TESTS'], 'true'))
 
   jobs:


### PR DESCRIPTION
* [devops] Make the tests pipeline use a pr: trigger. (#25239)
* [devops] Make the API diff pipeline use a pr: trigger. (#25284)
* [devops] Fix PR latest-commit detection (#25231)
* [devops] Add a timeout to the 'Publish to Artifact Services Drop' step. (#25210)
* [devops] Disable implicit CI triggers on xamarin-macios-pr pipeline (#25211)
* [devops] Remove the branch-based trigger for pull requests. (#25182)