### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 14411: Build ID 14073055

### DIFF
--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.cs.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.cs.resx
@@ -845,6 +845,18 @@
   <data name="MX2257" xml:space="preserve">
 		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
 	</data>
+  <data name="MX2258" xml:space="preserve">
+		<value>'{0}' is marked with a malformed simulator availability attribute: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2259" xml:space="preserve">
+		<value>'{0}' is marked with a simulator availability attribute with an invalid version: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2260" xml:space="preserve">
+		<value>'{0}' has conflicting simulator availability attributes for the '{1}' platform (both SupportedSimulator and UnsupportedSimulator). Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2261" xml:space="preserve">
+		<value>'{0}' has multiple SupportedSimulator attributes for the '{1}' platform. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.de.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.de.resx
@@ -845,6 +845,18 @@
   <data name="MX2257" xml:space="preserve">
 		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
 	</data>
+  <data name="MX2258" xml:space="preserve">
+		<value>'{0}' is marked with a malformed simulator availability attribute: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2259" xml:space="preserve">
+		<value>'{0}' is marked with a simulator availability attribute with an invalid version: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2260" xml:space="preserve">
+		<value>'{0}' has conflicting simulator availability attributes for the '{1}' platform (both SupportedSimulator and UnsupportedSimulator). Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2261" xml:space="preserve">
+		<value>'{0}' has multiple SupportedSimulator attributes for the '{1}' platform. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.es.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.es.resx
@@ -845,6 +845,18 @@
   <data name="MX2257" xml:space="preserve">
 		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
 	</data>
+  <data name="MX2258" xml:space="preserve">
+		<value>'{0}' is marked with a malformed simulator availability attribute: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2259" xml:space="preserve">
+		<value>'{0}' is marked with a simulator availability attribute with an invalid version: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2260" xml:space="preserve">
+		<value>'{0}' has conflicting simulator availability attributes for the '{1}' platform (both SupportedSimulator and UnsupportedSimulator). Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2261" xml:space="preserve">
+		<value>'{0}' has multiple SupportedSimulator attributes for the '{1}' platform. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.fr.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.fr.resx
@@ -845,6 +845,18 @@
   <data name="MX2257" xml:space="preserve">
 		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
 	</data>
+  <data name="MX2258" xml:space="preserve">
+		<value>'{0}' is marked with a malformed simulator availability attribute: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2259" xml:space="preserve">
+		<value>'{0}' is marked with a simulator availability attribute with an invalid version: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2260" xml:space="preserve">
+		<value>'{0}' has conflicting simulator availability attributes for the '{1}' platform (both SupportedSimulator and UnsupportedSimulator). Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2261" xml:space="preserve">
+		<value>'{0}' has multiple SupportedSimulator attributes for the '{1}' platform. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.it.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.it.resx
@@ -845,6 +845,18 @@
   <data name="MX2257" xml:space="preserve">
 		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
 	</data>
+  <data name="MX2258" xml:space="preserve">
+		<value>'{0}' is marked with a malformed simulator availability attribute: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2259" xml:space="preserve">
+		<value>'{0}' is marked with a simulator availability attribute with an invalid version: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2260" xml:space="preserve">
+		<value>'{0}' has conflicting simulator availability attributes for the '{1}' platform (both SupportedSimulator and UnsupportedSimulator). Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2261" xml:space="preserve">
+		<value>'{0}' has multiple SupportedSimulator attributes for the '{1}' platform. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.ja.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.ja.resx
@@ -845,6 +845,18 @@
   <data name="MX2257" xml:space="preserve">
 		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
 	</data>
+  <data name="MX2258" xml:space="preserve">
+		<value>'{0}' is marked with a malformed simulator availability attribute: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2259" xml:space="preserve">
+		<value>'{0}' is marked with a simulator availability attribute with an invalid version: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2260" xml:space="preserve">
+		<value>'{0}' has conflicting simulator availability attributes for the '{1}' platform (both SupportedSimulator and UnsupportedSimulator). Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2261" xml:space="preserve">
+		<value>'{0}' has multiple SupportedSimulator attributes for the '{1}' platform. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.ko.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.ko.resx
@@ -845,6 +845,18 @@
   <data name="MX2257" xml:space="preserve">
 		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
 	</data>
+  <data name="MX2258" xml:space="preserve">
+		<value>'{0}' is marked with a malformed simulator availability attribute: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2259" xml:space="preserve">
+		<value>'{0}' is marked with a simulator availability attribute with an invalid version: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2260" xml:space="preserve">
+		<value>'{0}' has conflicting simulator availability attributes for the '{1}' platform (both SupportedSimulator and UnsupportedSimulator). Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2261" xml:space="preserve">
+		<value>'{0}' has multiple SupportedSimulator attributes for the '{1}' platform. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.pl.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.pl.resx
@@ -845,6 +845,18 @@
   <data name="MX2257" xml:space="preserve">
 		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
 	</data>
+  <data name="MX2258" xml:space="preserve">
+		<value>'{0}' is marked with a malformed simulator availability attribute: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2259" xml:space="preserve">
+		<value>'{0}' is marked with a simulator availability attribute with an invalid version: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2260" xml:space="preserve">
+		<value>'{0}' has conflicting simulator availability attributes for the '{1}' platform (both SupportedSimulator and UnsupportedSimulator). Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2261" xml:space="preserve">
+		<value>'{0}' has multiple SupportedSimulator attributes for the '{1}' platform. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.pt-BR.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.pt-BR.resx
@@ -845,6 +845,18 @@
   <data name="MX2257" xml:space="preserve">
 		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
 	</data>
+  <data name="MX2258" xml:space="preserve">
+		<value>'{0}' is marked with a malformed simulator availability attribute: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2259" xml:space="preserve">
+		<value>'{0}' is marked with a simulator availability attribute with an invalid version: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2260" xml:space="preserve">
+		<value>'{0}' has conflicting simulator availability attributes for the '{1}' platform (both SupportedSimulator and UnsupportedSimulator). Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2261" xml:space="preserve">
+		<value>'{0}' has multiple SupportedSimulator attributes for the '{1}' platform. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.ru.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.ru.resx
@@ -845,6 +845,18 @@
   <data name="MX2257" xml:space="preserve">
 		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
 	</data>
+  <data name="MX2258" xml:space="preserve">
+		<value>'{0}' is marked with a malformed simulator availability attribute: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2259" xml:space="preserve">
+		<value>'{0}' is marked with a simulator availability attribute with an invalid version: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2260" xml:space="preserve">
+		<value>'{0}' has conflicting simulator availability attributes for the '{1}' platform (both SupportedSimulator and UnsupportedSimulator). Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2261" xml:space="preserve">
+		<value>'{0}' has multiple SupportedSimulator attributes for the '{1}' platform. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.tr.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.tr.resx
@@ -845,6 +845,18 @@
   <data name="MX2257" xml:space="preserve">
 		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
 	</data>
+  <data name="MX2258" xml:space="preserve">
+		<value>'{0}' is marked with a malformed simulator availability attribute: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2259" xml:space="preserve">
+		<value>'{0}' is marked with a simulator availability attribute with an invalid version: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2260" xml:space="preserve">
+		<value>'{0}' has conflicting simulator availability attributes for the '{1}' platform (both SupportedSimulator and UnsupportedSimulator). Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2261" xml:space="preserve">
+		<value>'{0}' has multiple SupportedSimulator attributes for the '{1}' platform. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.zh-Hans.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.zh-Hans.resx
@@ -845,6 +845,18 @@
   <data name="MX2257" xml:space="preserve">
 		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
 	</data>
+  <data name="MX2258" xml:space="preserve">
+		<value>'{0}' is marked with a malformed simulator availability attribute: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2259" xml:space="preserve">
+		<value>'{0}' is marked with a simulator availability attribute with an invalid version: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2260" xml:space="preserve">
+		<value>'{0}' has conflicting simulator availability attributes for the '{1}' platform (both SupportedSimulator and UnsupportedSimulator). Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2261" xml:space="preserve">
+		<value>'{0}' has multiple SupportedSimulator attributes for the '{1}' platform. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.zh-Hant.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.zh-Hant.resx
@@ -845,6 +845,18 @@
   <data name="MX2257" xml:space="preserve">
 		<value>Unknown IL sequence for method with call to Dlfcn.CachePointer: '{0}' in method '{1}'. The call will not be inlined. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
 	</data>
+  <data name="MX2258" xml:space="preserve">
+		<value>'{0}' is marked with a malformed simulator availability attribute: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2259" xml:space="preserve">
+		<value>'{0}' is marked with a simulator availability attribute with an invalid version: {1}. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2260" xml:space="preserve">
+		<value>'{0}' has conflicting simulator availability attributes for the '{1}' platform (both SupportedSimulator and UnsupportedSimulator). Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
+  <data name="MX2261" xml:space="preserve">
+		<value>'{0}' has multiple SupportedSimulator attributes for the '{1}' platform. Please file an issue at https://github.com/dotnet/macios/issues/new</value>
+	</data>
   <!-- 2300 -> 2399 is used by/reserved for ConfigurationAwareStep subclasses in the linker -->
   <data name="MX_ConfigurationAwareStep" xml:space="preserve">
 		<value>The linker step '{0}' failed during processing: {1}</value>


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.