### PR TITLE
[tools] Fix IL2009 warning for generic types in linker XML descriptors

### DIFF
--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -2601,11 +2601,34 @@ namespace Xamarin.Tests {
 			properties ["TrimmerSingleWarn"] = "false";
 			var rv = DotNet.AssertBuild (project_path, properties);
 
-			var warnings = BinLog.GetBuildLogWarnings (rv.BinLogPath).ToArray ();
-
-			// Verify that we don't get any IL2009 warnings (the bug we're testing for).
-			var il2009Warnings = warnings.Where (v => v.Code == "IL2009").ToArray ();
-			Assert.That (il2009Warnings, Is.Empty, $"Expected no IL2009 warnings, but got:\n\t{string.Join ("\n\t", il2009Warnings.Select (v => v.ToString ()))}");
+			var config = "Debug";
+			var runtimeIdentifierInfix = $"/{runtimeIdentifiers}/";
+			var warnings = BinLog.GetBuildLogWarnings (rv.BinLogPath)
+								.Where (evt => {
+									if (platform == ApplePlatform.iOS && evt.Message?.Trim () == "Supported iPhone orientations have not been set")
+										return false;
+									return true;
+								});
+			var expectedWarnings = new ExpectedBuildMessage [] {
+				new ExpectedBuildMessage ($"ILLINK", $"It's not safe to remove the dynamic registrar, because monotouchtest references 'ObjCRuntime.Runtime.ConnectMethod (System.Reflection.MethodInfo, ObjCRuntime.Selector)'."),
+				new ExpectedBuildMessage ($"ILLINK", $"It's not safe to remove the dynamic registrar, because monotouchtest references 'ObjCRuntime.Runtime.ConnectMethod (System.Type, System.Reflection.MethodInfo, Foundation.ExportAttribute)'."),
+				new ExpectedBuildMessage ($"ILLINK", $"It's not safe to remove the dynamic registrar, because monotouchtest references 'ObjCRuntime.Runtime.ConnectMethod (System.Type, System.Reflection.MethodInfo, ObjCRuntime.Selector)'."),
+				new ExpectedBuildMessage ($"ILLINK", $"It's not safe to remove the dynamic registrar, because monotouchtest references 'ObjCRuntime.Runtime.RegisterAssembly (System.Reflection.Assembly)'."),
+				new ExpectedBuildMessage ($"tests/bindings-test/RegistrarBindingTest.cs", $"Unable to locate the block to delegate conversion method for the method System.Void Xamarin.BindingTests.RegistrarBindingTest/FakePropertyBlock::set_MyOptionalProperty(Bindings.Test.SimpleCallback)'s parameter #1."),
+				new ExpectedBuildMessage ($"tests/bindings-test/RegistrarBindingTest.cs", $"Unable to locate the block to delegate conversion method for the method System.Void Xamarin.BindingTests.RegistrarBindingTest/FakePropertyBlock::set_MyOptionalStaticProperty(Bindings.Test.SimpleCallback)'s parameter #1."),
+				new ExpectedBuildMessage ($"tests/bindings-test/RegistrarBindingTest.cs", $"Unable to locate the block to delegate conversion method for the method System.Void Xamarin.BindingTests.RegistrarBindingTest/FakePropertyBlock::set_MyRequiredProperty(Bindings.Test.SimpleCallback)'s parameter #1."),
+				new ExpectedBuildMessage ($"tests/bindings-test/RegistrarBindingTest.cs", $"Unable to locate the block to delegate conversion method for the method System.Void Xamarin.BindingTests.RegistrarBindingTest/FakePropertyBlock::set_MyRequiredStaticProperty(Bindings.Test.SimpleCallback)'s parameter #1."),
+				new ExpectedBuildMessage ($"tests/bindings-test/RegistrarBindingTest.cs", $"Unable to locate the delegate to block conversion type for the return value of the method Bindings.Test.SimpleCallback Xamarin.BindingTests.RegistrarBindingTest/FakePropertyBlock::get_MyOptionalProperty()."),
+				new ExpectedBuildMessage ($"tests/bindings-test/RegistrarBindingTest.cs", $"Unable to locate the delegate to block conversion type for the return value of the method Bindings.Test.SimpleCallback Xamarin.BindingTests.RegistrarBindingTest/FakePropertyBlock::get_MyOptionalStaticProperty()."),
+				new ExpectedBuildMessage ($"tests/bindings-test/RegistrarBindingTest.cs", $"Unable to locate the delegate to block conversion type for the return value of the method Bindings.Test.SimpleCallback Xamarin.BindingTests.RegistrarBindingTest/FakePropertyBlock::get_MyRequiredProperty()."),
+				new ExpectedBuildMessage ($"tests/bindings-test/RegistrarBindingTest.cs", $"Unable to locate the delegate to block conversion type for the return value of the method Bindings.Test.SimpleCallback Xamarin.BindingTests.RegistrarBindingTest/FakePropertyBlock::get_MyRequiredStaticProperty()."),
+				new ExpectedBuildMessage ($"tests/monotouch-test/dotnet/{platform.AsString ()}/obj/{config}/{Configuration.DotNetTfm}-{platform.AsString ().ToLower ()}{runtimeIdentifierInfix}linked/nunit.framework.dll", $"Assembly 'nunit.framework' produced AOT analysis warnings."),
+				new ExpectedBuildMessage ($"tests/monotouch-test/ObjCRuntime/ClassTest.cs", $"MonoTouchFixtures.ObjCRuntime.ClassTest.GetHandle(): Using member 'System.Type.MakeArrayType()' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. The code for an array of the specified type might not be available."),
+				new ExpectedBuildMessage ($"tests/monotouch-test/ObjCRuntime/RegistrarTest.cs", $"Unable to locate the block to delegate conversion method for the method System.Void MonoTouchFixtures.ObjCRuntime.GHIssue7733::DoWork(System.String,MonoTouchFixtures.ObjCRuntime.ACompletionHandler)'s parameter #2."),
+				new ExpectedBuildMessage ($"tests/monotouch-test/ObjCRuntime/RegistrarTest.cs", $"Unable to locate the block to delegate conversion method for the method System.Void MonoTouchFixtures.ObjCRuntime.RegistrarTest/ClosedGenericParameter::Foo(System.Action`1<System.String>)'s parameter #1."),
+				new ExpectedBuildMessage ($"tests/monotouch-test/ObjCRuntime/RegistrarTest.cs", $"Unable to locate the block to delegate conversion method for the method System.Void MonoTouchFixtures.ObjCRuntime.RegistrarTest/RegistrarTestClass::TestNSAction(System.Action)'s parameter #1."),
+			};
+			warnings.AssertWarnings (expectedWarnings);
 		}
 
 		void AssertThatDylibExistsAndIsReidentified (string appPath, string dylibRelPath)

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -2583,6 +2583,35 @@ namespace Xamarin.Tests {
 			});
 		}
 
+		[Test]
+		[TestCase (ApplePlatform.iOS, "iossimulator-arm64")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
+		[TestCase (ApplePlatform.TVOS, "tvossimulator-arm64")]
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64")]
+		public void PublishAotMonoTouchTest_NoIL2009 (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var project_path = Path.Combine (Configuration.SourceRoot, "tests", "monotouch-test", "dotnet", platform.AsString (), "monotouch-test.csproj");
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["PublishAot"] = "true";
+			properties ["_IsPublishing"] = "true";
+			properties ["TrimmerSingleWarn"] = "false";
+			var rv = DotNet.AssertBuild (project_path, properties);
+
+			var warnings = BinLog.GetBuildLogWarnings (rv.BinLogPath).ToArray ();
+
+			// Verify that we don't get any IL2009 warnings (the bug we're testing for).
+			var il2009Warnings = warnings.Where (v => v.Code == "IL2009").ToArray ();
+			Assert.That (il2009Warnings, Is.Empty, $"Expected no IL2009 warnings, but got:\n\t{string.Join ("\n\t", il2009Warnings.Select (v => v.ToString ()))}");
+
+			// Verify that we still get some expected warnings (so that we're notified if they're ever fixed/go away).
+			var il2026Warnings = warnings.Where (v => v.Code == "IL2026").ToArray ();
+			Assert.That (il2026Warnings, Is.Not.Empty, "Expected IL2026 warnings from monotouch-test");
+		}
+
 		void AssertThatDylibExistsAndIsReidentified (string appPath, string dylibRelPath)
 		{
 			var dylibPath = Path.Join (appPath, "Contents", "MonoBundle", dylibRelPath);

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -2606,10 +2606,6 @@ namespace Xamarin.Tests {
 			// Verify that we don't get any IL2009 warnings (the bug we're testing for).
 			var il2009Warnings = warnings.Where (v => v.Code == "IL2009").ToArray ();
 			Assert.That (il2009Warnings, Is.Empty, $"Expected no IL2009 warnings, but got:\n\t{string.Join ("\n\t", il2009Warnings.Select (v => v.ToString ()))}");
-
-			// Verify that we still get some expected warnings (so that we're notified if they're ever fixed/go away).
-			var il2026Warnings = warnings.Where (v => v.Code == "IL2026").ToArray ();
-			Assert.That (il2026Warnings, Is.Not.Empty, "Expected IL2026 warnings from monotouch-test");
 		}
 
 		void AssertThatDylibExistsAndIsReidentified (string appPath, string dylibRelPath)

--- a/tools/dotnet-linker/ApplyPreserveAttributeStep.cs
+++ b/tools/dotnet-linker/ApplyPreserveAttributeStep.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Linker.Steps {
 			public bool PreserveFields { get; set; }
 			public bool PreserveType { get; set; }
 			public Dictionary<string, bool> Fields { get; } = new (StringComparer.Ordinal);
-			public Dictionary<string, bool> Methods { get; } = new (StringComparer.Ordinal);
+			public Dictionary<string, (bool Conditional, MethodDefinition Method)> Methods { get; } = new (StringComparer.Ordinal);
 		}
 
 		ApplyPreserveAttributeImpl impl;
@@ -186,6 +186,19 @@ namespace Xamarin.Linker.Steps {
 			return method.FullName.Substring (0, index) + method.FullName.Substring (index + marker.Length);
 		}
 
+		// Check if a method has any parameters whose type is a generic parameter (from the declaring type or method).
+		// The linker XML descriptor can't resolve generic parameter names like 'T' in method signatures.
+		static bool HasGenericParameterInSignature (MethodDefinition method)
+		{
+			if (method.ReturnType is GenericParameter)
+				return true;
+			foreach (var param in method.Parameters) {
+				if (param.ParameterType is GenericParameter)
+					return true;
+			}
+			return false;
+		}
+
 		XmlTypeDescription GetOrCreateXmlDescription (TypeDefinition type)
 		{
 			var assemblyName = type.Module.Assembly.Name.Name;
@@ -222,7 +235,7 @@ namespace Xamarin.Linker.Steps {
 			var description = GetOrCreateXmlDescription (onType);
 			if (!conditional)
 				description.PreserveType = true;
-			description.Methods [GetXmlSignature (forMethod)] = conditional;
+			description.Methods [GetXmlSignature (forMethod)] = (conditional, forMethod);
 		}
 
 		void AddUnconditionalXmlDescription (IMetadataTokenProvider provider)
@@ -261,8 +274,18 @@ namespace Xamarin.Linker.Steps {
 			foreach (var field in description.Fields.OrderBy (v => v.Key, System.StringComparer.Ordinal))
 				type.Add (new XElement ("field", new XAttribute ("name", field.Key), new XAttribute ("required", field.Value ? "false" : "true")));
 
-			foreach (var method in description.Methods.OrderBy (v => v.Key, System.StringComparer.Ordinal))
-				type.Add (new XElement ("method", new XAttribute ("signature", method.Key), new XAttribute ("required", method.Value ? "false" : "true")));
+			foreach (var method in description.Methods.OrderBy (v => v.Key, System.StringComparer.Ordinal)) {
+				var element = new XElement ("method");
+				// ILC (NativeAOT compiler) can't resolve generic parameter names (like 'T') in XML descriptor
+				// method signatures (see https://github.com/dotnet/runtime/issues/128121), so use the method
+				// name instead of the full signature when the method has generic parameter types.
+				if (HasGenericParameterInSignature (method.Value.Method))
+					element.SetAttributeValue ("name", method.Value.Method.Name);
+				else
+					element.SetAttributeValue ("signature", method.Key);
+				element.SetAttributeValue ("required", method.Value.Conditional ? "false" : "true");
+				type.Add (element);
+			}
 
 			return type;
 		}

--- a/tools/dotnet-linker/ApplyPreserveAttributeStep.cs
+++ b/tools/dotnet-linker/ApplyPreserveAttributeStep.cs
@@ -186,14 +186,15 @@ namespace Xamarin.Linker.Steps {
 			return method.FullName.Substring (0, index) + method.FullName.Substring (index + marker.Length);
 		}
 
-		// Check if a method has any parameters whose type is a generic parameter (from the declaring type or method).
+		// Check if a method has any generic parameters in its signature (return type or parameter types).
+		// This includes generic parameters nested inside other types (e.g. Action<T>, T[], ref T, Nullable<T>).
 		// The linker XML descriptor can't resolve generic parameter names like 'T' in method signatures.
 		static bool HasGenericParameterInSignature (MethodDefinition method)
 		{
-			if (method.ReturnType is GenericParameter)
+			if (method.ReturnType.ContainsGenericParameter)
 				return true;
 			foreach (var param in method.Parameters) {
-				if (param.ParameterType is GenericParameter)
+				if (param.ParameterType.ContainsGenericParameter)
 					return true;
 			}
 			return false;


### PR DESCRIPTION
When a method has generic parameter types (like 'T' in Callback<T>),
the linker XML descriptor can't resolve the generic parameter name in
the method signature. Use the method 'name' attribute instead of
'signature' for such methods, which matches by name and avoids the
IL2009 warning.

Fixes this warning, which shows up in MAUI's tests (and our own too, just not
in a place where we were validating warnings):

> warning IL2009: Could not find method 'System.Void Activated(T)' on type 'UIKit.UIGestureRecognizer.Callback`1'