### PR TITLE
Fix nullability errors in mono-api-html and mono-api-info

### DIFF
--- a/tools/api-tools/mono-api-html/ApiChange.cs
+++ b/tools/api-tools/mono-api-html/ApiChange.cs
@@ -7,7 +7,7 @@ using System.Xml.Linq;
 namespace Mono.ApiTools {
 
 	class ApiChange {
-		public string Header;
+		public string Header = "";
 		public TextChunk Member = new TextChunk ();
 		public bool AnyChange;
 		public string SourceDescription;
@@ -61,8 +61,7 @@ namespace Mono.ApiTools {
 			if (!change.AnyChange)
 				return;
 
-			List<ApiChange> list;
-			if (!TryGetValue (change.Header, out list)) {
+			if (!TryGetValue (change.Header, out List<ApiChange>? list)) {
 				list = new List<ApiChange> ();
 				base.Add (change.Header, list);
 			}

--- a/tools/api-tools/mono-api-html/ApiDiff.cs
+++ b/tools/api-tools/mono-api-html/ApiDiff.cs
@@ -42,17 +42,17 @@ using System.Xml.Linq;
 namespace Mono.ApiTools {
 
 	class State {
-		public Formatter Formatter { get; set; }
-		public Formatter [] Formatters { get; set; }
-		public string Assembly { get; set; }
-		public string Namespace { get; set; }
-		public string Type { get; set; }
-		public string BaseType { get; set; }
-		public string Parent { get; set; }
+		public Formatter Formatter { get; set; } = null!;
+		public Formatter [] Formatters { get; set; } = [];
+		public string Assembly { get; set; } = "";
+		public string Namespace { get; set; } = "";
+		public string Type { get; set; } = "";
+		public string BaseType { get; set; } = "";
+		public string Parent { get; set; } = "";
 		public bool Colorize { get; set; } = true;
 		public int Verbosity { get; set; }
-		public string SourceFile;
-		public string TargetFile;
+		public string SourceFile = "";
+		public string TargetFile = "";
 
 		public void LogDebugMessage (string value)
 		{
@@ -70,7 +70,7 @@ namespace Mono.ApiTools {
 		public static int Main (string [] args)
 		{
 			var showHelp = false;
-			List<string> extra = null;
+			List<string>? extra = null;
 			var config = new ApiDiffFormattedConfig ();
 
 			var options = new Mono.Options.OptionSet {
@@ -130,9 +130,9 @@ namespace Mono.ApiTools {
 #endif
 
 	public class ApiDiffFormattedConfig {
-		public string HtmlOutput { get; set; }
-		public string HtmlHeader { get; set; }
-		public string MarkdownOutput { get; set; }
+		public string? HtmlOutput { get; set; }
+		public string? HtmlHeader { get; set; }
+		public string? MarkdownOutput { get; set; }
 		// public bool IgnoreDuplicateXml { get; set; }
 		public bool Colorize { get; set; } = true;
 
@@ -140,7 +140,7 @@ namespace Mono.ApiTools {
 	}
 
 	public static class ApiDiffFormatted {
-		public static void Generate (string firstInfo, string secondInfo, ApiDiffFormattedConfig config = null)
+		public static void Generate (string firstInfo, string secondInfo, ApiDiffFormattedConfig? config = null)
 		{
 			var state = CreateState (config, firstInfo, secondInfo);
 			var ac = new AssemblyComparer (state);
@@ -171,14 +171,14 @@ namespace Mono.ApiTools {
 			}
 		}
 
-		static State CreateState (ApiDiffFormattedConfig config, string firstInfo, string secondInfo)
+		static State CreateState (ApiDiffFormattedConfig? config, string firstInfo, string secondInfo)
 		{
 			if (config is null)
 				config = new ApiDiffFormattedConfig ();
 
 			var state = new State {
 				Colorize = config.Colorize,
-				Formatter = null,
+				Formatter = null!,
 				SourceFile = firstInfo,
 				TargetFile = secondInfo,
 
@@ -187,9 +187,9 @@ namespace Mono.ApiTools {
 
 			var formatters = new List<Formatter> ();
 			if (!string.IsNullOrWhiteSpace (config.HtmlOutput))
-				formatters.Add (new HtmlFormatter (state) { OutputPath = config.HtmlOutput, Header = config.HtmlHeader });
+				formatters.Add (new HtmlFormatter (state) { OutputPath = config.HtmlOutput!, Header = config.HtmlHeader ?? "" });
 			if (!string.IsNullOrWhiteSpace (config.MarkdownOutput))
-				formatters.Add (new MarkdownFormatter (state) { OutputPath = config.MarkdownOutput });
+				formatters.Add (new MarkdownFormatter (state) { OutputPath = config.MarkdownOutput! });
 			if (formatters.Count > 1) {
 				state.Formatter = new MultiplexedFormatter (state, formatters.ToArray ());
 			} else if (formatters.Count == 0) {

--- a/tools/api-tools/mono-api-html/AssemblyComparer.cs
+++ b/tools/api-tools/mono-api-html/AssemblyComparer.cs
@@ -58,18 +58,18 @@ namespace Mono.ApiTools {
 			get { return "assembly"; }
 		}
 
-		public string SourceAssembly { get; private set; }
-		public string TargetAssembly { get; private set; }
+		public string SourceAssembly { get; private set; } = "";
+		public string TargetAssembly { get; private set; } = "";
 
 		public void Compare ()
 		{
-			Compare (source.Element ("assemblies").Elements ("assembly"),
-					 target.Element ("assemblies").Elements ("assembly"));
+			Compare (source.Element ("assemblies")!.Elements ("assembly"),
+					 target.Element ("assemblies")!.Elements ("assembly"));
 		}
 
 		public override void SetContext (XElement current)
 		{
-			State.Assembly = current.GetAttribute ("name");
+			State.Assembly = current.GetAttribute ("name") ?? "";
 		}
 
 		public override void Added (XElement target, bool wasParentAdded)
@@ -79,13 +79,13 @@ namespace Mono.ApiTools {
 
 		public override void Modified (XElement source, XElement target, ApiChanges diff)
 		{
-			SourceAssembly = source.GetAttribute ("name");
-			TargetAssembly = target.GetAttribute ("name");
+			SourceAssembly = source.GetAttribute ("name") ?? "";
+			TargetAssembly = target.GetAttribute ("name") ?? "";
 
 			var sb = source.GetAttribute ("version");
 			var tb = target.GetAttribute ("version");
 			if (sb != tb) {
-				Output.WriteLine ("<h4>Assembly Version Changed: {0} -> {1}</h4>", sb, tb);
+				Output.WriteLine ("<h4>Assembly Version Changed: {0} -> {1}</h4>", sb ?? "", tb ?? "");
 				Output.WriteLine ();
 			}
 

--- a/tools/api-tools/mono-api-html/ClassComparer.cs
+++ b/tools/api-tools/mono-api-html/ClassComparer.cs
@@ -43,7 +43,7 @@ namespace Mono.ApiTools {
 		PropertyComparer pcomparer;
 		EventComparer ecomparer;
 		MethodComparer mcomparer;
-		ClassComparer kcomparer;
+		ClassComparer? kcomparer;
 
 		public ClassComparer (State state)
 			: base (state)
@@ -66,8 +66,8 @@ namespace Mono.ApiTools {
 
 		public override void SetContext (XElement current)
 		{
-			State.Type = current.GetAttribute ("name");
-			State.BaseType = current.GetAttribute ("base");
+			State.Type = current.GetAttribute ("name") ?? "";
+			State.BaseType = current.GetAttribute ("base") ?? "";
 		}
 
 		public void Compare (XElement source, XElement target)
@@ -76,7 +76,7 @@ namespace Mono.ApiTools {
 			var t = target.Element ("classes");
 			if (XNode.DeepEquals (s, t))
 				return;
-			Compare (s.Elements ("class"), t.Elements ("class"));
+			Compare (s!.Elements ("class"), t!.Elements ("class"));
 		}
 
 		public override void Added (XElement target, bool wasParentAdded)
@@ -92,7 +92,7 @@ namespace Mono.ApiTools {
 			if (target.IsTrue ("serializable"))
 				Indent ().WriteLine ("[Serializable]");
 
-			var type = target.Attribute ("type").Value;
+			var type = target.Attribute ("type")!.Value;
 
 			WriteAttributes (target);
 
@@ -112,7 +112,7 @@ namespace Mono.ApiTools {
 			Output.Write (' ');
 			Output.Write (type);
 			Output.Write (' ');
-			Output.Write (target.GetAttribute ("name"));
+			Output.Write (target.GetAttribute ("name") ?? "");
 
 			var baseclass = target.GetAttribute ("base");
 			if ((type != "enum") && (type != "struct")) {
@@ -206,7 +206,7 @@ namespace Mono.ApiTools {
 				foreach (var @assembly in assemblies.Elements ("assembly")) {
 					foreach (var e in assembly.Elements ("namespaces")) {
 						foreach (var nsElement in e.Elements ("namespace")) {
-							var ns = nsElement.GetAttribute ("name");
+							var ns = nsElement.GetAttribute ("name") ?? "";
 							foreach (var classesElement in nsElement.Elements ("classes")) {
 								MapClasses (rv, ns, string.Empty, classesElement);
 							}
@@ -219,8 +219,8 @@ namespace Mono.ApiTools {
 			static void MapClasses (Dictionary<string, string> dictionary, string @namespace, string declaringType, XElement classes)
 			{
 				foreach (var classElement in classes.Elements ("class")) {
-					var className = classElement.GetAttribute ("name");
-					var baseType = classElement.GetAttribute ("base");
+					var className = classElement.GetAttribute ("name") ?? "";
+					var baseType = classElement.GetAttribute ("base") ?? "";
 					string fullname;
 					if (string.IsNullOrEmpty (@namespace)) {
 						// nested type
@@ -255,7 +255,7 @@ namespace Mono.ApiTools {
 			State.LogDebugMessage ($"Possible -r value: {rm}");
 			if (sb != tb) {
 				Formatter.BeginMemberModification ("Modified base type");
-				var apichange = new ApiChange ($"{State.Namespace}.{State.Type}", State).AppendModified (sb, tb);
+				var apichange = new ApiChange ($"{State.Namespace}.{State.Type}", State).AppendModified (sb ?? "", tb ?? "");
 				Formatter.Diff (apichange);
 				Formatter.EndMemberModification ();
 			}
@@ -272,7 +272,7 @@ namespace Mono.ApiTools {
 				var ti = target.Element ("classes");
 				kcomparer = new NestedClassComparer (State);
 				State.Parent = State.Type;
-				kcomparer.Compare (si.Elements ("class"), ti is null ? null : ti.Elements ("class"));
+				kcomparer.Compare (si.Elements ("class"), ti?.Elements ("class"));
 				State.Type = State.Parent;
 			}
 
@@ -293,7 +293,7 @@ namespace Mono.ApiTools {
 			Formatter.EndTypeRemoval ();
 		}
 
-		public virtual string GetTypeName (XElement type)
+		public virtual string? GetTypeName (XElement type)
 		{
 			return type.GetAttribute ("name");
 		}
@@ -308,11 +308,11 @@ namespace Mono.ApiTools {
 
 		public override void SetContext (XElement current)
 		{
-			State.Type = State.Parent + "." + current.GetAttribute ("name");
-			State.BaseType = current.GetAttribute ("base");
+			State.Type = State.Parent + "." + (current.GetAttribute ("name") ?? "");
+			State.BaseType = current.GetAttribute ("base") ?? "";
 		}
 
-		public override string GetTypeName (XElement type)
+		public override string? GetTypeName (XElement type)
 		{
 			return State.Parent + "." + base.GetTypeName (type);
 		}

--- a/tools/api-tools/mono-api-html/Comparer.cs
+++ b/tools/api-tools/mono-api-html/Comparer.cs
@@ -156,14 +156,14 @@ namespace Mono.ApiTools {
 
 		public abstract void SetContext (XElement current);
 
-		public virtual void Compare (IEnumerable<XElement> source, IEnumerable<XElement> target)
+		public virtual void Compare (IEnumerable<XElement> source, IEnumerable<XElement>? target)
 		{
 			removed.Clear ();
 			modified.Clear ();
 
 			foreach (var s in source) {
 				SetContext (s);
-				string sn = s.GetAttribute ("name");
+				string? sn = s.GetAttribute ("name");
 				var t = target is null ? null : target.SingleOrDefault (x => x.GetAttribute ("name") == sn);
 				if (t is null) {
 					// not in target, it was removed

--- a/tools/api-tools/mono-api-html/ConstructorComparer.cs
+++ b/tools/api-tools/mono-api-html/ConstructorComparer.cs
@@ -50,7 +50,7 @@ namespace Mono.ApiTools {
 
 		public override bool Find (XElement e)
 		{
-			return (e.Attribute ("name").Value == Source.Attribute ("name").Value);
+			return (e.Attribute ("name")!.Value == Source.Attribute ("name")!.Value);
 		}
 
 		void RenderReturnType (XElement source, XElement target, ApiChange change)
@@ -59,7 +59,7 @@ namespace Mono.ApiTools {
 			var tgtType = target.GetTypeName ("returntype", State);
 
 			if (srcType != tgtType) {
-				change.AppendModified (srcType, tgtType);
+				change.AppendModified (srcType ?? "", tgtType ?? "");
 				change.Append (" ");
 			} else if (srcType is not null) {
 				// ctor don't have a return type
@@ -114,7 +114,7 @@ namespace Mono.ApiTools {
 				}
 			}
 
-			string name = e.GetAttribute ("name");
+			string name = e.GetAttribute ("name") ?? "";
 
 			var r = e.GetTypeName ("returntype", State);
 			if (r is not null) {
@@ -133,7 +133,7 @@ namespace Mono.ApiTools {
 			if (genericp is not null) {
 				var list = new List<string> ();
 				foreach (var p in genericp.Elements ("generic-parameter")) {
-					list.Add (p.GetTypeName ("name", State));
+					list.Add (p.GetTypeName ("name", State) ?? "");
 				}
 				sb.Append (Formatter.LesserThan).Append (String.Join (", ", list)).Append (Formatter.GreaterThan);
 			}

--- a/tools/api-tools/mono-api-html/EventComparer.cs
+++ b/tools/api-tools/mono-api-html/EventComparer.cs
@@ -55,8 +55,8 @@ namespace Mono.ApiTools {
 			RenderAttributes (source, target, change);
 			change.Append ("public event ");
 
-			var srcEventType = source.GetTypeName ("eventtype", State);
-			var tgtEventType = target.GetTypeName ("eventtype", State);
+			var srcEventType = source.GetTypeName ("eventtype", State) ?? "";
+			var tgtEventType = target.GetTypeName ("eventtype", State) ?? "";
 
 			if (srcEventType != tgtEventType) {
 				change.AppendModified (srcEventType, tgtEventType);
@@ -64,7 +64,7 @@ namespace Mono.ApiTools {
 				change.Append (srcEventType);
 			}
 			change.Append (" ");
-			change.Append (source.GetAttribute ("name")).Append (";");
+			change.Append (source.GetAttribute ("name") ?? "").Append (";");
 			return false;
 		}
 
@@ -73,8 +73,8 @@ namespace Mono.ApiTools {
 			var sb = new StringBuilder ();
 			// TODO: attribs
 			sb.Append ("public event ");
-			sb.Append (e.GetTypeName ("eventtype", State)).Append (' ');
-			sb.Append (e.GetAttribute ("name")).Append (';');
+			sb.Append (e.GetTypeName ("eventtype", State) ?? "").Append (' ');
+			sb.Append (e.GetAttribute ("name") ?? "").Append (';');
 			return sb.ToString ();
 		}
 	}

--- a/tools/api-tools/mono-api-html/FieldComparer.cs
+++ b/tools/api-tools/mono-api-html/FieldComparer.cs
@@ -106,15 +106,15 @@ namespace Mono.ApiTools {
 
 		string GetFullName (XElement element)
 		{
-			var rv = element.GetAttribute ("name");
-			element = element.Parent;
+			var rv = element.GetAttribute ("name") ?? "";
+			element = element.Parent!;
 			while (element is not null) {
 				if (element.Name.LocalName == "assembly")
 					break;
 				var name = element.GetAttribute ("name");
 				if (!string.IsNullOrEmpty (name))
 					rv = name + "." + rv;
-				element = element.Parent;
+				element = element.Parent!;
 			}
 			return rv;
 		}
@@ -124,7 +124,7 @@ namespace Mono.ApiTools {
 			if (base.Equals (source, target, changes))
 				return true;
 
-			var name = source.GetAttribute ("name");
+			var name = source.GetAttribute ("name") ?? "";
 			var srcValue = source.GetAttribute ("value");
 			var tgtValue = target.GetAttribute ("value");
 			var change = new ApiChange (GetDescription (source), State);
@@ -135,15 +135,15 @@ namespace Mono.ApiTools {
 			if (State.BaseType == "System.Enum") {
 				change.Append (name).Append (" = ");
 				if (srcValue != tgtValue) {
-					change.AppendModified (srcValue, tgtValue);
+					change.AppendModified (srcValue ?? "", tgtValue ?? "");
 				} else {
-					change.Append (srcValue);
+					change.Append (srcValue ?? "");
 				}
 			} else {
 				RenderFieldAttributes (source.GetFieldAttributes (), target.GetFieldAttributes (), change);
 
-				var srcType = source.GetTypeName ("fieldtype", State);
-				var tgtType = target.GetTypeName ("fieldtype", State);
+				var srcType = source.GetTypeName ("fieldtype", State) ?? "";
+				var tgtType = target.GetTypeName ("fieldtype", State) ?? "";
 
 				if (srcType != tgtType) {
 					change.AppendModified (srcType, tgtType);
@@ -183,8 +183,8 @@ namespace Mono.ApiTools {
 		{
 			var sb = new StringBuilder ();
 
-			string name = e.GetAttribute ("name");
-			string value = e.GetAttribute ("value");
+			string name = e.GetAttribute ("name") ?? "";
+			string? value = e.GetAttribute ("value");
 
 			if (State.BaseType == "System.Enum") {
 				sb.Append (name).Append (" = ").Append (value).Append (',');
@@ -205,8 +205,8 @@ namespace Mono.ApiTools {
 						sb.Append ("const ");
 				}
 
-				string ftype = e.GetTypeName ("fieldtype", State);
-				sb.Append (ftype).Append (' ');
+				string? ftype = e.GetTypeName ("fieldtype", State);
+				sb.Append (ftype ?? "").Append (' ');
 				sb.Append (name);
 				if (ftype == "string" && e.Attribute ("value") is not null) {
 					if (value is null)

--- a/tools/api-tools/mono-api-html/Formatter.cs
+++ b/tools/api-tools/mono-api-html/Formatter.cs
@@ -33,11 +33,11 @@ using System.Text;
 namespace Mono.ApiTools {
 
 	abstract class Formatter {
-		public string OutputPath { get; set; }
+		public string OutputPath { get; set; } = "";
 
-		Stack<(StringBuilder, TextWriter)> builders;
-		public StringBuilder StringBuilder { get; private set; }
-		protected TextWriter output;
+		Stack<(StringBuilder, TextWriter)> builders = null!;
+		public StringBuilder StringBuilder { get; private set; } = null!;
+		protected TextWriter output = null!;
 
 		protected int IndentLevel { get; set; }
 

--- a/tools/api-tools/mono-api-html/Helpers.cs
+++ b/tools/api-tools/mono-api-html/Helpers.cs
@@ -39,7 +39,7 @@ namespace Mono.ApiTools {
 			return (self.GetAttribute (name) == "true");
 		}
 
-		public static string GetAttribute (this XElement self, string name)
+		public static string? GetAttribute (this XElement self, string name)
 		{
 			var n = self.Attribute (name);
 			if (n is null)
@@ -47,7 +47,7 @@ namespace Mono.ApiTools {
 			return n.Value;
 		}
 
-		public static IEnumerable<XElement> EnumerateAttributes (this XElement self, string attributeName = null)
+		public static IEnumerable<XElement> EnumerateAttributes (this XElement self, string? attributeName = null)
 		{
 			if (self is null)
 				yield break;
@@ -63,7 +63,7 @@ namespace Mono.ApiTools {
 			}
 		}
 
-		static bool TryGetAttributeProperty (this XElement self, string attributeName, bool recursive, out string firstArgument)
+		static bool TryGetAttributeProperty (this XElement? self, string attributeName, bool recursive, out string? firstArgument)
 		{
 			firstArgument = null;
 
@@ -89,16 +89,16 @@ namespace Mono.ApiTools {
 		}
 
 		// null == no obsolete, String.Empty == no description
-		public static string GetObsoleteMessage (this XElement self)
+		public static string? GetObsoleteMessage (this XElement self)
 		{
-			if (TryGetAttributeProperty (self, "System.ObsoleteAttribute", false, out string message))
+			if (TryGetAttributeProperty (self, "System.ObsoleteAttribute", false, out string? message))
 				return message ?? String.Empty;
 			return null;
 		}
 
-		public static IEnumerable<XElement> Descendants (this XElement self, params string [] names)
+		public static IEnumerable<XElement>? Descendants (this XElement self, params string [] names)
 		{
-			XElement el = self;
+			XElement? el = self;
 			if (el is null)
 				return null;
 
@@ -110,7 +110,7 @@ namespace Mono.ApiTools {
 			return el.Elements (names [names.Length - 1]);
 		}
 
-		public static List<XElement> DescendantList (this XElement self, params string [] names)
+		public static List<XElement>? DescendantList (this XElement self, params string [] names)
 		{
 			var descendants = self.Descendants (names);
 			if (descendants is null)
@@ -119,13 +119,13 @@ namespace Mono.ApiTools {
 		}
 
 		// make it beautiful (.NET -> C#)
-		public static string GetTypeName (this XElement self, string name, State state)
+		public static string? GetTypeName (this XElement self, string name, State state)
 		{
-			string type = self.GetAttribute (name);
+			string? type = self.GetAttribute (name);
 			if (type is null)
 				return null;
 
-			StringBuilder sb = null;
+			StringBuilder sb = null!;
 			bool is_nullable = false;
 			if (type.StartsWith ("System.Nullable`1[", StringComparison.Ordinal)) {
 				is_nullable = true;

--- a/tools/api-tools/mono-api-html/InterfaceComparer.cs
+++ b/tools/api-tools/mono-api-html/InterfaceComparer.cs
@@ -46,7 +46,7 @@ namespace Mono.ApiTools {
 
 		public override string GetDescription (XElement e)
 		{
-			return e.GetTypeName ("name", State);
+			return e.GetTypeName ("name", State) ?? "";
 		}
 	}
 }

--- a/tools/api-tools/mono-api-html/MemberComparer.cs
+++ b/tools/api-tools/mono-api-html/MemberComparer.cs
@@ -51,7 +51,7 @@ namespace Mono.ApiTools {
 				return;
 
 			if (s is null) {
-				Add (t.Elements (ElementName));
+				Add (t!.Elements (ElementName));
 			} else if (t is null) {
 				Remove (s.Elements (ElementName));
 			} else {
@@ -65,7 +65,7 @@ namespace Mono.ApiTools {
 
 		string GetContainingType (XElement el)
 		{
-			return el.Ancestors ("class").First ().Attribute ("type").Value;
+			return el.Ancestors ("class").First ().Attribute ("type")!.Value;
 		}
 
 		bool IsInInterface (XElement el)
@@ -73,19 +73,19 @@ namespace Mono.ApiTools {
 			return GetContainingType (el) == "interface";
 		}
 
-		public XElement Source { get; set; }
+		public XElement Source { get; set; } = null!;
 
 		public virtual bool Find (XElement e)
 		{
 			return e.GetAttribute ("name") == Source.GetAttribute ("name");
 		}
 
-		XElement Find (IEnumerable<XElement> target)
+		XElement? Find (IEnumerable<XElement> target)
 		{
 			return target.SingleOrDefault (Find);
 		}
 
-		public override void Compare (IEnumerable<XElement> source, IEnumerable<XElement> target)
+		public override void Compare (IEnumerable<XElement> source, IEnumerable<XElement>? target)
 		{
 			removed.Clear ();
 			modified.Clear ();
@@ -93,7 +93,7 @@ namespace Mono.ApiTools {
 			foreach (var s in source) {
 				SetContext (s);
 				Source = s;
-				var t = Find (target);
+				var t = target is null ? null : Find (target);
 				if (t is null) {
 					// not in target, it was removed
 					removed.Add (s);
@@ -112,7 +112,8 @@ namespace Mono.ApiTools {
 			Modify (modified);
 
 			// remaining == newly added in target
-			Add (target);
+			if (target is not null)
+				Add (target);
 		}
 
 		void Add (IEnumerable<XElement> elements)
@@ -162,7 +163,7 @@ namespace Mono.ApiTools {
 		protected StringBuilder GetObsoleteMessage (XElement e)
 		{
 			var sb = new StringBuilder ();
-			string o = e.GetObsoleteMessage ();
+			string? o = e.GetObsoleteMessage ();
 			if (o is not null) {
 				sb.Append ("[Obsolete");
 				if (o.Length > 0)
@@ -237,12 +238,12 @@ namespace Mono.ApiTools {
 				if (i > 0)
 					change.Append (", ");
 				if (i >= srcCount) {
-					change.AppendAdded (RenderGenericParameter (tgt [i]));
+					change.AppendAdded (RenderGenericParameter (tgt! [i]));
 				} else if (i >= tgtCount) {
-					change.AppendRemoved (RenderGenericParameter (src [i]));
+					change.AppendRemoved (RenderGenericParameter (src! [i]));
 				} else {
-					var srcName = RenderGenericParameter (src [i]);
-					var tgtName = RenderGenericParameter (tgt [i]);
+					var srcName = RenderGenericParameter (src! [i]);
+					var tgtName = RenderGenericParameter (tgt! [i]);
 
 					if (srcName != tgtName) {
 						change.AppendModified (srcName, tgtName);
@@ -254,7 +255,7 @@ namespace Mono.ApiTools {
 			change.Append (Formatter.GreaterThan);
 		}
 
-		protected string FormatValue (string type, string value)
+		protected string FormatValue (string? type, string? value)
 		{
 			if (value is null)
 				return "null";
@@ -287,8 +288,8 @@ namespace Mono.ApiTools {
 				if (i > 0)
 					change.Append (", ");
 
-				string mods_tgt = tgt [i].GetAttribute ("direction") ?? "";
-				string mods_src = src [i].GetAttribute ("direction") ?? "";
+				string mods_tgt = tgt! [i].GetAttribute ("direction") ?? "";
+				string mods_src = src! [i].GetAttribute ("direction") ?? "";
 
 				if (mods_tgt.Length > 0)
 					mods_tgt = mods_tgt + " ";
@@ -297,12 +298,12 @@ namespace Mono.ApiTools {
 					mods_src = mods_src + " ";
 
 				if (i >= srcCount) {
-					change.AppendAdded (mods_tgt + tgt [i].GetTypeName ("type", State) + " " + tgt [i].GetAttribute ("name"));
+					change.AppendAdded (mods_tgt + tgt! [i].GetTypeName ("type", State) + " " + tgt [i].GetAttribute ("name"));
 				} else if (i >= tgtCount) {
-					change.AppendRemoved (mods_src + src [i].GetTypeName ("type", State) + " " + src [i].GetAttribute ("name"));
+					change.AppendRemoved (mods_src + src! [i].GetTypeName ("type", State) + " " + src [i].GetAttribute ("name"));
 				} else {
-					var paramSourceType = src [i].GetTypeName ("type", State);
-					var paramTargetType = tgt [i].GetTypeName ("type", State);
+					var paramSourceType = src! [i].GetTypeName ("type", State);
+					var paramTargetType = tgt! [i].GetTypeName ("type", State);
 
 					var paramSourceName = src [i].GetAttribute ("name");
 					var paramTargetName = tgt [i].GetAttribute ("name");
@@ -314,15 +315,15 @@ namespace Mono.ApiTools {
 					}
 
 					if (paramSourceType != paramTargetType) {
-						change.AppendModified (paramSourceType, paramTargetType);
+						change.AppendModified (paramSourceType ?? "", paramTargetType ?? "");
 					} else {
-						change.Append (paramSourceType);
+						change.Append (paramSourceType ?? "");
 					}
 					change.Append (" ");
 					if (paramSourceName != paramTargetName) {
-						change.AppendModified (paramSourceName, paramTargetName);
+						change.AppendModified (paramSourceName ?? "", paramTargetName ?? "");
 					} else {
-						change.Append (paramSourceName);
+						change.Append (paramSourceName ?? "");
 					}
 
 					var optSource = src [i].Attribute ("optional");
@@ -467,13 +468,13 @@ namespace Mono.ApiTools {
 			// Changing between 'protected' and 'protected internal' is not visible in the API, so remove the 'internal' part.
 			if ((attrib & MethodAttributes.FamORAssem) == MethodAttributes.FamORAssem) {
 				attrib = (attrib & ~MethodAttributes.MemberAccessMask) | MethodAttributes.Family;
-				element.Attribute ("attrib").Value = ((int) attrib).ToString ();
+				element.Attribute ("attrib")!.Value = ((int) attrib).ToString ();
 			}
 		}
 
 		protected void RenderName (XElement source, XElement target, ApiChange change)
 		{
-			var name = target.GetAttribute ("name");
+			var name = target.GetAttribute ("name") ?? "";
 			// show the constructor as it would be defined in C#
 			name = name.Replace (".ctor", State.Type);
 

--- a/tools/api-tools/mono-api-html/MethodComparer.cs
+++ b/tools/api-tools/mono-api-html/MethodComparer.cs
@@ -63,8 +63,8 @@ namespace Mono.ApiTools {
 			else if (eGP is null ^ sGP is null)
 				return false;
 			else {
-				var eGPs = eGP.Elements ("generic-parameter");
-				var sGPs = sGP.Elements ("generic-parameter");
+				var eGPs = eGP!.Elements ("generic-parameter");
+				var sGPs = sGP!.Elements ("generic-parameter");
 				return eGPs.Count () == sGPs.Count ();
 			}
 		}

--- a/tools/api-tools/mono-api-html/NamespaceComparer.cs
+++ b/tools/api-tools/mono-api-html/NamespaceComparer.cs
@@ -56,20 +56,20 @@ namespace Mono.ApiTools {
 			var t = target.Element ("namespaces");
 			if (XNode.DeepEquals (s, t))
 				return;
-			Compare (s.Elements ("namespace"), t.Elements ("namespace"));
+			Compare (s!.Elements ("namespace"), t!.Elements ("namespace"));
 		}
 
 		public override void SetContext (XElement current)
 		{
-			State.Namespace = current.Attribute ("name").Value;
+			State.Namespace = current.Attribute ("name")!.Value;
 		}
 
 		public override void Added (XElement target, bool wasParentAdded)
 		{
 			Formatter.BeginNamespace ("New ");
 			// list all new types
-			foreach (var addedType in target.Element ("classes").Elements ("class")) {
-				State.Type = addedType.Attribute ("name").Value;
+			foreach (var addedType in target.Element ("classes")!.Elements ("class")) {
+				State.Type = addedType.Attribute ("name")!.Value;
 				comparer.Added (addedType, true);
 			}
 			Formatter.EndNamespace ();
@@ -96,8 +96,8 @@ namespace Mono.ApiTools {
 			Formatter.BeginNamespace ("Removed ");
 			Output.WriteLine ();
 			// list all removed types
-			foreach (var removedType in source.Element ("classes").Elements ("class")) {
-				State.Type = comparer.GetTypeName (removedType);
+			foreach (var removedType in source.Element ("classes")!.Elements ("class")) {
+				State.Type = comparer.GetTypeName (removedType) ?? "";
 				comparer.Removed (removedType);
 			}
 			Formatter.EndNamespace ();

--- a/tools/api-tools/mono-api-html/PropertyComparer.cs
+++ b/tools/api-tools/mono-api-html/PropertyComparer.cs
@@ -189,8 +189,8 @@ namespace Mono.ApiTools {
 			RenderAttributes (source, target, change);
 			RenderMethodAttributes (source, target, GetMethodAttributes (srcGetter, srcSetter), GetMethodAttributes (tgtGetter, tgtSetter), change);
 			RenderPropertyType (source, target, change);
-			if (isIndexer) {
-				RenderIndexers (srcIndexers!, tgtIndexers!, change);
+			if (isIndexer && tgtIndexers is not null) {
+				RenderIndexers (srcIndexers!, tgtIndexers, change);
 			} else {
 				RenderName (source, target, change);
 			}

--- a/tools/api-tools/mono-api-html/PropertyComparer.cs
+++ b/tools/api-tools/mono-api-html/PropertyComparer.cs
@@ -55,7 +55,7 @@ namespace Mono.ApiTools {
 			return e.GetAttribute ("params") == Source.GetAttribute ("params");
 		}
 
-		void GetAccessors (XElement element, out XElement getter, out XElement setter)
+		void GetAccessors (XElement element, out XElement? getter, out XElement? setter)
 		{
 			var methods = element.Element ("methods");
 
@@ -66,7 +66,7 @@ namespace Mono.ApiTools {
 				return;
 
 			foreach (var m in methods.Elements ("method")) {
-				var n = m.GetAttribute ("name");
+				var n = m.GetAttribute ("name") ?? "";
 				if (n.StartsWith ("get_", StringComparison.Ordinal)) {
 					getter = m;
 				} else if (n.StartsWith ("set_", StringComparison.Ordinal)) {
@@ -75,10 +75,10 @@ namespace Mono.ApiTools {
 			}
 		}
 
-		MethodAttributes GetMethodAttributes (XElement getter, XElement setter)
+		MethodAttributes GetMethodAttributes (XElement? getter, XElement? setter)
 		{
 			if (getter is null)
-				return setter.GetMethodAttributes ();
+				return setter!.GetMethodAttributes ();
 			else if (setter is null)
 				return getter.GetMethodAttributes ();
 
@@ -97,8 +97,8 @@ namespace Mono.ApiTools {
 
 		void RenderPropertyType (XElement source, XElement target, ApiChange change)
 		{
-			var srcType = source.GetTypeName ("ptype", State);
-			var tgtType = target.GetTypeName ("ptype", State);
+			var srcType = source.GetTypeName ("ptype", State) ?? "";
+			var tgtType = target.GetTypeName ("ptype", State) ?? "";
 
 			if (srcType == tgtType) {
 				change.Append (tgtType);
@@ -108,7 +108,7 @@ namespace Mono.ApiTools {
 			change.Append (" ");
 		}
 
-		void RenderAccessors (XElement srcGetter, XElement tgtGetter, XElement srcSetter, XElement tgtSetter, ApiChange change)
+		void RenderAccessors (XElement? srcGetter, XElement? tgtGetter, XElement? srcSetter, XElement? tgtSetter, ApiChange change)
 		{
 			// FIXME: this doesn't render changes in the accessor visibility (a protected setter can become public for instance).
 			change.Append (" {");
@@ -145,8 +145,8 @@ namespace Mono.ApiTools {
 				if (i > 0)
 					change.Append (", ");
 
-				var srcType = source.GetTypeName ("type", State);
-				var tgtType = target.GetTypeName ("type", State);
+				var srcType = source.GetTypeName ("type", State) ?? "";
+				var tgtType = target.GetTypeName ("type", State) ?? "";
 				if (srcType == tgtType) {
 					change.Append (tgtType);
 				} else {
@@ -154,8 +154,8 @@ namespace Mono.ApiTools {
 				}
 				change.Append (" ");
 
-				var srcName = source.GetAttribute ("name");
-				var tgtName = target.GetAttribute ("name");
+				var srcName = source.GetAttribute ("name") ?? "";
+				var tgtName = target.GetAttribute ("name") ?? "";
 				if (srcName == tgtName) {
 					change.Append (tgtName);
 				} else {
@@ -170,17 +170,17 @@ namespace Mono.ApiTools {
 			if (base.Equals (source, target, changes))
 				return true;
 
-			XElement srcGetter, srcSetter;
-			XElement tgtGetter, tgtSetter;
+			XElement? srcGetter, srcSetter;
+			XElement? tgtGetter, tgtSetter;
 			GetAccessors (source, out srcGetter, out srcSetter);
 			GetAccessors (target, out tgtGetter, out tgtSetter);
 
-			List<XElement> srcIndexers = null;
-			List<XElement> tgtIndexers = null;
+			List<XElement>? srcIndexers = null;
+			List<XElement>? tgtIndexers = null;
 			bool isIndexer = false;
 			if (srcGetter is not null) {
 				srcIndexers = srcGetter.DescendantList ("parameters", "parameter");
-				tgtIndexers = tgtGetter.DescendantList ("parameters", "parameter");
+				tgtIndexers = tgtGetter?.DescendantList ("parameters", "parameter");
 				isIndexer = srcIndexers is not null && srcIndexers.Count > 0;
 			}
 
@@ -190,7 +190,7 @@ namespace Mono.ApiTools {
 			RenderMethodAttributes (source, target, GetMethodAttributes (srcGetter, srcSetter), GetMethodAttributes (tgtGetter, tgtSetter), change);
 			RenderPropertyType (source, target, change);
 			if (isIndexer) {
-				RenderIndexers (srcIndexers, tgtIndexers, change);
+				RenderIndexers (srcIndexers!, tgtIndexers!, change);
 			} else {
 				RenderName (source, target, change);
 			}
@@ -211,10 +211,10 @@ namespace Mono.ApiTools {
 				foreach (var m in methods.Elements ("method")) {
 					@virtual |= m.IsTrue ("virtual");
 					@static |= m.IsTrue ("static");
-					var n = m.GetAttribute ("name");
+					var n = m.GetAttribute ("name") ?? "";
 					getter |= n.StartsWith ("get_", StringComparison.Ordinal);
 					setter |= n.StartsWith ("set_", StringComparison.Ordinal);
-					var attribs = (MethodAttributes) Int32.Parse (m.GetAttribute ("attrib"));
+					var attribs = (MethodAttributes) Int32.Parse (m.GetAttribute ("attrib") ?? "0");
 					family = ((attribs & MethodAttributes.Public) != MethodAttributes.Public);
 					@override |= (attribs & MethodAttributes.NewSlot) == 0;
 				}
@@ -223,8 +223,8 @@ namespace Mono.ApiTools {
 
 		public override string GetDescription (XElement e)
 		{
-			string name = e.Attribute ("name").Value;
-			string ptype = e.GetTypeName ("ptype", State);
+			string name = e.Attribute ("name")!.Value;
+			string ptype = e.GetTypeName ("ptype", State) ?? "";
 
 			bool virt = false;
 			bool over = false;

--- a/tools/api-tools/mono-api-info/Util.cs
+++ b/tools/api-tools/mono-api-info/Util.cs
@@ -90,7 +90,7 @@ namespace Mono.ApiTools {
 			return ifaces.Values;
 		}
 
-		internal TypeDefinition GetBaseType (TypeDefinition child)
+		internal TypeDefinition? GetBaseType (TypeDefinition child)
 		{
 			if (child.BaseType is null)
 				return null;
@@ -102,7 +102,7 @@ namespace Mono.ApiTools {
 			}
 		}
 
-		internal MethodDefinition GetMethod (MethodReference method)
+		internal MethodDefinition? GetMethod (MethodReference method)
 		{
 			if (method is null)
 				throw new ArgumentNullException (nameof (method));
@@ -134,14 +134,14 @@ namespace Mono.ApiTools {
 			return method.IsVirtual && !method.IsNewSlot;
 		}
 
-		public MethodDefinition GetBaseMethodInTypeHierarchy (MethodDefinition method)
+		public MethodDefinition? GetBaseMethodInTypeHierarchy (MethodDefinition method)
 		{
 			if (!IsOverride (method))
 				return method;
 
 			var @base = GetBaseType (method.DeclaringType);
 			while (@base is not null) {
-				MethodDefinition base_method = TryMatchMethod (@base.Resolve (), method);
+				MethodDefinition? base_method = TryMatchMethod (@base.Resolve (), method);
 				if (base_method is not null)
 					return GetBaseMethodInTypeHierarchy (base_method) ?? base_method;
 
@@ -151,7 +151,7 @@ namespace Mono.ApiTools {
 			return method;
 		}
 
-		MethodDefinition TryMatchMethod (TypeDefinition type, MethodDefinition method)
+		MethodDefinition? TryMatchMethod (TypeDefinition type, MethodDefinition method)
 		{
 			if (!type.HasMethods)
 				return null;

--- a/tools/api-tools/mono-api-info/WellFormedXmlWriter.cs
+++ b/tools/api-tools/mono-api-info/WellFormedXmlWriter.cs
@@ -79,9 +79,13 @@ namespace Mono.ApiTools {
 
 		public override void WriteString (string? text)
 		{
-			int i = IndexOfInvalid (text!, true);
+			if (text is null) {
+				Writer.WriteString (text);
+				return;
+			}
+			int i = IndexOfInvalid (text, true);
 			if (i >= 0) {
-				char [] arr = text!.ToCharArray ();
+				char [] arr = text.ToCharArray ();
 				Writer.WriteChars (arr, 0, i);
 				WriteChars (arr, i, arr.Length - i);
 			} else {

--- a/tools/api-tools/mono-api-info/WellFormedXmlWriter.cs
+++ b/tools/api-tools/mono-api-info/WellFormedXmlWriter.cs
@@ -77,11 +77,11 @@ namespace Mono.ApiTools {
 		{
 		}
 
-		public override void WriteString (string text)
+		public override void WriteString (string? text)
 		{
-			int i = IndexOfInvalid (text, true);
+			int i = IndexOfInvalid (text!, true);
 			if (i >= 0) {
-				char [] arr = text.ToCharArray ();
+				char [] arr = text!.ToCharArray ();
 				Writer.WriteChars (arr, 0, i);
 				WriteChars (arr, i, arr.Length - i);
 			} else {
@@ -131,7 +131,7 @@ namespace Mono.ApiTools {
 			writer.Flush ();
 		}
 
-		public override string LookupPrefix (string ns)
+		public override string? LookupPrefix (string ns)
 		{
 			return writer.LookupPrefix (ns);
 		}
@@ -146,7 +146,7 @@ namespace Mono.ApiTools {
 			writer.WriteBinHex (buffer, index, count);
 		}
 
-		public override void WriteCData (string text)
+		public override void WriteCData (string? text)
 		{
 			writer.WriteCData (text);
 		}
@@ -161,12 +161,12 @@ namespace Mono.ApiTools {
 			writer.WriteChars (buffer, index, count);
 		}
 
-		public override void WriteComment (string text)
+		public override void WriteComment (string? text)
 		{
 			writer.WriteComment (text);
 		}
 
-		public override void WriteDocType (string name, string pubid, string sysid, string subset)
+		public override void WriteDocType (string name, string? pubid, string? sysid, string? subset)
 		{
 			writer.WriteDocType (name, pubid, sysid, subset);
 		}
@@ -211,12 +211,12 @@ namespace Mono.ApiTools {
 			writer.WriteNode (reader, defattr);
 		}
 
-		public override void WriteProcessingInstruction (string name, string text)
+		public override void WriteProcessingInstruction (string name, string? text)
 		{
 			writer.WriteProcessingInstruction (name, text);
 		}
 
-		public override void WriteQualifiedName (string localName, string ns)
+		public override void WriteQualifiedName (string localName, string? ns)
 		{
 			writer.WriteQualifiedName (localName, ns);
 		}
@@ -231,7 +231,7 @@ namespace Mono.ApiTools {
 			writer.WriteRaw (buffer, index, count);
 		}
 
-		public override void WriteStartAttribute (string prefix, string localName, string ns)
+		public override void WriteStartAttribute (string? prefix, string localName, string? ns)
 		{
 			writer.WriteStartAttribute (prefix, localName, ns);
 		}
@@ -246,12 +246,12 @@ namespace Mono.ApiTools {
 			writer.WriteStartDocument ();
 		}
 
-		public override void WriteStartElement (string prefix, string localName, string ns)
+		public override void WriteStartElement (string? prefix, string localName, string? ns)
 		{
 			writer.WriteStartElement (prefix, localName, ns);
 		}
 
-		public override void WriteString (string text)
+		public override void WriteString (string? text)
 		{
 			writer.WriteString (text);
 		}
@@ -261,7 +261,7 @@ namespace Mono.ApiTools {
 			writer.WriteSurrogateCharEntity (lowChar, highChar);
 		}
 
-		public override void WriteWhitespace (string ws)
+		public override void WriteWhitespace (string? ws)
 		{
 			writer.WriteWhitespace (ws);
 		}
@@ -272,7 +272,7 @@ namespace Mono.ApiTools {
 			}
 		}
 
-		public override string XmlLang {
+		public override string? XmlLang {
 			get {
 				return writer.XmlLang;
 			}

--- a/tools/api-tools/mono-api-info/mono-api-info.cs
+++ b/tools/api-tools/mono-api-info/mono-api-info.cs
@@ -29,8 +29,8 @@ namespace Mono.ApiTools {
 		public static int Main (string [] args)
 		{
 			bool showHelp = false;
-			string output = null;
-			List<string> asms = null;
+			string? output = null;
+			List<string>? asms = null;
 			ApiInfoConfig config = new ApiInfoConfig ();
 
 			var options = new Mono.Options.OptionSet {
@@ -82,7 +82,7 @@ namespace Mono.ApiTools {
 				return showHelp ? 0 : 1;
 			}
 
-			TextWriter outputStream = null;
+			TextWriter? outputStream = null;
 			try {
 				if (!string.IsNullOrEmpty (output))
 					outputStream = new StreamWriter (output);
@@ -116,7 +116,7 @@ namespace Mono.ApiTools {
 
 		public List<Stream> ResolveStreams { get; } = new List<Stream> ();
 
-		public TypeHelper TypeHelper { get; private set; }
+		public TypeHelper TypeHelper { get; private set; } = null!;
 
 		public void ResolveTypes ()
 		{
@@ -156,7 +156,7 @@ namespace Mono.ApiTools {
 	}
 
 	public static class ApiInfo {
-		public static void Generate (string assemblyPath, TextWriter outStream, ApiInfoConfig config = null)
+		public static void Generate (string assemblyPath, TextWriter outStream, ApiInfoConfig? config = null)
 		{
 			if (assemblyPath is null)
 				throw new ArgumentNullException (nameof (assemblyPath));
@@ -164,7 +164,7 @@ namespace Mono.ApiTools {
 			Generate (new [] { assemblyPath }, null, outStream, config);
 		}
 
-		public static void Generate (Stream assemblyStream, TextWriter outStream, ApiInfoConfig config = null)
+		public static void Generate (Stream assemblyStream, TextWriter outStream, ApiInfoConfig? config = null)
 		{
 			if (assemblyStream is null)
 				throw new ArgumentNullException (nameof (assemblyStream));
@@ -172,17 +172,17 @@ namespace Mono.ApiTools {
 			Generate (null, new [] { assemblyStream }, outStream, config);
 		}
 
-		public static void Generate (IEnumerable<string> assemblyPaths, TextWriter outStream, ApiInfoConfig config = null)
+		public static void Generate (IEnumerable<string> assemblyPaths, TextWriter outStream, ApiInfoConfig? config = null)
 		{
 			Generate (assemblyPaths, null, outStream, config);
 		}
 
-		public static void Generate (IEnumerable<Stream> assemblyStreams, TextWriter outStream, ApiInfoConfig config = null)
+		public static void Generate (IEnumerable<Stream> assemblyStreams, TextWriter outStream, ApiInfoConfig? config = null)
 		{
 			Generate (null, assemblyStreams, outStream, config);
 		}
 
-		public static void Generate (IEnumerable<string> assemblyPaths, IEnumerable<Stream> assemblyStreams, TextWriter outStream, ApiInfoConfig config = null)
+		public static void Generate (IEnumerable<string>? assemblyPaths, IEnumerable<Stream>? assemblyStreams, TextWriter outStream, ApiInfoConfig? config = null)
 		{
 			if (outStream is null)
 				throw new ArgumentNullException (nameof (outStream));
@@ -204,7 +204,7 @@ namespace Mono.ApiTools {
 			Generate (assemblyPaths, assemblyStreams, outStream, state);
 		}
 
-		internal static void Generate (IEnumerable<string> assemblyFiles, IEnumerable<Stream> assemblyStreams, TextWriter outStream, State state = null)
+		internal static void Generate (IEnumerable<string>? assemblyFiles, IEnumerable<Stream>? assemblyStreams, TextWriter outStream, State? state = null)
 		{
 			if (outStream is null)
 				throw new ArgumentNullException (nameof (outStream));
@@ -295,7 +295,7 @@ namespace Mono.ApiTools {
 	}
 
 	class AssemblyCollection {
-		XmlWriter writer;
+		XmlWriter writer = null!;
 		List<AssemblyDefinition> assemblies = new List<AssemblyDefinition> ();
 		State state;
 
@@ -384,7 +384,7 @@ namespace Mono.ApiTools {
 					continue;
 
 				writer.WriteStartElement ("attribute");
-				AddAttribute ("name", typeof (TypeForwardedToAttribute).FullName);
+				AddAttribute ("name", typeof (TypeForwardedToAttribute).FullName!);
 				writer.WriteStartElement ("properties");
 				writer.WriteStartElement ("property");
 				AddAttribute ("name", "Destination");
@@ -497,7 +497,7 @@ namespace Mono.ApiTools {
 			this.members = members;
 		}
 
-		protected virtual ICustomAttributeProvider GetAdditionalCustomAttributeProvider (MemberReference member)
+		protected virtual ICustomAttributeProvider? GetAdditionalCustomAttributeProvider (MemberReference member)
 		{
 			return null;
 		}
@@ -510,10 +510,10 @@ namespace Mono.ApiTools {
 				writer.WriteStartElement (Tag);
 				AddAttribute ("name", GetName (member));
 				if (!NoMemberAttributes)
-					AddAttribute ("attrib", GetMemberAttributes (member));
+					AddAttribute ("attrib", GetMemberAttributes (member) ?? "");
 				AddExtraAttributes (member);
 
-				AttributeData.OutputAttributes (writer, state, (ICustomAttributeProvider) member, GetAdditionalCustomAttributeProvider (member));
+				AttributeData.OutputAttributes (writer, state, (ICustomAttributeProvider) member, GetAdditionalCustomAttributeProvider (member)!);
 
 				AddExtraData (member);
 				writer.WriteEndElement (); // Tag
@@ -535,7 +535,7 @@ namespace Mono.ApiTools {
 			return "NoNAME";
 		}
 
-		protected virtual string GetMemberAttributes (MemberReference memberDefenition)
+		protected virtual string? GetMemberAttributes (MemberReference memberDefenition)
 		{
 			return null;
 		}
@@ -596,7 +596,7 @@ namespace Mono.ApiTools {
 		TypeDefinition type;
 
 		public TypeData (XmlWriter writer, TypeDefinition type, State state)
-			: base (writer, null, state)
+			: base (writer, null!, state)
 		{
 			this.type = type;
 		}
@@ -625,7 +625,7 @@ namespace Mono.ApiTools {
 			string charSet = GetCharSet (type);
 			AddAttribute ("charset", charSet);
 
-			string layout = GetLayout (type);
+			string? layout = GetLayout (type);
 			if (layout is not null)
 				AddAttribute ("layout", layout);
 
@@ -732,7 +732,7 @@ namespace Mono.ApiTools {
 			writer.WriteEndElement (); // class
 		}
 
-		static FieldReference GetEnumValueField (TypeDefinition type)
+		static FieldReference? GetEnumValueField (TypeDefinition type)
 		{
 			foreach (FieldDefinition field in type.Fields)
 				if (field.IsSpecialName && field.Name == "value__")
@@ -793,7 +793,7 @@ namespace Mono.ApiTools {
 			return CharSet.None.ToString ();
 		}
 
-		static string GetLayout (TypeDefinition type)
+		static string? GetLayout (TypeDefinition type)
 		{
 			TypeAttributes maskedLayout = type.Attributes & TypeAttributes.LayoutMask;
 			if (maskedLayout == TypeAttributes.AutoLayout)
@@ -926,9 +926,9 @@ namespace Mono.ApiTools {
 		}
 
 		sealed class ParameterComparer : IEqualityComparer<ParameterDefinition> {
-			public bool Equals (ParameterDefinition x, ParameterDefinition y)
+			public bool Equals (ParameterDefinition? x, ParameterDefinition? y)
 			{
-				return x.ParameterType.Name == y.ParameterType.Name;
+				return x!.ParameterType.Name == y!.ParameterType.Name;
 			}
 
 			public int GetHashCode (ParameterDefinition obj)
@@ -1012,7 +1012,7 @@ namespace Mono.ApiTools {
 
 			if (field.IsLiteral) {
 				object value = field.Constant;//object value = field.GetValue (null);
-				string stringValue = null;
+				string? stringValue = null;
 				//if (value is Enum) {
 				//    // FIXME: when Mono bug #60090 has been
 				//    // fixed, we should just be able to use
@@ -1049,21 +1049,21 @@ namespace Mono.ApiTools {
 			return prop.Name;
 		}
 
-		MethodDefinition [] GetMethods (PropertyDefinition prop, out bool haveParameters)
+		MethodDefinition []? GetMethods (PropertyDefinition prop, out bool haveParameters)
 		{
 			MethodDefinition _get = prop.GetMethod;
 			MethodDefinition _set = prop.SetMethod;
 			bool haveGet = (_get is not null && TypeData.MustDocumentMethod (_get));
 			bool haveSet = (_set is not null && TypeData.MustDocumentMethod (_set));
-			haveParameters = haveGet || (haveSet && _set.Parameters.Count > 1);
+			haveParameters = haveGet || (haveSet && _set!.Parameters.Count > 1);
 			MethodDefinition [] methods;
 
 			if (haveGet && haveSet) {
-				methods = new MethodDefinition [] { _get, _set };
+				methods = new MethodDefinition [] { _get!, _set! };
 			} else if (haveGet) {
-				methods = new MethodDefinition [] { _get };
+				methods = new MethodDefinition [] { _get! };
 			} else if (haveSet) {
-				methods = new MethodDefinition [] { _set };
+				methods = new MethodDefinition [] { _set! };
 			} else {
 				//odd
 				return null;
@@ -1080,7 +1080,7 @@ namespace Mono.ApiTools {
 			AddAttribute ("ptype", Utils.CleanupTypeName (prop.PropertyType));
 
 			bool haveParameters;
-			MethodDefinition [] methods = GetMethods ((PropertyDefinition) memberDefinition, out haveParameters);
+			MethodDefinition []? methods = GetMethods ((PropertyDefinition) memberDefinition, out haveParameters);
 
 			if (methods is not null && haveParameters) {
 				string parms = Parameters.GetSignature (methods [0].Parameters);
@@ -1095,7 +1095,7 @@ namespace Mono.ApiTools {
 			base.AddExtraData (memberDefenition);
 
 			bool haveParameters;
-			MethodDefinition [] methods = GetMethods ((PropertyDefinition) memberDefenition, out haveParameters);
+			MethodDefinition []? methods = GetMethods ((PropertyDefinition) memberDefenition, out haveParameters);
 
 			if (methods is null)
 				return;
@@ -1301,7 +1301,7 @@ namespace Mono.ApiTools {
 				if (parameter.IsOptional) {
 					AddAttribute ("optional", "true");
 					if (parameter.HasConstant)
-						AddAttribute ("defaultValue", parameter.Constant is null ? "NULL" : parameter.Constant.ToString ());
+						AddAttribute ("defaultValue", parameter.Constant is null ? "NULL" : parameter.Constant.ToString () ?? "");
 				}
 
 				if (direction != "in")
@@ -1453,9 +1453,9 @@ namespace Mono.ApiTools {
 	class TypeReferenceComparer : IComparer<TypeReference> {
 		public static TypeReferenceComparer Default = new TypeReferenceComparer ();
 
-		public int Compare (TypeReference a, TypeReference b)
+		public int Compare (TypeReference? a, TypeReference? b)
 		{
-			int result = String.Compare (a.Namespace, b.Namespace, StringComparison.Ordinal);
+			int result = String.Compare (a!.Namespace, b!.Namespace, StringComparison.Ordinal);
 			if (result != 0)
 				return result;
 
@@ -1466,10 +1466,10 @@ namespace Mono.ApiTools {
 	class MemberReferenceComparer : IComparer {
 		public static MemberReferenceComparer Default = new MemberReferenceComparer ();
 
-		public int Compare (object a, object b)
+		public int Compare (object? a, object? b)
 		{
-			MemberReference ma = (MemberReference) a;
-			MemberReference mb = (MemberReference) b;
+			MemberReference ma = (MemberReference) a!;
+			MemberReference mb = (MemberReference) b!;
 			return String.Compare (ma.Name, mb.Name, StringComparison.Ordinal);
 		}
 	}
@@ -1477,9 +1477,9 @@ namespace Mono.ApiTools {
 	class PropertyDefinitionComparer : IComparer<PropertyDefinition> {
 		public static PropertyDefinitionComparer Default = new PropertyDefinitionComparer ();
 
-		public int Compare (PropertyDefinition ma, PropertyDefinition mb)
+		public int Compare (PropertyDefinition? ma, PropertyDefinition? mb)
 		{
-			int res = String.Compare (ma.Name, mb.Name, StringComparison.Ordinal);
+			int res = String.Compare (ma!.Name, mb!.Name, StringComparison.Ordinal);
 			if (res != 0)
 				return res;
 
@@ -1499,10 +1499,10 @@ namespace Mono.ApiTools {
 	class MethodDefinitionComparer : IComparer {
 		public static MethodDefinitionComparer Default = new MethodDefinitionComparer ();
 
-		public int Compare (object a, object b)
+		public int Compare (object? a, object? b)
 		{
-			MethodDefinition ma = (MethodDefinition) a;
-			MethodDefinition mb = (MethodDefinition) b;
+			MethodDefinition ma = (MethodDefinition) a!;
+			MethodDefinition mb = (MethodDefinition) b!;
 			int res = String.Compare (ma.Name, mb.Name, StringComparison.Ordinal);
 			if (res != 0)
 				return res;

--- a/tools/api-tools/mono-api-info/mono-api-info.cs
+++ b/tools/api-tools/mono-api-info/mono-api-info.cs
@@ -513,7 +513,11 @@ namespace Mono.ApiTools {
 					AddAttribute ("attrib", GetMemberAttributes (member) ?? "");
 				AddExtraAttributes (member);
 
-				AttributeData.OutputAttributes (writer, state, (ICustomAttributeProvider) member, GetAdditionalCustomAttributeProvider (member)!);
+				var additionalProvider = GetAdditionalCustomAttributeProvider (member);
+				if (additionalProvider is not null)
+					AttributeData.OutputAttributes (writer, state, (ICustomAttributeProvider) member, additionalProvider);
+				else
+					AttributeData.OutputAttributes (writer, state, (ICustomAttributeProvider) member);
 
 				AddExtraData (member);
 				writer.WriteEndElement (); // Tag
@@ -596,7 +600,7 @@ namespace Mono.ApiTools {
 		TypeDefinition type;
 
 		public TypeData (XmlWriter writer, TypeDefinition type, State state)
-			: base (writer, null!, state)
+			: base (writer, [], state)
 		{
 			this.type = type;
 		}
@@ -928,7 +932,9 @@ namespace Mono.ApiTools {
 		sealed class ParameterComparer : IEqualityComparer<ParameterDefinition> {
 			public bool Equals (ParameterDefinition? x, ParameterDefinition? y)
 			{
-				return x!.ParameterType.Name == y!.ParameterType.Name;
+				if (x is null || y is null)
+					return x is null && y is null;
+				return x.ParameterType.Name == y.ParameterType.Name;
 			}
 
 			public int GetHashCode (ParameterDefinition obj)
@@ -1455,7 +1461,10 @@ namespace Mono.ApiTools {
 
 		public int Compare (TypeReference? a, TypeReference? b)
 		{
-			int result = String.Compare (a!.Namespace, b!.Namespace, StringComparison.Ordinal);
+			if (a is null && b is null) return 0;
+			if (a is null) return -1;
+			if (b is null) return 1;
+			int result = String.Compare (a.Namespace, b.Namespace, StringComparison.Ordinal);
 			if (result != 0)
 				return result;
 
@@ -1468,8 +1477,11 @@ namespace Mono.ApiTools {
 
 		public int Compare (object? a, object? b)
 		{
-			MemberReference ma = (MemberReference) a!;
-			MemberReference mb = (MemberReference) b!;
+			if (a is null && b is null) return 0;
+			if (a is null) return -1;
+			if (b is null) return 1;
+			MemberReference ma = (MemberReference) a;
+			MemberReference mb = (MemberReference) b;
 			return String.Compare (ma.Name, mb.Name, StringComparison.Ordinal);
 		}
 	}
@@ -1479,7 +1491,10 @@ namespace Mono.ApiTools {
 
 		public int Compare (PropertyDefinition? ma, PropertyDefinition? mb)
 		{
-			int res = String.Compare (ma!.Name, mb!.Name, StringComparison.Ordinal);
+			if (ma is null && mb is null) return 0;
+			if (ma is null) return -1;
+			if (mb is null) return 1;
+			int res = String.Compare (ma.Name, mb.Name, StringComparison.Ordinal);
 			if (res != 0)
 				return res;
 
@@ -1501,8 +1516,11 @@ namespace Mono.ApiTools {
 
 		public int Compare (object? a, object? b)
 		{
-			MethodDefinition ma = (MethodDefinition) a!;
-			MethodDefinition mb = (MethodDefinition) b!;
+			if (a is null && b is null) return 0;
+			if (a is null) return -1;
+			if (b is null) return 1;
+			MethodDefinition ma = (MethodDefinition) a;
+			MethodDefinition mb = (MethodDefinition) b;
 			int res = String.Compare (ma.Name, mb.Name, StringComparison.Ordinal);
 			if (res != 0)
 				return res;


### PR DESCRIPTION
Fix all nullability warnings/errors in the api-tools:

- **mono-api-html**: ~50 fixes across 15 files —
- **mono-api-info**: ~55 fixes across 3 files — nullable XmlWriter override params, nullable return types for `GetBaseType`/`GetMethod`/`GetLayout`, IComparer interface params, late-initialized fields

Both projects now build with 0 errors and 0 warnings.

🤖 Pull request created by Copilot