### PR TITLE
[tests] Upgrade tests/msbuild to NUnit v4 Assert.That syntax

### DIFF
--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Tests {
 		public static ExecutionResult AssertPackFailure (string project, Dictionary<string, string>? properties = null, bool? msbuildParallelism = null)
 		{
 			var rv = Execute ("pack", project, properties, false, msbuildParallelism: msbuildParallelism);
-			Assert.AreNotEqual (0, rv.ExitCode, "Unexpected success");
+			Assert.That (rv.ExitCode, Is.Not.EqualTo (0), "Unexpected success");
 			return rv;
 		}
 
@@ -45,7 +45,7 @@ namespace Xamarin.Tests {
 		public static ExecutionResult AssertPublishFailure (string project, Dictionary<string, string>? properties = null)
 		{
 			var rv = Execute ("publish", project, properties, false);
-			Assert.AreNotEqual (0, rv.ExitCode, "Unexpected success");
+			Assert.That (rv.ExitCode, Is.Not.EqualTo (0), "Unexpected success");
 			return rv;
 		}
 
@@ -73,7 +73,7 @@ namespace Xamarin.Tests {
 		public static ExecutionResult AssertBuildFailure (string project, Dictionary<string, string>? properties = null)
 		{
 			var rv = Execute ("build", project, properties, false);
-			Assert.AreNotEqual (0, rv.ExitCode, "Unexpected success");
+			Assert.That (rv.ExitCode, Is.Not.EqualTo (0), "Unexpected success");
 			return rv;
 		}
 
@@ -107,7 +107,7 @@ namespace Xamarin.Tests {
 			if (rv.ExitCode != 0) {
 				Console.WriteLine ($"'{Executable} {StringUtils.FormatArguments (args)}' failed with exit code {rv.ExitCode}.");
 				Console.WriteLine (output);
-				Assert.AreEqual (0, rv.ExitCode, $"Exit code: {Executable} {StringUtils.FormatArguments (args)}");
+				Assert.That (rv.ExitCode, Is.EqualTo (0), $"Exit code: {Executable} {StringUtils.FormatArguments (args)}");
 			}
 			return new ExecutionResult (output, output, rv.ExitCode);
 		}
@@ -336,7 +336,7 @@ namespace Xamarin.Tests {
 #endif
 						Assert.Fail (msg.ToString ());
 					}
-					Assert.AreEqual (0, rv.ExitCode, $"Exit code: {Executable} {StringUtils.FormatArguments (args)}");
+					Assert.That (rv.ExitCode, Is.EqualTo (0), $"Exit code: {Executable} {StringUtils.FormatArguments (args)}");
 				}
 				return new ExecutionResult (output, output, rv.ExitCode) {
 					BinLogPath = binlogPath,

--- a/tests/common/mac/ProjectTestHelpers.cs
+++ b/tests/common/mac/ProjectTestHelpers.cs
@@ -247,11 +247,11 @@ namespace Xamarin.MMP.Tests {
 		public static string RunEXEAndVerifyGUID (string tmpDir, Guid guid, string path)
 		{
 			// Assert that the program actually runs and returns our guid
-			Assert.IsTrue (File.Exists (path), string.Format ("{0} did not generate an exe?", path));
+			Assert.That (File.Exists (path), Is.True, string.Format ("{0} did not generate an exe?", path));
 			string output = RunAndAssert (path, Array.Empty<string> (), "Run");
 
 			string guidPath = Path.Combine (tmpDir, guid.ToString ());
-			Assert.IsTrue (File.Exists (guidPath), "Generated program did not create expected guid file: " + output);
+			Assert.That (File.Exists (guidPath), Is.True, "Generated program did not create expected guid file: " + output);
 
 			// Let's delete the guid file so re-runs inside same tests are accurate
 			File.Delete (guidPath);
@@ -442,7 +442,7 @@ namespace Xamarin.MMP.Tests {
 
 		public static void CopyDirectory (string src, string target)
 		{
-			Assert.AreEqual (0, ExecutionHelper.Execute ("/bin/cp", new [] { "-r", src, target }));
+			Assert.That (ExecutionHelper.Execute ("/bin/cp", new [] { "-r", src, target }), Is.EqualTo (0));
 		}
 
 		public static string CopyFileWithSubstitutions (string src, string target, Func<string, string> replacementAction)

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ACToolTaskTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ACToolTaskTest.cs
@@ -92,10 +92,10 @@ namespace Xamarin.MacDev.Tasks {
 			var actool = CreateACToolTaskWithResources (platform);
 			ExecuteTask (actool);
 
-			Assert.IsNotNull (actool.PartialAppManifest, "PartialAppManifest");
+			Assert.That (actool.PartialAppManifest, Is.Not.Null, "PartialAppManifest");
 			var appIconsManifestPath = actool.PartialAppManifest?.ItemSpec ?? "";
 			var appIconsManifest = PDictionary.FromFile (appIconsManifestPath)!;
-			Assert.AreEqual (0, appIconsManifest.Count, $"Partial plist contents: {actool.PartialAppManifest?.ItemSpec}");
+			Assert.That (appIconsManifest.Count, Is.EqualTo (0), $"Partial plist contents: {actool.PartialAppManifest?.ItemSpec}");
 			var expectedXml =
 				"""
 				<?xml version="1.0" encoding="UTF-8"?>
@@ -120,7 +120,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			ExecuteTask (actool);
 
-			Assert.IsNotNull (actool.PartialAppManifest, "PartialAppManifest");
+			Assert.That (actool.PartialAppManifest, Is.Not.Null, "PartialAppManifest");
 
 			var appIconsManifestPath = actool.PartialAppManifest?.ItemSpec ?? "";
 			string expectedXml;
@@ -168,7 +168,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			ExecuteTask (actool);
 
-			Assert.IsNotNull (actool.PartialAppManifest, "PartialAppManifest");
+			Assert.That (actool.PartialAppManifest, Is.Not.Null, "PartialAppManifest");
 
 			var appIconsManifestPath = actool.PartialAppManifest?.ItemSpec!;
 			string expectedXml;
@@ -293,7 +293,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			ExecuteTask (actool);
 
-			Assert.IsNotNull (actool.PartialAppManifest, "PartialAppManifest");
+			Assert.That (actool.PartialAppManifest, Is.Not.Null, "PartialAppManifest");
 
 			var appIconsManifestPath = actool.PartialAppManifest?.ItemSpec ?? "";
 			string expectedXml;
@@ -390,7 +390,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			ExecuteTask (actool);
 
-			Assert.IsNotNull (actool.PartialAppManifest, "PartialAppManifest");
+			Assert.That (actool.PartialAppManifest, Is.Not.Null, "PartialAppManifest");
 
 			var appIconsManifestPath = actool.PartialAppManifest?.ItemSpec ?? "";
 			string expectedXml;
@@ -575,7 +575,7 @@ namespace Xamarin.MacDev.Tasks {
 			default:
 				throw new NotImplementedException (platform.ToString ());
 			}
-			Assert.AreEqual (expectedErrorMessage, Engine.Logger.ErrorEvents [0].Message, "Error message");
+			Assert.That (Engine.Logger.ErrorEvents [0].Message, Is.EqualTo (expectedErrorMessage), "Error message");
 		}
 
 		[Test]
@@ -602,7 +602,7 @@ namespace Xamarin.MacDev.Tasks {
 			default:
 				throw new NotImplementedException (platform.ToString ());
 			}
-			Assert.AreEqual (expectedErrorMessage, Engine.Logger.ErrorEvents [0].Message, "Error message");
+			Assert.That (Engine.Logger.ErrorEvents [0].Message, Is.EqualTo (expectedErrorMessage), "Error message");
 		}
 
 		[Test]
@@ -617,7 +617,7 @@ namespace Xamarin.MacDev.Tasks {
 			actool.AppIcon = "AppIcons";
 
 			ExecuteTask (actool, 1);
-			Assert.AreEqual ($"The image resource '{actool.AppIcon}' is specified as both 'AppIcon' and 'AlternateAppIcon'.", Engine.Logger.ErrorEvents [0].Message, "Error message");
+			Assert.That (Engine.Logger.ErrorEvents [0].Message, Is.EqualTo ($"The image resource '{actool.AppIcon}' is specified as both 'AppIcon' and 'AlternateAppIcon'."), "Error message");
 		}
 
 		[Test]
@@ -632,7 +632,7 @@ namespace Xamarin.MacDev.Tasks {
 			actool.XSAppIconAssets = "Resources/Images.xcassets/AppIcons.appiconset";
 
 			ExecuteTask (actool, 1);
-			Assert.AreEqual ("Can't specify both 'XSAppIconAssets' in the Info.plist and 'AppIcon' in the project file. Please select one or the other.", Engine.Logger.ErrorEvents [0].Message, "Error message");
+			Assert.That (Engine.Logger.ErrorEvents [0].Message, Is.EqualTo ("Can't specify both 'XSAppIconAssets' in the Info.plist and 'AppIcon' in the project file. Please select one or the other."), "Error message");
 		}
 	}
 }

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/BundleResourceTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/BundleResourceTests.cs
@@ -38,8 +38,7 @@ namespace Xamarin.MacDev.Tasks {
 		public void GetVirtualProjectPathTest ()
 		{
 			Assert.Multiple (() => {
-				Assert.AreEqual ("Archer_Attack.atlas/archer_attack_0001.png",
-					BundleResource.GetVirtualProjectPath (
+				Assert.That (BundleResource.GetVirtualProjectPath (
 						new ResourceTask {
 							BuildEngine = new TestEngine (),
 							ProjectDir = "/Users/rolf/work/maccore/windows/xamarin-macios/tests/dotnet/LibraryWithResources/iOS",
@@ -48,11 +47,9 @@ namespace Xamarin.MacDev.Tasks {
 							"../Archer_Attack.atlas/archer_attack_0001.png",
 							localMSBuildProjectFullPath: "/Users/rolf/work/maccore/windows/xamarin-macios/tests/dotnet/LibraryWithResources/shared.csproj",
 							localDefiningProjectFullPath: "/Users/rolf/work/maccore/windows/xamarin-macios/tests/dotnet/LibraryWithResources/shared.csproj"
-						)),
-					"A");
+						)), Is.EqualTo ("Archer_Attack.atlas/archer_attack_0001.png"), "A");
 
-				Assert.AreEqual ("Archer_Attack.atlas/archer_attack_0001.png",
-					BundleResource.GetVirtualProjectPath (
+				Assert.That (BundleResource.GetVirtualProjectPath (
 						new ResourceTask {
 							BuildEngine = new TestEngine (),
 							ProjectDir = "C:/src/xamarin-macios/tests/dotnet/LibraryWithResources/iOS",
@@ -62,8 +59,7 @@ namespace Xamarin.MacDev.Tasks {
 							"../Archer_Attack.atlas/archer_attack_0001.png",
 							localMSBuildProjectFullPath: @"C:\src\xamarin-macios\tests\dotnet\LibraryWithResources\shared.csproj",
 							localDefiningProjectFullPath: @"C:\src\xamarin-macios\tests\dotnet\LibraryWithResources\shared.csproj"
-						)),
-					"B");
+						)), Is.EqualTo ("Archer_Attack.atlas/archer_attack_0001.png"), "B");
 			});
 		}
 	}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CollectITunesArtworkTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CollectITunesArtworkTaskTests.cs
@@ -69,10 +69,10 @@ namespace Xamarin.MacDev.Tasks {
 			};
 
 			ExecuteTask (task);
-			Assert.AreEqual (2, task.ITunesArtworkWithLogicalNames.Length, "ITunesArtworkWithLogicalNames.Count");
+			Assert.That (task.ITunesArtworkWithLogicalNames.Length, Is.EqualTo (2), "ITunesArtworkWithLogicalNames.Count");
 			for (var i = 0; i < task.ITunesArtworkWithLogicalNames.Length; i++) {
-				Assert.AreEqual (Path.GetFileNameWithoutExtension (task.ITunesArtwork [i].GetMetadata ("FullPath")), task.ITunesArtworkWithLogicalNames [i].GetMetadata ("LogicalName"), $"LogicalName #{i}");
-				Assert.AreEqual ("false", task.ITunesArtworkWithLogicalNames [i].GetMetadata ("Optimize"), $"Optimize #{i}");
+				Assert.That (task.ITunesArtworkWithLogicalNames [i].GetMetadata ("LogicalName"), Is.EqualTo (Path.GetFileNameWithoutExtension (task.ITunesArtwork [i].GetMetadata ("FullPath"))), $"LogicalName #{i}");
+				Assert.That (task.ITunesArtworkWithLogicalNames [i].GetMetadata ("Optimize"), Is.EqualTo ("false"), $"Optimize #{i}");
 			}
 
 		}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileAppManifestTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileAppManifestTaskTests.cs
@@ -46,7 +46,7 @@ namespace Xamarin.MacDev.Tasks {
 			ExecuteTask (task);
 
 			var plist = PDictionary.FromFile (task.CompiledAppManifest!.ItemSpec)!;
-			Assert.AreEqual ("14.0", plist.GetMinimumOSVersion (), "MinimumOSVersion");
+			Assert.That (plist.GetMinimumOSVersion (), Is.EqualTo ("14.0"), "MinimumOSVersion");
 		}
 
 		[Test]
@@ -73,7 +73,7 @@ namespace Xamarin.MacDev.Tasks {
 			ExecuteTask (task);
 
 			var plist = PDictionary.FromFile (task.CompiledAppManifest!.ItemSpec)!;
-			Assert.AreEqual ("13.0", plist.GetMinimumOSVersion (), "MinimumOSVersion");
+			Assert.That (plist.GetMinimumOSVersion (), Is.EqualTo ("13.0"), "MinimumOSVersion");
 		}
 
 		[Test]
@@ -103,7 +103,7 @@ namespace Xamarin.MacDev.Tasks {
 			ExecuteTask (task);
 
 			var plist = PDictionary.FromFile (task.CompiledAppManifest!.ItemSpec)!;
-			Assert.AreEqual (expectedMinimumOSVersion, plist.GetMinimumOSVersion (), "MinimumOSVersion");
+			Assert.That (plist.GetMinimumOSVersion (), Is.EqualTo (expectedMinimumOSVersion), "MinimumOSVersion");
 		}
 
 		[Test]
@@ -120,7 +120,7 @@ namespace Xamarin.MacDev.Tasks {
 			task.SupportedOSPlatformVersion = "11.0";
 
 			ExecuteTask (task, expectedErrorCount: 1);
-			Assert.AreEqual ("The MinimumOSVersion value in the Info.plist (10.0) does not match the SupportedOSPlatformVersion value (11.0) in the project file (if there is no SupportedOSPlatformVersion value in the project file, then a default value has been assumed). Either change the value in the Info.plist to match the SupportedOSPlatformVersion value, or remove the value in the Info.plist (and add a SupportedOSPlatformVersion value to the project file if it doesn't already exist).", Engine.Logger.ErrorEvents [0].Message);
+			Assert.That (Engine.Logger.ErrorEvents [0].Message, Is.EqualTo ("The MinimumOSVersion value in the Info.plist (10.0) does not match the SupportedOSPlatformVersion value (11.0) in the project file (if there is no SupportedOSPlatformVersion value in the project file, then a default value has been assumed). Either change the value in the Info.plist to match the SupportedOSPlatformVersion value, or remove the value in the Info.plist (and add a SupportedOSPlatformVersion value to the project file if it doesn't already exist)."));
 		}
 
 		[Test]
@@ -134,7 +134,7 @@ namespace Xamarin.MacDev.Tasks {
 			ExecuteTask (task);
 
 			var plist = PDictionary.FromFile (task.CompiledAppManifest!.ItemSpec)!;
-			Assert.AreEqual ("11.0", plist.GetMinimumOSVersion (), "MinimumOSVersion");
+			Assert.That (plist.GetMinimumOSVersion (), Is.EqualTo ("11.0"), "MinimumOSVersion");
 		}
 
 		[Test]
@@ -145,7 +145,7 @@ namespace Xamarin.MacDev.Tasks {
 			ExecuteTask (task);
 
 			var plist = PDictionary.FromFile (task.CompiledAppManifest!.ItemSpec)!;
-			Assert.AreEqual ("11.0", plist.GetMinimumSystemVersion (), "MinimumOSVersion");
+			Assert.That (plist.GetMinimumSystemVersion (), Is.EqualTo ("11.0"), "MinimumOSVersion");
 		}
 
 		[Test]
@@ -186,7 +186,7 @@ namespace Xamarin.MacDev.Tasks {
 				var value = plist.GetString (variable)?.Value;
 				Assert.That (value, Is.Not.Null.And.Not.Empty, variable);
 			}
-			Assert.AreEqual (expectedDTPlatformName, plist.GetString ("DTPlatformName")?.Value, "Expected DTPlatformName");
+			Assert.That (plist.GetString ("DTPlatformName")?.Value, Is.EqualTo (expectedDTPlatformName), "Expected DTPlatformName");
 		}
 	}
 }

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileEntitlementsTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileEntitlementsTaskTests.cs
@@ -115,7 +115,7 @@ namespace Xamarin.MacDev.Tasks {
 					expectedCode = expectedMessage [0..6];
 					expectedMessage = expectedMessage [7..];
 				}
-				Assert.AreEqual (expectedMessage, buildEvents [i].Message, $"Error message #{i + 1}");
+				Assert.That (buildEvents [i].Message, Is.EqualTo (expectedMessage), $"Error message #{i + 1}");
 				if (expectedCode is not null) {
 					string actualCode;
 					if (buildEvents [i] is BuildErrorEventArgs beea) {
@@ -140,16 +140,16 @@ namespace Xamarin.MacDev.Tasks {
 				"The app requests the entitlement 'com.apple.developer.ubiquity-kvstore-identifier', but the provisioning profile 'iOS Team Provisioning Profile: *' doesn't contain this entitlement.");
 
 			var compiled = PDictionary.FromFile (compiledEntitlements)!;
-			Assert.IsTrue (compiled.Get<PBoolean> (EntitlementKeys.GetTaskAllow)?.Value, "#1");
-			Assert.AreEqual ("32UV7A8CDE.com.xamarin.MySingleView", compiled.Get<PString> ("application-identifier")?.Value, "#2");
-			Assert.AreEqual ("Z8CSQKJE7R", compiled.Get<PString> ("com.apple.developer.team-identifier")?.Value, "#3");
-			Assert.AreEqual ("applinks:*.xamarin.com", compiled.GetAssociatedDomains ().ToStringArray ().First (), "#4");
-			Assert.AreEqual ("Z8CSQKJE7R.*", compiled.GetPassBookIdentifiers ().ToStringArray ().First (), "#5");
-			Assert.AreEqual ("Z8CSQKJE7R.com.xamarin.MySingleView", compiled.GetUbiquityKeyValueStore (), "#6");
-			Assert.AreEqual ("32UV7A8CDE.com.xamarin.MySingleView", compiled.GetKeychainAccessGroups ().ToStringArray ().First (), "#7");
+			Assert.That (compiled.Get<PBoolean> (EntitlementKeys.GetTaskAllow)?.Value, Is.True, "#1");
+			Assert.That (compiled.Get<PString> ("application-identifier")?.Value, Is.EqualTo ("32UV7A8CDE.com.xamarin.MySingleView"), "#2");
+			Assert.That (compiled.Get<PString> ("com.apple.developer.team-identifier")?.Value, Is.EqualTo ("Z8CSQKJE7R"), "#3");
+			Assert.That (compiled.GetAssociatedDomains ().ToStringArray ().First (), Is.EqualTo ("applinks:*.xamarin.com"), "#4");
+			Assert.That (compiled.GetPassBookIdentifiers ().ToStringArray ().First (), Is.EqualTo ("Z8CSQKJE7R.*"), "#5");
+			Assert.That (compiled.GetUbiquityKeyValueStore (), Is.EqualTo ("Z8CSQKJE7R.com.xamarin.MySingleView"), "#6");
+			Assert.That (compiled.GetKeychainAccessGroups ().ToStringArray ().First (), Is.EqualTo ("32UV7A8CDE.com.xamarin.MySingleView"), "#7");
 
 			var archived = PDictionary.FromFile (archivedEntitlements);
-			Assert.IsTrue (compiled.ContainsKey ("application-identifier"), "archived");
+			Assert.That (compiled.ContainsKey ("application-identifier"), Is.True, "archived");
 		}
 
 		[TestCase ("Invalid", null, "Unknown type 'Invalid' for the entitlement 'com.xamarin.custom.entitlement' specified in the CustomEntitlements item group. Expected 'Remove', 'Boolean', 'String', or 'StringArray'.")]
@@ -172,7 +172,7 @@ namespace Xamarin.MacDev.Tasks {
 			task.CustomEntitlements = customEntitlements;
 			task.ProvisioningProfile = GetResourcePath ("WildCardMacAppDevelopment.provisionprofile");
 			ExecuteTask (task, expectedErrorCount: 1);
-			Assert.AreEqual (errorMessage, Engine.Logger.ErrorEvents [0].Message, "Error message");
+			Assert.That (Engine.Logger.ErrorEvents [0].Message, Is.EqualTo (errorMessage), "Error message");
 		}
 
 		[Test]
@@ -194,8 +194,8 @@ namespace Xamarin.MacDev.Tasks {
 			task.ProvisioningProfile = GetResourcePath ("WildCardMacAppDevelopment.provisionprofile");
 			ExecuteTask (task);
 			var compiled = PDictionary.FromFile (compiledEntitlements)!;
-			Assert.AreEqual (value ?? string.Empty, compiled.GetString ("com.xamarin.custom.entitlement")?.Value, "#1");
-			Assert.IsTrue (Engine.Logger.MessageEvents.Any (v => v.Message?.Contains ("The app requests the entitlement 'com.xamarin.custom.entitlement', but provisioning profile WildCardMacAppDevelopment does not grant this entitlement. This is probably not OK.") == true), "custom entitlement");
+			Assert.That (compiled.GetString ("com.xamarin.custom.entitlement")?.Value, Is.EqualTo (value ?? string.Empty), "#1");
+			Assert.That (Engine.Logger.MessageEvents.Any (v => v.Message?.Contains ("The app requests the entitlement 'com.xamarin.custom.entitlement', but provisioning profile WildCardMacAppDevelopment does not grant this entitlement. This is probably not OK.") == true), Is.True, "custom entitlement");
 		}
 
 		[Test]
@@ -216,9 +216,9 @@ namespace Xamarin.MacDev.Tasks {
 			ExecuteTask (task);
 			var compiled = PDictionary.FromFile (compiledEntitlements)!;
 			var array = compiled.GetArray ("com.xamarin.custom.entitlement");
-			Assert.NotNull (array, "array");
-			Assert.AreEqual (new string [] { "A", "B", "C" }, array.ToStringArray (), "array contents");
-			Assert.IsTrue (Engine.Logger.MessageEvents.Any (v => v.Message?.Contains ("The app requests the entitlement 'com.xamarin.custom.entitlement', but provisioning profile WildCardMacAppDevelopment does not grant this entitlement. This is probably not OK.") == true), "custom entitlement");
+			Assert.That (array, Is.Not.Null, "array");
+			Assert.That (array.ToStringArray (), Is.EqualTo (new string [] { "A", "B", "C" }), "array contents");
+			Assert.That (Engine.Logger.MessageEvents.Any (v => v.Message?.Contains ("The app requests the entitlement 'com.xamarin.custom.entitlement', but provisioning profile WildCardMacAppDevelopment does not grant this entitlement. This is probably not OK.") == true), Is.True, "custom entitlement");
 		}
 
 		[Test]
@@ -241,8 +241,8 @@ namespace Xamarin.MacDev.Tasks {
 			ExecuteTask (task);
 			var compiled = PDictionary.FromFile (compiledEntitlements)!;
 			var array = compiled.GetArray ("com.xamarin.custom.entitlement");
-			Assert.NotNull (array, "array");
-			Assert.AreEqual (new string [] { "A;B;C", "D", "E" }, array.ToStringArray (), "array contents");
+			Assert.That (array, Is.Not.Null, "array");
+			Assert.That (array.ToStringArray (), Is.EqualTo (new string [] { "A;B;C", "D", "E" }), "array contents");
 		}
 
 		[Test]
@@ -253,7 +253,7 @@ namespace Xamarin.MacDev.Tasks {
 			task.ProvisioningProfile = GetResourcePath ("WildCardMacAppDevelopment.provisionprofile");
 			ExecuteTask (task);
 			var compiled = PDictionary.FromFile (compiledEntitlements)!;
-			Assert.IsFalse (compiled.ContainsKey (EntitlementKeys.AllowExecutionOfJitCode), "#1");
+			Assert.That (compiled.ContainsKey (EntitlementKeys.AllowExecutionOfJitCode), Is.False, "#1");
 		}
 
 		[Test]
@@ -268,8 +268,8 @@ namespace Xamarin.MacDev.Tasks {
 			task.CustomEntitlements = customEntitlements;
 			ExecuteTask (task);
 			var compiled = PDictionary.FromFile (compiledEntitlements)!;
-			Assert.IsTrue (compiled.ContainsKey (EntitlementKeys.AllowExecutionOfJitCode), "#1");
-			Assert.IsTrue (compiled.Get<PBoolean> (EntitlementKeys.AllowExecutionOfJitCode)?.Value, "#2");
+			Assert.That (compiled.ContainsKey (EntitlementKeys.AllowExecutionOfJitCode), Is.True, "#1");
+			Assert.That (compiled.Get<PBoolean> (EntitlementKeys.AllowExecutionOfJitCode)?.Value, Is.True, "#2");
 		}
 
 		[Test]
@@ -284,8 +284,8 @@ namespace Xamarin.MacDev.Tasks {
 			task.CustomEntitlements = customEntitlements;
 			ExecuteTask (task);
 			var compiled = PDictionary.FromFile (compiledEntitlements)!;
-			Assert.IsTrue (compiled.ContainsKey (EntitlementKeys.AllowExecutionOfJitCode), "#1");
-			Assert.IsFalse (compiled.Get<PBoolean> (EntitlementKeys.AllowExecutionOfJitCode)?.Value, "#2");
+			Assert.That (compiled.ContainsKey (EntitlementKeys.AllowExecutionOfJitCode), Is.True, "#1");
+			Assert.That (compiled.Get<PBoolean> (EntitlementKeys.AllowExecutionOfJitCode)?.Value, Is.False, "#2");
 
 			Assert.That (archivedEntitlements, Does.Not.Exist, "No archived entitlements");
 		}
@@ -302,7 +302,7 @@ namespace Xamarin.MacDev.Tasks {
 			task.CustomEntitlements = customEntitlements;
 			ExecuteTask (task);
 			var compiled = PDictionary.FromFile (compiledEntitlements)!;
-			Assert.IsFalse (compiled.ContainsKey (EntitlementKeys.AllowExecutionOfJitCode), "#1");
+			Assert.That (compiled.ContainsKey (EntitlementKeys.AllowExecutionOfJitCode), Is.False, "#1");
 		}
 
 		[Test]
@@ -316,12 +316,12 @@ namespace Xamarin.MacDev.Tasks {
 			task.CustomEntitlements = customEntitlements;
 			ExecuteTask (task);
 			var compiled = PDictionary.FromFile (compiledEntitlements)!;
-			Assert.IsFalse (compiled.ContainsKey (EntitlementKeys.AllowExecutionOfJitCode), "#1");
+			Assert.That (compiled.ContainsKey (EntitlementKeys.AllowExecutionOfJitCode), Is.False, "#1");
 			var kag = ((PString?) compiled ["keychain-access-groups"])?.Value;
 			Assert.That (kag, Is.EqualTo ("32UV7A8CDE.org.xamarin"), "value 1");
 
 			var archived = PDictionary.FromFile (archivedEntitlements)!;
-			Assert.IsTrue (archived.ContainsKey ("keychain-access-groups"), "archived");
+			Assert.That (archived.ContainsKey ("keychain-access-groups"), Is.True, "archived");
 			var archivedKag = ((PString?) archived ["keychain-access-groups"])?.Value;
 			Assert.That (archivedKag, Is.EqualTo ("32UV7A8CDE.org.xamarin"), "archived value 1");
 		}
@@ -337,12 +337,12 @@ namespace Xamarin.MacDev.Tasks {
 			task.CustomEntitlements = customEntitlements;
 			ExecuteTask (task);
 			var compiled = PDictionary.FromFile (compiledEntitlements)!;
-			Assert.IsFalse (compiled.ContainsKey (EntitlementKeys.AllowExecutionOfJitCode), "#1");
+			Assert.That (compiled.ContainsKey (EntitlementKeys.AllowExecutionOfJitCode), Is.False, "#1");
 			var kag = ((PString?) compiled ["keychain-access-groups"])?.Value;
 			Assert.That (kag, Is.EqualTo ("Z8CSQKJE7R.org.xamarin"), "value 1");
 
 			var archived = PDictionary.FromFile (archivedEntitlements)!;
-			Assert.IsTrue (archived.ContainsKey ("keychain-access-groups"), "archived");
+			Assert.That (archived.ContainsKey ("keychain-access-groups"), Is.True, "archived");
 			var archivedKag = ((PString?) archived ["keychain-access-groups"])?.Value;
 			Assert.That (archivedKag, Is.EqualTo ("Z8CSQKJE7R.org.xamarin"), "archived value 1");
 		}
@@ -364,12 +364,12 @@ namespace Xamarin.MacDev.Tasks {
 
 				var inExecutable = PDictionary.FromFile (task.EntitlementsInExecutable!.ItemSpec)!;
 				Assert.That (inExecutable.Count, Is.EqualTo (4), $"in executable count");
-				Assert.IsFalse (inExecutable.ContainsKey (EntitlementKeys.AllowExecutionOfJitCode), "#1");
-				Assert.IsTrue (inExecutable.ContainsKey ("keychain-access-groups"), "in executable");
+				Assert.That (inExecutable.ContainsKey (EntitlementKeys.AllowExecutionOfJitCode), Is.False, "#1");
+				Assert.That (inExecutable.ContainsKey ("keychain-access-groups"), Is.True, "in executable");
 				Assert.That (((PString?) inExecutable ["keychain-access-groups"])?.Value, Is.EqualTo ("Z8CSQKJE7R.org.xamarin"), "in executable value 1");
 
-				Assert.IsFalse (inExecutable.ContainsKey ("com.apple.security.get-task-allow"), "in executable com.apple.security.get-task-allow");
-				Assert.IsTrue (inExecutable.ContainsKey ("get-task-allow"), $"in executable get-task-allow");
+				Assert.That (inExecutable.ContainsKey ("com.apple.security.get-task-allow"), Is.False, "in executable com.apple.security.get-task-allow");
+				Assert.That (inExecutable.ContainsKey ("get-task-allow"), Is.True, $"in executable get-task-allow");
 
 				var inSignature = PDictionary.FromFile (task.EntitlementsInSignature!.ItemSpec)!;
 				Assert.That (inSignature.Count, Is.EqualTo (0), $"in signature count");

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ComputeCodesignItemsTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ComputeCodesignItemsTaskTests.cs
@@ -345,7 +345,7 @@ namespace Xamarin.MacDev.Tasks {
 				task.NativeStripItems = nativeStripItems.ToArray ();
 				task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (platform).ToString ();
 				ExecuteTask (task);
-				Assert.AreEqual (0, Engine.Logger.WarningsEvents.Count, "Warning Count");
+				Assert.That (Engine.Logger.WarningsEvents.Count, Is.EqualTo (0), "Warning Count");
 
 				VerifyCodesigningResults (infos, task.OutputCodesignItems, platform);
 			} finally {
@@ -413,7 +413,7 @@ namespace Xamarin.MacDev.Tasks {
 				task.CodesignStampPath = "codesign-stamp-path/";
 				task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (platform).ToString ();
 				ExecuteTask (task);
-				Assert.AreEqual (0, Engine.Logger.WarningsEvents.Count, "Warning Count");
+				Assert.That (Engine.Logger.WarningsEvents.Count, Is.EqualTo (0), "Warning Count");
 
 				VerifyCodesigningResults (infos, task.OutputCodesignItems, platform);
 			} finally {
@@ -494,7 +494,7 @@ namespace Xamarin.MacDev.Tasks {
 				task.CodesignStampPath = "codesign-stamp-path/";
 				task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (platform).ToString ();
 				ExecuteTask (task);
-				Assert.AreEqual (0, Engine.Logger.WarningsEvents.Count, "Warning Count");
+				Assert.That (Engine.Logger.WarningsEvents.Count, Is.EqualTo (0), "Warning Count");
 
 				VerifyCodesigningResults (infos, task.OutputCodesignItems, platform);
 			} finally {
@@ -557,7 +557,7 @@ namespace Xamarin.MacDev.Tasks {
 				task.CodesignStampPath = "codesign-stamp-path/";
 				task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (platform).ToString ();
 				ExecuteTask (task);
-				Assert.AreEqual (0, Engine.Logger.WarningsEvents.Count, "Warning Count");
+				Assert.That (Engine.Logger.WarningsEvents.Count, Is.EqualTo (0), "Warning Count");
 
 				VerifyCodesigningResults (infos, task.OutputCodesignItems, platform);
 			} finally {
@@ -631,10 +631,10 @@ namespace Xamarin.MacDev.Tasks {
 				task.CodesignStampPath = "codesign-stamp-path/";
 				task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (platform).ToString ();
 				ExecuteTask (task);
-				Assert.AreEqual (3, Engine.Logger.WarningsEvents.Count, "Warning Count");
-				Assert.AreEqual ("Code signing has been requested multiple times for 'Bundle.app/Contents/MonoBundle/createdump', with different metadata. The metadata 'OnlyIn1=true' has been set for one item, but not the other.", Engine.Logger.WarningsEvents [0].Message, "Message #0");
-				Assert.AreEqual ("Code signing has been requested multiple times for 'Bundle.app/Contents/MonoBundle/createdump', with different metadata. The metadata 'InOneAndTwoWithDifferentValues' has different values for each item (once it's '1', another time it's '2').", Engine.Logger.WarningsEvents [1].Message, "Message #1");
-				Assert.AreEqual ("Code signing has been requested multiple times for 'Bundle.app/Contents/MonoBundle/createdump', with different metadata. The metadata for one are: 'CodesignStampFile, InOneAndTwoWithDifferentValues, OnlyIn1, RequireCodeSigning', while the metadata for the other are: 'CodesignStampFile, RequireCodeSigning'", Engine.Logger.WarningsEvents [2].Message, "Message #2");
+				Assert.That (Engine.Logger.WarningsEvents.Count, Is.EqualTo (3), "Warning Count");
+				Assert.That (Engine.Logger.WarningsEvents [0].Message, Is.EqualTo ("Code signing has been requested multiple times for 'Bundle.app/Contents/MonoBundle/createdump', with different metadata. The metadata 'OnlyIn1=true' has been set for one item, but not the other."), "Message #0");
+				Assert.That (Engine.Logger.WarningsEvents [1].Message, Is.EqualTo ("Code signing has been requested multiple times for 'Bundle.app/Contents/MonoBundle/createdump', with different metadata. The metadata 'InOneAndTwoWithDifferentValues' has different values for each item (once it's '1', another time it's '2')."), "Message #1");
+				Assert.That (Engine.Logger.WarningsEvents [2].Message, Is.EqualTo ("Code signing has been requested multiple times for 'Bundle.app/Contents/MonoBundle/createdump', with different metadata. The metadata for one are: 'CodesignStampFile, InOneAndTwoWithDifferentValues, OnlyIn1, RequireCodeSigning', while the metadata for the other are: 'CodesignStampFile, RequireCodeSigning'"), "Message #2");
 
 				VerifyCodesigningResults (infos, task.OutputCodesignItems, platform);
 			} finally {

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CreateBindingResourceTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CreateBindingResourceTaskTests.cs
@@ -95,7 +95,7 @@ namespace Xamarin.MacDev.Tasks {
 			unzipArguments.Add (targetDirectory);
 			unzipArguments.Add (zipArchive);
 			var rv = Execution.RunAsync ("unzip", unzipArguments).Result;
-			Assert.AreEqual (0, rv.ExitCode, "ExitCode\n" + rv.Output.MergedOutput);
+			Assert.That (rv.ExitCode, Is.EqualTo (0), "ExitCode\n" + rv.Output.MergedOutput);
 		}
 
 		void AssertResourceDirectory (string directory, bool symlinks)
@@ -104,22 +104,22 @@ namespace Xamarin.MacDev.Tasks {
 			foreach (var file in allFiles)
 				Console.WriteLine (file);
 			if (symlinks) {
-				Assert.AreEqual (7, allFiles.Length, "Length");
+				Assert.That (allFiles.Length, Is.EqualTo (7), "Length");
 			} else {
-				Assert.AreEqual (5, allFiles.Length, "Length");
+				Assert.That (allFiles.Length, Is.EqualTo (5), "Length");
 			}
-			Assert.AreEqual ("ABCDEFGHIJKLMAAA", File.ReadAllText (Path.Combine (directory, "A.txt")), "A.txt");
-			Assert.AreEqual ("ABCDEFGHIJKLMBBB", File.ReadAllText (Path.Combine (directory, "B.txt")), "B.txt");
-			Assert.AreEqual ("ABCDEFGHIJKLMCCC", File.ReadAllText (Path.Combine (directory, "C.framework/C.txt")), "C.txt");
+			Assert.That (File.ReadAllText (Path.Combine (directory, "A.txt")), Is.EqualTo ("ABCDEFGHIJKLMAAA"), "A.txt");
+			Assert.That (File.ReadAllText (Path.Combine (directory, "B.txt")), Is.EqualTo ("ABCDEFGHIJKLMBBB"), "B.txt");
+			Assert.That (File.ReadAllText (Path.Combine (directory, "C.framework/C.txt")), Is.EqualTo ("ABCDEFGHIJKLMCCC"), "C.txt");
 			if (symlinks) {
 				var linkToCPath = Path.Combine (directory, "C.framework/LinkToC.txt");
-				Assert.AreEqual ("ABCDEFGHIJKLMCCC", File.ReadAllText (linkToCPath), "LinkToC.txt");
-				Assert.IsTrue (PathUtils.IsSymlink (linkToCPath), "LinkToC.txt - IsSymlink");
-				Assert.AreEqual ("C.txt", PathUtils.GetSymlinkTarget (linkToCPath), "LinkToC.txt - IsSymlink target");
+				Assert.That (File.ReadAllText (linkToCPath), Is.EqualTo ("ABCDEFGHIJKLMCCC"), "LinkToC.txt");
+				Assert.That (PathUtils.IsSymlink (linkToCPath), Is.True, "LinkToC.txt - IsSymlink");
+				Assert.That (PathUtils.GetSymlinkTarget (linkToCPath), Is.EqualTo ("C.txt"), "LinkToC.txt - IsSymlink target");
 
 				var linkToNowherePath = Path.Combine (directory, "C.framework/LinkToNowhere.txt");
 				Assert.Throws<FileNotFoundException> (() => File.ReadAllText (linkToNowherePath), "LinkToNowhere.txt");
-				Assert.AreEqual ("Nowhere.txt", PathUtils.GetSymlinkTarget (linkToNowherePath), "LinkToNowhere.txt - IsSymlink target");
+				Assert.That (PathUtils.GetSymlinkTarget (linkToNowherePath), Is.EqualTo ("Nowhere.txt"), "LinkToNowhere.txt - IsSymlink target");
 			}
 
 			var manifest = @"<BindingAssembly>
@@ -157,7 +157,7 @@ namespace Xamarin.MacDev.Tasks {
 		<WeakFrameworks></WeakFrameworks>
 	</NativeReference>
 </BindingAssembly>";
-			Assert.AreEqual (manifest, File.ReadAllText (Path.Combine (directory, "manifest")), "Manifest");
+			Assert.That (File.ReadAllText (Path.Combine (directory, "manifest")), Is.EqualTo (manifest), "Manifest");
 		}
 
 		ITaskItem [] CreateNativeReferences (string tmpdir, bool symlinks)

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/DetectSdkLocationsTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/DetectSdkLocationsTaskTests.cs
@@ -18,7 +18,7 @@ namespace Xamarin.MacDev.Tasks {
 			task.TargetFrameworkMoniker = TargetFramework.DotNet_iOS_String;
 			ExecuteTask (task, 1);
 
-			Assert.AreEqual ("XYZ", task.XamarinSdkRoot, "#1");
+			Assert.That (task.XamarinSdkRoot, Is.EqualTo ("XYZ"), "#1");
 		}
 	}
 }

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/DetectSigningIdentityTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/DetectSigningIdentityTaskTests.cs
@@ -35,11 +35,11 @@ namespace Xamarin.MacDev.Tasks {
 			ExecuteTask (task);
 
 			Assert.That (task.DetectedAppId, Is.Null.Or.Empty, "DetectedAppId");
-			Assert.AreEqual ("-", task.DetectedCodeSigningKey, "DetectedCodeSigningKey");
-			Assert.AreEqual ($"{Xamarin.Tests.Configuration.XcodeLocation}/Toolchains/XcodeDefault.xctoolchain/usr/bin/codesign_allocate", task.DetectedCodesignAllocate, "DetectedCodesignAllocate");
-			Assert.AreEqual ("Any", task.DetectedDistributionType, "DetectedDistributionType");
+			Assert.That (task.DetectedCodeSigningKey, Is.EqualTo ("-"), "DetectedCodeSigningKey");
+			Assert.That (task.DetectedCodesignAllocate, Is.EqualTo ($"{Xamarin.Tests.Configuration.XcodeLocation}/Toolchains/XcodeDefault.xctoolchain/usr/bin/codesign_allocate"), "DetectedCodesignAllocate");
+			Assert.That (task.DetectedDistributionType, Is.EqualTo ("Any"), "DetectedDistributionType");
 			Assert.That (task.DetectedProvisioningProfile, Is.Null.Or.Empty, "DetectedProvisioningProfile");
-			Assert.IsFalse (task.HasEntitlements, "HasEntitlements");
+			Assert.That (task.HasEntitlements, Is.False, "HasEntitlements");
 		}
 
 		const string EmptyEntitlements1 = @"<?xml version=""1.0"" encoding=""UTF-8""?>
@@ -142,17 +142,17 @@ namespace Xamarin.MacDev.Tasks {
 				Assert.That (task.DetectedAppId, Does.EndWith (".com.tests.emptyentitlements"), "DetectedAppId");
 				Assert.That (task.DetectedProvisioningProfile, Is.Not.Null.And.Not.Empty, "DetectedProvisioningProfile");
 			} else {
-				Assert.AreEqual ("com.tests.emptyentitlements", task.DetectedAppId, "DetectedAppId");
+				Assert.That (task.DetectedAppId, Is.EqualTo ("com.tests.emptyentitlements"), "DetectedAppId");
 				Assert.That (task.DetectedProvisioningProfile, Is.Null.Or.Empty, "DetectedProvisioningProfile");
 			}
 			if (testCase.IsSimulator || !requiresProvisioningProfile) {
-				Assert.AreEqual ("-", task.DetectedCodeSigningKey, "DetectedCodeSigningKey");
+				Assert.That (task.DetectedCodeSigningKey, Is.EqualTo ("-"), "DetectedCodeSigningKey");
 				Assert.That (task.DetectedDistributionType, Is.EqualTo ("Any"), "DetectedDistributionType");
 			} else {
 				Assert.That (task.DetectedCodeSigningKey, Has.Length.EqualTo ("20D63576DE3EA7BE419C18997CF948D759B43D53".Length), "DetectedCodeSigningKey");
 				Assert.That (task.DetectedDistributionType, Is.EqualTo ("Development").Or.EqualTo ("AppStore").Or.EqualTo ("Any"), "DetectedDistributionType");
 			}
-			Assert.AreEqual ($"{Xamarin.Tests.Configuration.XcodeLocation}/Toolchains/XcodeDefault.xctoolchain/usr/bin/codesign_allocate", task.DetectedCodesignAllocate, "DetectedCodesignAllocate");
+			Assert.That (task.DetectedCodesignAllocate, Is.EqualTo ($"{Xamarin.Tests.Configuration.XcodeLocation}/Toolchains/XcodeDefault.xctoolchain/usr/bin/codesign_allocate"), "DetectedCodesignAllocate");
 		}
 
 		[Test]
@@ -164,11 +164,11 @@ namespace Xamarin.MacDev.Tasks {
 			ExecuteTask (task);
 
 			Assert.That (task.DetectedAppId, Is.Not.Null.And.Not.Empty, "DetectedAppId");
-			Assert.AreEqual ("-", task.DetectedCodeSigningKey, "DetectedCodeSigningKey");
-			Assert.AreEqual ($"{Xamarin.Tests.Configuration.XcodeLocation}/Toolchains/XcodeDefault.xctoolchain/usr/bin/codesign_allocate", task.DetectedCodesignAllocate, "DetectedCodesignAllocate");
-			Assert.AreEqual ("Any", task.DetectedDistributionType, "DetectedDistributionType");
+			Assert.That (task.DetectedCodeSigningKey, Is.EqualTo ("-"), "DetectedCodeSigningKey");
+			Assert.That (task.DetectedCodesignAllocate, Is.EqualTo ($"{Xamarin.Tests.Configuration.XcodeLocation}/Toolchains/XcodeDefault.xctoolchain/usr/bin/codesign_allocate"), "DetectedCodesignAllocate");
+			Assert.That (task.DetectedDistributionType, Is.EqualTo ("Any"), "DetectedDistributionType");
 			Assert.That (task.DetectedProvisioningProfile, Is.Not.Null.And.Not.Empty, "DetectedProvisioningProfile");
-			Assert.IsTrue (task.HasEntitlements, "HasEntitlements");
+			Assert.That (task.HasEntitlements, Is.True, "HasEntitlements");
 		}
 
 		[Test]
@@ -183,11 +183,11 @@ namespace Xamarin.MacDev.Tasks {
 
 			Assert.Multiple (() => {
 				Assert.That (task.DetectedAppId, Does.EndWith ("." + task.BundleIdentifier), "DetectedAppId");
-				Assert.AreEqual ("-", task.DetectedCodeSigningKey, "DetectedCodeSigningKey");
-				Assert.AreEqual ($"{Xamarin.Tests.Configuration.XcodeLocation}/Toolchains/XcodeDefault.xctoolchain/usr/bin/codesign_allocate", task.DetectedCodesignAllocate, "DetectedCodesignAllocate");
-				Assert.AreEqual ("Any", task.DetectedDistributionType, "DetectedDistributionType");
+				Assert.That (task.DetectedCodeSigningKey, Is.EqualTo ("-"), "DetectedCodeSigningKey");
+				Assert.That (task.DetectedCodesignAllocate, Is.EqualTo ($"{Xamarin.Tests.Configuration.XcodeLocation}/Toolchains/XcodeDefault.xctoolchain/usr/bin/codesign_allocate"), "DetectedCodesignAllocate");
+				Assert.That (task.DetectedDistributionType, Is.EqualTo ("Any"), "DetectedDistributionType");
 				Assert.That (task.DetectedProvisioningProfile, Is.Not.Null.And.Not.Empty, "DetectedProvisioningProfile");
-				Assert.IsTrue (task.HasEntitlements, "HasEntitlements");
+				Assert.That (task.HasEntitlements, Is.True, "HasEntitlements");
 			});
 		}
 	}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_Core.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_Core.cs
@@ -68,16 +68,16 @@ namespace Xamarin.MacDev.Tasks {
 		public void PlistMissing ()
 		{
 			File.Delete (Task.AppManifest!.ItemSpec);
-			Assert.IsTrue (Task.Execute (), "#1");
+			Assert.That (Task.Execute (), Is.True, "#1");
 			Assert.That (Task.CompiledAppManifest!.ItemSpec, Does.Exist, "#2");
 		}
 
 		[Test]
 		public void NormalPlist ()
 		{
-			Assert.IsTrue (Task.Execute (), "#1");
-			Assert.IsNotNull (Task.CompiledAppManifest?.ItemSpec, "#2");
-			Assert.IsTrue (File.Exists (Task.CompiledAppManifest!.ItemSpec), "#3");
+			Assert.That (Task.Execute (), Is.True, "#1");
+			Assert.That (Task.CompiledAppManifest?.ItemSpec, Is.Not.Null, "#2");
+			Assert.That (File.Exists (Task.CompiledAppManifest!.ItemSpec), Is.True, "#3");
 		}
 
 		[Test]
@@ -85,7 +85,7 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			Plist.Remove ("CFBundleIdentifier");
 			Plist.Save (Task.AppManifest!.ItemSpec);
-			Assert.IsTrue (Task.Execute (), "#1");
+			Assert.That (Task.Execute (), Is.True, "#1");
 		}
 
 		[Test]
@@ -93,7 +93,7 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			Plist.Remove ("CFBundleDisplayName");
 			Plist.Save (Task.AppManifest!.ItemSpec);
-			Assert.IsTrue (Task.Execute (), "#1");
+			Assert.That (Task.Execute (), Is.True, "#1");
 		}
 
 		[Test]
@@ -116,28 +116,28 @@ namespace Xamarin.MacDev.Tasks {
 		[Test]
 		public void BundleDevelopmentRegion ()
 		{
-			Assert.IsFalse (CompiledPlist.ContainsKey (ManifestKeys.CFBundleDevelopmentRegion), "#1");
+			Assert.That (CompiledPlist.ContainsKey (ManifestKeys.CFBundleDevelopmentRegion), Is.False, "#1");
 		}
 
 		[Test]
 		public virtual void BundleExecutable ()
 		{
 			Assert.That (CompiledPlist.ContainsKey (ManifestKeys.CFBundleExecutable), "#1");
-			Assert.AreEqual (CompiledPlist.Get<PString> (ManifestKeys.CFBundleExecutable)?.Value, assemblyName, "#2");
+			Assert.That (assemblyName, Is.EqualTo (CompiledPlist.Get<PString> (ManifestKeys.CFBundleExecutable)?.Value), "#2");
 		}
 
 		[Test]
 		public virtual void BundleName ()
 		{
 			Assert.That (CompiledPlist.ContainsKey (ManifestKeys.CFBundleName), "#1");
-			Assert.AreEqual (CompiledPlist.Get<PString> (ManifestKeys.CFBundleName)?.Value, appBundleName, "#2");
+			Assert.That (appBundleName, Is.EqualTo (CompiledPlist.Get<PString> (ManifestKeys.CFBundleName)?.Value), "#2");
 		}
 
 		[Test]
 		public virtual void BundleIdentifier ()
 		{
 			Assert.That (CompiledPlist.ContainsKey (ManifestKeys.CFBundleIdentifier), "#1");
-			Assert.AreEqual (CompiledPlist.Get<PString> (ManifestKeys.CFBundleIdentifier)?.Value, bundleIdentifier, "#2");
+			Assert.That (bundleIdentifier, Is.EqualTo (CompiledPlist.Get<PString> (ManifestKeys.CFBundleIdentifier)?.Value), "#2");
 		}
 
 		[Test]
@@ -151,14 +151,14 @@ namespace Xamarin.MacDev.Tasks {
 		public virtual void BundlePackageType ()
 		{
 			Assert.That (CompiledPlist.ContainsKey (ManifestKeys.CFBundlePackageType), "#1");
-			Assert.AreEqual (CompiledPlist.Get<PString> (ManifestKeys.CFBundlePackageType)?.Value, "APPL", "#2");
+			Assert.That ("APPL", Is.EqualTo (CompiledPlist.Get<PString> (ManifestKeys.CFBundlePackageType)?.Value), "#2");
 		}
 
 		[Test]
 		public virtual void BundleSignature ()
 		{
 			Assert.That (CompiledPlist.ContainsKey (ManifestKeys.CFBundleSignature), "#1");
-			Assert.AreEqual (CompiledPlist.Get<PString> (ManifestKeys.CFBundleSignature)?.Value, "????", "#2");
+			Assert.That ("????", Is.EqualTo (CompiledPlist.Get<PString> (ManifestKeys.CFBundleSignature)?.Value), "#2");
 		}
 
 		[Test]

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_iOS.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_iOS.cs
@@ -26,14 +26,14 @@ namespace Xamarin.MacDev.Tasks {
 			base.BundleExecutable ();
 			// Adding ".app" to the assembly name isn't allowed because iOS may fail to launch the app.
 			Task.BundleExecutable = "AssemblyName.app";
-			Assert.IsFalse (Task.Execute (), "#1");
+			Assert.That (Task.Execute (), Is.False, "#1");
 		}
 
 		[Test]
 		public override void BundleName ()
 		{
 			Assert.That (CompiledPlist.ContainsKey (ManifestKeys.CFBundleName), "#1");
-			Assert.AreEqual (CompiledPlist.Get<PString> (ManifestKeys.CFBundleName)?.Value, appBundleName, "#2");
+			Assert.That (appBundleName, Is.EqualTo (CompiledPlist.Get<PString> (ManifestKeys.CFBundleName)?.Value), "#2");
 		}
 
 		[Test]
@@ -41,10 +41,10 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			PArray? array;
 
-			Assert.IsTrue (CompiledPlist.TryGetValue (ManifestKeys.UIRequiredDeviceCapabilities, out array), "#1");
-			Assert.IsTrue (array?.OfType<PString> ().Any (x => x.Value == "arm64") == true, "#2");
-			Assert.IsFalse (array?.OfType<PString> ().Any (x => x.Value == "armv6") == true, "#3");
-			Assert.IsFalse (array?.OfType<PString> ().Any (x => x.Value == "armv7") == true, "#4");
+			Assert.That (CompiledPlist.TryGetValue (ManifestKeys.UIRequiredDeviceCapabilities, out array), Is.True, "#1");
+			Assert.That (array?.OfType<PString> ().Any (x => x.Value == "arm64") == true, Is.True, "#2");
+			Assert.That (array?.OfType<PString> ().Any (x => x.Value == "armv6") == true, Is.False, "#3");
+			Assert.That (array?.OfType<PString> ().Any (x => x.Value == "armv7") == true, Is.False, "#4");
 		}
 	}
 }

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_iOS_AppExtension.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GeneratePlistTaskTests/GeneratePlistTaskTests_iOS_AppExtension.cs
@@ -14,7 +14,7 @@ namespace Xamarin.MacDev.Tasks {
 		public override void BundlePackageType ()
 		{
 			Assert.That (CompiledPlist.ContainsKey (ManifestKeys.CFBundlePackageType), "#1");
-			Assert.AreEqual (CompiledPlist.Get<PString> (ManifestKeys.CFBundlePackageType)?.Value, "XPC!", "#2");
+			Assert.That ("XPC!", Is.EqualTo (CompiledPlist.Get<PString> (ManifestKeys.CFBundlePackageType)?.Value), "#2");
 		}
 	}
 }

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetAvailableDevicesTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetAvailableDevicesTest.cs
@@ -58,7 +58,7 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			var platform = ApplePlatform.iOS;
 			var task = CreateTask (platform, simctl, devicectl);
-			Assert.IsTrue (task.Execute (), "Task should have succeeded.");
+			Assert.That (task.Execute (), Is.True, "Task should have succeeded.");
 			Assert.That (task.Devices.Count, Is.EqualTo (0), "Devices should be empty.");
 			Assert.That (task.DiscardedDevices.Count, Is.EqualTo (0), "No devices should have been discarded.");
 		}
@@ -68,7 +68,7 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			var platform = ApplePlatform.iOS;
 			var task = CreateTask (platform, "", DEVICECTL_JSON_1);
-			Assert.IsTrue (task.Execute (), "Task should have succeeded.");
+			Assert.That (task.Execute (), Is.True, "Task should have succeeded.");
 			Assert.Multiple (() => {
 				Assert.That (task.Devices.Count, Is.EqualTo (3), "Devices count mismatch.");
 				Assert.That (task.DiscardedDevices.Count, Is.EqualTo (1), "Discarded device count mismatch.");
@@ -111,7 +111,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			var platform = ApplePlatform.iOS;
 			var task = CreateTask (platform, SIMCTL_JSON_1, "");
-			Assert.IsTrue (task.Execute (), "Task should have succeeded.");
+			Assert.That (task.Execute (), Is.True, "Task should have succeeded.");
 			Assert.Multiple (() => {
 				Assert.That (task.Devices.Count, Is.EqualTo (2), "Devices count mismatch.");
 				Assert.That (task.DiscardedDevices.Count, Is.EqualTo (3), "Discarded device count mismatch.");
@@ -160,7 +160,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			var platform = ApplePlatform.iOS;
 			var task = CreateTask (platform, SIMCTL_JSON_1, DEVICECTL_JSON_1);
-			Assert.IsTrue (task.Execute (), "Task should have succeeded.");
+			Assert.That (task.Execute (), Is.True, "Task should have succeeded.");
 			Assert.Multiple (() => {
 				Assert.That (task.Devices.Count, Is.EqualTo (5), "Devices count mismatch.");
 				Assert.That (task.DiscardedDevices.Count, Is.EqualTo (4), "Discarded device count mismatch.");
@@ -250,7 +250,7 @@ namespace Xamarin.MacDev.Tasks {
 			</plist>
 			""";
 			var task = CreateTask (platform, SIMCTL_JSON_1, DEVICECTL_JSON_1, appManifestXml);
-			Assert.IsTrue (task.Execute (), "Task should have succeeded.");
+			Assert.That (task.Execute (), Is.True, "Task should have succeeded.");
 			Assert.Multiple (() => {
 				Assert.That (task.Devices.Count, Is.EqualTo (5), "Devices count mismatch.");
 				Assert.That (task.DiscardedDevices.Count, Is.EqualTo (4), "Discarded device count mismatch.");
@@ -344,7 +344,7 @@ namespace Xamarin.MacDev.Tasks {
 			var task = CreateTask (platform, SIMCTL_JSON_1, DEVICECTL_JSON_1, appManifestXml);
 
 
-			Assert.IsTrue (task.Execute (), "Task should have succeeded.");
+			Assert.That (task.Execute (), Is.True, "Task should have succeeded.");
 			Assert.Multiple (() => {
 				Assert.That (task.Devices.Count, Is.EqualTo (2), "Devices count mismatch.");
 				Assert.That (task.DiscardedDevices.Count, Is.EqualTo (7), "Discarded device count mismatch.");
@@ -438,7 +438,7 @@ namespace Xamarin.MacDev.Tasks {
 			File.WriteAllText (appManifestPath, appManifestXml);
 			task.AppBundleManifestPath = appManifestPath;
 
-			Assert.IsTrue (task.Execute (), "Task should have succeeded.");
+			Assert.That (task.Execute (), Is.True, "Task should have succeeded.");
 			Assert.Multiple (() => {
 				Assert.That (task.Devices.Count, Is.EqualTo (3), "Devices count mismatch.");
 				Assert.That (task.DiscardedDevices.Count, Is.EqualTo (6), "Discarded device count mismatch.");
@@ -531,7 +531,7 @@ namespace Xamarin.MacDev.Tasks {
 			task.AppBundleManifestPath = appManifestPath;
 			task.RuntimeIdentifier = $"ios-arm64";
 
-			Assert.IsTrue (task.Execute (), "Task should have succeeded.");
+			Assert.That (task.Execute (), Is.True, "Task should have succeeded.");
 			Assert.Multiple (() => {
 				Assert.That (task.Devices.Count, Is.EqualTo (3), "Devices count mismatch.");
 				Assert.That (task.DiscardedDevices.Count, Is.EqualTo (6), "Discarded device count mismatch.");
@@ -609,7 +609,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			var platform = ApplePlatform.TVOS;
 			var task = CreateTask (platform, SIMCTL_JSON_1, DEVICECTL_JSON_1);
-			Assert.IsTrue (task.Execute (), "Task should have succeeded.");
+			Assert.That (task.Execute (), Is.True, "Task should have succeeded.");
 			Assert.Multiple (() => {
 				Assert.That (task.Devices.Count, Is.EqualTo (1), "Devices count mismatch.");
 				Assert.That (task.DiscardedDevices.Count, Is.EqualTo (8), "Discarded device count mismatch.");
@@ -684,7 +684,7 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			var platform = ApplePlatform.iOS;
 			var task = CreateTask (platform, "", DEVICECTL_JSON_2);
-			Assert.IsTrue (task.Execute (), "Task should have succeeded.");
+			Assert.That (task.Execute (), Is.True, "Task should have succeeded.");
 
 			Assert.Multiple (() => {
 				Assert.That (task.DiscardedDevices [0].ItemSpec, Is.EqualTo ("12345678-1234-1234-ABCD-1234567980AB"), "Discarded Device 1 itemspec mismatch.");

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetBundleNameTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetBundleNameTaskTests.cs
@@ -21,7 +21,7 @@ namespace Xamarin.MacDev.Tasks {
 			task.ProjectName = "!@£///Hello_World%£";
 
 			ExecuteTask (task);
-			Assert.AreEqual ("Hello_World", task.BundleName, "#2");
+			Assert.That (task.BundleName, Is.EqualTo ("Hello_World"), "#2");
 		}
 	}
 }

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetPropertyListValueTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetPropertyListValueTaskTests.cs
@@ -23,7 +23,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			ExecuteTask (task);
 
-			Assert.AreEqual (expected, task.Value, "Task produced the incorrect plist output.");
+			Assert.That (task.Value, Is.EqualTo (expected), "Task produced the incorrect plist output.");
 		}
 
 		[Test]

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/IBToolTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/IBToolTaskTests.cs
@@ -62,10 +62,10 @@ namespace Xamarin.MacDev.Tasks {
 			var ibtool = CreateIBToolTask (ApplePlatform.iOS, srcdir, tmp);
 			var bundleResources = new HashSet<string> ();
 
-			Assert.IsTrue (ibtool.Execute (), "Execution of IBTool task failed.");
+			Assert.That (ibtool.Execute (), Is.True, "Execution of IBTool task failed.");
 
 			foreach (var bundleResource in ibtool.BundleResources) {
-				Assert.IsTrue (File.Exists (bundleResource.ItemSpec), "File does not exist: {0}", bundleResource.ItemSpec);
+				Assert.That (File.Exists (bundleResource.ItemSpec), Is.True, $"File does not exist: {bundleResource.ItemSpec}");
 				Assert.That (bundleResource.GetMetadata ("LogicalName"), Is.Not.Null.Or.Empty, "The 'LogicalName' metadata must be set.");
 				Assert.That (bundleResource.GetMetadata ("Optimize"), Is.Not.Null.Or.Empty, "The 'Optimize' metadata must be set.");
 
@@ -104,18 +104,18 @@ namespace Xamarin.MacDev.Tasks {
 
 			ibtool.EnableOnDemandResources = true;
 
-			Assert.IsTrue (ibtool.Execute (), "Execution of IBTool task failed.");
+			Assert.That (ibtool.Execute (), Is.True, "Execution of IBTool task failed.");
 
 			foreach (var bundleResource in ibtool.BundleResources) {
 				var bundleName = bundleResource.GetMetadata ("LogicalName");
 				var tag = bundleResource.GetMetadata ("ResourceTags");
 
-				Assert.IsTrue (File.Exists (bundleResource.ItemSpec), "File does not exist: {0}", bundleResource.ItemSpec);
+				Assert.That (File.Exists (bundleResource.ItemSpec), Is.True, $"File does not exist: {bundleResource.ItemSpec}");
 				Assert.That (bundleResource.GetMetadata ("LogicalName"), Is.Not.Null.Or.Empty, "The 'LogicalName' metadata must be set.");
 				Assert.That (bundleResource.GetMetadata ("Optimize"), Is.Not.Null.Or.Empty, "The 'Optimize' metadata must be set.");
 
 				Assert.That (tag, Is.Not.Null.Or.Empty, "The 'ResourceTags' metadata should be set.");
-				Assert.IsTrue (bundleName.Contains (".lproj/" + tag + ".storyboardc/"), "BundleResource does not have the proper ResourceTags set: {0}", bundleName);
+				Assert.That (bundleName.Contains (".lproj/" + tag + ".storyboardc/"), Is.True, $"BundleResource does not have the proper ResourceTags set: {bundleName}");
 
 				bundleResources.Add (bundleName);
 			}
@@ -179,18 +179,18 @@ namespace Xamarin.MacDev.Tasks {
 
 			ibtool.EnableOnDemandResources = true;
 
-			Assert.IsTrue (ibtool.Execute (), "Execution of IBTool task failed.");
+			Assert.That (ibtool.Execute (), Is.True, "Execution of IBTool task failed.");
 
 			foreach (var bundleResource in ibtool.BundleResources) {
 				var bundleName = bundleResource.GetMetadata ("LogicalName");
 				var tag = bundleResource.GetMetadata ("ResourceTags");
 
-				Assert.IsTrue (File.Exists (bundleResource.ItemSpec), "File does not exist: {0}", bundleResource.ItemSpec);
+				Assert.That (File.Exists (bundleResource.ItemSpec), Is.True, $"File does not exist: {bundleResource.ItemSpec}");
 				Assert.That (bundleResource.GetMetadata ("LogicalName"), Is.Not.Null.Or.Empty, "The 'LogicalName' metadata must be set.");
 				Assert.That (bundleResource.GetMetadata ("Optimize"), Is.Not.Null.Or.Empty, "The 'Optimize' metadata must be set.");
 
 				Assert.That (tag, Is.Not.Null.Or.Empty, "The 'ResourceTags' metadata should be set.");
-				Assert.AreEqual (Path.Combine (tmp, "ibtool", tag + ".nib"), bundleResource.ItemSpec, $"BundleResource {bundleName} is not at the expected location.");
+				Assert.That (bundleResource.ItemSpec, Is.EqualTo (Path.Combine (tmp, "ibtool", tag + ".nib")), $"BundleResource {bundleName} is not at the expected location.");
 
 				bundleResources.Add (bundleName);
 			}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/LocalizationStringTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/LocalizationStringTest.cs
@@ -43,7 +43,7 @@ namespace Xamarin.MacDev.Tasks {
 
 				ExecuteTask (task, 1);
 				bool isTranslated = Engine.Logger.ErrorEvents [0].Message?.Contains (errorMessage) == true;
-				Assert.IsTrue (isTranslated, $"Should contain \"{errorMessage}\", but instead has value: \"{Engine.Logger.ErrorEvents [0].Message}\"");
+				Assert.That (isTranslated, Is.True, $"Should contain \"{errorMessage}\", but instead has value: \"{Engine.Logger.ErrorEvents [0].Message}\"");
 			} finally {
 				Thread.CurrentThread.CurrentUICulture = originalUICulture;
 				Thread.CurrentThread.CurrentCulture = originalCulture;
@@ -71,11 +71,11 @@ namespace Xamarin.MacDev.Tasks {
 			CultureInfo originalCulture = Thread.CurrentThread.CurrentCulture;
 
 			try {
-				Assert.IsFalse (string.IsNullOrEmpty (errorCode), "Error code is null or empty");
+				Assert.That (string.IsNullOrEmpty (errorCode), Is.False, "Error code is null or empty");
 				string? englishError = TranslateError ("en-US", errorCode);
 				string? newCultureError = TranslateError (culture, errorCode);
 
-				Assert.AreNotEqual (englishError, newCultureError, $"\"{errorCode}\" is not translated in {culture}.");
+				Assert.That (newCultureError, Is.Not.EqualTo (englishError), $"\"{errorCode}\" is not translated in {culture}.");
 			} catch (NullReferenceException) {
 				Assert.Fail ($"Error code \"{errorCode}\" was not found");
 			} finally {
@@ -110,8 +110,8 @@ namespace Xamarin.MacDev.Tasks {
 			var errorsNotInResources = string.Join (" ", resxHashSet.Where (n => !resourceHashSet.Contains (n) && !ignoreList.Contains (n)));
 			var errorsNotInResx = string.Join (" ", resourceHashSet.Where (n => !resxHashSet.Contains (n) && !ignoreList.Contains (n)));
 
-			Assert.IsEmpty (errorsNotInResources, $"The following error(s) were found in MSBStrings.resx but not through the MSBStrings resource. Try to recompile the msbuild project and then the test project\n{errorsNotInResources}");
-			Assert.IsEmpty (errorsNotInResx, $"The following error(s) were found in the MSBStrings resource but not in MSBStrings.resx. Try to recompile the msbuild project and then the test project\n{errorsNotInResx}");
+			Assert.That (errorsNotInResources, Is.Empty, $"The following error(s) were found in MSBStrings.resx but not through the MSBStrings resource. Try to recompile the msbuild project and then the test project\n{errorsNotInResources}");
+			Assert.That (errorsNotInResx, Is.Empty, $"The following error(s) were found in the MSBStrings resource but not in MSBStrings.resx. Try to recompile the msbuild project and then the test project\n{errorsNotInResx}");
 		}
 	}
 }

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/MergeAppBundleTaskTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/MergeAppBundleTaskTest.cs
@@ -102,13 +102,13 @@ namespace Xamarin.MacDev.Tasks {
 			ExecuteTask (task);
 
 			// The bundle should only contain a single file.
-			Assert.AreEqual (1, Directory.GetFileSystemEntries (outputBundle).Length, "Files in bundle");
+			Assert.That (Directory.GetFileSystemEntries (outputBundle).Length, Is.EqualTo (1), "Files in bundle");
 
 			// The resulting dylib should contain 2 architectures.
 			var fatLibrary = Path.Combine (outputBundle, "libframework.dylib");
 			Assert.That (fatLibrary, Does.Exist, "Existence");
 			var machO = MachO.Read (fatLibrary).ToArray ();
-			Assert.AreEqual (2, machO.Length, "Architecture Count");
+			Assert.That (machO.Length, Is.EqualTo (2), "Architecture Count");
 		}
 
 		[Test]
@@ -132,7 +132,7 @@ namespace Xamarin.MacDev.Tasks {
 			ExecuteTask (task);
 
 			// The bundle should have all the files
-			Assert.AreEqual (complexFiles.Length, Directory.GetFileSystemEntries (outputBundle).Length, "Files in bundle");
+			Assert.That (Directory.GetFileSystemEntries (outputBundle).Length, Is.EqualTo (complexFiles.Length), "Files in bundle");
 
 			// with the same structure
 			foreach (var file in complexFiles)
@@ -152,7 +152,7 @@ namespace Xamarin.MacDev.Tasks {
 			var outputBundle = Path.Combine (Cache.CreateTemporaryDirectory (), "Merged.app");
 			var task = CreateTask (outputBundle, bundles);
 			ExecuteTask (task, 3);
-			Assert.AreEqual ("Unable to merge the file 'Something.txt', it's different between the input app bundles.", Engine.Logger.ErrorEvents [0].Message, "Error message");
+			Assert.That (Engine.Logger.ErrorEvents [0].Message, Is.EqualTo ("Unable to merge the file 'Something.txt', it's different between the input app bundles."), "Error message");
 			Assert.That (Engine.Logger.ErrorEvents [1].Message, Does.Match ("App bundle file #1: .*/MergeMe.app/Something.txt"), "Error message 2");
 			Assert.That (Engine.Logger.ErrorEvents [2].Message, Does.Match ("App bundle file #2: .*/MergeMe.app/Something.txt"), "Error message 3");
 		}
@@ -170,14 +170,14 @@ namespace Xamarin.MacDev.Tasks {
 			File.WriteAllText (fileB, "A");
 			var linkA = Path.Combine (bundleA, "B.txt");
 			var linkB = Path.Combine (bundleB, "B.txt");
-			Assert.IsTrue (PathUtils.Symlink ("A.txt", linkA), "Link A");
-			Assert.IsTrue (PathUtils.Symlink ("A.txt", linkB), "Link B");
+			Assert.That (PathUtils.Symlink ("A.txt", linkA), Is.True, "Link A");
+			Assert.That (PathUtils.Symlink ("A.txt", linkB), Is.True, "Link B");
 
 
 			var outputBundle = Path.Combine (Cache.CreateTemporaryDirectory (), "Merged.app");
 			var task = CreateTask (outputBundle, bundleA, bundleB);
 			ExecuteTask (task);
-			Assert.IsTrue (PathUtils.IsSymlink (Path.Combine (outputBundle, "B.txt")), "IsSymlink");
+			Assert.That (PathUtils.IsSymlink (Path.Combine (outputBundle, "B.txt")), Is.True, "IsSymlink");
 		}
 
 		[Test]
@@ -198,14 +198,14 @@ namespace Xamarin.MacDev.Tasks {
 			// There's a symlink in both apps, but they have different targets.
 			var linkA = Path.Combine (bundleA, "B.txt");
 			var linkB = Path.Combine (bundleB, "B.txt");
-			Assert.IsTrue (PathUtils.Symlink ("A.txt", linkA), "Link A");
-			Assert.IsTrue (PathUtils.Symlink ("C.txt", linkB), "Link B");
+			Assert.That (PathUtils.Symlink ("A.txt", linkA), Is.True, "Link A");
+			Assert.That (PathUtils.Symlink ("C.txt", linkB), Is.True, "Link B");
 
 
 			var outputBundle = Path.Combine (Cache.CreateTemporaryDirectory (), "Merged.app");
 			var task = CreateTask (outputBundle, bundleA, bundleB);
 			ExecuteTask (task, 3);
-			Assert.AreEqual ("Can't merge the symlink 'B.txt', it has different targets.", Engine.Logger.ErrorEvents [0].Message, "Error message");
+			Assert.That (Engine.Logger.ErrorEvents [0].Message, Is.EqualTo ("Can't merge the symlink 'B.txt', it has different targets."), "Error message");
 			Assert.That (Engine.Logger.ErrorEvents [1].Message, Does.Match ("App bundle file #1: .*/MergeMe.app/B.txt"), "Error message 2");
 			Assert.That (Engine.Logger.ErrorEvents [2].Message, Does.Match ("App bundle file #2: .*/MergeMe.app/B.txt"), "Error message 3");
 		}
@@ -248,7 +248,7 @@ namespace Xamarin.MacDev.Tasks {
 			Assert.That (Path.Combine (outputBundle, nestedSharedOnlyB), Does.Exist, "nestedSharedOnlyB");
 
 			// Verify that there aren't any other directories
-			Assert.AreEqual (7, Directory.GetFileSystemEntries (outputBundle).Length, "Directories in bundle");
+			Assert.That (Directory.GetFileSystemEntries (outputBundle).Length, Is.EqualTo (7), "Directories in bundle");
 		}
 
 		[Test]
@@ -262,13 +262,13 @@ namespace Xamarin.MacDev.Tasks {
 			ExecuteTask (task);
 
 			// The bundle should only contain a single file.
-			Assert.AreEqual (1, Directory.GetFileSystemEntries (outputBundle).Length, "Files in bundle");
+			Assert.That (Directory.GetFileSystemEntries (outputBundle).Length, Is.EqualTo (1), "Files in bundle");
 
 			// The resulting dylib should contain 1 architecture.
 			var nonFatBinary = Path.Combine (outputBundle, "libframework.dylib");
 			Assert.That (nonFatBinary, Does.Exist, "Existence");
 			var machO = MachO.Read (nonFatBinary).ToArray ();
-			Assert.AreEqual (1, machO.Length, "Architecture Count");
+			Assert.That (machO.Length, Is.EqualTo (1), "Architecture Count");
 
 			// and the file size should be the same as the input
 			Assert.That (new FileInfo (fileA).Length, Is.EqualTo (new FileInfo (nonFatBinary).Length), "File length");
@@ -287,15 +287,15 @@ namespace Xamarin.MacDev.Tasks {
 			File.WriteAllText (fileB, "A");
 			var linkA = Path.Combine (bundleA, "B");
 			var linkB = Path.Combine (bundleB, "B");
-			Assert.IsTrue (PathUtils.Symlink ("A", linkA), "Link A");
-			Assert.IsTrue (PathUtils.Symlink ("A", linkB), "Link B");
+			Assert.That (PathUtils.Symlink ("A", linkA), Is.True, "Link A");
+			Assert.That (PathUtils.Symlink ("A", linkB), Is.True, "Link B");
 
 			var outputBundle = Path.Combine (Cache.CreateTemporaryDirectory (), "Merged.app");
 			var task = CreateTask (outputBundle, bundleA, bundleB);
 			ExecuteTask (task);
-			Assert.IsTrue (PathUtils.IsSymlink (Path.Combine (outputBundle, "B")), "IsSymlink");
-			Assert.IsFalse (PathUtils.IsSymlink (Path.Combine (outputBundle, "A", "A.txt")), "IsSymlink");
-			Assert.IsFalse (PathUtils.IsSymlink (Path.Combine (outputBundle, "B", "A.txt")), "IsSymlink");
+			Assert.That (PathUtils.IsSymlink (Path.Combine (outputBundle, "B")), Is.True, "IsSymlink");
+			Assert.That (PathUtils.IsSymlink (Path.Combine (outputBundle, "A", "A.txt")), Is.False, "IsSymlink");
+			Assert.That (PathUtils.IsSymlink (Path.Combine (outputBundle, "B", "A.txt")), Is.False, "IsSymlink");
 		}
 	}
 }

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ParseBundlerArgumentsTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ParseBundlerArgumentsTests.cs
@@ -16,14 +16,14 @@ namespace Xamarin.MacDev.Tasks {
 		{
 			var task = CreateTask<CustomParseBundlerArguments> ();
 			ExecuteTask (task);
-			Assert.AreEqual ("false", task.NoSymbolStrip, "nosymbolstrip");
-			Assert.AreEqual ("false", task.NoDSymUtil, "nodsymutil");
+			Assert.That (task.NoSymbolStrip, Is.EqualTo ("false"), "nosymbolstrip");
+			Assert.That (task.NoDSymUtil, Is.EqualTo ("false"), "nodsymutil");
 
 			task = CreateTask<CustomParseBundlerArguments> ();
 			task.ExtraArgs = string.Empty;
 			ExecuteTask (task);
-			Assert.AreEqual ("false", task.NoSymbolStrip, "nosymbolstrip");
-			Assert.AreEqual ("false", task.NoDSymUtil, "nodsymutil");
+			Assert.That (task.NoSymbolStrip, Is.EqualTo ("false"), "nosymbolstrip");
+			Assert.That (task.NoDSymUtil, Is.EqualTo ("false"), "nodsymutil");
 		}
 
 		[Test]
@@ -48,16 +48,16 @@ namespace Xamarin.MacDev.Tasks {
 				var task = CreateTask<CustomParseBundlerArguments> ();
 				task.ExtraArgs = variation;
 				ExecuteTask (task, message: "execute: " + variation);
-				Assert.AreEqual ("false", task.NoSymbolStrip, "nosymbolstrip: " + variation);
-				Assert.AreEqual ("false", task.NoDSymUtil, "nodsymutil: " + variation);
+				Assert.That (task.NoSymbolStrip, Is.EqualTo ("false"), "nosymbolstrip: " + variation);
+				Assert.That (task.NoDSymUtil, Is.EqualTo ("false"), "nodsymutil: " + variation);
 			}
 
 			foreach (var variation in true_variations) {
 				var task = CreateTask<CustomParseBundlerArguments> ();
 				task.ExtraArgs = variation;
 				ExecuteTask (task, message: "execute: " + variation);
-				Assert.AreEqual ("true", task.NoSymbolStrip, "nosymbolstrip: " + variation);
-				Assert.AreEqual ("false", task.NoDSymUtil, "nodsymutil: " + variation);
+				Assert.That (task.NoSymbolStrip, Is.EqualTo ("true"), "nosymbolstrip: " + variation);
+				Assert.That (task.NoDSymUtil, Is.EqualTo ("false"), "nodsymutil: " + variation);
 			}
 		}
 
@@ -86,16 +86,16 @@ namespace Xamarin.MacDev.Tasks {
 				var task = CreateTask<CustomParseBundlerArguments> ();
 				task.ExtraArgs = variation;
 				ExecuteTask (task, message: "execute: " + variation);
-				Assert.AreEqual ("false", task.NoSymbolStrip, "nosymbolstrip: " + variation);
-				Assert.AreEqual ("false", task.NoDSymUtil, "nodsymutil: " + variation);
+				Assert.That (task.NoSymbolStrip, Is.EqualTo ("false"), "nosymbolstrip: " + variation);
+				Assert.That (task.NoDSymUtil, Is.EqualTo ("false"), "nodsymutil: " + variation);
 			}
 
 			foreach (var variation in true_variations) {
 				var task = CreateTask<CustomParseBundlerArguments> ();
 				task.ExtraArgs = variation;
 				ExecuteTask (task, message: "execute: " + variation);
-				Assert.AreEqual ("false", task.NoSymbolStrip, "nosymbolstrip: " + variation);
-				Assert.AreEqual ("true", task.NoDSymUtil, "nodsymutil: " + variation);
+				Assert.That (task.NoSymbolStrip, Is.EqualTo ("false"), "nosymbolstrip: " + variation);
+				Assert.That (task.NoDSymUtil, Is.EqualTo ("true"), "nodsymutil: " + variation);
 			}
 		}
 
@@ -117,7 +117,7 @@ namespace Xamarin.MacDev.Tasks {
 			task.MarshalManagedExceptionMode = existingValue;
 			task.ExtraArgs = input;
 			ExecuteTask (task, message: input);
-			Assert.AreEqual (output, task.MarshalManagedExceptionMode, output);
+			Assert.That (task.MarshalManagedExceptionMode, Is.EqualTo (output), output);
 		}
 
 		[Test]
@@ -138,7 +138,7 @@ namespace Xamarin.MacDev.Tasks {
 			task.MarshalObjectiveCExceptionMode = existingValue;
 			task.ExtraArgs = input;
 			ExecuteTask (task, message: input);
-			Assert.AreEqual (output, task.MarshalObjectiveCExceptionMode, output);
+			Assert.That (task.MarshalObjectiveCExceptionMode, Is.EqualTo (output), output);
 		}
 
 		[Test]
@@ -156,7 +156,7 @@ namespace Xamarin.MacDev.Tasks {
 			var task = CreateTask<CustomParseBundlerArguments> ();
 			task.ExtraArgs = input;
 			ExecuteTask (task, message: input);
-			Assert.AreEqual (output, task.Optimize, output);
+			Assert.That (task.Optimize, Is.EqualTo (output), output);
 		}
 
 		[TestCase ("--registrar", "")]
@@ -172,7 +172,7 @@ namespace Xamarin.MacDev.Tasks {
 			var task = CreateTask<CustomParseBundlerArguments> ();
 			task.ExtraArgs = input;
 			ExecuteTask (task, message: input);
-			Assert.AreEqual (output, task.Registrar, output);
+			Assert.That (task.Registrar, Is.EqualTo (output), output);
 		}
 
 		[TestCase ("--xml", null, "")]
@@ -198,7 +198,7 @@ namespace Xamarin.MacDev.Tasks {
 				task.XmlDefinitions = existing.Split (new char [] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select (v => new TaskItem (v)).ToArray ();
 			task.ExtraArgs = input;
 			ExecuteTask (task, message: input);
-			Assert.AreEqual (output, string.Join (";", task.XmlDefinitions.Select (v => v.ItemSpec).ToArray ()), output);
+			Assert.That (string.Join (";", task.XmlDefinitions.Select (v => v.ItemSpec).ToArray ()), Is.EqualTo (output), output);
 		}
 
 		[TestCase ("/xml:\\path\\a /xml:/path/b", null, "/path/a;/path/b")]
@@ -219,7 +219,7 @@ namespace Xamarin.MacDev.Tasks {
 			var task = CreateTask<CustomParseBundlerArguments> ();
 			task.ExtraArgs = input;
 			ExecuteTask (task, message: input);
-			Assert.AreEqual (output, task.CustomBundleName, output);
+			Assert.That (task.CustomBundleName, Is.EqualTo (output), output);
 		}
 
 		[TestCase ("--gcc_flags -dead_strip", new string [] { "-dead_strip" })]
@@ -236,7 +236,7 @@ namespace Xamarin.MacDev.Tasks {
 			var task = CreateTask<CustomParseBundlerArguments> ();
 			task.ExtraArgs = input;
 			ExecuteTask (task, message: input);
-			CollectionAssert.AreEquivalent (output, task.CustomLinkFlags.Select (v => v.ItemSpec).ToArray (), string.Join (" ", output));
+			Assert.That (task.CustomLinkFlags.Select (v => v.ItemSpec).ToArray (), Is.EquivalentTo (output), string.Join (" ", output));
 		}
 
 		[TestCase ("-v", "1")]
@@ -250,7 +250,7 @@ namespace Xamarin.MacDev.Tasks {
 			var task = CreateTask<CustomParseBundlerArguments> ();
 			task.ExtraArgs = input;
 			ExecuteTask (task, message: input);
-			Assert.AreEqual (output, task.Verbosity, "Equality");
+			Assert.That (task.Verbosity, Is.EqualTo (output), "Equality");
 		}
 
 		[TestCase ("--nowarn", "-1")]
@@ -264,7 +264,7 @@ namespace Xamarin.MacDev.Tasks {
 			var task = CreateTask<CustomParseBundlerArguments> ();
 			task.ExtraArgs = input;
 			ExecuteTask (task, message: input);
-			Assert.AreEqual (output, task.NoWarn, output);
+			Assert.That (task.NoWarn, Is.EqualTo (output), output);
 		}
 
 		[TestCase ("--warnaserror", "-1")]
@@ -278,7 +278,7 @@ namespace Xamarin.MacDev.Tasks {
 			var task = CreateTask<CustomParseBundlerArguments> ();
 			task.ExtraArgs = input;
 			ExecuteTask (task, message: input);
-			Assert.AreEqual (output, task.WarnAsError, output);
+			Assert.That (task.WarnAsError, Is.EqualTo (output), output);
 		}
 	}
 }

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/PropertyListEditorTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/PropertyListEditorTaskTests.cs
@@ -11,10 +11,10 @@ namespace Xamarin.MacDev.Tasks {
 	public class PropertyListEditorTaskTests : TestBase {
 		static void CheckArray (PArray array, PArray expected)
 		{
-			Assert.AreEqual (expected.Count, array.Count, "Unexpected number of array elements");
+			Assert.That (array.Count, Is.EqualTo (expected.Count), "Unexpected number of array elements");
 
 			for (int i = 0; i < expected.Count; i++) {
-				Assert.AreEqual (expected [i].Type, array [i].Type, "Type-mismatch for array element {0}", i);
+				Assert.That (array [i].Type, Is.EqualTo (expected [i].Type), $"Type-mismatch for array element {i}");
 				CheckValue (array [i], expected [i]);
 			}
 		}
@@ -22,10 +22,10 @@ namespace Xamarin.MacDev.Tasks {
 		static void CheckDictionary (PDictionary dict, PDictionary expected)
 		{
 			foreach (var kvp in expected) {
-				Assert.IsTrue (dict.TryGetValue (kvp.Key, out PObject? value), "Expected key '{0}'", kvp.Key);
+				Assert.That (dict.TryGetValue (kvp.Key, out PObject? value), Is.True, $"Expected key '{kvp.Key}'");
 				if (value is null)
 					continue;
-				Assert.AreEqual (kvp.Value.Type, value.Type, "Type-mismatch for '{0}'", kvp.Key);
+				Assert.That (value.Type, Is.EqualTo (kvp.Value.Type), $"Type-mismatch for '{kvp.Key}'");
 
 				CheckValue (value, kvp.Value);
 			}
@@ -45,22 +45,22 @@ namespace Xamarin.MacDev.Tasks {
 				CheckArray ((PArray) value, (PArray) expected);
 				break;
 			case PObjectType.Real:
-				Assert.AreEqual (((PReal) expected).Value, ((PReal) value).Value);
+				Assert.That (((PReal) value).Value, Is.EqualTo (((PReal) expected).Value));
 				break;
 			case PObjectType.Number:
-				Assert.AreEqual (((PNumber) expected).Value, ((PNumber) value).Value);
+				Assert.That (((PNumber) value).Value, Is.EqualTo (((PNumber) expected).Value));
 				break;
 			case PObjectType.Boolean:
-				Assert.AreEqual (((PBoolean) expected).Value, ((PBoolean) value).Value);
+				Assert.That (((PBoolean) value).Value, Is.EqualTo (((PBoolean) expected).Value));
 				break;
 			case PObjectType.Data:
 				// TODO: implement this
 				break;
 			case PObjectType.String:
-				Assert.AreEqual (((PString) expected).Value, ((PString) value).Value);
+				Assert.That (((PString) value).Value, Is.EqualTo (((PString) expected).Value));
 				break;
 			case PObjectType.Date:
-				Assert.AreEqual (((PDate) expected).Value, ((PDate) value).Value);
+				Assert.That (((PDate) value).Value, Is.EqualTo (((PDate) expected).Value));
 				break;
 			}
 		}
@@ -90,7 +90,7 @@ namespace Xamarin.MacDev.Tasks {
 
 			var output = PObject.FromFile (task.PropertyList) ?? throw new InvalidOperationException ("PObject.FromFile returned null");
 
-			Assert.AreEqual (expected.Type, output.Type, "Task produced the incorrect plist output.");
+			Assert.That (output.Type, Is.EqualTo (expected.Type), "Task produced the incorrect plist output.");
 
 			CheckValue (output, expected);
 		}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ReadAppManifestTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ReadAppManifestTaskTests.cs
@@ -35,7 +35,7 @@ namespace Xamarin.MacDev.Tasks {
 				plist.SetMinimumSystemVersion ("10.15.2");
 			});
 			ExecuteTask (task);
-			Assert.AreEqual ("13.3", task.MinimumOSVersion, "MinimumOSVersion");
+			Assert.That (task.MinimumOSVersion, Is.EqualTo ("13.3"), "MinimumOSVersion");
 		}
 
 		[Test]

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ResolveNativeReferencesTaskTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ResolveNativeReferencesTaskTest.cs
@@ -38,7 +38,7 @@ namespace Xamarin.MacDev.Tasks.Tests {
 			var path = Path.Combine (Path.GetDirectoryName (GetType ().Assembly.Location)!, "Resources", "xcf-xcode12.2.plist");
 			var plist = PDictionary.FromFile (path)!;
 			var result = ResolveNativeReferences.TryResolveXCFramework (log, plist, "N/A", targetFrameworkMoniker, isSimulator, architecture, null, out var frameworkPath);
-			Assert.AreEqual (result, !string.IsNullOrEmpty (expected), "result");
+			Assert.That (!string.IsNullOrEmpty (expected), Is.EqualTo (result), "result");
 			Assert.That (frameworkPath, Is.EqualTo (expected), "frameworkPath");
 		}
 
@@ -48,7 +48,7 @@ namespace Xamarin.MacDev.Tasks.Tests {
 			var path = Path.Combine (Path.GetDirectoryName (GetType ().Assembly.Location)!, "Resources", "xcf-prexcode12.plist");
 			var plist = PDictionary.FromFile (path)!;
 			var result = ResolveNativeReferences.TryResolveXCFramework (log, plist, "N/A", targetFrameworkMoniker, isSimulator, architecture, null, out var frameworkPath);
-			Assert.AreEqual (result, !string.IsNullOrEmpty (expected), "result");
+			Assert.That (!string.IsNullOrEmpty (expected), Is.EqualTo (result), "result");
 			Assert.That (frameworkPath, Is.EqualTo (expected), "frameworkPath");
 		}
 
@@ -57,7 +57,7 @@ namespace Xamarin.MacDev.Tasks.Tests {
 		{
 			var plist = new PDictionary ();
 			var result = ResolveNativeReferences.TryResolveXCFramework (log, plist, "N/A", TargetFramework.DotNet_iOS_String, false, "x86_64", null, out var frameworkPath);
-			Assert.IsFalse (result, "Invalid Info.plist");
+			Assert.That (result, Is.False, "Invalid Info.plist");
 		}
 	}
 }

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TestHelpers/TestBase.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TestHelpers/TestBase.cs
@@ -73,9 +73,9 @@ namespace Xamarin.MacDev.Tasks {
 				messages = "\n\t" + string.Join ("\n\t", allEvents.Select ((v) => v.AsString ()).ToArray ());
 			}
 			if (expectedErrorCount != Engine.Logger.ErrorEvents.Count) {
-				Assert.AreEqual (expectedErrorCount, Engine.Logger.ErrorEvents.Count, $"#RunTask-ErrorCount{(string.IsNullOrEmpty (message) ? "" : $" ({message})")}" + messages);
+				Assert.That (Engine.Logger.ErrorEvents.Count, Is.EqualTo (expectedErrorCount), $"#RunTask-ErrorCount{(string.IsNullOrEmpty (message) ? "" : $" ({message})")}" + messages);
 			}
-			Assert.AreEqual (expectedErrorCount == 0, rv, $"Failure{(string.IsNullOrEmpty (message) ? "" : $" ({message})")}" + messages);
+			Assert.That (rv, Is.EqualTo (expectedErrorCount == 0), $"Failure{(string.IsNullOrEmpty (message) ? "" : $" ({message})")}" + messages);
 		}
 
 		protected string CreateTempFile (string path)

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/UtilityTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/UtilityTests.cs
@@ -19,7 +19,7 @@ namespace Xamarin.MacDev.Tasks {
 			string rpath;
 
 			rpath = PathUtils.AbsoluteToRelative ("/Users/user/source/Project", "/Users/user/Source/Project/Info.plist");
-			Assert.AreEqual ("Info.plist", rpath, "#1");
+			Assert.That (rpath, Is.EqualTo ("Info.plist"), "#1");
 		}
 	}
 }

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/Xamarin.MacDev.Tasks.Tests.csproj
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/Xamarin.MacDev.Tasks.Tests.csproj
@@ -37,9 +37,9 @@
     <ProjectReference Include="../../../external/Xamarin.MacDev/Xamarin.MacDev/Xamarin.MacDev.csproj" Condition="'$(DesignTimeBuild)' == 'true'"/>
     <ProjectReference Include="../../../msbuild/Xamarin.Localization.MSBuild/Xamarin.Localization.MSBuild.csproj" Condition="'$(DesignTimeBuild)' == 'true'" />
 
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="NUnit" Version="$(NUnitPackageVersion)" />
+    <PackageReference Include="NUnit3TestAdapter" Version="$(NUnit3TestAdapterPackageVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCorePackageVersion)" />

--- a/tests/msbuild/Xamarin.MacDev.Tests/TargetTests/CollectAppManifestsTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/TargetTests/CollectAppManifestsTests.cs
@@ -65,14 +65,14 @@ namespace Xamarin.MacDev.Tasks {
 				{ "_CreateAppManifest", "true" },
 			};
 			var rv = engine.RunTarget (ApplePlatform.MacOSX, csprojPath, target: "_WriteAppManifest", properties: properties);
-			Assert.AreEqual (0, rv.ExitCode, "Exit code");
+			Assert.That (rv.ExitCode, Is.EqualTo (0), "Exit code");
 
 			var appManifestPath = Path.Combine (tmpdir, "bin", "Debug", Configuration.DotNetTfm + "-macos", "osx-x64", "PartialAppManifest.app", "Contents", "Info.plist");
 			Assert.That (appManifestPath, Does.Exist, "App manifest existence");
 
 			var plist = PDictionary.FromFile (appManifestPath);
-			Assert.AreEqual ("PartialAppManifestDisplayName", plist.GetCFBundleDisplayName (), "Bundle display name");
-			Assert.AreEqual ("com.xamarin.partialappmanifest", plist.GetCFBundleIdentifier (), "Bundle identifier");
+			Assert.That (plist.GetCFBundleDisplayName (), Is.EqualTo ("PartialAppManifestDisplayName"), "Bundle display name");
+			Assert.That (plist.GetCFBundleIdentifier (), Is.EqualTo ("com.xamarin.partialappmanifest"), "Bundle identifier");
 		}
 	}
 }

--- a/tests/msbuild/Xamarin.MacDev.Tests/TargetTests/DetectSigningIdentityTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/TargetTests/DetectSigningIdentityTests.cs
@@ -59,7 +59,7 @@ namespace Xamarin.MacDev.Tasks {
 				{ "_CanOutputAppBundle", "true" },
 			};
 			var rv = engine.RunTarget (ApplePlatform.MacOSX, csprojPath, target: "_DetectSigningIdentity", properties: properties);
-			Assert.AreEqual (0, rv.ExitCode, "Exit code");
+			Assert.That (rv.ExitCode, Is.EqualTo (0), "Exit code");
 
 			// Find the BundleIdentifier parameter to the DetectSigningIdentity task.
 			var recordArgs = BinLog.ReadBuildEvents (rv.BinLogPath).ToList ();
@@ -85,7 +85,7 @@ namespace Xamarin.MacDev.Tasks {
 			} else {
 				bundleIdentifier = "Unhandled task message format.";
 			}
-			Assert.AreEqual ("com.xamarin.detectsigningidentitytest", bundleIdentifier, "Bundle identifier");
+			Assert.That (bundleIdentifier, Is.EqualTo ("com.xamarin.detectsigningidentitytest"), "Bundle identifier");
 		}
 	}
 }

--- a/tests/msbuild/Xamarin.MacDev.Tests/TargetTests/TargetTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/TargetTests/TargetTests.cs
@@ -25,14 +25,14 @@ namespace Xamarin.MacDev.Tasks {
 			// .NET: we don't have a test that verifies that the Clean target works as expected, this needs to be added before we can remove this test.
 
 			RunTarget (MonoTouchProject, TargetName.Clean);
-			Assert.IsFalse (Directory.Exists (MonoTouchProjectBinPath), "#1a");
-			Assert.IsFalse (Directory.Exists (MonoTouchProjectObjPath), "#1b");
+			Assert.That (Directory.Exists (MonoTouchProjectBinPath), Is.False, "#1a");
+			Assert.That (Directory.Exists (MonoTouchProjectObjPath), Is.False, "#1b");
 
 			RunTarget (MonoTouchProject, TargetName.Build);
 			RunTarget (MonoTouchProject, TargetName.Clean);
-			Assert.IsEmpty (Directory.GetDirectories (MonoTouchProjectBinPath, "*.dSYM", SearchOption.AllDirectories), "#2a");
-			Assert.IsEmpty (Directory.GetFiles (MonoTouchProjectBinPath, "*.*", SearchOption.AllDirectories), "#2b");
-			Assert.IsFalse (Directory.Exists (MonoTouchProjectObjPath), "#2c");
+			Assert.That (Directory.GetDirectories (MonoTouchProjectBinPath, "*.dSYM", SearchOption.AllDirectories), Is.Empty, "#2a");
+			Assert.That (Directory.GetFiles (MonoTouchProjectBinPath, "*.*", SearchOption.AllDirectories), Is.Empty, "#2b");
+			Assert.That (Directory.Exists (MonoTouchProjectObjPath), Is.False, "#2c");
 		}
 
 		[Test]
@@ -43,13 +43,13 @@ namespace Xamarin.MacDev.Tasks {
 			// .NET: we don't have a test that verifies that the Clean target works as expected, this needs to be added before we can remove this test.
 
 			RunTarget (LibraryProject, TargetName.Clean);
-			Assert.IsFalse (Directory.Exists (LibraryProjectBinPath), "#1a");
-			Assert.IsFalse (Directory.Exists (LibraryProjectObjPath), "#1b");
+			Assert.That (Directory.Exists (LibraryProjectBinPath), Is.False, "#1a");
+			Assert.That (Directory.Exists (LibraryProjectObjPath), Is.False, "#1b");
 
 			RunTarget (LibraryProject, TargetName.Build);
 			RunTarget (LibraryProject, TargetName.Clean);
-			Assert.IsEmpty (Directory.GetFiles (LibraryProjectBinPath, "*.*", SearchOption.AllDirectories), "#2a");
-			Assert.IsFalse (Directory.Exists (LibraryProjectObjPath), "#2b");
+			Assert.That (Directory.GetFiles (LibraryProjectBinPath, "*.*", SearchOption.AllDirectories), Is.Empty, "#2a");
+			Assert.That (Directory.Exists (LibraryProjectObjPath), Is.False, "#2b");
 		}
 
 		[Test]
@@ -87,11 +87,11 @@ namespace Xamarin.MacDev.Tasks {
 
 			RunTarget (MonoTouchProject, TargetName.Build);
 
-			Assert.IsTrue (File.Exists (optimisedFile), "#1");
+			Assert.That (File.Exists (optimisedFile), Is.True, "#1");
 			if (shouldBeDifferent)
-				CollectionAssert.AreNotEqual (File.ReadAllBytes (originalFile), File.ReadAllBytes (optimisedFile), "#2a");
+				Assert.That (File.ReadAllBytes (optimisedFile), Is.Not.EqualTo (File.ReadAllBytes (originalFile)), "#2a");
 			else
-				CollectionAssert.AreEqual (File.ReadAllBytes (originalFile), File.ReadAllBytes (optimisedFile), "#2b");
+				Assert.That (File.ReadAllBytes (optimisedFile), Is.EqualTo (File.ReadAllBytes (originalFile)), "#2b");
 		}
 	}
 }

--- a/tests/msbuild/Xamarin.MacDev.Tests/TestHelpers/TestBase.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tests/TestHelpers/TestBase.cs
@@ -119,13 +119,13 @@ namespace Xamarin.Tests {
 		public void TestFilesDoNotExist (string baseDir, IEnumerable<string> files)
 		{
 			foreach (var v in files.Select (s => Path.Combine (baseDir, s)))
-				Assert.IsFalse (File.Exists (v) || Directory.Exists (v), "Unexpected file: {0} exists", v);
+				Assert.That (File.Exists (v) || Directory.Exists (v), Is.False, $"Unexpected file: {v} exists");
 		}
 
 		public void TestFilesExists (string baseDir, string [] files)
 		{
 			foreach (var v in files.Select (s => Path.Combine (baseDir, s)))
-				Assert.IsTrue (File.Exists (v) || Directory.Exists (v), "Expected file: {0} does not exist", v);
+				Assert.That (File.Exists (v) || Directory.Exists (v), Is.True, $"Expected file: {v} does not exist");
 		}
 
 		public void TestFilesExists (string [] baseDirs, string [] files)
@@ -134,14 +134,14 @@ namespace Xamarin.Tests {
 				TestFilesExists (baseDirs [0], files);
 			} else {
 				foreach (var file in files)
-					Assert.IsTrue (baseDirs.Select (s => File.Exists (Path.Combine (s, file))).Any (v => v), $"Expected file: {file} does not exist in any of the directories: {string.Join (", ", baseDirs)}");
+					Assert.That (baseDirs.Select (s => File.Exists (Path.Combine (s, file))).Any (v => v), Is.True, $"Expected file: {file} does not exist in any of the directories: {string.Join (", ", baseDirs)}");
 			}
 		}
 
 		public void TestStoryboardC (string path)
 		{
-			Assert.IsTrue (Directory.Exists (path), "Storyboard {0} does not exist", path);
-			Assert.IsTrue (File.Exists (Path.Combine (path, "Info.plist")));
+			Assert.That (Directory.Exists (path), Is.True, $"Storyboard {path} does not exist");
+			Assert.That (File.Exists (Path.Combine (path, "Info.plist")), Is.True);
 			TestPList (path, new string [] { "CFBundleVersion", "CFBundleExecutable" });
 		}
 
@@ -149,15 +149,15 @@ namespace Xamarin.Tests {
 		{
 			var plist = PDictionary.FromFile (Path.Combine (path, "Info.plist"));
 			if (plist is null) {
-				Assert.Fail ("Could not load Info.plist from {0}", path);
+				Assert.Fail ($"Could not load Info.plist from {path}");
 				return;
 			}
 			foreach (var x in keys) {
-				Assert.IsTrue (plist.ContainsKey (x), "Key {0} is not present in {1} Info.plist", x, path);
+				Assert.That (plist.ContainsKey (x), Is.True, $"Key {x} is not present in {path} Info.plist");
 				if (plist [x] is PString pstring)
-					Assert.IsNotEmpty (pstring.Value, "Key {0} is empty in {1} Info.plist", x, path);
+					Assert.That (pstring.Value, Is.Not.Empty, $"Key {x} is empty in {path} Info.plist");
 				else
-					Assert.Fail ("Key {0} is not a PString in {1} Info.plist", x, path);
+					Assert.Fail ($"Key {x} is not a PString in {path} Info.plist");
 			}
 		}
 
@@ -175,7 +175,7 @@ namespace Xamarin.Tests {
 				file = Path.Combine (file, "runtime.nib");
 
 			if (!File.Exists (file))
-				Assert.Fail ("Expected file '{0}' did not exist", file);
+				Assert.Fail ($"Expected file '{file}' did not exist");
 
 			return File.GetLastWriteTimeUtc (file);
 		}
@@ -183,7 +183,7 @@ namespace Xamarin.Tests {
 		protected void Touch (string file)
 		{
 			if (!File.Exists (file))
-				Assert.Fail ("Expected file '{0}' did not exist", file);
+				Assert.Fail ($"Expected file '{file}' did not exist");
 			EnsureFilestampChange ();
 			File.SetLastWriteTimeUtc (file, DateTime.UtcNow);
 			EnsureFilestampChange ();
@@ -217,12 +217,12 @@ namespace Xamarin.Tests {
 			if (expectedErrorCount != Engine.ErrorEvents.Count) {
 				foreach (var e in Engine.ErrorEvents)
 					Console.WriteLine (e.ToString ());
-				Assert.AreEqual (expectedErrorCount, Engine.ErrorEvents.Count, $"Unexpected number of errors when executing target '{target}'");
+				Assert.That (Engine.ErrorEvents.Count, Is.EqualTo (expectedErrorCount), $"Unexpected number of errors when executing target '{target}'");
 			}
 			if (expectedErrorCount > 0) {
-				Assert.AreEqual (1, rv.ExitCode, "ExitCode (failure)");
+				Assert.That (rv.ExitCode, Is.EqualTo (1), "ExitCode (failure)");
 			} else {
-				Assert.AreEqual (0, rv.ExitCode, "ExitCode (success)");
+				Assert.That (rv.ExitCode, Is.EqualTo (0), "ExitCode (success)");
 			}
 		}
 

--- a/tests/msbuild/Xamarin.MacDev.Tests/Xamarin.MacDev.Tests.csproj
+++ b/tests/msbuild/Xamarin.MacDev.Tests/Xamarin.MacDev.Tests.csproj
@@ -8,9 +8,9 @@
     <AssemblyOriginatorKeyFile>../../../product.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="NUnit" Version="$(NUnitPackageVersion)" />
+    <PackageReference Include="NUnit3TestAdapter" Version="$(NUnit3TestAdapterPackageVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
     <PackageReference Include="Mono.Cecil" Version="$(MonoCecilPackageVersion)" />
     <PackageReference Include="MSBuild.StructuredLogger" Version="$(MSBuildStructuredLoggerPackageVersion)" />
     <PackageReference Include="NUnitXml.TestLogger" Version="$(NUnitXmlTestLoggerPackageVersion)" />


### PR DESCRIPTION
Convert classic NUnit assertions (`Assert.AreEqual`, `Assert.IsTrue`, `Assert.IsNotNull`, etc.) to NUnit v4's constraint-based `Assert.That` syntax in the msbuild test projects.

Also update package references to use centralized version properties from `Directory.Build.props`:
- `NUnit` → `$(NUnitPackageVersion)`
- `NUnit3TestAdapter` → `$(NUnit3TestAdapterPackageVersion)`
- `Microsoft.NET.Test.Sdk` → `$(MicrosoftNETTestSdkPackageVersion)`

Two shared files (`tests/common/DotNet.cs`, `tests/common/mac/ProjectTestHelpers.cs`) are also converted — the `Assert.That` constraint syntax is compatible with both NUnit 3 and 4, so other projects referencing these files are unaffected.

All `tests-msbuild` tests pass (495 passed, 0 failed).

🤖 Pull request created by Copilot