### PR TITLE
docs: fix broken link in native-library-interop.md

### DIFF
--- a/docs/native-library-interop.md
+++ b/docs/native-library-interop.md
@@ -19,7 +19,7 @@ the build process will attempt to create an XCFramework from the specified Xcode
 output will be added as a `@(NativeReference)` to the .NET project so that it can be bound and have its
 API surfaced via an [API definition][0] file.
 
-Please see the [build-items](build-apps/build-items.md) docs for more information about
+Please see the [build-items](building-apps/build-items.md) docs for more information about
 the `@(XcodeProject)` build action.
 
 Additional documentation and references can be found below:


### PR DESCRIPTION
## Summary

Line 22 of `docs/native-library-interop.md` contained a broken internal link pointing to `build-apps/build-items.md`. The directory `docs/build-apps/` does not exist in the repository; the correct path is `docs/building-apps/build-items.md`.

## Changes

- Fixed the link target on line 22: `build-apps/build-items.md` → `building-apps/build-items.md`

## Verification

- `docs/building-apps/build-items.md` exists in the repo ✅
- The corrected line reads `[build-items](building-apps/build-items.md)` ✅