### PR TITLE
[tests] Ignore the AppSize tests for now.

### DIFF
--- a/tests/dotnet/UnitTests/AppSizeTest.cs
+++ b/tests/dotnet/UnitTests/AppSizeTest.cs
@@ -8,6 +8,7 @@ using Mono.Cecil;
 
 namespace Xamarin.Tests {
 	[TestFixture]
+	[Ignore ("The results depend on the macOS version of the bot running the test")]
 	public class AppSizeTest : TestBaseClass {
 
 		[TestCase (ApplePlatform.iOS, "ios-arm64")]


### PR DESCRIPTION
It seems that the results depend on the macOS version of the machine executing
the tests.

That's unfortunate when all my macs are at 26.5 and the bots are at 26.2,
because I can't re-generate the expected app sizes locally.

So ignore these tests until I can come up with a better solution.