### PR TITLE
[net11.0] Default to Full link for iOS/tvOS device builds

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.Trimming.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.Trimming.props
@@ -70,7 +70,9 @@
 		<_DefaultLinkMode Condition="'$(_DefaultLinkMode)' == '' And '$(_SdkIsSimulator)' == 'true' And '$(UseMonoRuntime)' == 'true' And $(RuntimeIdentifier.Contains('arm64')) And '$(MtouchInterpreter)' == ''">SdkOnly</_DefaultLinkMode>
 		<!-- Linking is off by default in the simulator when not building for arm64 and using MonoVM -->
 		<_DefaultLinkMode Condition="'$(_DefaultLinkMode)' == '' And '$(_SdkIsSimulator)' == 'true' And '$(UseMonoRuntime)' == 'true' And (!$(RuntimeIdentifier.Contains('arm64')) Or '$(MtouchInterpreter)' != '')">None</_DefaultLinkMode>
-		<!-- Otherwise, default linking is SdkOnly for iOS/tvOS apps -->
+		<!-- For iOS/tvOS device builds, default to Full link to keep the deploy bundle small -->
+		<_DefaultLinkMode Condition="'$(_DefaultLinkMode)' == '' And '$(_SdkIsSimulator)' != 'true'">Full</_DefaultLinkMode>
+		<!-- SdkOnly for any iOS/tvOS scenario not matched above -->
 		<_DefaultLinkMode Condition="'$(_DefaultLinkMode)' == ''">SdkOnly</_DefaultLinkMode>
 
 	</PropertyGroup>


### PR DESCRIPTION
## Description

iOS/tvOS device builds currently default to `MtouchLink=SdkOnly`. The managed debugger isn't enabled on device, so `SdkOnly` isn't needed there. Flipping the device default to `Full` measured on a default `maui` template app, ios-arm64, Debug, physical iPhone, clean build:

| Runtime | Link mode | Bundle | Startup | Build |
|---------|-----------|--------|---------|-------|
| CoreCLR | SdkOnly (today) | 395.92 MB | 308.66 ms | 104.62 s |
| CoreCLR | Full (this PR) | 107.07 MB | 89.51 ms | 30.89 s |
| | **delta** | **-73%** | **-71%** | **-70%** |
| Mono | SdkOnly (today) | 100.91 MB | 441.26 ms | 63.86 s |
| Mono | Full (this PR) | 39.28 MB | 165.21 ms | 25.85 s |
| | **delta** | **-61%** | **-63%** | **-60%** |
