### PR TITLE
[tools] Use the new UnsupportedSimulator attribute to determine whether a Dlfcn method should be inlined or not.

### DIFF
--- a/tests/common/shared-dotnet.mk
+++ b/tests/common/shared-dotnet.mk
@@ -178,12 +178,13 @@ reload-and-run:
 	$(Q) $(MAKE) run
 
 build: prepare
-	@echo "Building $(wildcard *.?.csproj)..."
+	@echo "Building $(wildcard *.?sproj)..."
 	$(Q) $(DOTNET) build "/bl:$(abspath $@-$(BINLOG_TIMESTAMP).binlog)" *.?sproj $(DOTNET_BUILD_VERBOSITY) $(BUILD_ARGUMENTS) $(CONFIG_ARGUMENT) $(UNIVERSAL_ARGUMENT) $(NATIVEAOT_ARGUMENTS) $(TEST_VARIATION_ARGUMENT)
 
 run: export SIMCTL_CHILD_NUNIT_AUTOSTART=true
 run: export SIMCTL_CHILD_NUNIT_AUTOEXIT=true
 run: prepare
+	@echo "Running $(wildcard *.?sproj)..."
 	$(Q) $(DOTNET) build "/bl:$(abspath $@-$(BINLOG_TIMESTAMP).binlog)" *.?sproj $(DOTNET_BUILD_VERBOSITY) $(BUILD_ARGUMENTS) $(CONFIG_ARGUMENT) $(UNIVERSAL_ARGUMENT) $(NATIVEAOT_ARGUMENTS) $(TEST_VARIATION_ARGUMENT) -t:Run $(RUN_ARGUMENTS) -tl:off
 
 run-bare:

--- a/tests/common/test-variations.csproj
+++ b/tests/common/test-variations.csproj
@@ -161,13 +161,6 @@
 		<DefineConstants>$(DefineConstants);STATIC_NATIVE_SYMBOL_LOOKUP</DefineConstants>
 	</PropertyGroup>
 
-	<ItemGroup Condition="$(_TestVariationForComparison.Contains('|inline-dlfcn-methods-strict|'))">
-		<!-- fields that aren't available in the simulator -->
-		<ReferenceNativeSymbol Condition="'$(SdkIsSimulator)' == 'true'" SymbolMode="Ignore" SymbolType="Field" Include="MTL4CommandQueueErrorDomain" />
-		<ReferenceNativeSymbol Condition="'$(SdkIsSimulator)' == 'true'" SymbolMode="Ignore" SymbolType="Field" Include="MTLIOErrorDomain" />
-		<ReferenceNativeSymbol Condition="'$(SdkIsSimulator)' == 'true'" SymbolMode="Ignore" SymbolType="Field" Include="MTLTensorDomain"/>
-	</ItemGroup>
-
 	<Target Name="ValidateTestVariation" Condition="'$(TestVariation)' != '' And '$(OutputType)' == 'exe'" BeforeTargets="Build">
 		<ItemGroup>
 			<_InvalidTestVariations Include="$(TestVariation.Split('|'))" Exclude="@(TestVariations)" />

--- a/tools/common/DerivedLinkContext.cs
+++ b/tools/common/DerivedLinkContext.cs
@@ -276,6 +276,7 @@ namespace Xamarin.Tuner {
 
 			// Pass 2: check for any matching SupportedSimulator attributes — evaluate as OR across versions.
 			var hasSupported = false;
+			var supportedCount = 0;
 			var isAvailable = false;
 			foreach (var attrib in provider.CustomAttributes) {
 				if (!attrib.AttributeType.Is ("ObjCRuntime", "SupportedSimulatorAttribute"))
@@ -285,6 +286,7 @@ namespace Xamarin.Tuner {
 						continue;
 
 					hasSupported = true;
+					supportedCount++;
 					var osVersion = supportedPlatform.Substring (platformName.Length);
 					if (string.IsNullOrEmpty (osVersion)) {
 						// no version constraint: available in the simulator
@@ -308,6 +310,12 @@ namespace Xamarin.Tuner {
 			// Conflicting attributes: both Supported and Unsupported for the same platform
 			if (hasUnsupported && hasSupported) {
 				LinkerConfiguration.Report (LinkerConfiguration.Context, ErrorHelper.CreateError (App, 2260, methodForErrorReporting, Errors.MX2260, provider.AsString (), platformName));
+				return true; // treat as unavailable
+			}
+
+			// Multiple SupportedSimulator attributes for the same platform
+			if (supportedCount > 1) {
+				LinkerConfiguration.Report (LinkerConfiguration.Context, ErrorHelper.CreateError (App, 2261, methodForErrorReporting, Errors.MX2261, provider.AsString (), platformName));
 				return true; // treat as unavailable
 			}
 

--- a/tools/common/DerivedLinkContext.cs
+++ b/tools/common/DerivedLinkContext.cs
@@ -261,43 +261,63 @@ namespace Xamarin.Tuner {
 				return false;
 			}
 
+			// Pass 1: check for any matching UnsupportedSimulator attribute — if found, it's unavailable.
+			var hasUnsupported = false;
 			foreach (var attrib in provider.CustomAttributes) {
-				if (attrib.AttributeType.Is ("ObjCRuntime", "UnsupportedSimulatorAttribute")) {
-					if (attrib.ConstructorArguments.Count == 1 && attrib.ConstructorArguments [0].Value is string reason) {
-						if (string.Equals (reason, platformName, StringComparison.OrdinalIgnoreCase))
-							return true;
-					} else {
-						LinkerConfiguration.Report (LinkerConfiguration.Context, ErrorHelper.CreateWarning (App, 2258, methodForErrorReporting, Errors.MX2258, provider.AsString (), attrib.RenderAttribute ()));
-					}
+				if (!attrib.AttributeType.Is ("ObjCRuntime", "UnsupportedSimulatorAttribute"))
 					continue;
-				}
-
-				if (attrib.AttributeType.Is ("ObjCRuntime", "SupportedSimulatorAttribute")) {
-					if (attrib.ConstructorArguments.Count == 1 && attrib.ConstructorArguments [0].Value is string reason) {
-						if (!reason.StartsWith (platformName, StringComparison.OrdinalIgnoreCase))
-							continue;
-
-						var osVersion = reason.Substring (platformName.Length);
-						if (string.IsNullOrEmpty (osVersion)) {
-							// empty version: always available in the simulator
-							return false;
-						} else if (Version.TryParse (osVersion, out var version)) {
-							var simulatorVersion = App.DeploymentTarget;
-							if (simulatorVersion is null) {
-								LinkerConfiguration.Report (LinkerConfiguration.Context, ErrorHelper.CreateWarning (App, 99, methodForErrorReporting, "No deployment target available. Please file an issue at https://github.com/dotnet/macios/issues."));
-								continue;
-							}
-							return version > simulatorVersion;
-						} else {
-							LinkerConfiguration.Report (LinkerConfiguration.Context, ErrorHelper.CreateWarning (App, 2259, methodForErrorReporting, Errors.MX2259, provider.AsString (), attrib.RenderAttribute ()));
-						}
-					} else {
-						LinkerConfiguration.Report (LinkerConfiguration.Context, ErrorHelper.CreateWarning (App, 2258, methodForErrorReporting, Errors.MX2258, provider.AsString (), attrib.RenderAttribute ()));
-					}
-					continue;
+				if (attrib.ConstructorArguments.Count == 1 && attrib.ConstructorArguments [0].Value is string unsupportedPlatform) {
+					if (string.Equals (unsupportedPlatform, platformName, StringComparison.OrdinalIgnoreCase))
+						hasUnsupported = true;
+				} else {
+					LinkerConfiguration.Report (LinkerConfiguration.Context, ErrorHelper.CreateWarning (App, 2258, methodForErrorReporting, Errors.MX2258, provider.AsString (), attrib.RenderAttribute ()));
 				}
 			}
 
+			// Pass 2: check for any matching SupportedSimulator attributes — evaluate as OR across versions.
+			var hasSupported = false;
+			var isAvailable = false;
+			foreach (var attrib in provider.CustomAttributes) {
+				if (!attrib.AttributeType.Is ("ObjCRuntime", "SupportedSimulatorAttribute"))
+					continue;
+				if (attrib.ConstructorArguments.Count == 1 && attrib.ConstructorArguments [0].Value is string supportedPlatform) {
+					if (!supportedPlatform.StartsWith (platformName, StringComparison.OrdinalIgnoreCase))
+						continue;
+
+					hasSupported = true;
+					var osVersion = supportedPlatform.Substring (platformName.Length);
+					if (string.IsNullOrEmpty (osVersion)) {
+						// no version constraint: available in the simulator
+						isAvailable = true;
+					} else if (Version.TryParse (osVersion, out var version)) {
+						var simulatorVersion = App.DeploymentTarget;
+						if (simulatorVersion is null) {
+							LinkerConfiguration.Report (LinkerConfiguration.Context, ErrorHelper.CreateWarning (App, 99, methodForErrorReporting, "No deployment target available. Please file an issue at https://github.com/dotnet/macios/issues."));
+							continue;
+						}
+						if (simulatorVersion >= version)
+							isAvailable = true;
+					} else {
+						LinkerConfiguration.Report (LinkerConfiguration.Context, ErrorHelper.CreateWarning (App, 2259, methodForErrorReporting, Errors.MX2259, provider.AsString (), attrib.RenderAttribute ()));
+					}
+				} else {
+					LinkerConfiguration.Report (LinkerConfiguration.Context, ErrorHelper.CreateWarning (App, 2258, methodForErrorReporting, Errors.MX2258, provider.AsString (), attrib.RenderAttribute ()));
+				}
+			}
+
+			// Conflicting attributes: both Supported and Unsupported for the same platform
+			if (hasUnsupported && hasSupported) {
+				LinkerConfiguration.Report (LinkerConfiguration.Context, ErrorHelper.CreateError (App, 2260, methodForErrorReporting, Errors.MX2260, provider.AsString (), platformName));
+				return true; // treat as unavailable
+			}
+
+			if (hasUnsupported)
+				return true;
+
+			if (hasSupported)
+				return !isAvailable;
+
+			// No matching attributes: assume available
 			return false;
 		}
 

--- a/tools/common/DerivedLinkContext.cs
+++ b/tools/common/DerivedLinkContext.cs
@@ -9,6 +9,7 @@ using Registrar;
 using Mono.Tuner;
 using Xamarin.Bundler;
 using Xamarin.Linker;
+using Xamarin.Utils;
 
 #if !LEGACY_TOOLS
 using LinkContext = Xamarin.Bundler.DotNetLinkContext;
@@ -236,6 +237,70 @@ namespace Xamarin.Tuner {
 		}
 
 #if !LEGACY_TOOLS
+		public bool HasAvailabilityAttributesShowingUnavailableInSimulator (ICustomAttributeProvider provider, MethodDefinition? methodForErrorReporting = null)
+		{
+			if (!App.IsSimulatorBuild) {
+				LinkerConfiguration.Report (LinkerConfiguration.Context, ErrorHelper.CreateError (99, "HasAvailabilityAttributesShowingUnavailableInSimulator should not be called when not building for the simulator. Please file an issue at https://github.com/dotnet/macios/issues."));
+				return false;
+			}
+
+			if (!provider.HasCustomAttributes)
+				return false; // no attributes to say otherwise, so available
+
+			string platformName;
+
+			switch (App.Platform) {
+			case ApplePlatform.iOS:
+				platformName = "ios";
+				break;
+			case ApplePlatform.TVOS:
+				platformName = "tvos";
+				break;
+			default:
+				LinkerConfiguration.Report (LinkerConfiguration.Context, ErrorHelper.CreateWarning (App, 99, methodForErrorReporting, "Unexpected platform '{0}'. Please file an issue at https://github.com/dotnet/macios/issues.", App.Platform));
+				return false;
+			}
+
+			foreach (var attrib in provider.CustomAttributes) {
+				if (attrib.AttributeType.Is ("ObjCRuntime", "UnsupportedSimulatorAttribute")) {
+					if (attrib.ConstructorArguments.Count == 1 && attrib.ConstructorArguments [0].Value is string reason) {
+						if (string.Equals (reason, platformName, StringComparison.OrdinalIgnoreCase))
+							return true;
+					} else {
+						LinkerConfiguration.Report (LinkerConfiguration.Context, ErrorHelper.CreateWarning (App, 2258, methodForErrorReporting, Errors.MX2258, provider.AsString (), attrib.RenderAttribute ()));
+					}
+					continue;
+				}
+
+				if (attrib.AttributeType.Is ("ObjCRuntime", "SupportedSimulatorAttribute")) {
+					if (attrib.ConstructorArguments.Count == 1 && attrib.ConstructorArguments [0].Value is string reason) {
+						if (!reason.StartsWith (platformName, StringComparison.OrdinalIgnoreCase))
+							continue;
+
+						var osVersion = reason.Substring (platformName.Length);
+						if (string.IsNullOrEmpty (osVersion)) {
+							// empty version: always available in the simulator
+							return false;
+						} else if (Version.TryParse (osVersion, out var version)) {
+							var simulatorVersion = App.DeploymentTarget;
+							if (simulatorVersion is null) {
+								LinkerConfiguration.Report (LinkerConfiguration.Context, ErrorHelper.CreateWarning (App, 99, methodForErrorReporting, "No deployment target available. Please file an issue at https://github.com/dotnet/macios/issues."));
+								continue;
+							}
+							return version > simulatorVersion;
+						} else {
+							LinkerConfiguration.Report (LinkerConfiguration.Context, ErrorHelper.CreateWarning (App, 2259, methodForErrorReporting, Errors.MX2259, provider.AsString (), attrib.RenderAttribute ()));
+						}
+					} else {
+						LinkerConfiguration.Report (LinkerConfiguration.Context, ErrorHelper.CreateWarning (App, 2258, methodForErrorReporting, Errors.MX2258, provider.AsString (), attrib.RenderAttribute ()));
+					}
+					continue;
+				}
+			}
+
+			return false;
+		}
+
 		class AttributeStorage : ICustomAttribute {
 			public CustomAttribute Attribute { get; }
 			public TypeReference AttributeType { get; set; }

--- a/tools/dotnet-linker/Steps/InlineDlfcnMethodsStep.cs
+++ b/tools/dotnet-linker/Steps/InlineDlfcnMethodsStep.cs
@@ -539,6 +539,18 @@ public class InlineDlfcnMethodsStep : AssemblyModifierStep {
 		if (method.DeclaringType.Name == "Dlfcn" && method.DeclaringType.Namespace == "ObjCRuntime")
 			return modified; // don't process the Dlfcn methods themselves
 
+		if (DerivedLinkContext.App.IsSimulatorBuild) {
+			// if the method or its declaring type aren't available in the simulator, and we're building for the simulator, then don't inline.
+			if (DerivedLinkContext.HasAvailabilityAttributesShowingUnavailableInSimulator (method, method)) {
+				Driver.Log (3, $"Method {method.FullName} is not available in the simulator. Skipping inlining Dlfcn calls for this method.");
+				return modified;
+			}
+			if (DerivedLinkContext.HasAvailabilityAttributesShowingUnavailableInSimulator (method.DeclaringType, method)) {
+				Driver.Log (3, $"Type {method.DeclaringType.FullName} is not available in the simulator. Skipping inlining Dlfcn calls for this type.");
+				return modified;
+			}
+		}
+
 		foreach (var instr in method.Body.Instructions) {
 			if (instr.Operand is not MethodReference mr)
 				continue;

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -3561,6 +3561,24 @@ namespace Xamarin.Bundler {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; is marked with a malformed simulator availability attribute: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new.
+        /// </summary>
+        public static string MX2258 {
+            get {
+                return ResourceManager.GetString("MX2258", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; is marked with a simulator availability attribute with an invalid version: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new.
+        /// </summary>
+        public static string MX2259 {
+            get {
+                return ResourceManager.GetString("MX2259", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not {0} the assembly &apos;{1}&apos;.
         /// </summary>
         public static string MX3001 {

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -3588,6 +3588,15 @@ namespace Xamarin.Bundler {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; has multiple SupportedSimulator attributes for the &apos;{1}&apos; platform. Please file an issue at https://github.com/dotnet/macios/issues/new.
+        /// </summary>
+        public static string MX2261 {
+            get {
+                return ResourceManager.GetString("MX2261", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not {0} the assembly &apos;{1}&apos;.
         /// </summary>
         public static string MX3001 {

--- a/tools/mtouch/Errors.designer.cs
+++ b/tools/mtouch/Errors.designer.cs
@@ -3579,6 +3579,15 @@ namespace Xamarin.Bundler {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; has conflicting simulator availability attributes for the &apos;{1}&apos; platform (both SupportedSimulator and UnsupportedSimulator). Please file an issue at https://github.com/dotnet/macios/issues/new.
+        /// </summary>
+        public static string MX2260 {
+            get {
+                return ResourceManager.GetString("MX2260", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not {0} the assembly &apos;{1}&apos;.
         /// </summary>
         public static string MX3001 {

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -1115,6 +1115,14 @@
 		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
 	</data>
 
+	<data name="MX2258" xml:space="preserve">
+		<value>'{0}' is marked with a malformed simulator availability attribute: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+
+	<data name="MX2259" xml:space="preserve">
+		<value>'{0}' is marked with a simulator availability attribute with an invalid version: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+
 	<!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
 
 	<data name="MX_ConfigurationAwareStep" xml:space="preserve">

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -1123,6 +1123,10 @@
 		<value>'{0}' is marked with a simulator availability attribute with an invalid version: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
 	</data>
 
+	<data name="MX2260" xml:space="preserve">
+		<value>'{0}' has conflicting simulator availability attributes for the '{1}' platform (both SupportedSimulator and UnsupportedSimulator). Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+
 	<!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
 
 	<data name="MX_ConfigurationAwareStep" xml:space="preserve">

--- a/tools/mtouch/Errors.resx
+++ b/tools/mtouch/Errors.resx
@@ -1127,6 +1127,10 @@
 		<value>'{0}' has conflicting simulator availability attributes for the '{1}' platform (both SupportedSimulator and UnsupportedSimulator). Please file an issue at https://github.com/dotnet/macios/issues/new</value>
 	</data>
 
+	<data name="MX2261" xml:space="preserve">
+		<value>'{0}' has multiple SupportedSimulator attributes for the '{1}' platform. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+
 	<!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
 
 	<data name="MX_ConfigurationAwareStep" xml:space="preserve">


### PR DESCRIPTION
This allows us to remove a few special cases.