### PR TITLE
[xharness] Honor system dark mode in xharness web UI

### DIFF
--- a/tests/xharness/Jenkins/Reports/HtmlReportWriter.cs
+++ b/tests/xharness/Jenkins/Reports/HtmlReportWriter.cs
@@ -124,7 +124,7 @@ namespace Xharness.Jenkins.Reports {
 				writer.WriteLine ("<a href='{0}' type='text/plain;charset=UTF-8'>{1}</a><br />", GetLinkFullPath (log.FullPath.Substring (jenkins.LogDirectory.Length + 1)), log.Description);
 			writer.WriteLine ("</span>");
 
-			var headerColor = "black";
+			var headerColor = "currentcolor";
 			if (unfinishedTests.Any ()) {
 				; // default
 			} else if (failedTests.Any ()) {

--- a/tests/xharness/Jenkins/TestTasks/ITestTaskExtensions.cs
+++ b/tests/xharness/Jenkins/TestTasks/ITestTaskExtensions.cs
@@ -7,7 +7,7 @@ namespace Xharness.Jenkins.TestTasks {
 		public static string GetTestColor (this IEnumerable<TestTask> tests)
 		{
 			if (!tests.Any ())
-				return "black";
+				return "currentcolor";
 
 			var first = tests.First ();
 			if (tests.All ((v) => v.ExecutionResult == first.ExecutionResult))
@@ -23,7 +23,7 @@ namespace Xharness.Jenkins.TestTasks {
 			else if (tests.Any ((v) => v.Failed))
 				return "red";
 			else if (tests.Any ((v) => v.NotStarted))
-				return "black";
+				return "currentcolor";
 			else if (tests.Any ((v) => v.Ignored))
 				return "gray";
 			else if (tests.Any ((v) => v.DeviceNotFound))
@@ -33,13 +33,13 @@ namespace Xharness.Jenkins.TestTasks {
 			else if (tests.All ((v) => v.Succeeded))
 				return "green";
 			else
-				return "black";
+				return "currentcolor";
 		}
 
 		public static string GetTestColor (this TestTask test)
 		{
 			if (test.NotStarted) {
-				return "black";
+				return "currentcolor";
 			} else if (test.InProgress) {
 				if (test.Building) {
 					return "darkblue";

--- a/tests/xharness/xharness.css
+++ b/tests/xharness/xharness.css
@@ -1,3 +1,27 @@
+:root {
+    color-scheme: light dark;
+}
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #1e1e1e;
+        color: #d4d4d4;
+    }
+
+    a {
+        color: #6db3f2;
+    }
+
+    a:visited {
+        color: #b48ead;
+    }
+
+    #nav ul {
+        background: #2d2d2d;
+        border-color: #555;
+    }
+}
+
 .pdiv {
     display: table;
     padding-top: 10px;
@@ -43,7 +67,7 @@
 }
 
 #nav ul {
-    background: #ffffff;
+    background: Canvas;
     list-style: none;
     position: absolute;
     left: -9999px;


### PR DESCRIPTION
Add @media (prefers-color-scheme: dark) rules to xharness.css with
dark background, light text, and appropriate link/nav colors. Replace
hardcoded 'black' color values with 'currentcolor' so text remains
visible in both light and dark modes. Use CSS system color 'Canvas'
for nav dropdown background instead of hardcoded #ffffff.