### PR TITLE
[tests] Fix transient TLS/network failures in MessageHandlerTest tests

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -1732,9 +1732,19 @@ partial class TestRuntime {
 
 	public static void IgnoreInCIIfSshConnectionError (Exception ex)
 	{
-		var msg = ex.Message;
-		if (msg.Contains ("The SSL connection could not be established")) {
-			IgnoreInCI ($"Ignored due to network error: {ex}");
+		// Check all exceptions in the chain for TLS/SSL error messages
+		var current = ex;
+		while (current is not null) {
+			var msg = current.Message;
+			if (msg.Contains ("The SSL connection could not be established") ||
+				msg.Contains ("A TLS error caused the secure connection to fail")) {
+				IgnoreInCI ($"Ignored due to network error: {ex}");
+			}
+			if (current is NSErrorException nex) {
+				// CFNetworkErrors.SecureConnectionFailed = -1200
+				IgnoreNetworkError (nex.Error, CFNetworkErrors.SecureConnectionFailed);
+			}
+			current = current.InnerException;
 		}
 	}
 

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -594,6 +594,7 @@ namespace MonoTests.System.Net.Http {
 					Assert.AreNotEqual (ex.InnerException.Message, "Error: TrustFailure");
 				}
 			}
+			TestRuntime.IgnoreInCIIfBadNetwork (ex);
 			Assert.IsNull (ex);
 			// Assert.IsTrue (servicePointManagerCbWasExcuted, "Executed");
 		}
@@ -902,6 +903,7 @@ namespace MonoTests.System.Net.Http {
 			if (!done) { // timeouts happen in the bots due to dns issues, connection issues etc.. we do not want to fail
 				Assert.Inconclusive ("Request timedout.");
 			} else {
+				TestRuntime.IgnoreInCIIfBadNetwork (ex);
 				TestRuntime.IgnoreInCIIfBadNetwork (httpStatus);
 				Assert.IsNull (ex, "Exception not null");
 				Assert.AreEqual (expectedStatus, httpStatus, "Status not ok");
@@ -928,6 +930,7 @@ namespace MonoTests.System.Net.Http {
 			if (!done) {
 				Assert.Inconclusive ("Request timedout.");
 			} else {
+				TestRuntime.IgnoreInCIIfBadNetwork (ex);
 				TestRuntime.IgnoreInCIIfBadNetwork (httpStatus);
 				Assert.IsNull (ex, "Exception not null");
 				Assert.AreEqual (expectedStatus, httpStatus, "Status not ok");
@@ -1039,6 +1042,7 @@ namespace MonoTests.System.Net.Http {
 			if (!done) { // timeouts happen in the bots due to dns issues, connection issues etc.. we do not want to fail
 				Assert.Inconclusive ("Request timedout.");
 			} else {
+				TestRuntime.IgnoreInCIIfBadNetwork (ex);
 				Assert.IsNull (ex, "Exception");
 
 				for (var i = 0; i < iterations; i++) {


### PR DESCRIPTION
Expand IgnoreInCIIfSshConnectionError to also detect 'A TLS error
caused the secure connection to fail' messages and
CFNetworkErrors.SecureConnectionFailed NSError codes by walking the
entire exception chain.

Add IgnoreInCIIfBadNetwork(ex) calls to tests that were only checking
HTTP status codes but not exceptions:
- GHIssue8342
- SupportsDigestAuthentication
- GHIssue16339
- AcceptSslCertificatesServicePointManager

Fixes https://github.com/dotnet/macios/issues/25444