### PR TITLE
[src] Add [Un]SupportedSimulator attributes.

### DIFF
--- a/src/MLCompute/MLHelpers.cs
+++ b/src/MLCompute/MLHelpers.cs
@@ -10,6 +10,8 @@ namespace MLCompute {
 	public static class MLCActivationTypeExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
+		[UnsupportedSimulator ("ios")]
+		[UnsupportedSimulator ("tvos")]
 		static extern /* NSString */ IntPtr MLCActivationTypeDebugDescription (MLCActivationType activationType);
 
 		public static string? GetDebugDescription (this MLCActivationType self)
@@ -25,6 +27,8 @@ namespace MLCompute {
 	public static class MLCArithmeticOperationExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
+		[UnsupportedSimulator ("ios")]
+		[UnsupportedSimulator ("tvos")]
 		static extern /* NSString */ IntPtr MLCArithmeticOperationDebugDescription (MLCArithmeticOperation operation);
 
 		public static string? GetDebugDescription (this MLCArithmeticOperation self)
@@ -40,6 +44,8 @@ namespace MLCompute {
 	public static class MLCPaddingPolicyExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
+		[UnsupportedSimulator ("ios")]
+		[UnsupportedSimulator ("tvos")]
 		static extern /* NSString */ IntPtr MLCPaddingPolicyDebugDescription (MLCPaddingPolicy paddingPolicy);
 
 		public static string? GetDebugDescription (this MLCPaddingPolicy self)
@@ -55,6 +61,8 @@ namespace MLCompute {
 	public static class MLCLossTypeExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
+		[UnsupportedSimulator ("ios")]
+		[UnsupportedSimulator ("tvos")]
 		static extern /* NSString */ IntPtr MLCLossTypeDebugDescription (MLCLossType lossType);
 
 		public static string? GetDebugDescription (this MLCLossType self)
@@ -70,6 +78,8 @@ namespace MLCompute {
 	public static class MLCReductionTypeExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
+		[UnsupportedSimulator ("ios")]
+		[UnsupportedSimulator ("tvos")]
 		static extern /* NSString */ IntPtr MLCReductionTypeDebugDescription (MLCReductionType reductionType);
 
 		public static string? GetDebugDescription (this MLCReductionType self)
@@ -85,6 +95,8 @@ namespace MLCompute {
 	public static class MLCPaddingTypeExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
+		[UnsupportedSimulator ("ios")]
+		[UnsupportedSimulator ("tvos")]
 		static extern /* NSString */ IntPtr MLCPaddingTypeDebugDescription (MLCPaddingType paddingType);
 
 		public static string? GetDebugDescription (this MLCPaddingType self)
@@ -100,6 +112,8 @@ namespace MLCompute {
 	public static class MLCConvolutionTypeExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
+		[UnsupportedSimulator ("ios")]
+		[UnsupportedSimulator ("tvos")]
 		static extern /* NSString */ IntPtr MLCConvolutionTypeDebugDescription (MLCConvolutionType convolutionType);
 
 		public static string? GetDebugDescription (this MLCConvolutionType self)
@@ -115,6 +129,8 @@ namespace MLCompute {
 	public static class MLCPoolingTypeExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
+		[UnsupportedSimulator ("ios")]
+		[UnsupportedSimulator ("tvos")]
 		static extern /* NSString */ IntPtr MLCPoolingTypeDebugDescription (MLCPoolingType poolingType);
 
 		public static string? GetDebugDescription (this MLCPoolingType self)
@@ -130,6 +146,8 @@ namespace MLCompute {
 	public static class MLCSoftmaxOperationExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
+		[UnsupportedSimulator ("ios")]
+		[UnsupportedSimulator ("tvos")]
 		static extern /* NSString */ IntPtr MLCSoftmaxOperationDebugDescription (MLCSoftmaxOperation operation);
 
 		public static string? GetDebugDescription (this MLCSoftmaxOperation self)
@@ -145,6 +163,8 @@ namespace MLCompute {
 	public static class MLCSampleModeExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
+		[UnsupportedSimulator ("ios")]
+		[UnsupportedSimulator ("tvos")]
 		static extern /* NSString */ IntPtr MLCSampleModeDebugDescription (MLCSampleMode mode);
 
 		public static string? GetDebugDescription (this MLCSampleMode self)
@@ -160,6 +180,8 @@ namespace MLCompute {
 	public static class MLCLstmResultModeExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
+		[UnsupportedSimulator ("ios")]
+		[UnsupportedSimulator ("tvos")]
 		static extern /* NSString */ IntPtr MLCLSTMResultModeDebugDescription (MLCLstmResultMode mode);
 
 		public static string? GetDebugDescription (this MLCLstmResultMode self)
@@ -175,6 +197,8 @@ namespace MLCompute {
 	public static class MLCComparisonOperationExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
+		[UnsupportedSimulator ("ios")]
+		[UnsupportedSimulator ("tvos")]
 		static extern /* NSString */ IntPtr MLCComparisonOperationDebugDescription (MLCComparisonOperation operation);
 
 		public static string? GetDebugDescription (this MLCComparisonOperation self)
@@ -190,6 +214,8 @@ namespace MLCompute {
 	public static class MLCGradientClippingTypeExtensions {
 
 		[DllImport (Constants.MLComputeLibrary)]
+		[UnsupportedSimulator ("ios")]
+		[UnsupportedSimulator ("tvos")]
 		static extern /* NSString */ IntPtr MLCGradientClippingTypeDebugDescription (MLCGradientClippingType gradientClippingType);
 
 		public static string? GetDebugDescription (this MLCGradientClippingType self)

--- a/src/Metal/MTLEnums.cs
+++ b/src/Metal/MTLEnums.cs
@@ -2358,6 +2358,8 @@ namespace Metal {
 	[Mac (13, 0), iOS (16, 0), MacCatalyst (16, 0), TV (16, 0)]
 	[Native]
 	[ErrorDomain ("MTLIOErrorDomain")]
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	public enum MTLIOError : long {
 		UrlInvalid = 1,
 		Internal = 2,
@@ -2466,6 +2468,8 @@ namespace Metal {
 	[Mac (26, 0), iOS (26, 0), MacCatalyst (26, 0), TV (26, 0)]
 	[Native]
 	[ErrorDomain ("MTL4CommandQueueErrorDomain")]
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	public enum MTL4CommandQueueError : long {
 		None = 0,
 		Timeout = 1,
@@ -2599,6 +2603,8 @@ namespace Metal {
 	[Mac (26, 0), iOS (26, 0), MacCatalyst (26, 0), TV (26, 0)]
 	[Native]
 	[ErrorDomain ("MTLTensorDomain")]
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	public enum MTLTensorError : long {
 		None = 0,
 		InternalError = 1,

--- a/src/Metal/MTLIOCompression.cs
+++ b/src/Metal/MTLIOCompression.cs
@@ -15,6 +15,8 @@ namespace Metal {
 		MTLIOCompressionContext (NativeHandle handle, bool owns) : base (handle, owns) { }
 
 		[DllImport (Constants.MetalLibrary)]
+		[UnsupportedSimulator ("ios")]
+		[UnsupportedSimulator ("tvos")]
 		static extern unsafe void MTLIOCompressionContextAppendData (IntPtr context, void* data, nuint size);
 
 		unsafe void AppendData (void* data, nuint size)
@@ -47,6 +49,8 @@ namespace Metal {
 		}
 
 		[DllImport (Constants.MetalLibrary)]
+		[UnsupportedSimulator ("ios")]
+		[UnsupportedSimulator ("tvos")]
 		// [return: NullAllowed]
 		static extern IntPtr MTLIOCreateCompressionContext (IntPtr path, long type, long chunkSize);
 
@@ -74,6 +78,8 @@ namespace Metal {
 		}
 
 		[DllImport (Constants.MetalLibrary)]
+		[UnsupportedSimulator ("ios")]
+		[UnsupportedSimulator ("tvos")]
 		static extern long MTLIOFlushAndDestroyCompressionContext (IntPtr context);
 
 		public MTLIOCompressionStatus FlushAndDestroy ()
@@ -86,6 +92,8 @@ namespace Metal {
 		}
 
 		[DllImport (Constants.MetalLibrary)]
+		[UnsupportedSimulator ("ios")]
+		[UnsupportedSimulator ("tvos")]
 		static extern nint MTLIOCompressionContextDefaultChunkSize ();
 
 		public static nint DefaultChunkSize => MTLIOCompressionContextDefaultChunkSize ();

--- a/src/ObjCRuntime/SupportedSimulatorAttribute.cs
+++ b/src/ObjCRuntime/SupportedSimulatorAttribute.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+namespace ObjCRuntime {
+	/// <summary>Indicates that an API is supported for a specified platform. If a version is specified, the API is available starting in the specified OS version. Multiple attributes can be applied to indicate support on multiple operating systems.</summary>
+	/// <remarks>
+	///   <para>Contrary to standard availability attributes (such as <see cref="SupportedOSPlatformAttribute" /> attributes), the presence of this attribute for some platforms does not imply any meaning for other platforms.</para>
+	///   <para>If there are no <see cref="SupportedSimulatorAttribute" /> or <see cref="UnsupportedSimulatorAttribute" /> attributes on an API, the API is assumed to be available in the simulator.</para>
+	///   <para>This attribute will be trimmed away if the app is trimmed.</para>
+	/// </remarks>
+	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Enum | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor | AttributeTargets.Field, AllowMultiple = true)]
+	public sealed class SupportedSimulatorAttribute : Attribute {
+		/// <summary>Initializes a new <see cref="SupportedSimulatorAttribute" /> attribute.</summary>
+		/// <param name="platformName">The platform where this API is supported in the simulator. Optionally specifies a platform version.</param>
+		public SupportedSimulatorAttribute (string platformName)
+		{
+			PlatformName = platformName;
+		}
+
+		/// <summary>The name of the platform.</summary>
+		public string PlatformName { get; set; }
+	}
+
+	/// <summary>Indicates that an API is not supported in the simulator for the specified platform. Multiple attributes can be applied to indicate lack of support on multiple platforms.</summary>
+	/// <remarks>
+	///   <para>Contrary to standard availability attributes (such as <see cref="SupportedOSPlatformAttribute" /> attributes), the presence of this attribute for some platforms does not imply any meaning for other platforms.</para>
+	///   <para>If there are no <see cref="SupportedSimulatorAttribute" /> or <see cref="UnsupportedSimulatorAttribute" /> attributes on an API, the API is assumed to be available in the simulator.</para>
+	///   <para>This attribute will be trimmed away if the app is trimmed.</para>
+	/// </remarks>
+	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Enum | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor | AttributeTargets.Field, AllowMultiple = true)]
+	public sealed class UnsupportedSimulatorAttribute : Attribute {
+		/// <summary>Initializes a new <see cref="UnsupportedSimulatorAttribute" /> attribute.</summary>
+		/// <param name="platformName">The platform where this API is not supported in the simulator.</param>
+		public UnsupportedSimulatorAttribute (string platformName)
+		{
+			PlatformName = platformName;
+		}
+
+		/// <summary>The name of the platform.</summary>
+		public string PlatformName { get; set; }
+	}
+}

--- a/src/ObjCRuntime/SupportedSimulatorAttribute.cs
+++ b/src/ObjCRuntime/SupportedSimulatorAttribute.cs
@@ -13,14 +13,15 @@ namespace ObjCRuntime {
 	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Enum | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Constructor | AttributeTargets.Field, AllowMultiple = true)]
 	public sealed class SupportedSimulatorAttribute : Attribute {
 		/// <summary>Initializes a new <see cref="SupportedSimulatorAttribute" /> attribute.</summary>
-		/// <param name="platformName">The platform where this API is supported in the simulator. Optionally specifies a platform version.</param>
+		/// <param name="platformName">The platform where this API is supported in the simulator.
+		/// Format: platform name (e.g., "ios", "tvos") optionally followed by a version number (e.g., "ios17.0").</param>
 		public SupportedSimulatorAttribute (string platformName)
 		{
 			PlatformName = platformName;
 		}
 
 		/// <summary>The name of the platform.</summary>
-		public string PlatformName { get; set; }
+		public string PlatformName { get; init; }
 	}
 
 	/// <summary>Indicates that an API is not supported in the simulator for the specified platform. Multiple attributes can be applied to indicate lack of support on multiple platforms.</summary>
@@ -39,6 +40,6 @@ namespace ObjCRuntime {
 		}
 
 		/// <summary>The name of the platform.</summary>
-		public string PlatformName { get; set; }
+		public string PlatformName { get; init; }
 	}
 }

--- a/src/TrimAttributes.LinkDescription.xml
+++ b/src/TrimAttributes.LinkDescription.xml
@@ -290,6 +290,18 @@
       </attribute>
     </type>
   </assembly>
+
+  <!-- Attributes that are allowed to be in any assembly -->
+  <assembly fullname="*">
+    <!-- Simulator availability attributes: these are documented to be trimmed away, so just do it unconditionally. -->
+    <type fullname="ObjCRuntime.SupportedSimulatorAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="ObjCRuntime.UnsupportedSimulatorAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+  </assembly>
+
   <!-- Suppress the IL2026 warning from System.StartupHookProvider.ProcessStartupHooks when we're the ones enabling StartupHookSupport -->
   <assembly fullname="System.Private.CoreLib" feature="ObjCRuntime.SuppressStartupHookTrimWarning" featurevalue="true">
     <type fullname="System.StartupHookProvider">

--- a/src/bgen/AttributeManager.cs
+++ b/src/bgen/AttributeManager.cs
@@ -142,6 +142,10 @@ public class AttributeManager {
 			return typeof (ObjCRuntime.RequiresSuperAttribute);
 		case "ObjCRuntime.ObjectiveCFrameworkAttribute":
 			return typeof (ObjCRuntime.ObjectiveCFrameworkAttribute);
+		case "ObjCRuntime.SupportedSimulatorAttribute":
+			return typeof (ObjCRuntime.SupportedSimulatorAttribute);
+		case "ObjCRuntime.UnsupportedSimulatorAttribute":
+			return typeof (ObjCRuntime.UnsupportedSimulatorAttribute);
 		case "UnavailableAttribute":
 			return typeof (UnavailableAttribute);
 		case "OptionalImplementationAttribute":

--- a/src/bgen/Enums.cs
+++ b/src/bgen/Enums.cs
@@ -200,6 +200,7 @@ public partial class Generator {
 				}
 			}
 			// the *Extensions has the same version requirement as the enum itself
+			PrintSimulatorAvailabilityAttributes (type);
 			PrintPlatformAttributes (type);
 			PrintExperimentalAttribute (type);
 			print_generated_code ();

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -5589,19 +5589,25 @@ public partial class Generator : IMemberGatherer {
 
 	public void PrintSimulatorAvailabilityAttributes (ICustomAttributeProvider? provider)
 	{
-		switch (CurrentPlatform) {
-		case PlatformName.MacCatalyst:
-		case PlatformName.MacOSX:
+		if (!IsSimulatorAvailabilityRelevantPlatform ())
 			return;
-		case PlatformName.iOS:
-		case PlatformName.TvOS:
-			break;
-		default:
-			throw new BindingException (1047, CurrentPlatform);
-		}
 
 		PrintSupportedSimulatorAttribute (provider);
 		PrintUnsupportedSimulatorAttribute (provider);
+	}
+
+	bool IsSimulatorAvailabilityRelevantPlatform ()
+	{
+		switch (CurrentPlatform) {
+		case PlatformName.MacCatalyst:
+		case PlatformName.MacOSX:
+			return false;
+		case PlatformName.iOS:
+		case PlatformName.TvOS:
+			return true;
+		default:
+			throw new BindingException (1047, CurrentPlatform);
+		}
 	}
 
 	void PrintSupportedSimulatorAttribute (ICustomAttributeProvider? provider)
@@ -5613,9 +5619,6 @@ public partial class Generator : IMemberGatherer {
 		// Only print the attribute for the current platform, we don't care about other platforms.
 		foreach (var attrib in attribs) {
 			switch (CurrentPlatform) {
-			case PlatformName.MacCatalyst:
-			case PlatformName.MacOSX:
-				break;
 			case PlatformName.iOS:
 				if (!attrib.PlatformName.StartsWith ("ios", StringComparison.OrdinalIgnoreCase))
 					continue;
@@ -5640,9 +5643,6 @@ public partial class Generator : IMemberGatherer {
 		// Only print the attribute for the current platform, we don't care about other platforms.
 		foreach (var attrib in attribs) {
 			switch (CurrentPlatform) {
-			case PlatformName.MacCatalyst:
-			case PlatformName.MacOSX:
-				break;
 			case PlatformName.iOS:
 				if (!attrib.PlatformName.StartsWith ("ios", StringComparison.OrdinalIgnoreCase))
 					continue;

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -5547,7 +5547,7 @@ public partial class Generator : IMemberGatherer {
 	// Not adding the experimental attribute is bad (it would mean that an API
 	// we meant to be experimental ended up being released as stable), so it's
 	// opt-out instead of opt-in.
-	public void PrintAttributes (ICustomAttributeProvider? mi, bool platform = false, bool preserve = false, bool advice = false, bool notImplemented = false, bool bindAs = false, bool requiresSuper = false, Type? inlinedType = null, bool experimental = true, bool obsolete = false, bool objectiveCFramework = false)
+	public void PrintAttributes (ICustomAttributeProvider? mi, bool platform = false, bool preserve = false, bool advice = false, bool notImplemented = false, bool bindAs = false, bool requiresSuper = false, Type? inlinedType = null, bool experimental = true, bool obsolete = false, bool objectiveCFramework = false, bool simulatorAvailability = true)
 	{
 		if (platform)
 			PrintPlatformAttributes (mi as MemberInfo, inlinedType);
@@ -5567,6 +5567,8 @@ public partial class Generator : IMemberGatherer {
 			PrintObsoleteAttributes (mi);
 		if (objectiveCFramework)
 			PrintObjectiveCFrameworkAttribute (mi);
+		if (simulatorAvailability)
+			PrintSimulatorAvailabilityAttributes (mi);
 	}
 
 	public void PrintExperimentalAttribute (ICustomAttributeProvider? mi)
@@ -5583,6 +5585,77 @@ public partial class Generator : IMemberGatherer {
 		if (attrib is null)
 			return;
 		print ($"[ObjectiveCFramework (\"{attrib.Framework}\")]");
+	}
+
+	public void PrintSimulatorAvailabilityAttributes (ICustomAttributeProvider? provider)
+	{
+		switch (CurrentPlatform) {
+		case PlatformName.MacCatalyst:
+		case PlatformName.MacOSX:
+			return;
+		case PlatformName.iOS:
+		case PlatformName.TvOS:
+			break;
+		default:
+			throw new BindingException (1047, CurrentPlatform);
+		}
+
+		PrintSupportedSimulatorAttribute (provider);
+		PrintUnsupportedSimulatorAttribute (provider);
+	}
+
+	void PrintSupportedSimulatorAttribute (ICustomAttributeProvider? provider)
+	{
+		var attribs = AttributeManager.GetCustomAttributes<SupportedSimulatorAttribute> (provider);
+		if (attribs?.Any () != true)
+			return;
+
+		// Only print the attribute for the current platform, we don't care about other platforms.
+		foreach (var attrib in attribs) {
+			switch (CurrentPlatform) {
+			case PlatformName.MacCatalyst:
+			case PlatformName.MacOSX:
+				break;
+			case PlatformName.iOS:
+				if (!attrib.PlatformName.StartsWith ("ios", StringComparison.OrdinalIgnoreCase))
+					continue;
+				break;
+			case PlatformName.TvOS:
+				if (!attrib.PlatformName.StartsWith ("tvos", StringComparison.OrdinalIgnoreCase))
+					continue;
+				break;
+			default:
+				throw new BindingException (1047, CurrentPlatform);
+			}
+			print ($"[SupportedSimulator (\"{attrib.PlatformName}\")]");
+		}
+	}
+
+	void PrintUnsupportedSimulatorAttribute (ICustomAttributeProvider? provider)
+	{
+		var attribs = AttributeManager.GetCustomAttributes<UnsupportedSimulatorAttribute> (provider);
+		if (attribs?.Any () != true)
+			return;
+
+		// Only print the attribute for the current platform, we don't care about other platforms.
+		foreach (var attrib in attribs) {
+			switch (CurrentPlatform) {
+			case PlatformName.MacCatalyst:
+			case PlatformName.MacOSX:
+				break;
+			case PlatformName.iOS:
+				if (!attrib.PlatformName.StartsWith ("ios", StringComparison.OrdinalIgnoreCase))
+					continue;
+				break;
+			case PlatformName.TvOS:
+				if (!attrib.PlatformName.StartsWith ("tvos", StringComparison.OrdinalIgnoreCase))
+					continue;
+				break;
+			default:
+				throw new BindingException (1047, CurrentPlatform);
+			}
+			print ($"[UnsupportedSimulator (\"{attrib.PlatformName}\")]");
+		}
 	}
 
 	bool WriteDocumentation (MemberInfo info, Func<XmlNode, XmlNode>? transformNode = null)

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -5589,7 +5589,7 @@ public partial class Generator : IMemberGatherer {
 
 	public void PrintSimulatorAvailabilityAttributes (ICustomAttributeProvider? provider)
 	{
-		if (!TryGetSimulatorAvailabilityPlatformName (out var platforName))
+		if (!TryGetSimulatorAvailabilityPlatformName (out var platformName))
 			return;
 
 		PrintSupportedSimulatorAttribute (provider, platformName);
@@ -5605,10 +5605,10 @@ public partial class Generator : IMemberGatherer {
 		case PlatformName.MacOSX:
 			return false;
 		case PlatformName.iOS:
-			platforName = "ios";
+			platformName = "ios";
 			return true;
 		case PlatformName.TvOS:
-			platforName = "tvos";
+			platformName = "tvos";
 			return true;
 		default:
 			throw new BindingException (1047, CurrentPlatform);

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -5589,28 +5589,33 @@ public partial class Generator : IMemberGatherer {
 
 	public void PrintSimulatorAvailabilityAttributes (ICustomAttributeProvider? provider)
 	{
-		if (!IsSimulatorAvailabilityRelevantPlatform ())
+		if (!TryGetSimulatorAvailabilityPlatformName (out var platforName))
 			return;
 
-		PrintSupportedSimulatorAttribute (provider);
-		PrintUnsupportedSimulatorAttribute (provider);
+		PrintSupportedSimulatorAttribute (provider, platformName);
+		PrintUnsupportedSimulatorAttribute (provider, platformName);
 	}
 
-	bool IsSimulatorAvailabilityRelevantPlatform ()
+	bool TryGetSimulatorAvailabilityPlatformName ([NotNullWhen (true)] out string? platformName)
 	{
+		platformName = null;
+
 		switch (CurrentPlatform) {
 		case PlatformName.MacCatalyst:
 		case PlatformName.MacOSX:
 			return false;
 		case PlatformName.iOS:
+			platforName = "ios";
+			return true;
 		case PlatformName.TvOS:
+			platforName = "tvos";
 			return true;
 		default:
 			throw new BindingException (1047, CurrentPlatform);
 		}
 	}
 
-	void PrintSupportedSimulatorAttribute (ICustomAttributeProvider? provider)
+	void PrintSupportedSimulatorAttribute (ICustomAttributeProvider? provider, string platformName)
 	{
 		var attribs = AttributeManager.GetCustomAttributes<SupportedSimulatorAttribute> (provider);
 		if (attribs?.Any () != true)
@@ -5618,23 +5623,13 @@ public partial class Generator : IMemberGatherer {
 
 		// Only print the attribute for the current platform, we don't care about other platforms.
 		foreach (var attrib in attribs) {
-			switch (CurrentPlatform) {
-			case PlatformName.iOS:
-				if (!attrib.PlatformName.StartsWith ("ios", StringComparison.OrdinalIgnoreCase))
-					continue;
-				break;
-			case PlatformName.TvOS:
-				if (!attrib.PlatformName.StartsWith ("tvos", StringComparison.OrdinalIgnoreCase))
-					continue;
-				break;
-			default:
-				throw new BindingException (1047, CurrentPlatform);
-			}
+			if (!attrib.PlatformName.StartsWith (platformName, StringComparison.OrdinalIgnoreCase))
+				continue;
 			print ($"[SupportedSimulator (\"{attrib.PlatformName}\")]");
 		}
 	}
 
-	void PrintUnsupportedSimulatorAttribute (ICustomAttributeProvider? provider)
+	void PrintUnsupportedSimulatorAttribute (ICustomAttributeProvider? provider, string platformName)
 	{
 		var attribs = AttributeManager.GetCustomAttributes<UnsupportedSimulatorAttribute> (provider);
 		if (attribs?.Any () != true)
@@ -5642,18 +5637,8 @@ public partial class Generator : IMemberGatherer {
 
 		// Only print the attribute for the current platform, we don't care about other platforms.
 		foreach (var attrib in attribs) {
-			switch (CurrentPlatform) {
-			case PlatformName.iOS:
-				if (!attrib.PlatformName.StartsWith ("ios", StringComparison.OrdinalIgnoreCase))
-					continue;
-				break;
-			case PlatformName.TvOS:
-				if (!attrib.PlatformName.StartsWith ("tvos", StringComparison.OrdinalIgnoreCase))
-					continue;
-				break;
-			default:
-				throw new BindingException (1047, CurrentPlatform);
-			}
+			if (!attrib.PlatformName.StartsWith (platformName, StringComparison.OrdinalIgnoreCase))
+				continue;
 			print ($"[UnsupportedSimulator (\"{attrib.PlatformName}\")]");
 		}
 	}

--- a/src/bgen/bgen.csproj
+++ b/src/bgen/bgen.csproj
@@ -59,6 +59,7 @@
     <Compile Include="$(RepositoryPath)\src\ObjCRuntime\NativeAttribute.cs" />
     <Compile Include="$(RepositoryPath)\src\ObjCRuntime\NativeNameAttribute.cs" />
     <Compile Include="$(RepositoryPath)\src\ObjCRuntime\ObjectiveCFrameworkAttribute.cs" />
+    <Compile Include="$(RepositoryPath)\src\ObjCRuntime\SupportedSimulatorAttribute.cs" />
     <Compile Include="$(RepositoryPath)\src\ObjCRuntime\Registrar.core.cs" />
     <Compile Include="$(RepositoryPath)\src\ObjCRuntime\RequiresSuperAttribute.cs" />
     <Compile Include="$(RepositoryPath)\tools\common\Execution.cs">

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -1912,6 +1912,7 @@ SHARED_CORE_SOURCES = \
 	ObjCRuntime/Registrar.core.cs \
 	ObjCRuntime/RequiresSuperAttribute.cs \
 	ObjCRuntime/Selector.cs \
+	ObjCRuntime/SupportedSimulatorAttribute.cs \
 	ObjCRuntime/SystemVersion.cs \
 	ObjCRuntime/ThrowHelper.cs \
 	Simd/MathHelper.cs \

--- a/src/metal.cs
+++ b/src/metal.cs
@@ -5926,6 +5926,8 @@ namespace Metal {
 		MTLResourceId GpuResourceID { get; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[iOS (13, 0), TV (13, 0)]
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
@@ -7804,6 +7806,8 @@ namespace Metal {
 
 	interface IMTL4Archive { }
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[Protocol (BackwardsCompatibleCodeGeneration = false)]
 	interface MTL4Archive {
@@ -7843,6 +7847,9 @@ namespace Metal {
 	}
 
 	interface IMTL4ArgumentTable { }
+
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[Protocol (BackwardsCompatibleCodeGeneration = false)]
 	interface MTL4ArgumentTable {
@@ -7877,6 +7884,8 @@ namespace Metal {
 
 	interface IMTL4BinaryFunction { }
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[Protocol (BackwardsCompatibleCodeGeneration = false)]
 	interface MTL4BinaryFunction {
@@ -7891,6 +7900,8 @@ namespace Metal {
 
 	interface IMTL4CommandAllocator { }
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[Protocol (BackwardsCompatibleCodeGeneration = false)]
 	interface MTL4CommandAllocator {
@@ -7913,6 +7924,8 @@ namespace Metal {
 
 	interface IMTL4CommandBuffer { }
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[Protocol (BackwardsCompatibleCodeGeneration = false)]
 	interface MTL4CommandBuffer {
@@ -7983,6 +7996,8 @@ namespace Metal {
 
 	interface IMTL4CommandEncoder { }
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[Protocol (BackwardsCompatibleCodeGeneration = false)]
 	interface MTL4CommandEncoder {
@@ -8033,6 +8048,8 @@ namespace Metal {
 
 	interface IMTL4CommandQueue { }
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[Protocol (BackwardsCompatibleCodeGeneration = false)]
 	interface MTL4CommandQueue {
@@ -8103,6 +8120,8 @@ namespace Metal {
 
 	interface IMTL4CommitFeedback { }
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[Protocol (BackwardsCompatibleCodeGeneration = false)]
 	interface MTL4CommitFeedback {
@@ -8122,6 +8141,8 @@ namespace Metal {
 
 	interface IMTL4CompilerTask { }
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[Protocol (BackwardsCompatibleCodeGeneration = false)]
 	interface MTL4CompilerTask {
@@ -8149,6 +8170,8 @@ namespace Metal {
 
 	interface IMTL4Compiler { }
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[Protocol (BackwardsCompatibleCodeGeneration = false)]
 	interface MTL4Compiler {
@@ -8277,6 +8300,8 @@ namespace Metal {
 
 	interface IMTL4ComputeCommandEncoder { }
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[Protocol (BackwardsCompatibleCodeGeneration = false)]
 	interface MTL4ComputeCommandEncoder : MTL4CommandEncoder {
@@ -8427,6 +8452,8 @@ namespace Metal {
 
 	interface IMTL4CounterHeap { }
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[Protocol (BackwardsCompatibleCodeGeneration = false)]
 	interface MTL4CounterHeap {
@@ -8454,6 +8481,8 @@ namespace Metal {
 
 	interface IMTL4MachineLearningCommandEncoder { }
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[Protocol (BackwardsCompatibleCodeGeneration = false)]
 	interface MTL4MachineLearningCommandEncoder : MTL4CommandEncoder {
@@ -8472,6 +8501,8 @@ namespace Metal {
 
 	interface IMTL4MachineLearningPipelineState { }
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[Protocol (BackwardsCompatibleCodeGeneration = false)]
 	interface MTL4MachineLearningPipelineState : MTLAllocation {
@@ -8494,6 +8525,8 @@ namespace Metal {
 
 	interface IMTL4PipelineDataSetSerializer { }
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[Protocol (BackwardsCompatibleCodeGeneration = false)]
 	interface MTL4PipelineDataSetSerializer {
@@ -8509,6 +8542,8 @@ namespace Metal {
 
 	interface IMTL4RenderCommandEncoder { }
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[Protocol (BackwardsCompatibleCodeGeneration = false)]
 	interface MTL4RenderCommandEncoder : MTL4CommandEncoder {
@@ -8782,6 +8817,8 @@ namespace Metal {
 		MTLResourceId SetTextureViewFromBuffer (IMTLBuffer buffer, MTLTextureDescriptor descriptor, nuint offset, nuint bytesPerRow, nuint index);
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (MTL4AccelerationStructureGeometryDescriptor))]
 	interface MTL4AccelerationStructureBoundingBoxGeometryDescriptor {
@@ -8795,6 +8832,8 @@ namespace Metal {
 		nuint BoundingBoxCount { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (MTL4AccelerationStructureGeometryDescriptor))]
 	interface MTL4AccelerationStructureCurveGeometryDescriptor {
@@ -8841,11 +8880,15 @@ namespace Metal {
 		MTLCurveEndCaps CurveEndCaps { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (MTLAccelerationStructureDescriptor))]
 	interface MTL4AccelerationStructureDescriptor {
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4AccelerationStructureGeometryDescriptor : NSCopying {
@@ -8871,6 +8914,8 @@ namespace Metal {
 		nuint PrimitiveDataElementSize { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (MTL4AccelerationStructureGeometryDescriptor))]
 	interface MTL4AccelerationStructureMotionBoundingBoxGeometryDescriptor {
@@ -8884,6 +8929,8 @@ namespace Metal {
 		nuint BoundingBoxCount { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (MTL4AccelerationStructureGeometryDescriptor))]
 	interface MTL4AccelerationStructureMotionCurveGeometryDescriptor {
@@ -8930,6 +8977,8 @@ namespace Metal {
 		MTLCurveEndCaps CurveEndCaps { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (MTL4AccelerationStructureGeometryDescriptor))]
 	interface MTL4AccelerationStructureMotionTriangleGeometryDescriptor {
@@ -8958,6 +9007,8 @@ namespace Metal {
 		MTLMatrixLayout TransformationMatrixLayout { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (MTL4AccelerationStructureGeometryDescriptor))]
 	interface MTL4AccelerationStructureTriangleGeometryDescriptor {
@@ -8986,6 +9037,8 @@ namespace Metal {
 		MTLMatrixLayout TransformationMatrixLayout { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4ArgumentTableDescriptor : NSCopying {
@@ -9008,6 +9061,8 @@ namespace Metal {
 		string Label { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4BinaryFunctionDescriptor : NSCopying {
@@ -9021,6 +9076,8 @@ namespace Metal {
 		MTL4BinaryFunctionOptions Options { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4CommandAllocatorDescriptor : NSCopying {
@@ -9028,6 +9085,8 @@ namespace Metal {
 		string Label { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4CommandBufferOptions : NSCopying {
@@ -9035,6 +9094,8 @@ namespace Metal {
 		IMTLLogState LogState { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4CommandQueueDescriptor : NSCopying {
@@ -9047,6 +9108,8 @@ namespace Metal {
 
 	delegate void MTL4CommitFeedbackHandler (IMTL4CommitFeedback commitFeedback);
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4CommitOptions {
@@ -9054,6 +9117,8 @@ namespace Metal {
 		void AddFeedbackHandler (MTL4CommitFeedbackHandler block);
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4CompilerDescriptor : NSCopying {
@@ -9064,6 +9129,8 @@ namespace Metal {
 		IMTL4PipelineDataSetSerializer PipelineDataSetSerializer { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4CompilerTaskOptions : NSCopying {
@@ -9071,6 +9138,8 @@ namespace Metal {
 		IMTL4Archive [] LookupArchives { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (MTL4PipelineDescriptor))]
 	interface MTL4ComputePipelineDescriptor {
@@ -9099,6 +9168,8 @@ namespace Metal {
 		void Reset ();
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4CounterHeapDescriptor : NSCopying {
@@ -9109,11 +9180,15 @@ namespace Metal {
 		nuint Count { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4FunctionDescriptor : NSCopying {
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (MTL4AccelerationStructureDescriptor))]
 	interface MTL4IndirectInstanceAccelerationStructureDescriptor {
@@ -9151,6 +9226,8 @@ namespace Metal {
 		nuint MotionTransformStride { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (MTL4AccelerationStructureDescriptor))]
 	interface MTL4InstanceAccelerationStructureDescriptor {
@@ -9182,6 +9259,8 @@ namespace Metal {
 		nuint MotionTransformStride { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4LibraryDescriptor : NSCopying {
@@ -9195,6 +9274,8 @@ namespace Metal {
 		string Name { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (MTL4FunctionDescriptor))]
 	interface MTL4LibraryFunctionDescriptor {
@@ -9205,6 +9286,8 @@ namespace Metal {
 		IMTLLibrary Library { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (MTL4PipelineDescriptor))]
 	interface MTL4MachineLearningPipelineDescriptor {
@@ -9228,6 +9311,8 @@ namespace Metal {
 		void Reset ();
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4MachineLearningPipelineReflection {
@@ -9235,6 +9320,8 @@ namespace Metal {
 		IMTLBinding [] Bindings { get; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (MTL4PipelineDescriptor))]
 	interface MTL4MeshRenderPipelineDescriptor {
@@ -9317,6 +9404,8 @@ namespace Metal {
 		void Reset ();
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4PipelineDataSetSerializerDescriptor : NSCopying {
@@ -9324,6 +9413,8 @@ namespace Metal {
 		MTL4PipelineDataSetSerializerConfiguration Configuration { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4PipelineDescriptor : NSCopying {
@@ -9335,6 +9426,8 @@ namespace Metal {
 		MTL4PipelineOptions Options { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4PipelineOptions : NSCopying {
@@ -9345,6 +9438,8 @@ namespace Metal {
 		MTL4ShaderReflection ShaderReflection { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4PipelineStageDynamicLinkingDescriptor : NSCopying {
@@ -9358,6 +9453,8 @@ namespace Metal {
 		IMTLDynamicLibrary [] PreloadedLibraries { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (MTL4AccelerationStructureDescriptor))]
 	interface MTL4PrimitiveAccelerationStructureDescriptor {
@@ -9380,6 +9477,8 @@ namespace Metal {
 		nuint MotionKeyframeCount { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4RenderPassDescriptor : NSCopying {
@@ -9435,6 +9534,8 @@ namespace Metal {
 		bool SupportColorAttachmentMapping { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4RenderPipelineBinaryFunctionsDescriptor : NSCopying {
@@ -9457,6 +9558,8 @@ namespace Metal {
 		void Reset ();
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4RenderPipelineColorAttachmentDescriptor : NSCopying {
@@ -9491,6 +9594,8 @@ namespace Metal {
 		void Reset ();
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4RenderPipelineColorAttachmentDescriptorArray : NSCopying {
@@ -9504,6 +9609,8 @@ namespace Metal {
 		void Reset ();
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (MTL4PipelineDescriptor))]
 	interface MTL4RenderPipelineDescriptor {
@@ -9559,6 +9666,8 @@ namespace Metal {
 		void Reset ();
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4RenderPipelineDynamicLinkingDescriptor : NSCopying {
@@ -9578,6 +9687,8 @@ namespace Metal {
 		MTL4PipelineStageDynamicLinkingDescriptor MeshLinkingDescriptor { get; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (MTL4FunctionDescriptor))]
 	interface MTL4SpecializedFunctionDescriptor {
@@ -9591,6 +9702,8 @@ namespace Metal {
 		MTLFunctionConstantValues ConstantValues { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTL4StaticLinkingDescriptor : NSCopying {
@@ -9604,6 +9717,8 @@ namespace Metal {
 		NSDictionary<NSString, NSArray<MTL4FunctionDescriptor>> Groups { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (MTL4FunctionDescriptor))]
 	interface MTL4StitchedFunctionDescriptor {
@@ -9614,6 +9729,8 @@ namespace Metal {
 		MTL4FunctionDescriptor [] FunctionDescriptors { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (MTL4PipelineDescriptor))]
 	interface MTL4TileRenderPipelineDescriptor {
@@ -9656,6 +9773,8 @@ namespace Metal {
 		string UserAnnotation { get; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTLLogicalToPhysicalColorAttachmentMap : NSCopying {
@@ -9669,6 +9788,8 @@ namespace Metal {
 		void Reset ();
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTLResourceViewPoolDescriptor : NSCopying {
@@ -9679,6 +9800,8 @@ namespace Metal {
 		string Label { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTLTensorDescriptor : NSCopying {
@@ -9708,6 +9831,8 @@ namespace Metal {
 		MTLHazardTrackingMode HazardTrackingMode { get; set; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // all properties are readonly, and has a non-default ctor
@@ -9723,6 +9848,8 @@ namespace Metal {
 		nint GetExtent (nuint dimensionIndex);
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (MTLType))]
 	interface MTLTensorReferenceType {
@@ -9739,6 +9866,8 @@ namespace Metal {
 		MTLBindingAccess Access { get; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), TV (26, 0), MacCatalyst (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTLTextureViewDescriptor : NSCopying {

--- a/src/metalfx.cs
+++ b/src/metalfx.cs
@@ -165,6 +165,8 @@ namespace MetalFX {
 		bool SupportsMetal4FX (IMTLDevice device);
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), MacCatalyst (26, 0), TV (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTLFXFrameInterpolatorDescriptor : NSCopying {
@@ -405,6 +407,8 @@ namespace MetalFX {
 		void Encode (IMTL4CommandBuffer commandBuffer);
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[Mac (26, 0), iOS (26, 0), MacCatalyst (26, 0), TV (26, 0)]
 	[BaseType (typeof (NSObject))]
 	interface MTLFXTemporalDenoisedScalerDescriptor : NSCopying {

--- a/src/videotoolbox.cs
+++ b/src/videotoolbox.cs
@@ -3127,6 +3127,8 @@ namespace VideoToolbox {
 		VTFrameProcessorOpticalFlow DestinationOpticalFlow { get; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[TV (26, 0), MacCatalyst (26, 0), Mac (26, 0), iOS (26, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3275,6 +3277,8 @@ namespace VideoToolbox {
 		VTSuperResolutionScalerParametersSubmissionMode SubmissionMode { get; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[MacCatalyst (26, 0), NoTV, Mac (26, 0), iOS (26, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]

--- a/src/videotoolbox.cs
+++ b/src/videotoolbox.cs
@@ -2906,6 +2906,8 @@ namespace VideoToolbox {
 		SequentialReferencesUnchanged = 3,
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[MacCatalyst (18, 4), NoTV, iOS (26, 0), Mac (15, 4)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -2946,6 +2948,8 @@ namespace VideoToolbox {
 		bool Supported { [Bind ("isSupported")] get; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[MacCatalyst (18, 4), NoTV, iOS (26, 0), Mac (15, 4)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -2987,6 +2991,8 @@ namespace VideoToolbox {
 		Sequential = 2,
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[MacCatalyst (26, 0), NoTV, iOS (26, 0), Mac (15, 4)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3027,6 +3033,8 @@ namespace VideoToolbox {
 		bool Supported { [Bind ("isSupported")] get; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[MacCatalyst (26, 0), NoTV, iOS (26, 0), Mac (15, 4)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3073,6 +3081,8 @@ namespace VideoToolbox {
 		Sequential = 2,
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[MacCatalyst (26, 0), NoTV, iOS (26, 0), Mac (15, 4)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3110,6 +3120,8 @@ namespace VideoToolbox {
 		bool Supported { [Bind ("isSupported")] get; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[MacCatalyst (26, 0), NoTV, iOS (26, 0), Mac (15, 4)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3158,6 +3170,8 @@ namespace VideoToolbox {
 		bool Supported { [Bind ("isSupported")] get; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[TV (26, 0), MacCatalyst (26, 0), Mac (26, 0), iOS (26, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3173,6 +3187,8 @@ namespace VideoToolbox {
 		NSNumber [] InterpolationPhase { get; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[TV (26, 0), MacCatalyst (26, 0), Mac (26, 0), iOS (26, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3199,6 +3215,8 @@ namespace VideoToolbox {
 		NSNumber [] GetSupportedScaleFactors (nint frameWidth, nint frameHeight);
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[NoTV, MacCatalyst (26, 0), Mac (26, 0), iOS (26, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3257,6 +3275,8 @@ namespace VideoToolbox {
 
 	delegate void VTSuperResolutionScalerConfigurationDownloadConfigurationModelCallback ([NullAllowed] NSError error);
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[MacCatalyst (26, 0), NoTV, Mac (26, 0), iOS (26, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3302,6 +3322,8 @@ namespace VideoToolbox {
 		bool Supported { [Bind ("isSupported")] get; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[MacCatalyst (26, 0), NoTV, Mac (26, 0), iOS (26, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
@@ -3349,6 +3371,8 @@ namespace VideoToolbox {
 		NSString Label { get; }
 	}
 
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
 	[TV (26, 0), MacCatalyst (26, 0), Mac (26, 0), iOS (26, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]

--- a/tests/bgen/BGenTests.cs
+++ b/tests/bgen/BGenTests.cs
@@ -1657,5 +1657,72 @@ namespace GeneratorTests {
 			var bgen = BuildFile (profile, "both-protected-and-internal.cs");
 			bgen.AssertNoWarnings ();
 		}
+
+		[Test]
+		[TestCase (Profile.iOS)]
+		[TestCase (Profile.tvOS)]
+		public void SimulatorAvailabilityAttributes (Profile profile)
+		{
+			Configuration.IgnoreIfIgnoredPlatform (profile.AsPlatform ());
+			var bgen = BuildFile (profile, "simulator-availability-attributes.cs");
+			bgen.AssertNoWarnings ();
+
+			var module = bgen.ApiAssembly.MainModule;
+
+			// Verify [UnsupportedSimulator] is copied for the current platform
+			var unsupportedAll = module.GetType ("NS", "UnsupportedOnAllSimulators");
+			var unsupportedAttrs = unsupportedAll.CustomAttributes
+				.Where (a => a.AttributeType.Name == "UnsupportedSimulatorAttribute")
+				.ToArray ();
+			Assert.That (unsupportedAttrs.Length, Is.EqualTo (1), "UnsupportedOnAllSimulators: one attribute for current platform");
+			var platformName = (string) unsupportedAttrs [0].ConstructorArguments [0].Value;
+			var expectedPlatform = profile == Profile.iOS ? "ios" : "tvos";
+			Assert.That (platformName, Is.EqualTo (expectedPlatform), "UnsupportedOnAllSimulators platform name");
+
+			// Verify only the current platform's attribute is emitted
+			var iosOnly = module.GetType ("NS", "UnsupportedOnIosSimulatorOnly");
+			var iosOnlyAttrs = iosOnly.CustomAttributes
+				.Where (a => a.AttributeType.Name == "UnsupportedSimulatorAttribute")
+				.ToArray ();
+			if (profile == Profile.iOS)
+				Assert.That (iosOnlyAttrs.Length, Is.EqualTo (1), "UnsupportedOnIosSimulatorOnly: present for iOS");
+			else
+				Assert.That (iosOnlyAttrs.Length, Is.EqualTo (0), "UnsupportedOnIosSimulatorOnly: absent for tvOS");
+
+			// Verify [SupportedSimulator] with version is copied
+			var supported = module.GetType ("NS", "SupportedOnSimulatorFromVersion");
+			var supportedAttrs = supported.CustomAttributes
+				.Where (a => a.AttributeType.Name == "SupportedSimulatorAttribute")
+				.ToArray ();
+			Assert.That (supportedAttrs.Length, Is.EqualTo (1), "SupportedOnSimulatorFromVersion: one attribute");
+			var expectedVersion = profile == Profile.iOS ? "ios17.0" : "tvos17.0";
+			Assert.That ((string) supportedAttrs [0].ConstructorArguments [0].Value, Is.EqualTo (expectedVersion), "SupportedOnSimulatorFromVersion platform name");
+
+			// Verify no simulator attributes when none are specified
+			var noAttrs = module.GetType ("NS", "NoSimulatorAttributes");
+			var simulatorAttrs = noAttrs.CustomAttributes
+				.Where (a => a.AttributeType.Name == "UnsupportedSimulatorAttribute" || a.AttributeType.Name == "SupportedSimulatorAttribute")
+				.ToArray ();
+			Assert.That (simulatorAttrs.Length, Is.EqualTo (0), "NoSimulatorAttributes: no simulator attributes");
+		}
+
+		[Test]
+		[TestCase (Profile.macOSMobile)]
+		[TestCase (Profile.MacCatalyst)]
+		public void SimulatorAvailabilityAttributes_NotEmittedForMacPlatforms (Profile profile)
+		{
+			Configuration.IgnoreIfIgnoredPlatform (profile.AsPlatform ());
+			var bgen = BuildFile (profile, "simulator-availability-attributes.cs");
+			bgen.AssertNoWarnings ();
+
+			var module = bgen.ApiAssembly.MainModule;
+			foreach (var typeName in new [] { "UnsupportedOnAllSimulators", "UnsupportedOnIosSimulatorOnly", "SupportedOnSimulatorFromVersion", "NoSimulatorAttributes" }) {
+				var type = module.GetType ("NS", typeName);
+				var simulatorAttrs = type.CustomAttributes
+					.Where (a => a.AttributeType.Name == "UnsupportedSimulatorAttribute" || a.AttributeType.Name == "SupportedSimulatorAttribute")
+					.ToArray ();
+				Assert.That (simulatorAttrs.Length, Is.EqualTo (0), $"{typeName}: no simulator attributes on Mac platforms");
+			}
+		}
 	}
 }

--- a/tests/bgen/tests/simulator-availability-attributes.cs
+++ b/tests/bgen/tests/simulator-availability-attributes.cs
@@ -1,0 +1,30 @@
+using System;
+using Foundation;
+using ObjCRuntime;
+
+namespace NS {
+	[UnsupportedSimulator ("ios")]
+	[UnsupportedSimulator ("tvos")]
+	[iOS (16, 0), TV (16, 0), Mac (13, 0), MacCatalyst (16, 0)]
+	[BaseType (typeof (NSObject))]
+	interface UnsupportedOnAllSimulators {
+	}
+
+	[UnsupportedSimulator ("ios")]
+	[iOS (16, 0), TV (16, 0), Mac (13, 0), MacCatalyst (16, 0)]
+	[BaseType (typeof (NSObject))]
+	interface UnsupportedOnIosSimulatorOnly {
+	}
+
+	[SupportedSimulator ("ios17.0")]
+	[SupportedSimulator ("tvos17.0")]
+	[iOS (16, 0), TV (16, 0), Mac (13, 0), MacCatalyst (16, 0)]
+	[BaseType (typeof (NSObject))]
+	interface SupportedOnSimulatorFromVersion {
+	}
+
+	[iOS (16, 0), TV (16, 0), Mac (13, 0), MacCatalyst (16, 0)]
+	[BaseType (typeof (NSObject))]
+	interface NoSimulatorAttributes {
+	}
+}

--- a/tests/common/PlatformInfo.cs
+++ b/tests/common/PlatformInfo.cs
@@ -134,10 +134,12 @@ namespace Xamarin.Tests {
 
 			// There's a SupportedSimulator attribute for the current platform - check version
 			foreach (var attr in supportedAttrs) {
-				var versionString = attr.PlatformName.Substring (platformPrefix.Length);
-				if (string.IsNullOrEmpty (versionString))
+				var versionString = attr.PlatformName.AsSpan (platformPrefix.Length);
+				if (versionString.IsEmpty)
 					return true; // supported, no version constraint
-				if (Version.TryParse (versionString, out var version) && PlatformInfo.Host.Version >= version)
+				if (!Version.TryParse (versionString, out var version))
+					throw new InvalidOperationException ($"Invalid version string in SupportedSimulator attribute: '{attr.PlatformName}'");
+				if (PlatformInfo.Host.Version >= version)
 					return true;
 			}
 

--- a/tests/common/PlatformInfo.cs
+++ b/tests/common/PlatformInfo.cs
@@ -98,6 +98,52 @@ namespace Xamarin.Tests {
 			return attributeProvider.IsAvailable (PlatformInfo.Host);
 		}
 
+		public static bool IsAvailableInSimulator (this ICustomAttributeProvider attributeProvider)
+		{
+			if (!TestRuntime.IsSimulator)
+				return true;
+
+			var customAttributes = attributeProvider.GetCustomAttributes (true);
+
+			string platformPrefix;
+			switch (PlatformInfo.Host.Name) {
+			case ApplePlatform.iOS:
+				platformPrefix = "ios";
+				break;
+			case ApplePlatform.TVOS:
+				platformPrefix = "tvos";
+				break;
+			default:
+				return true;
+			}
+
+			// Check for [UnsupportedSimulator] attributes
+			foreach (var attr in customAttributes.OfType<ObjCRuntime.UnsupportedSimulatorAttribute> ()) {
+				if (attr.PlatformName.StartsWith (platformPrefix, StringComparison.OrdinalIgnoreCase))
+					return false;
+			}
+
+			// Check for [SupportedSimulator] attributes
+			var supportedAttrs = customAttributes.OfType<ObjCRuntime.SupportedSimulatorAttribute> ()
+				.Where (a => a.PlatformName.StartsWith (platformPrefix, StringComparison.OrdinalIgnoreCase))
+				.ToArray ();
+
+			// If no SupportedSimulator attributes for the current platform, assume available
+			if (supportedAttrs.Length == 0)
+				return true;
+
+			// There's a SupportedSimulator attribute for the current platform - check version
+			foreach (var attr in supportedAttrs) {
+				var versionString = attr.PlatformName.Substring (platformPrefix.Length);
+				if (string.IsNullOrEmpty (versionString))
+					return true; // supported, no version constraint
+				if (Version.TryParse (versionString, out var version) && PlatformInfo.Host.Version >= version)
+					return true;
+			}
+
+			return false;
+		}
+
 		[UnconditionalSuppressMessage ("Trimming", "IL2045", Justification = "Some of the attributes this method uses may have been linked away, so things might not work. It actually works though, so unless something changes, we're going to assume it's trimmer-compatible.")]
 		public static bool IsAvailable (this ICustomAttributeProvider attributeProvider, PlatformInfo targetPlatform)
 		{

--- a/tests/introspection/ApiBaseTest.cs
+++ b/tests/introspection/ApiBaseTest.cs
@@ -158,6 +158,7 @@ namespace Introspection {
 				return false;
 
 			return !member.IsAvailableOnHostPlatform () ||
+						  !member.IsAvailableInSimulator () ||
 						  SkipDueToAttribute (member.DeclaringType) ||
 						  SkipDueToAttributeInProperty (member);
 		}

--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -176,52 +176,7 @@ namespace Introspection {
 #endif
 			case "PhaseConeDirectivityModelParameters":
 				return !TestRuntime.IsSimulator; // fails on device
-			case "MTL4AccelerationStructureBoundingBoxGeometryDescriptor":
-			case "MTL4AccelerationStructureCurveGeometryDescriptor":
-			case "MTL4AccelerationStructureDescriptor":
-			case "MTL4AccelerationStructureGeometryDescriptor":
-			case "MTL4AccelerationStructureMotionBoundingBoxGeometryDescriptor":
-			case "MTL4AccelerationStructureMotionCurveGeometryDescriptor":
-			case "MTL4AccelerationStructureMotionTriangleGeometryDescriptor":
-			case "MTL4AccelerationStructureTriangleGeometryDescriptor":
-			case "MTL4ArgumentTableDescriptor":
-			case "MTL4BinaryFunctionDescriptor":
-			case "MTL4CommandAllocatorDescriptor":
-			case "MTL4CommandBufferOptions":
-			case "MTL4CommandQueueDescriptor":
-			case "MTL4CommitOptions":
-			case "MTL4CompilerDescriptor":
-			case "MTL4CompilerTaskOptions":
-			case "MTL4ComputePipelineDescriptor":
-			case "MTL4CounterHeapDescriptor":
-			case "MTL4FunctionDescriptor":
-			case "MTL4IndirectInstanceAccelerationStructureDescriptor":
-			case "MTL4InstanceAccelerationStructureDescriptor":
-			case "MTL4LibraryDescriptor":
-			case "MTL4LibraryFunctionDescriptor":
-			case "MTL4MachineLearningPipelineDescriptor":
-			case "MTL4MachineLearningPipelineReflection":
-			case "MTL4MeshRenderPipelineDescriptor":
-			case "MTL4PipelineDataSetSerializerDescriptor":
-			case "MTL4PipelineDescriptor":
-			case "MTL4PipelineOptions":
-			case "MTL4PipelineStageDynamicLinkingDescriptor":
-			case "MTL4PrimitiveAccelerationStructureDescriptor":
-			case "MTL4RenderPassDescriptor":
-			case "MTL4RenderPipelineBinaryFunctionsDescriptor":
-			case "MTL4RenderPipelineColorAttachmentDescriptor":
-			case "MTL4RenderPipelineColorAttachmentDescriptorArray":
-			case "MTL4RenderPipelineDescriptor":
-			case "MTL4RenderPipelineDynamicLinkingDescriptor":
-			case "MTL4SpecializedFunctionDescriptor":
-			case "MTL4StaticLinkingDescriptor":
-			case "MTL4StitchedFunctionDescriptor":
-			case "MTL4TileRenderPipelineDescriptor":
-			case "MTLLogicalToPhysicalColorAttachmentMap":
-			case "MTLResourceViewPoolDescriptor":
-			case "MTLTensorDescriptor":
 			case "MTLTensorReferenceType":
-			case "MTLTextureViewDescriptor":
 			case "MTLFXFrameInterpolatorDescriptor":
 			case "MTLFXTemporalDenoisedScalerDescriptor":
 				if (TestRuntime.IsSimulator)

--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -150,38 +150,12 @@ namespace Introspection {
 			case "ASAccountAuthenticationModificationController":
 				return true; // started failing in Xcode 16.3 beta 1 for unknown reasons (it works in an Xcode project).
 #if __TVOS__
-			case "MTLAccelerationStructureDescriptor":
-			case "MTLAccelerationStructureGeometryDescriptor":
-			case "MTLAccelerationStructureMotionBoundingBoxGeometryDescriptor":
-			case "MTLAccelerationStructureMotionTriangleGeometryDescriptor":
-			case "MTLAccelerationStructurePassDescriptor":
-			case "MTLAccelerationStructurePassSampleBufferAttachmentDescriptor":
-			case "MTLAccelerationStructurePassSampleBufferAttachmentDescriptorArray":
-			case "MTLAccelerationStructureTriangleGeometryDescriptor":
-			case "MTLMeshRenderPipelineDescriptor":
-			case "MTLMotionKeyframeData":
-			case "MTLRasterizationRateLayerArray":
-			case "MTLRasterizationRateMapDescriptor":
-			case "MTLRasterizationRateSampleArray":
-			case "MTLRenderPipelineFunctionsDescriptor":
-			case "MTLResourceStatePassSampleBufferAttachmentDescriptor":
-			case "MTLResourceStatePassSampleBufferAttachmentDescriptorArray":
-				// The initial tvOS 16.0 simulator doesn't have these classes, but the tvOS 16.1 simulator doess
-				if (TestRuntime.IsSimulator && !TestRuntime.CheckXcodeVersion (14, 1))
-					return true;
-				break;
 			case "CIPersonSegmentation": // removed in Xcode 26?
 			case "CISaliencyMapFilter": // removed in Xcode 26?
 				return TestRuntime.CheckXcodeVersion (26, 0);
 #endif
 			case "PhaseConeDirectivityModelParameters":
 				return !TestRuntime.IsSimulator; // fails on device
-			case "MTLTensorReferenceType":
-			case "MTLFXFrameInterpolatorDescriptor":
-			case "MTLFXTemporalDenoisedScalerDescriptor":
-				if (TestRuntime.IsSimulator)
-					return true;
-				break;
 			}
 
 			switch (type.Namespace) {

--- a/tests/introspection/ApiFieldTest.cs
+++ b/tests/introspection/ApiFieldTest.cs
@@ -75,14 +75,6 @@ namespace Introspection {
 				default:
 					return false;
 				}
-			case "CMSampleAttachmentKey": // kCMSampleAttachmentKey_HDR10PlusPerFrameData":
-				switch (property.Name) {
-				case "Hdr10PlusPerFrameDataKey":
-					if (TestRuntime.IsSimulator)
-						return !TestRuntime.CheckXcodeVersion (14, 1); // not available in the iOS 16.0 simulator, but it is in the iOS 16.1 simulator
-					break;
-				}
-				break;
 			}
 			return SkipDueToAttribute (property);
 		}

--- a/tests/introspection/ApiPInvokeTest.cs
+++ b/tests/introspection/ApiPInvokeTest.cs
@@ -170,7 +170,7 @@ namespace Introspection {
 
 				IntPtr lib = Dlfcn.dlopen (path, 0);
 				if (Dlfcn.GetIndirect (lib, name) == IntPtr.Zero && !failed_api.Contains (name)) {
-					ReportError ("Could not find the field '{0}' in {1}", name, path);
+					ReportError ("Could not find the symbol '{0}' in {1}", name, path);
 					failed_api.Add (name);
 				}
 				Dlfcn.dlclose (lib);

--- a/tests/introspection/ApiProtocolTest.cs
+++ b/tests/introspection/ApiProtocolTest.cs
@@ -38,10 +38,6 @@ namespace Introspection {
 				if (TestRuntime.IsSimulatorOrDesktop)
 					return true;
 				break;
-			case "SafetyKit":
-				if (TestRuntime.IsSimulator)
-					return !TestRuntime.CheckXcodeVersion (15, 0); // doesn't seem to be available in the iOS simulator until iOS 17+
-				break;
 			case "SensorKit": // SensorKit doesn't exist on iPads
 				if (TestRuntime.IsDevice && TestRuntime.IsiPad)
 					return true;
@@ -67,108 +63,12 @@ namespace Introspection {
 			// was removed by apple and is a compat class.
 			case "HMMatterRequestHandler":
 				return true;
-			case "CIFilterGenerator":
-				// only present on device :/
-				return TestRuntime.IsSimulatorOrDesktop;
 #if !XAMCORE_5_0
 			case "GKHybridStrategist":
 				// We removed the bindings for this type.
 				return true;
 #endif
-#if __TVOS__
-			case "MTLAccelerationStructureBoundingBoxGeometryDescriptor":
-			case "MTLAccelerationStructureDescriptor":
-			case "MTLAccelerationStructureGeometryDescriptor":
-			case "MTLAccelerationStructureMotionBoundingBoxGeometryDescriptor":
-			case "MTLAccelerationStructureMotionTriangleGeometryDescriptor":
-			case "MTLAccelerationStructurePassDescriptor":
-			case "MTLAccelerationStructurePassSampleBufferAttachmentDescriptor":
-			case "MTLAccelerationStructurePassSampleBufferAttachmentDescriptorArray":
-			case "MTLAccelerationStructureTriangleGeometryDescriptor":
-			case "MTLInstanceAccelerationStructureDescriptor":
-			case "MTLIntersectionFunctionDescriptor":
-			case "MTLIntersectionFunctionTableDescriptor":
-			case "MTLMeshRenderPipelineDescriptor":
-			case "MTLMotionKeyframeData":
-			case "MTLPrimitiveAccelerationStructureDescriptor":
-			case "MTLRasterizationRateLayerArray":
-			case "MTLRasterizationRateLayerDescriptor":
-			case "MTLRasterizationRateMapDescriptor":
-			case "MTLRasterizationRateSampleArray":
-			case "MTLRenderPipelineFunctionsDescriptor":
-			case "MTLResourceStatePassDescriptor":
-			case "MTLResourceStatePassSampleBufferAttachmentDescriptor":
-			case "MTLResourceStatePassSampleBufferAttachmentDescriptorArray":
-			case "MTLVisibleFunctionTableDescriptor":
-				// The initial tvOS 16.0 simulator doesn't have these classes, but the tvOS 16.1 simulator doess
-				if (TestRuntime.IsSimulator && !TestRuntime.CheckXcodeVersion (14, 1))
-					return true;
-				goto default;
-#endif
-			case "MTL4AccelerationStructureBoundingBoxGeometryDescriptor":
-			case "MTL4AccelerationStructureCurveGeometryDescriptor":
-			case "MTL4AccelerationStructureDescriptor":
-			case "MTL4AccelerationStructureGeometryDescriptor":
-			case "MTL4AccelerationStructureMotionBoundingBoxGeometryDescriptor":
-			case "MTL4AccelerationStructureMotionCurveGeometryDescriptor":
-			case "MTL4AccelerationStructureMotionTriangleGeometryDescriptor":
-			case "MTL4AccelerationStructureTriangleGeometryDescriptor":
-			case "MTL4ArgumentTableDescriptor":
-			case "MTL4BinaryFunctionDescriptor":
-			case "MTL4CommandAllocatorDescriptor":
-			case "MTL4CommandBufferOptions":
-			case "MTL4CommandQueueDescriptor":
-			case "MTL4CommitOptions":
-			case "MTL4CompilerDescriptor":
-			case "MTL4CompilerTaskOptions":
-			case "MTL4ComputePipelineDescriptor":
-			case "MTL4CounterHeapDescriptor":
-			case "MTL4FunctionDescriptor":
-			case "MTL4IndirectInstanceAccelerationStructureDescriptor":
-			case "MTL4InstanceAccelerationStructureDescriptor":
-			case "MTL4LibraryDescriptor":
-			case "MTL4LibraryFunctionDescriptor":
-			case "MTL4MachineLearningPipelineDescriptor":
-			case "MTL4MachineLearningPipelineReflection":
-			case "MTL4MeshRenderPipelineDescriptor":
-			case "MTL4PipelineDataSetSerializerDescriptor":
-			case "MTL4PipelineDescriptor":
-			case "MTL4PipelineOptions":
-			case "MTL4PipelineStageDynamicLinkingDescriptor":
-			case "MTL4PrimitiveAccelerationStructureDescriptor":
-			case "MTL4RenderPassDescriptor":
-			case "MTL4RenderPipelineBinaryFunctionsDescriptor":
-			case "MTL4RenderPipelineColorAttachmentDescriptor":
-			case "MTL4RenderPipelineColorAttachmentDescriptorArray":
-			case "MTL4RenderPipelineDescriptor":
-			case "MTL4RenderPipelineDynamicLinkingDescriptor":
-			case "MTL4SpecializedFunctionDescriptor":
-			case "MTL4StaticLinkingDescriptor":
-			case "MTL4StitchedFunctionDescriptor":
-			case "MTL4TileRenderPipelineDescriptor":
-			case "MTLLogicalToPhysicalColorAttachmentMap":
-			case "MTLResourceViewPoolDescriptor":
-			case "MTLTensorDescriptor":
-			case "MTLTensorExtents":
-			case "MTLTensorReferenceType":
-			case "MTLTextureViewDescriptor":
-			case "VTFrameRateConversionConfiguration":
-			case "VTFrameRateConversionParameters":
-			case "VTLowLatencyFrameInterpolationConfiguration":
-			case "VTLowLatencyFrameInterpolationParameters":
-			case "VTLowLatencySuperResolutionScalerConfiguration":
-			case "VTLowLatencySuperResolutionScalerParameters":
-			case "VTMotionBlurConfiguration":
-			case "VTMotionBlurParameters":
-			case "VTOpticalFlowConfiguration":
-			case "VTOpticalFlowParameters":
-			case "VTSuperResolutionScalerConfiguration":
-			case "VTSuperResolutionScalerParameters":
-			case "VTTemporalNoiseFilterConfiguration":
-			case "VTTemporalNoiseFilterParameters":
-				if (TestRuntime.IsSimulator)
-					return true;
-				goto default;
+
 			default:
 				return SkipDueToAttribute (type);
 			}
@@ -1016,7 +916,6 @@ namespace Introspection {
 					// check that +supportsSecureCoding returns YES
 					if (!supports) {
 #if __IOS__ && !__MACCATALYST__
-						// broken in xcode 12 beta 1 simulator (only)
 						if (TestRuntime.IsSimulator) {
 							switch (type.Name) {
 							case "ARFaceGeometry":
@@ -1100,21 +999,6 @@ namespace Introspection {
 					switch (t.Name) {
 					case "AVPlayerInterstitialEventMonitor": // deprecated
 						continue;
-#if !MONOMAC
-					case "MTLCaptureManager":
-					case "NEHotspotConfiguration":
-					case "NEHotspotConfigurationManager":
-					case "NEHotspotEapSettings":
-					case "NEHotspotHS20Settings":
-					case "SCNGeometryTessellator":
-					case "SKRenderer":
-						// was not possible in iOS 11.4 (current minimum) simulator
-						if (!TestRuntime.CheckXcodeVersion (12, 0)) {
-							if (TestRuntime.IsSimulatorOrDesktop)
-								continue;
-						}
-						break;
-#endif
 					default:
 						var e = $"[FAIL] Could not load {t.FullName}";
 						list.Add (e);

--- a/tests/introspection/ApiSelectorTest.cs
+++ b/tests/introspection/ApiSelectorTest.cs
@@ -46,10 +46,6 @@ namespace Introspection {
 			}
 
 			switch (type.Namespace) {
-			case "SafetyKit":
-				if (TestRuntime.IsSimulator)
-					return !TestRuntime.CheckXcodeVersion (15, 0); // doesn't seem to be available in the iOS simulator until iOS 17+
-				break;
 			case "SensorKit": // SensorKit doesn't exist on iPads
 				if (TestRuntime.IsDevice && TestRuntime.IsiPad)
 					return true;
@@ -210,9 +206,6 @@ namespace Introspection {
 				break;
 #if !MONOMAC
 			case "MTLCaptureManager":
-			case "NEHotspotEapSettings": // Wireless Accessory Configuration is not supported in the simulator.
-			case "NEHotspotConfigurationManager":
-			case "NEHotspotHS20Settings":
 				if (TestRuntime.IsSimulatorOrDesktop)
 					return true;
 				break;
@@ -1303,8 +1296,6 @@ namespace Introspection {
 				}
 				break;
 			}
-
-			// old binding mistake
 			return (selectorName == "initWithCoder:");
 		}
 

--- a/tests/introspection/ApiSimulatorAvailabilityTest.cs
+++ b/tests/introspection/ApiSimulatorAvailabilityTest.cs
@@ -1,0 +1,201 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//
+// Verify that [UnsupportedSimulator] / [SupportedSimulator] attributes
+// are consistent with actual symbol availability in the simulator.
+//
+
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xamarin.Tests;
+
+#nullable enable
+
+namespace Introspection {
+	[Preserve (AllMembers = true)]
+	public abstract class ApiSimulatorAvailabilityTest : ApiBaseTest {
+
+		protected ApiSimulatorAvailabilityTest ()
+		{
+			ContinueOnFailure = true;
+			LogProgress = false;
+		}
+
+		protected virtual bool Skip (Type type)
+		{
+			return false;
+		}
+
+		protected virtual bool SkipPInvoke (MethodInfo mi)
+		{
+			return false;
+		}
+
+		protected virtual bool SkipField (PropertyInfo pi)
+		{
+			return false;
+		}
+
+		protected virtual bool SkipLibrary (string? libraryName)
+		{
+			return false;
+		}
+
+		/// <summary>
+		/// Verifies that P/Invokes marked as unsupported in the simulator are indeed unavailable.
+		/// Also detects P/Invokes not marked as unsupported that are missing from the simulator.
+		/// </summary>
+		[Test]
+		public void PInvokeSimulatorAvailability ()
+		{
+			if (!TestRuntime.IsSimulator) {
+				Assert.Ignore ("This test only runs in the simulator.");
+				return;
+			}
+
+			var failed_api = new List<string> ();
+			Errors = 0;
+			int n = 0;
+
+			foreach (var type in Assembly.GetTypes ()) {
+				if (Skip (type))
+					continue;
+
+				if (!type.IsAvailableOnHostPlatform ())
+					continue;
+
+				foreach (var mi in type.GetMethods (BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)) {
+					var dllimport = mi.GetCustomAttribute<DllImportAttribute> ();
+					if (dllimport is null)
+						continue;
+
+					if (!mi.IsAvailableOnHostPlatform ())
+						continue;
+
+					if (MemberHasObsolete (mi))
+						continue;
+
+					if (SkipPInvoke (mi))
+						continue;
+
+					var libname = dllimport.Value;
+					switch (libname) {
+					case "__Internal":
+					case "System.Native":
+					case "System.Security.Cryptography.Native.Apple":
+					case "System.Net.Security.Native":
+						continue;
+					}
+
+					if (SkipLibrary (libname))
+						continue;
+
+					string name = dllimport.EntryPoint ?? mi.Name;
+					// skip known missing symbols
+					switch (name) {
+					case "objc_msgSend_stret":
+					case "objc_msgSendSuper_stret":
+						continue;
+					}
+
+					string path = FindLibrary (libname!, requiresFullPath: true);
+					IntPtr lib = Dlfcn.dlopen (path, 0);
+					bool symbolExists = lib != IntPtr.Zero && Dlfcn.GetIndirect (lib, name) != IntPtr.Zero;
+					if (lib != IntPtr.Zero)
+						Dlfcn.dlclose (lib);
+
+					bool markedUnavailable = !mi.IsAvailableInSimulator () || !type.IsAvailableInSimulator ();
+
+					if (markedUnavailable && symbolExists) {
+						var msg = $"P/Invoke '{type.FullName}.{mi.Name}' (symbol '{name}') is marked as unavailable in the simulator, but the symbol exists in '{path}'.";
+						ReportError (msg);
+						failed_api.Add ($"{type.FullName}.{mi.Name}");
+					} else if (!markedUnavailable && !symbolExists && lib != IntPtr.Zero) {
+						// The library exists but the symbol doesn't - might need [UnsupportedSimulator]
+						var msg = $"P/Invoke '{type.FullName}.{mi.Name}' (symbol '{name}') is not marked as unavailable in the simulator, but the symbol was not found in '{path}'. Consider adding [UnsupportedSimulator].";
+						ReportError (msg);
+						failed_api.Add ($"{type.FullName}.{mi.Name}");
+					}
+					n++;
+				}
+			}
+
+			AssertIfErrors ("{0} errors found in {1} P/Invoke simulator availability checks: {2}",
+				Errors, n, string.Join (", ", failed_api));
+		}
+
+		/// <summary>
+		/// Verifies that [Field] properties marked as unsupported in the simulator are indeed unavailable.
+		/// Also detects [Field] properties not marked as unsupported that are missing from the simulator.
+		/// </summary>
+		[Test]
+		public void FieldSimulatorAvailability ()
+		{
+			if (!TestRuntime.IsSimulator) {
+				Assert.Ignore ("This test only runs in the simulator.");
+				return;
+			}
+
+			var failed_fields = new List<string> ();
+			Errors = 0;
+			int n = 0;
+
+			foreach (var type in Assembly.GetTypes ()) {
+				if (Skip (type))
+					continue;
+
+				if (!type.IsAvailableOnHostPlatform ())
+					continue;
+
+				foreach (var p in type.GetProperties (BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)) {
+					if (p.CanWrite || !p.CanRead)
+						continue;
+
+					var fieldAttr = p.GetCustomAttribute<FieldAttribute> ();
+					if (fieldAttr is null)
+						continue;
+
+					if (!p.IsAvailableOnHostPlatform ())
+						continue;
+
+					if (MemberHasObsolete (p))
+						continue;
+
+					if (SkipField (p))
+						continue;
+
+					string symbolName = fieldAttr.SymbolName;
+					string? libName = fieldAttr.LibraryName;
+
+					if (SkipLibrary (libName))
+						continue;
+
+					string path = FindLibrary (libName!);
+					IntPtr lib = Dlfcn.dlopen (path, 0);
+					bool symbolExists = lib != IntPtr.Zero && Dlfcn.GetIndirect (lib, symbolName) != IntPtr.Zero;
+					if (lib != IntPtr.Zero)
+						Dlfcn.dlclose (lib);
+
+					bool markedUnavailable = !p.IsAvailableInSimulator () || !type.IsAvailableInSimulator ();
+
+					if (markedUnavailable && symbolExists) {
+						var msg = $"Field '{type.FullName}.{p.Name}' (symbol '{symbolName}') is marked as unavailable in the simulator, but the symbol exists in '{path}'.";
+						ReportError (msg);
+						failed_fields.Add ($"{type.FullName}.{p.Name}");
+					} else if (!markedUnavailable && !symbolExists && lib != IntPtr.Zero) {
+						// The library exists but the symbol doesn't - might need [UnsupportedSimulator]
+						var msg = $"Field '{type.FullName}.{p.Name}' (symbol '{symbolName}') is not marked as unavailable in the simulator, but the symbol was not found in '{path}'. Consider adding [UnsupportedSimulator].";
+						ReportError (msg);
+						failed_fields.Add ($"{type.FullName}.{p.Name}");
+					}
+					n++;
+				}
+			}
+
+			AssertIfErrors ("{0} errors found in {1} field simulator availability checks: {2}",
+				Errors, n, string.Join (", ", failed_fields));
+		}
+	}
+}

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -1047,15 +1047,8 @@ namespace Introspection {
 					break;
 #endif
 #if __TVOS__
-				case "MetalPerformanceShadersLibrary":
 				case "MetalPerformanceShadersGraphLibrary":
 					// not supported in tvOS (12.1) simulator so load fails
-					if (TestRuntime.IsSimulatorOrDesktop)
-						break;
-					goto default;
-				case "PhaseLibrary":
-					// framework support for tvOS was added in xcode 15
-					// but not supported on tvOS simulator so load fails
 					if (TestRuntime.IsSimulatorOrDesktop)
 						break;
 					goto default;
@@ -1081,9 +1074,6 @@ namespace Introspection {
 						if (fi.Name == "CoreNFCLibrary") {
 							// NFC is currently not available on iPad
 							if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
-								continue;
-							// Phone works unless Xcode 12 on simulator
-							if (TestRuntime.IsSimulatorOrDesktop && TestRuntime.CheckXcodeVersion (12, 0))
 								continue;
 						}
 #endif

--- a/tests/introspection/dotnet/shared.csproj
+++ b/tests/introspection/dotnet/shared.csproj
@@ -58,6 +58,7 @@
     <Compile Include="$(IntrospectionTestDirectory)\iOSApiProtocolTest.cs" />
     <Compile Include="$(IntrospectionTestDirectory)\iOSApiWeakPropertyTest.cs" />
     <Compile Include="$(IntrospectionTestDirectory)\iOSApiPInvokeTest.cs" />
+    <Compile Include="$(IntrospectionTestDirectory)\iOSApiSimulatorAvailabilityTest.cs" />
     <Compile Include="$(IntrospectionTestDirectory)\iOSApiClassPtrTest.cs" />
     <Compile Include="$(IntrospectionTestDirectory)\iOSApiTypoTest.cs" />
     <Compile Include="$(IntrospectionTestDirectory)\iOSCoreImageFiltersTest.cs" />
@@ -98,6 +99,9 @@
     </Compile>
     <Compile Include="$(IntrospectionTestDirectory)\ApiPInvokeTest.cs">
       <Link>ApiPInvokeTest.cs</Link>
+    </Compile>
+    <Compile Include="$(IntrospectionTestDirectory)\ApiSimulatorAvailabilityTest.cs">
+      <Link>ApiSimulatorAvailabilityTest.cs</Link>
     </Compile>
     <Compile Include="$(IntrospectionTestDirectory)\ApiProtocolTest.cs">
       <Link>ApiProtocolTest.cs</Link>

--- a/tests/introspection/iOSApiCtorInitTest.cs
+++ b/tests/introspection/iOSApiCtorInitTest.cs
@@ -31,28 +31,12 @@ namespace Introspection {
 		protected override bool Skip (Type type)
 		{
 			switch (type.Namespace) {
-			// all default ctor did not work and were replaced with [Obsolete("",true)] placeholders
-			// reflecting on those would create invalid instances (no handle) that crash the app
-			case "CoreBluetooth":
-			case "MonoTouch.CoreBluetooth":
-				return true;
-
-			case "CoreAudioKit":
-			case "MonoTouch.CoreAudioKit":
-			case "Metal":
-			case "MonoTouch.Metal":
-				// they works with iOS9 beta 4 (but won't work on older simulators)
-				if (TestRuntime.IsSimulatorOrDesktop && !TestRuntime.CheckXcodeVersion (7, 0))
-					return true;
-				break;
 			case "MetalKit":
-			case "MonoTouch.MetalKit":
 			case "MetalPerformanceShaders":
-			case "MonoTouch.MetalPerformanceShaders":
-				if (TestRuntime.IsSimulatorOrDesktop)
-					return true;
 				// some devices don't support metal and that crash some API that does not check that, e.g. #33153
-				if (!TestRuntime.CheckXcodeVersion (7, 0) || (MTLDevice.SystemDefault is null))
+				if (MTLDevice.SystemDefault is null)
+					return true;
+				if (TestRuntime.IsSimulatorOrDesktop)
 					return true;
 				break;
 #if __TVOS__
@@ -156,10 +140,6 @@ namespace Introspection {
 			case "NSPersistentStoreCoordinator":
 				return true;
 
-			// Metal is not available on the (iOS8) simulator
-			case "CAMetalLayer":
-				return TestRuntime.IsSimulatorOrDesktop && !TestRuntime.CheckXcodeVersion (11, 0);
-
 			// in 8.2 beta 1 this crash the app (simulator) without giving any details in the logs
 			case "WKUserNotificationInterfaceController":
 				return true;
@@ -175,10 +155,6 @@ namespace Introspection {
 				// NSInvalidArgumentException Reason: image must be non-nil
 				return true;
 
-			// these work only on devices, so we skip the simulator
-			case "MTLHeapDescriptor":
-			case "MTLSharedEventListener":
-				return TestRuntime.IsSimulatorOrDesktop;
 			// iOS 11 Beta 1
 			case "UICollectionViewFocusUpdateContext": // [Assert] -init is not a useful initializer for this class. Use one of the designated initializers instead
 			case "UIFocusUpdateContext": // [Assert] -init is not a useful initializer for this class. Use one of the designated initializers instead
@@ -190,21 +166,11 @@ namespace Introspection {
 				return true;
 			case "IOSurface": // Only works on device before Xcode 11
 				return !TestRuntime.CheckXcodeVersion (11, 0);
-			case "NEHotspotEapSettings": // Wireless Accessory Configuration is not supported in the simulator.
-			case "NEHotspotConfigurationManager":
-			case "NEHotspotHS20Settings":
-				return TestRuntime.IsSimulatorOrDesktop;
 			// iOS 12
 			case "INGetAvailableRestaurantReservationBookingDefaultsIntentResponse": // Objective-C exception thrown.  Name: NSInternalInconsistencyException Reason: Unable to initialize 'INGetAvailableRestaurantReservationBookingDefaultsIntentResponse'. Please make sure that your intent definition file is valid.
 			case "INGetAvailableRestaurantReservationBookingsIntentResponse": // Objective-C exception thrown.  Name: NSInternalInconsistencyException Reason: Unable to initialize 'INGetAvailableRestaurantReservationBookingsIntentResponse'. Please make sure that your intent definition file is valid.
 			case "INGetRestaurantGuestIntentResponse": // Objective-C exception thrown.  Name: NSInternalInconsistencyException Reason: Unable to initialize 'INGetRestaurantGuestIntentResponse'. Please make sure that your intent definition file is valid.
 				return TestRuntime.CheckXcodeVersion (10, 0);
-			case "CMMovementDisorderManager": // Not available in simulator, added info to radar://41110708 
-				return TestRuntime.IsSimulatorOrDesktop;
-			case "RPSystemBroadcastPickerView": // Symbol not available in simulator
-				return TestRuntime.IsSimulatorOrDesktop;
-			case "ICNotificationManagerConfiguration": // This works on device but not on simulator, and docs explicitly says it is user creatable
-				return TestRuntime.IsSimulatorOrDesktop;
 			case "VNDocumentCameraViewController": // Name: NSGenericException Reason: Document camera is not available on simulator
 				return TestRuntime.IsSimulatorOrDesktop;
 			case "AVAudioRecorder": // Stopped working with Xcode 11.2 beta 2

--- a/tests/introspection/iOSApiFieldTest.cs
+++ b/tests/introspection/iOSApiFieldTest.cs
@@ -129,51 +129,15 @@ namespace Introspection {
 				if (Class.GetHandle ("NFCNDEFReaderSession") == IntPtr.Zero)
 					return true;
 				break;
-			case "IOSurface":
-				return TestRuntime.IsSimulatorOrDesktop && !TestRuntime.CheckXcodeVersion (9, 0);
 			}
 
 			switch (constantName) {
-			// grep ImageIO binary shows those symbols are not part of the binary
-			// that match older results (nil) when loading them (see above)
-			case "kCGImagePropertyAPNGLoopCount":
-			case "kCGImagePropertyAPNGDelayTime":
-			case "kCGImagePropertyAPNGUnclampedDelayTime":
-			case "kCGImagePropertyMakerFujiDictionary":
-			case "kCGImagePropertyMakerMinoltaDictionary":
-			case "kCGImagePropertyMakerOlympusDictionary":
-			case "kCGImagePropertyMakerPentaxDictionary":
-			// 
-			case "kCFHTTPAuthenticationSchemeOAuth1":
-				return true;
 			// Apple does not ship a PushKit for every arch on some devices :(
 			case "PKPushTypeVoIP":
 				return TestRuntime.IsDevice;
-			// there's only partial support for metal on the simulator (on iOS9 beta 5) but most other frameworks
-			// that interop with it are not (yet) supported
-			case "kCVMetalTextureCacheMaximumTextureAgeKey":
-			case "kCVMetalTextureUsage":
-			case "MPSRectNoClip":
-			case "MTLCommandBufferErrorDomain":
-			case "MTKTextureLoaderErrorDomain":
-			case "MTKTextureLoaderErrorKey":
-			case "MTKTextureLoaderOptionAllocateMipmaps":
-			case "MTKTextureLoaderOptionSRGB":
-			case "MTKTextureLoaderOptionTextureUsage":
-			case "MTKTextureLoaderOptionTextureCPUCacheMode":
-			case "MTKModelErrorDomain":
-			case "MTKModelErrorKey":
-				return TestRuntime.IsSimulatorOrDesktop;
-			// Xcode 12.2 Beta 1 does not ship this but it is available in Xcode 12.0...
-			case "HKMetadataKeyBarometricPressure":
-				return true;
-			case "kCMSampleAttachmentKey_HDR10PlusPerFrameData":
-				if (TestRuntime.IsSimulator)
-					return !TestRuntime.CheckXcodeVersion (14, 1); // not available in the iOS 16.0 simulator, but it is in the iOS 16.1 simulator
-				goto default;
-			default:
-				return false;
 			}
+
+			return base.Skip (constantName, libraryName);
 		}
 	}
 }

--- a/tests/introspection/iOSApiPInvokeTest.cs
+++ b/tests/introspection/iOSApiPInvokeTest.cs
@@ -18,54 +18,6 @@ namespace Introspection {
 	// we want the tests to be available because we use the linker
 	[Preserve (AllMembers = true)]
 	public class iOSApiPInvokeTest : ApiPInvokeTest {
-
-		protected override bool Skip (string symbolName)
-		{
-			var simulator = TestRuntime.IsSimulatorOrDesktop;
-			switch (symbolName) {
-			// Metal support inside simulator is only available in recent iOS9 SDK
-			case "MTLCreateSystemDefaultDevice":
-				return simulator && !UIDevice.CurrentDevice.CheckSystemVersion (9, 0);
-			// still most Metal helpers are not available on the simulator (even when the framework is present, it's missing symbols)
-			case "MPSSupportsMTLDevice":
-			case "MPSGetPreferredDevice":
-			// neither are the CoreVideo extensions for Metal
-			case "CVMetalTextureGetTexture":
-			case "CVMetalTextureIsFlipped":
-			case "CVMetalTextureGetCleanTexCoords":
-			case "CVMetalTextureCacheCreate":
-			case "CVMetalTextureCacheFlush":
-			case "CVMetalTextureCacheCreateTextureFromImage":
-			case "MTKMetalVertexDescriptorFromModelIO":
-			case "MTKModelIOVertexDescriptorFromMetal":
-			case "MTKModelIOVertexFormatFromMetal":
-			case "MTKMetalVertexFormatFromModelIO":
-			case "MTLIOCompressionContextAppendData":
-			case "MTLIOCreateCompressionContext":
-			case "MTLIOFlushAndDestroyCompressionContext":
-			case "MTLIOCompressionContextDefaultChunkSize":
-			case "MPSImageBatchIncrementReadCount":
-			case "MPSImageBatchSynchronize":
-			case "MPSImageBatchResourceSize":
-			case "MPSStateBatchIncrementReadCount":
-			case "MPSStateBatchSynchronize":
-			case "MPSStateBatchResourceSize":
-			case "MPSHintTemporaryMemoryHighWaterMark":
-			case "MPSSetHeapCacheDuration":
-			case "MPSGetImageType":
-				return simulator;
-			case "CVPixelBufferGetIOSurface":
-			case "CVPixelBufferCreateWithIOSurface":
-				return simulator && !TestRuntime.CheckXcodeVersion (11, 0);
-
-			default:
-				// MLCompute not available in simulator as of Xcode 12 beta 3
-				if (simulator && symbolName.StartsWith ("MLC", StringComparison.Ordinal))
-					return true;
-				return base.Skip (symbolName);
-			}
-		}
-
 		protected override bool SkipAssembly (Assembly a)
 		{
 			if (a == typeof (NSObject).Assembly) {

--- a/tests/introspection/iOSApiSimulatorAvailabilityTest.cs
+++ b/tests/introspection/iOSApiSimulatorAvailabilityTest.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Reflection;
+
+namespace Introspection {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class iOSApiSimulatorAvailabilityTest : ApiSimulatorAvailabilityTest {
+
+		protected override bool SkipPInvoke (MethodInfo mi)
+		{
+			switch (mi.DeclaringType?.Namespace) {
+			case "CoreNFC":
+				if (Class.GetHandle ("NFCNDEFReaderSession") == IntPtr.Zero)
+					return true;
+				break;
+			}
+
+			return base.SkipPInvoke (mi);
+		}
+
+		protected override bool SkipField (PropertyInfo pi)
+		{
+			switch (pi.DeclaringType?.Namespace) {
+			case "CoreNFC":
+				if (Class.GetHandle ("NFCNDEFReaderSession") == IntPtr.Zero)
+					return true;
+				break;
+			case "DeviceCheck":
+				return true;
+			case "Phase":
+				return true;
+			}
+
+			return base.SkipField (pi);
+		}
+	}
+}


### PR DESCRIPTION
Add two attributes to specify whether an API is available in the simulator:

* [UnsupportedSimulator ("<platform>")]: API is not available.
* [SupportedSimulator ("<platform>[osversion]")]: API is available, optionally
  only in the specified OS version or not.

If no attribute is found, then the API is available in the simulator.

Unlike the normal availability attributes, specifying simulator availability for
one platform does not mean anything for any other platforms.