### PR TITLE
[github] Simplify the yaml lint action to not post a comment.

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   rebase:
@@ -25,24 +25,4 @@ jobs:
         id: lint-pipeline
         working-directory: ./tools/devops/automation
         run: |
-            RESULT=$(yamllint . -f github)
-            if [ -n "$RESULT" ]; then
-                echo "YAML Lint found issues"
-                echo "$RESULT"
-                echo "::set-output name=result::$RESULT"
-                exit 1
-            fi
-
-      # only post a comment if the linting fails
-      - name: Post comment
-        uses: unsplash/comment-on-pr@v1.3.1
-        if: failure()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          msg: |
-            [yaml-lint] YamlLint found issues in the pipeline files.
-            ${{ steps.lint-pipeline.outputs.result }}
-          check_for_duplicate_msg: true
-          delete_prev_regex_msg: "YamlLint found issues in the pipeline files."
-          duplicate_msg_pattern: "YamlLint found issues in the pipeline files."
+            yamllint . -f github

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -22,7 +22,6 @@ jobs:
         run: pip install yamllint
 
       - name: Lint YAML pipeline files
-        id: lint-pipeline
         working-directory: ./tools/devops/automation
         run: |
             yamllint . -f github


### PR DESCRIPTION
The red checkmark should be enough, and this way we don't require write
permissions to the pull request.