### PR TITLE
[github] Enable cooldown for dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This makes us less susceptible to supply-chain attacks.

It also makes zizmor happy:

    $ zizmor .github/dependabot.yml
     INFO zizmor: 🌈 zizmor v1.25.2
     INFO audit: zizmor: 🌈 completed .github/dependabot.yml
    No findings to report. Good job!

References:
* https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns#fnref:apt
* https://mattsch.com/blog/2026/03/28/harden-your-github-actions-workflows-with-zizmor-dependency-pinning-and-dependency-cooldowns/