### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 14411: Build ID 14038264

### DIFF
--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.cs.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.cs.resx
@@ -832,6 +832,19 @@
   <!-- 222x: RemoveRejectedTypesStep -->
   <!-- 223x: CollectUnmarkedMembersSubStep -->
   <!-- 224x: PreserveBlockCodeSubStep -->
+  <!-- 225x: InlineDlfcnMethodsStep -->
+  <data name="MX2254" xml:space="preserve">
+		<value>Unsupported primitive field type '{0}' for symbol '{1}' in method '{2}'. Sub-optimal but functional code will be generated. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2255" xml:space="preserve">
+		<value>Unknown or unsupported Dlfcn pattern: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2256" xml:space="preserve">
+		<value>The field type '{0}' for symbol '{1}' in method '{2}' is not an NSObject subclass. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2257" xml:space="preserve">
+		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.de.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.de.resx
@@ -832,6 +832,19 @@
   <!-- 222x: RemoveRejectedTypesStep -->
   <!-- 223x: CollectUnmarkedMembersSubStep -->
   <!-- 224x: PreserveBlockCodeSubStep -->
+  <!-- 225x: InlineDlfcnMethodsStep -->
+  <data name="MX2254" xml:space="preserve">
+		<value>Unsupported primitive field type '{0}' for symbol '{1}' in method '{2}'. Sub-optimal but functional code will be generated. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2255" xml:space="preserve">
+		<value>Unknown or unsupported Dlfcn pattern: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2256" xml:space="preserve">
+		<value>The field type '{0}' for symbol '{1}' in method '{2}' is not an NSObject subclass. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2257" xml:space="preserve">
+		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.es.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.es.resx
@@ -832,6 +832,19 @@
   <!-- 222x: RemoveRejectedTypesStep -->
   <!-- 223x: CollectUnmarkedMembersSubStep -->
   <!-- 224x: PreserveBlockCodeSubStep -->
+  <!-- 225x: InlineDlfcnMethodsStep -->
+  <data name="MX2254" xml:space="preserve">
+		<value>Unsupported primitive field type '{0}' for symbol '{1}' in method '{2}'. Sub-optimal but functional code will be generated. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2255" xml:space="preserve">
+		<value>Unknown or unsupported Dlfcn pattern: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2256" xml:space="preserve">
+		<value>The field type '{0}' for symbol '{1}' in method '{2}' is not an NSObject subclass. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2257" xml:space="preserve">
+		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.fr.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.fr.resx
@@ -832,6 +832,19 @@
   <!-- 222x: RemoveRejectedTypesStep -->
   <!-- 223x: CollectUnmarkedMembersSubStep -->
   <!-- 224x: PreserveBlockCodeSubStep -->
+  <!-- 225x: InlineDlfcnMethodsStep -->
+  <data name="MX2254" xml:space="preserve">
+		<value>Unsupported primitive field type '{0}' for symbol '{1}' in method '{2}'. Sub-optimal but functional code will be generated. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2255" xml:space="preserve">
+		<value>Unknown or unsupported Dlfcn pattern: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2256" xml:space="preserve">
+		<value>The field type '{0}' for symbol '{1}' in method '{2}' is not an NSObject subclass. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2257" xml:space="preserve">
+		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.it.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.it.resx
@@ -832,6 +832,19 @@
   <!-- 222x: RemoveRejectedTypesStep -->
   <!-- 223x: CollectUnmarkedMembersSubStep -->
   <!-- 224x: PreserveBlockCodeSubStep -->
+  <!-- 225x: InlineDlfcnMethodsStep -->
+  <data name="MX2254" xml:space="preserve">
+		<value>Unsupported primitive field type '{0}' for symbol '{1}' in method '{2}'. Sub-optimal but functional code will be generated. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2255" xml:space="preserve">
+		<value>Unknown or unsupported Dlfcn pattern: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2256" xml:space="preserve">
+		<value>The field type '{0}' for symbol '{1}' in method '{2}' is not an NSObject subclass. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2257" xml:space="preserve">
+		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.ja.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.ja.resx
@@ -832,6 +832,19 @@
   <!-- 222x: RemoveRejectedTypesStep -->
   <!-- 223x: CollectUnmarkedMembersSubStep -->
   <!-- 224x: PreserveBlockCodeSubStep -->
+  <!-- 225x: InlineDlfcnMethodsStep -->
+  <data name="MX2254" xml:space="preserve">
+		<value>Unsupported primitive field type '{0}' for symbol '{1}' in method '{2}'. Sub-optimal but functional code will be generated. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2255" xml:space="preserve">
+		<value>Unknown or unsupported Dlfcn pattern: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2256" xml:space="preserve">
+		<value>The field type '{0}' for symbol '{1}' in method '{2}' is not an NSObject subclass. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2257" xml:space="preserve">
+		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.ko.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.ko.resx
@@ -832,6 +832,19 @@
   <!-- 222x: RemoveRejectedTypesStep -->
   <!-- 223x: CollectUnmarkedMembersSubStep -->
   <!-- 224x: PreserveBlockCodeSubStep -->
+  <!-- 225x: InlineDlfcnMethodsStep -->
+  <data name="MX2254" xml:space="preserve">
+		<value>Unsupported primitive field type '{0}' for symbol '{1}' in method '{2}'. Sub-optimal but functional code will be generated. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2255" xml:space="preserve">
+		<value>Unknown or unsupported Dlfcn pattern: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2256" xml:space="preserve">
+		<value>The field type '{0}' for symbol '{1}' in method '{2}' is not an NSObject subclass. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2257" xml:space="preserve">
+		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.pl.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.pl.resx
@@ -832,6 +832,19 @@
   <!-- 222x: RemoveRejectedTypesStep -->
   <!-- 223x: CollectUnmarkedMembersSubStep -->
   <!-- 224x: PreserveBlockCodeSubStep -->
+  <!-- 225x: InlineDlfcnMethodsStep -->
+  <data name="MX2254" xml:space="preserve">
+		<value>Unsupported primitive field type '{0}' for symbol '{1}' in method '{2}'. Sub-optimal but functional code will be generated. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2255" xml:space="preserve">
+		<value>Unknown or unsupported Dlfcn pattern: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2256" xml:space="preserve">
+		<value>The field type '{0}' for symbol '{1}' in method '{2}' is not an NSObject subclass. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2257" xml:space="preserve">
+		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.pt-BR.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.pt-BR.resx
@@ -832,6 +832,19 @@
   <!-- 222x: RemoveRejectedTypesStep -->
   <!-- 223x: CollectUnmarkedMembersSubStep -->
   <!-- 224x: PreserveBlockCodeSubStep -->
+  <!-- 225x: InlineDlfcnMethodsStep -->
+  <data name="MX2254" xml:space="preserve">
+		<value>Unsupported primitive field type '{0}' for symbol '{1}' in method '{2}'. Sub-optimal but functional code will be generated. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2255" xml:space="preserve">
+		<value>Unknown or unsupported Dlfcn pattern: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2256" xml:space="preserve">
+		<value>The field type '{0}' for symbol '{1}' in method '{2}' is not an NSObject subclass. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2257" xml:space="preserve">
+		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.ru.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.ru.resx
@@ -832,6 +832,19 @@
   <!-- 222x: RemoveRejectedTypesStep -->
   <!-- 223x: CollectUnmarkedMembersSubStep -->
   <!-- 224x: PreserveBlockCodeSubStep -->
+  <!-- 225x: InlineDlfcnMethodsStep -->
+  <data name="MX2254" xml:space="preserve">
+		<value>Unsupported primitive field type '{0}' for symbol '{1}' in method '{2}'. Sub-optimal but functional code will be generated. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2255" xml:space="preserve">
+		<value>Unknown or unsupported Dlfcn pattern: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2256" xml:space="preserve">
+		<value>The field type '{0}' for symbol '{1}' in method '{2}' is not an NSObject subclass. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2257" xml:space="preserve">
+		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.tr.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.tr.resx
@@ -832,6 +832,19 @@
   <!-- 222x: RemoveRejectedTypesStep -->
   <!-- 223x: CollectUnmarkedMembersSubStep -->
   <!-- 224x: PreserveBlockCodeSubStep -->
+  <!-- 225x: InlineDlfcnMethodsStep -->
+  <data name="MX2254" xml:space="preserve">
+		<value>Unsupported primitive field type '{0}' for symbol '{1}' in method '{2}'. Sub-optimal but functional code will be generated. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2255" xml:space="preserve">
+		<value>Unknown or unsupported Dlfcn pattern: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2256" xml:space="preserve">
+		<value>The field type '{0}' for symbol '{1}' in method '{2}' is not an NSObject subclass. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2257" xml:space="preserve">
+		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.zh-Hans.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.zh-Hans.resx
@@ -832,6 +832,19 @@
   <!-- 222x: RemoveRejectedTypesStep -->
   <!-- 223x: CollectUnmarkedMembersSubStep -->
   <!-- 224x: PreserveBlockCodeSubStep -->
+  <!-- 225x: InlineDlfcnMethodsStep -->
+  <data name="MX2254" xml:space="preserve">
+		<value>Unsupported primitive field type '{0}' for symbol '{1}' in method '{2}'. Sub-optimal but functional code will be generated. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2255" xml:space="preserve">
+		<value>Unknown or unsupported Dlfcn pattern: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2256" xml:space="preserve">
+		<value>The field type '{0}' for symbol '{1}' in method '{2}' is not an NSObject subclass. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2257" xml:space="preserve">
+		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.zh-Hant.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.zh-Hant.resx
@@ -832,6 +832,19 @@
   <!-- 222x: RemoveRejectedTypesStep -->
   <!-- 223x: CollectUnmarkedMembersSubStep -->
   <!-- 224x: PreserveBlockCodeSubStep -->
+  <!-- 225x: InlineDlfcnMethodsStep -->
+  <data name="MX2254" xml:space="preserve">
+		<value>Unsupported primitive field type '{0}' for symbol '{1}' in method '{2}'. Sub-optimal but functional code will be generated. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2255" xml:space="preserve">
+		<value>Unknown or unsupported Dlfcn pattern: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2256" xml:space="preserve">
+		<value>The field type '{0}' for symbol '{1}' in method '{2}' is not an NSObject subclass. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2257" xml:space="preserve">
+		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.