### PR TITLE
[main] Keep using the desktop MSBuild assemblies when building from within Visual Studio.

### DIFF
--- a/dotnet/Microsoft.iOS.Sdk/targets/Microsoft.iOS.Sdk.props
+++ b/dotnet/Microsoft.iOS.Sdk/targets/Microsoft.iOS.Sdk.props
@@ -4,6 +4,7 @@
     <_PlatformName>iOS</_PlatformName>
     <_PlatformRidNoArch>ios</_PlatformRidNoArch>
     <!-- Used by Microsoft.iOS.Windows.Sdk -->
+    <_UseDesktopTaskAssemblies Condition="'$(_UseDesktopTaskAssemblies)' == '' And '$(BuildingInsideVisualStudio)' == 'true'">true</_UseDesktopTaskAssemblies>
     <CoreiOSSdkDirectory Condition="'$(_UseDesktopTaskAssemblies)' != 'true'">$(MSBuildThisFileDirectory)..\tools\msbuild\net$(BundledNETCoreAppTargetFrameworkVersion)\</CoreiOSSdkDirectory>
     <CoreiOSSdkDirectory Condition="'$(_UseDesktopTaskAssemblies)' == 'true'">$(MSBuildThisFileDirectory)..\tools\msbuild\netstandard2.0\</CoreiOSSdkDirectory>
   </PropertyGroup>


### PR DESCRIPTION
Keep using the desktop MSBuild assemblies when building from within Visual
Studio, while we track down why it's not working and fix it for a future release.

Ref: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2968169
Ref: https://github.com/dotnet/macios/issues/25418

Backport of #25249.