### PR TITLE
[tests] Upgrade tests/linker to NUnit v4 Assert.That syntax

### DIFF
--- a/tests/linker/AppDelegate.cs
+++ b/tests/linker/AppDelegate.cs
@@ -12,6 +12,6 @@ public static partial class TestLoader {
 public class LoaderTest {
 	public void TestAssemblyCount ()
 	{
-		Assert.AreEqual (2, TestLoader.GetTestAssemblies ().Count (), "Test assembly count");
+		Assert.That (TestLoader.GetTestAssemblies ().Count (), Is.EqualTo (2), "Test assembly count");
 	}
 }

--- a/tests/linker/BaseOptimizeGeneratedCodeTest.cs
+++ b/tests/linker/BaseOptimizeGeneratedCodeTest.cs
@@ -33,7 +33,7 @@ namespace Linker.Shared {
 			var action = new Action (() => counter++);
 			Custom (action);
 			CustomWithAttribute (action);
-			Assert.AreEqual (2, counter, "Counter");
+			Assert.That (counter, Is.EqualTo (2), "Counter");
 		}
 
 		delegate void CustomDelegate (IntPtr block);
@@ -91,7 +91,7 @@ namespace Linker.Shared {
 				for (var i = 0; i < iterations; i++)
 					SetupBlockUnoptimized (unoptimizedAction);
 				unoptimizedWatch.Stop ();
-				Assert.AreEqual (iterations, unoptimizedCounter, "Unoptimized Counter");
+				Assert.That (unoptimizedCounter, Is.EqualTo (iterations), "Unoptimized Counter");
 
 				// Run optimized
 				var optimizedWatch = System.Diagnostics.Stopwatch.StartNew ();
@@ -99,7 +99,7 @@ namespace Linker.Shared {
 				for (var i = 0; i < iterations; i++)
 					SetupBlockOptimized (optimizedAction);
 				optimizedWatch.Stop ();
-				Assert.AreEqual (iterations, optimizedCounter, "Optimized Counter");
+				Assert.That (optimizedCounter, Is.EqualTo (iterations), "Optimized Counter");
 
 				//Console.WriteLine ("Optimized: {0} ms", optimizedWatch.ElapsedMilliseconds);
 				//Console.WriteLine ("Unoptimized: {0} ms", unoptimizedWatch.ElapsedMilliseconds);
@@ -145,7 +145,7 @@ namespace Linker.Shared {
 			SetupBlockOptimized_LoadLocalVariable4 (action);
 			SetupBlockOptimized_LoadLocalVariable (action);
 
-			Assert.AreEqual (19, counter, "Counter");
+			Assert.That (counter, Is.EqualTo (19), "Counter");
 		}
 
 		public delegate void Action_IntPtr (IntPtr param);
@@ -517,22 +517,22 @@ namespace Linker.Shared {
 			method = typeof (BaseOptimizeGeneratedCodeTest).GetMethod (nameof (GetIsARM64CallingConventionOptimized), BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public | BindingFlags.Static)!;
 			instructions = new ILReader (method);
 			call_instructions = instructions.Where ((v) => v.OpCode.Name == "ldsfld");
-			Assert.AreEqual (0, call_instructions.Count (), "optimized: no ldsfld instruction");
+			Assert.That (call_instructions.Count (), Is.EqualTo (0), "optimized: no ldsfld instruction");
 
 			method = typeof (BaseOptimizeGeneratedCodeTest).GetMethod (nameof (GetIsARM64CallingConventionNotOptimized), BindingFlags.NonPublic | BindingFlags.Instance)!;
 			instructions = new ILReader (method);
 			call_instructions = instructions.Where ((v) => v.OpCode.Name == "ldsfld");
-			Assert.AreEqual (1, call_instructions.Count (), "not optimized: 1 ldsfld instruction");
+			Assert.That (call_instructions.Count (), Is.EqualTo (1), "not optimized: 1 ldsfld instruction");
 
 			method = typeof (Runtime).GetMethod ("GetIsARM64CallingConvention", BindingFlags.Static | BindingFlags.NonPublic)!;
 			instructions = new ILReader (method);
-			Assert.AreEqual (2, instructions.Count (), "IL Count");
+			Assert.That (instructions.Count (), Is.EqualTo (2), "IL Count");
 			Assert.That (instructions.Skip (0).First ().OpCode, Is.EqualTo (OpCodes.Ldc_I4_0).Or.EqualTo (OpCodes.Ldc_I4_1), "IL 1");
 			Assert.That (instructions.Skip (1).First ().OpCode, Is.EqualTo (OpCodes.Ret), "IL 2");
 #endif
 
-			Assert.AreEqual (Runtime.IsARM64CallingConvention, GetIsARM64CallingConventionOptimized (), "Value optimized");
-			Assert.AreEqual (Runtime.IsARM64CallingConvention, GetIsARM64CallingConventionNotOptimized (), "Value unoptimized");
+			Assert.That (GetIsARM64CallingConventionOptimized (), Is.EqualTo (Runtime.IsARM64CallingConvention), "Value optimized");
+			Assert.That (GetIsARM64CallingConventionNotOptimized (), Is.EqualTo (Runtime.IsARM64CallingConvention), "Value unoptimized");
 		}
 
 		[BindingImplAttribute (BindingImplOptions.Optimizable)]

--- a/tests/linker/CommonLinkAllTest.cs
+++ b/tests/linker/CommonLinkAllTest.cs
@@ -69,7 +69,7 @@ namespace LinkAll {
 		[Test]
 		public void TypeConverter_BuiltIn ()
 		{
-			Assert.NotNull (TypeDescriptor.GetConverter (new BuiltInConverter ()), "BuiltInConverter");
+			Assert.That (TypeDescriptor.GetConverter (new BuiltInConverter ()), Is.Not.Null, "BuiltInConverter");
 
 			string? name = (typeof (BuiltInConverter).GetCustomAttributes (false) [0] as TypeConverterAttribute)?.ConverterTypeName;
 			var typename = $"System.ComponentModel.BooleanConverter, System.ComponentModel.TypeConverter, Version={typeof (int).Assembly.GetName ().Version}, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
@@ -79,7 +79,7 @@ namespace LinkAll {
 		[Test]
 		public void TypeConverter_Custom ()
 		{
-			Assert.NotNull (TypeDescriptor.GetConverter (new TypeDescriptorTest ()), "TypeDescriptorTest");
+			Assert.That (TypeDescriptor.GetConverter (new TypeDescriptorTest ()), Is.Not.Null, "TypeDescriptorTest");
 
 			string? name = (typeof (TypeDescriptorTest).GetCustomAttributes (false) [0] as TypeConverterAttribute)?.ConverterTypeName;
 			var typename = "LinkAll.CustomConverter, link all, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null";
@@ -91,7 +91,7 @@ namespace LinkAll {
 		{
 			// Check that the Makefile generated a valid version number, e.g. "12.3." was not
 			// reference: https://github.com/dotnet/macios/issues/4859
-			Assert.True (Version.TryParse (ObjCRuntime.Constants.Version, out var _), "Version");
+			Assert.That (Version.TryParse (ObjCRuntime.Constants.Version, out var _), Is.True, "Version");
 		}
 	}
 }

--- a/tests/linker/CommonLinkAnyTest.cs
+++ b/tests/linker/CommonLinkAnyTest.cs
@@ -25,10 +25,10 @@ namespace LinkAnyTest {
 				b = obj.ToString ()!;
 			});
 			// test behavior (we did not break anything)
-			Assert.AreEqual ("b", b, "Stop");
+			Assert.That (b, Is.EqualTo ("b"), "Stop");
 			// test that BlockLiteral is fully preserved
 			int size = Marshal.SizeOf (typeof (BlockLiteral)); // e.g. unused 'reserved' must not be removed
-			Assert.AreEqual (IntPtr.Size == 8 ? 48 : 28, size, "BlockLiteral size");
+			Assert.That (size, Is.EqualTo (IntPtr.Size == 8 ? 48 : 28), "BlockLiteral size");
 
 		}
 
@@ -41,15 +41,15 @@ namespace LinkAnyTest {
 		// https://bugzilla.xamarin.com/show_bug.cgi?id=7114
 		public static void Bug7114 ([CallerFilePath] string? filePath = null)
 		{
-			Assert.IsNotNull (filePath, "CallerFilePath");
+			Assert.That (filePath, Is.Not.Null, "CallerFilePath");
 		}
 
 		[Test]
 		public void AppContextGetData ()
 		{
 			// https://github.com/dotnet/runtime/issues/50290
-			Assert.IsNotNull (AppContext.GetData ("APP_PATHS"), "APP_PATHS");
-			Assert.IsNotNull (AppContext.GetData ("PINVOKE_OVERRIDE"), "PINVOKE_OVERRIDE");
+			Assert.That (AppContext.GetData ("APP_PATHS"), Is.Not.Null, "APP_PATHS");
+			Assert.That (AppContext.GetData ("PINVOKE_OVERRIDE"), Is.Not.Null, "PINVOKE_OVERRIDE");
 		}
 
 		[Test]
@@ -68,26 +68,26 @@ namespace LinkAnyTest {
 		public void JsonSerializer_Serialize ()
 		{
 			var a = JsonSerializer.Serialize (42);
-			Assert.AreEqual ("42", a, "serialized 42");
+			Assert.That (a, Is.EqualTo ("42"), "serialized 42");
 
 			var b = JsonSerializer.Serialize (new int [] { 42, 3, 14, 15 });
-			Assert.AreEqual ("[42,3,14,15]", b, "serialized array");
+			Assert.That (b, Is.EqualTo ("[42,3,14,15]"), "serialized array");
 		}
 
 		[Test]
 		public void JsonSerializer_Deserialize ()
 		{
 			var a = JsonSerializer.Deserialize<int> ("42");
-			Assert.AreEqual (42, a, "deserialized 42");
+			Assert.That (a, Is.EqualTo (42), "deserialized 42");
 
 			var b = JsonSerializer.Deserialize<int []> ("[42,3,14,15]");
-			CollectionAssert.AreEqual (new int [] { 42, 3, 14, 15 }, b, "deserialized array");
+			Assert.That (b!, Is.EqualTo (new int [] { 42, 3, 14, 15 }), "deserialized array");
 		}
 
 		[Test]
 		public void AES ()
 		{
-			Assert.NotNull (Aes.Create (), "AES");
+			Assert.That (Aes.Create (), Is.Not.Null, "AES");
 		}
 
 		static bool waited;
@@ -122,7 +122,7 @@ namespace LinkAnyTest {
 					string content = await response.Content.ReadAsStringAsync ();
 					waited = true;
 					bool success = !String.IsNullOrEmpty (content);
-					Assert.IsTrue (success, $"received {content.Length} bytes");
+					Assert.That (success, Is.True, $"received {content.Length} bytes");
 				}
 			}
 		}
@@ -138,7 +138,7 @@ namespace LinkAnyTest {
 				if (requestError) {
 					Assert.Inconclusive ($"Test cannot be trusted. Issues performing the request. Status code '{statusCode}'");
 				} else {
-					Assert.IsTrue (waited, "async/await worked");
+					Assert.That (waited, Is.True, "async/await worked");
 				}
 			} finally {
 				SynchronizationContext.SetSynchronizationContext (current_sc);

--- a/tests/linker/dont link/DontLinkRegressionTests.cs
+++ b/tests/linker/dont link/DontLinkRegressionTests.cs
@@ -30,7 +30,7 @@ namespace DontLink {
 		public void Bug587_FullAotRuntime ()
 		{
 			KeyValuePair<string, string> valuePair = queued.FirstOrDefault (delegate { return true; });
-			Assert.NotNull (valuePair);
+			Assert.That (valuePair, Is.Not.Null);
 			// should not crash with System.ExecutionEngineException
 		}
 
@@ -39,7 +39,7 @@ namespace DontLink {
 		{
 			// since we do not link the attributes will be available - used or not by the application
 			var fullname = typeof (NSObject).Assembly.FullName;
-			Assert.NotNull (Type.GetType ("ObjCRuntime.ThreadSafeAttribute, " + fullname), "ThreadSafeAttribute");
+			Assert.That (Type.GetType ("ObjCRuntime.ThreadSafeAttribute, " + fullname), Is.Not.Null, "ThreadSafeAttribute");
 		}
 
 #if !__MACOS__
@@ -65,7 +65,7 @@ namespace DontLink {
 			// https://bugzilla.xamarin.com/show_bug.cgi?id=29928
 			var de = System.Text.Encoding.Default;
 			Assert.That (de.WebName, Is.EqualTo ("utf-8"), "Name");
-			Assert.True (de.IsReadOnly, "IsReadOnly");
+			Assert.That (de.IsReadOnly, Is.True, "IsReadOnly");
 		}
 
 #if __TVOS__
@@ -77,7 +77,7 @@ namespace DontLink {
 			} catch (TargetInvocationException tie) {
 				var nse = tie.InnerException as TargetInvocationException;
 				if (nse is not null)
-					Assert.Fail ("An exception was thrown, but {0} instead of NotSupportedException. " + message, nse.GetType ().FullName);
+					Assert.Fail ($"An exception was thrown, but {nse.GetType ().FullName} instead of NotSupportedException. " + message);
 			}
 		}
 		[Test]

--- a/tests/linker/link all/AttributeTest.cs
+++ b/tests/linker/link all/AttributeTest.cs
@@ -115,9 +115,9 @@ namespace LinkAll.Attributes {
 					result = true;
 			}
 #if DEBUG
-			Assert.True (result, "DebuggableAttribute");
+			Assert.That (result, Is.True, "DebuggableAttribute");
 #else
-			Assert.False (result, "DebuggableAttribute");
+			Assert.That (result, Is.False, "DebuggableAttribute");
 #endif
 		}
 
@@ -157,9 +157,9 @@ namespace LinkAll.Attributes {
 					result = true;
 			}
 #if DEBUG
-			Assert.True (result, "DebuggerBrowsable");
+			Assert.That (result, Is.True, "DebuggerBrowsable");
 #else
-			Assert.False (result, "DebuggerBrowsable");
+			Assert.That (result, Is.False, "DebuggerBrowsable");
 #endif
 		}
 
@@ -167,15 +167,15 @@ namespace LinkAll.Attributes {
 		public void DebuggerTypeProxy_24203 ()
 		{
 			var d = new Dictionary<string, int> () { { "key", 0 } };
-			Assert.NotNull (d); // just to be 100% sure it won't be linked away (with the attribute we'll be looking for)
+			Assert.That (d, Is.Not.Null); // just to be 100% sure it won't be linked away (with the attribute we'll be looking for)
 			var proxy = Type.GetType ("System.Collections.Generic.IDictionaryDebugView`2, " + mscorlib)!;
 #if DEBUG
-			Assert.NotNull (proxy, "proxy");
+			Assert.That (proxy, Is.Not.Null, "proxy");
 			// having the type is nice, but it must not be empty to be useful
 			Assert.That (proxy.GetConstructors ().Length, Is.GreaterThan (0), "constructors");
 			Assert.That (proxy.GetProperties ().Length, Is.GreaterThan (0), "properties");
 #else
-			Assert.Null (proxy, "proxy");
+			Assert.That (proxy, Is.Null, "proxy");
 #endif
 		}
 
@@ -185,19 +185,19 @@ namespace LinkAll.Attributes {
 			var assembly = GetType ().Assembly;
 			var ta = assembly.GetCustomAttributes<CustomAttributeArray> ();
 			Assert.That (ta.Count (), Is.EqualTo (3), "Type[]");
-			Assert.NotNull (Type.GetType ("LinkAll.Attributes.CustomTypeA"), "CustomTypeA");
-			Assert.NotNull (Type.GetType ("LinkAll.Attributes.CustomTypeAA"), "CustomTypeAA");
-			Assert.NotNull (Type.GetType ("LinkAll.Attributes.CustomTypeAAA"), "CustomTypeAAA");
-			//Assert.NotNull (Type.GetType ("LinkAll.Attributes.CustomTypeAAAA"), "CustomTypeAAAA");
+			Assert.That (Type.GetType ("LinkAll.Attributes.CustomTypeA"), Is.Not.Null, "CustomTypeA");
+			Assert.That (Type.GetType ("LinkAll.Attributes.CustomTypeAA"), Is.Not.Null, "CustomTypeAA");
+			Assert.That (Type.GetType ("LinkAll.Attributes.CustomTypeAAA"), Is.Not.Null, "CustomTypeAAA");
+			//Assert.That (Type.GetType ("LinkAll.Attributes.CustomTypeAAAA"), Is.Not.Null, "CustomTypeAAAA");
 
 			var t = assembly.GetCustomAttributes<CustomAttribute> ();
 			Assert.That (t.Count (), Is.EqualTo (2), "Type");
-			Assert.NotNull (Type.GetType ("LinkAll.Attributes.CustomType"), "CustomType");
-			Assert.NotNull (Type.GetType ("LinkAll.Attributes.CustomTypeG"), "CustomTypeG");
+			Assert.That (Type.GetType ("LinkAll.Attributes.CustomType"), Is.Not.Null, "CustomType");
+			Assert.That (Type.GetType ("LinkAll.Attributes.CustomTypeG"), Is.Not.Null, "CustomTypeG");
 
 			//var to = assembly.GetCustomAttributes<CustomAttributeObject> ();
 			//Assert.That (to.Count (), Is.EqualTo (1), "Object");
-			//Assert.NotNull (Type.GetType ("LinkAll.Attributes.CustomTypeO"), "CustomTypeO");
+			//Assert.That (Type.GetType ("LinkAll.Attributes.CustomTypeO"), Is.Not.Null, "CustomTypeO");
 		}
 	}
 }

--- a/tests/linker/link all/ClassLayoutTest.cs
+++ b/tests/linker/link all/ClassLayoutTest.cs
@@ -54,9 +54,9 @@ namespace LinkAll.Layout {
 			Assert.That (fields.Length, Is.EqualTo (1), "Length");
 			Assert.That (fields [0].Name, Is.EqualTo ("used"), "Name");
 
-			Assert.True (t.IsAutoLayout, "IsAutoLayout");
-			Assert.False (t.IsExplicitLayout, "IsExplicitLayout");
-			Assert.False (t.IsLayoutSequential, "IsLayoutSequential");
+			Assert.That (t.IsAutoLayout, Is.True, "IsAutoLayout");
+			Assert.That (t.IsExplicitLayout, Is.False, "IsExplicitLayout");
+			Assert.That (t.IsLayoutSequential, Is.False, "IsLayoutSequential");
 		}
 
 		[Test]
@@ -70,9 +70,9 @@ namespace LinkAll.Layout {
 			Assert.That (fields.Length, Is.EqualTo (1), "Length");
 			Assert.That (fields [0].Name, Is.EqualTo ("used"), "Name");
 
-			Assert.True (t.IsAutoLayout, "IsAutoLayout");
-			Assert.False (t.IsExplicitLayout, "IsExplicitLayout");
-			Assert.False (t.IsLayoutSequential, "IsLayoutSequential");
+			Assert.That (t.IsAutoLayout, Is.True, "IsAutoLayout");
+			Assert.That (t.IsExplicitLayout, Is.False, "IsExplicitLayout");
+			Assert.That (t.IsLayoutSequential, Is.False, "IsLayoutSequential");
 		}
 
 		[Test]
@@ -85,9 +85,9 @@ namespace LinkAll.Layout {
 			var fields = t.GetFields ();
 			Assert.That (fields.Length, Is.EqualTo (2), "Length");
 
-			Assert.False (t.IsAutoLayout, "IsAutoLayout");
-			Assert.False (t.IsExplicitLayout, "IsExplicitLayout");
-			Assert.True (t.IsLayoutSequential, "IsLayoutSequential");
+			Assert.That (t.IsAutoLayout, Is.False, "IsAutoLayout");
+			Assert.That (t.IsExplicitLayout, Is.False, "IsExplicitLayout");
+			Assert.That (t.IsLayoutSequential, Is.True, "IsLayoutSequential");
 		}
 
 		[Test]
@@ -100,9 +100,9 @@ namespace LinkAll.Layout {
 			var fields = t.GetFields ();
 			Assert.That (fields.Length, Is.EqualTo (3), "Length");
 
-			Assert.False (t.IsAutoLayout, "IsAutoLayout");
-			Assert.True (t.IsExplicitLayout, "IsExplicitLayout");
-			Assert.False (t.IsLayoutSequential, "IsLayoutSequential");
+			Assert.That (t.IsAutoLayout, Is.False, "IsAutoLayout");
+			Assert.That (t.IsExplicitLayout, Is.True, "IsExplicitLayout");
+			Assert.That (t.IsLayoutSequential, Is.False, "IsLayoutSequential");
 		}
 	}
 }

--- a/tests/linker/link all/DataContractTest.cs
+++ b/tests/linker/link all/DataContractTest.cs
@@ -67,7 +67,7 @@ namespace LinkAll.Serialization.DataContract {
 			var t1 = new TestClass (SomeTypes.Audio | SomeTypes.Image);
 			var st = ToXml (t1);
 			var t2 = FromXml<TestClass> (st);
-			Assert.AreEqual (t2.Types, t1.Types);
+			Assert.That (t1.Types, Is.EqualTo (t2.Types));
 		}
 	}
 }

--- a/tests/linker/link all/InterfacesTest.cs
+++ b/tests/linker/link all/InterfacesTest.cs
@@ -74,23 +74,23 @@ namespace LinkAll.Interfaces {
 			F (new A ());
 
 			// Foo and Bar methods are both used on A and must be present
-			Assert.NotNull (type_a.GetMethod ("Foo", BindingFlags.Instance | BindingFlags.Public), "A::Foo");
-			Assert.NotNull (type_a.GetMethod ("Bar", BindingFlags.Instance | BindingFlags.Public), "A::Bar");
+			Assert.That (type_a.GetMethod ("Foo", BindingFlags.Instance | BindingFlags.Public), Is.Not.Null, "A::Foo");
+			Assert.That (type_a.GetMethod ("Bar", BindingFlags.Instance | BindingFlags.Public), Is.Not.Null, "A::Bar");
 
 			// I::Foo is never used and can be removed
-			Assert.Null (type_i.GetMethod ("Foo", BindingFlags.Instance | BindingFlags.Public), "I::Foo");
+			Assert.That (type_i.GetMethod ("Foo", BindingFlags.Instance | BindingFlags.Public), Is.Null, "I::Foo");
 			// I::Bar is used in F so everyone implementing I needs Bar 
-			Assert.NotNull (type_i.GetMethod ("Bar", BindingFlags.Instance | BindingFlags.Public), "I::Bar");
+			Assert.That (type_i.GetMethod ("Bar", BindingFlags.Instance | BindingFlags.Public), Is.Not.Null, "I::Bar");
 
 			// Foo and Bar are never used on B - so they can be removed
-			Assert.Null (type_b.GetMethod ("Foo", BindingFlags.Instance | BindingFlags.Public), "B::Foo");
+			Assert.That (type_b.GetMethod ("Foo", BindingFlags.Instance | BindingFlags.Public), Is.Null, "B::Foo");
 		}
 
 		[Test]
 		public void Issue9566 ()
 		{
 			var ifaces = (I []) (object) new B [0];
-			Assert.IsNotNull (ifaces, "Array cast");
+			Assert.That (ifaces, Is.Not.Null, "Array cast");
 		}
 
 		[DllImport ("/usr/lib/system/libsystem_dnssd.dylib")]

--- a/tests/linker/link all/InternalsTest.cs
+++ b/tests/linker/link all/InternalsTest.cs
@@ -22,7 +22,7 @@ namespace LinkAll.InernalCalls {
 		[Test]
 		public void RegionInfo_CountryCode ()
 		{
-			Assert.IsNotNull (xamarin_get_locale_country_code (), "xamarin_get_locale_country_code");
+			Assert.That (xamarin_get_locale_country_code (), Is.Not.Null, "xamarin_get_locale_country_code");
 		}
 
 		[DllImport ("__Internal", CharSet = CharSet.Unicode)]
@@ -47,7 +47,7 @@ namespace LinkAll.InernalCalls {
 			for (int i = 0, offset = 0; i < count; i++, offset += IntPtr.Size) {
 				IntPtr p = Marshal.ReadIntPtr (array, offset);
 				string s = Marshal.PtrToStringAnsi (p)!;
-				Assert.NotNull (s, i.ToString ());
+				Assert.That (s, Is.Not.Null, i.ToString ());
 				Marshal.FreeHGlobal (p);
 			}
 			Marshal.FreeHGlobal (array);

--- a/tests/linker/link all/LinkAllMacTest.cs
+++ b/tests/linker/link all/LinkAllMacTest.cs
@@ -18,14 +18,14 @@ namespace LinkAllTests {
 			NSApplication.EnsureUIThread ();
 
 			ThreadPool.QueueUserWorkItem ((v) => Tester.Test ());
-			Assert.IsTrue (Tester.mre.WaitOne (TimeSpan.FromSeconds (10)), "Successful wait");
+			Assert.That (Tester.mre.WaitOne (TimeSpan.FromSeconds (10)), Is.True, "Successful wait");
 			// The UI thread check only happens for debug builds, on release build it's linked away.
 #if DEBUG
 			var expected_ex_thrown = true;
 #else
 			var expected_ex_thrown = false;
 #endif
-			Assert.AreEqual (expected_ex_thrown, Tester.exception_thrown, "Success");
+			Assert.That (Tester.exception_thrown, Is.EqualTo (expected_ex_thrown), "Success");
 		}
 
 
@@ -59,7 +59,7 @@ namespace LinkAllTests {
 			using (var xr = new XmlTextReader (sr)) {
 				var xs = new XmlSerializer (typeof (SerializeMe));
 				var item = xs.Deserialize (xr) as SerializeMe;
-				Assert.AreEqual (2, item!.SetMe, "SetMe");
+				Assert.That (item!.SetMe, Is.EqualTo (2), "SetMe");
 			}
 		}
 

--- a/tests/linker/link all/LinkAllTest.cs
+++ b/tests/linker/link all/LinkAllTest.cs
@@ -277,7 +277,7 @@ namespace LinkAll {
 						UIPasteboard.General.Images = new UIImage [] { img, img };
 						Assert.That (UIPasteboard.General.Images.Length, Is.EqualTo (2), "b - length");
 						Assert.That (UIPasteboard.General.Images [0], Is.Not.Null, "b - nonnull[0]");
-						Assert.That (UIPasteboard.General.Images [1], Is.Not.Null, "b - nonnull[0]");
+						Assert.That (UIPasteboard.General.Images [1], Is.Not.Null, "b - nonnull[1]");
 					}
 				}
 			}

--- a/tests/linker/link all/LinkAllTest.cs
+++ b/tests/linker/link all/LinkAllTest.cs
@@ -100,8 +100,8 @@ namespace LinkAll {
 
 			PropertyInfo pi = not_preserved_type.GetProperty ("Two")!;
 			// check the *unused* setter absence from the application
-			Assert.NotNull (pi.GetGetMethod (), "getter");
-			Assert.Null (pi.GetSetMethod (), "setter");
+			Assert.That (pi.GetGetMethod (), Is.Not.Null, "getter");
+			Assert.That (pi.GetSetMethod (), Is.Null, "setter");
 		}
 
 		[Test]
@@ -113,8 +113,8 @@ namespace LinkAll {
 
 			PropertyInfo pi = not_preserved_type.GetProperty ("One")!;
 			// check the *unused* setter absence from the application
-			Assert.Null (pi.GetGetMethod (), "getter");
-			Assert.NotNull (pi.GetSetMethod (), "setter");
+			Assert.That (pi.GetGetMethod (), Is.Null, "getter");
+			Assert.That (pi.GetSetMethod (), Is.Not.Null, "setter");
 		}
 
 		[Test]
@@ -131,14 +131,16 @@ namespace LinkAll {
 					break;
 				}
 			}
-			Assert.True (default_value, "DefaultValue");
+			Assert.That (default_value, Is.True, "DefaultValue");
 		}
 
 		static void Check (string calendarName, bool present)
 		{
 			var type = Type.GetType ("System.Globalization." + calendarName);
-			bool success = present == (type is not null);
-			Assert.AreEqual (present, type is not null, calendarName);
+			if (present)
+				Assert.That (type, Is.Not.Null, calendarName);
+			else
+				Assert.That (type, Is.Null, calendarName);
 		}
 
 		[Test]
@@ -176,8 +178,8 @@ namespace LinkAll {
 		{
 			// for (future) nunit[lite] platform detection - if this test fails then platform detection won't work
 			var typename = NamespacePrefix + "UIKit.UIApplicationDelegate, " + AssemblyName;
-			Assert.NotNull (Helper.GetType (typename), typename);
-			Assert.Null (Helper.GetType ("Mono.Runtime"), "Mono.Runtime");
+			Assert.That (Helper.GetType (typename), Is.Not.Null, typename);
+			Assert.That (Helper.GetType ("Mono.Runtime"), Is.Null, "Mono.Runtime");
 		}
 #endif // !__MACOS__
 
@@ -194,20 +196,20 @@ namespace LinkAll {
 			string suffix = AssemblyName;
 
 			// since we're linking the attributes will NOT be available - even if they are used
-			Assert.Null (Helper.GetType (prefix + "ObjCRuntime.IntroducedAttribute, " + suffix), "IntroducedAttribute");
-			Assert.Null (Helper.GetType (prefix + "ObjCRuntime.DeprecatedAttribute, " + suffix), "DeprecatedAttribute");
-			Assert.Null (Helper.GetType (prefix + "ObjCRuntime.ObsoletedAttribute, " + suffix), "ObsoletedAttribute");
-			Assert.Null (Helper.GetType (prefix + "ObjCRuntime.UnavailableAttribute, " + suffix), "UnavailableAttribute");
-			Assert.Null (Helper.GetType (prefix + "ObjCRuntime.ThreadSafeAttribute, " + suffix), "ThreadSafeAttribute");
-			Assert.Null (Helper.GetType ("System.Runtime.Versioning.SupportedOSPlatformAttribute, " + suffix), "SupportedOSPlatformAttribute");
-			Assert.Null (Helper.GetType ("System.Runtime.Versioning.UnsupportedOSPlatformAttribute, " + suffix), "UnsupportedOSPlatformAttribute");
+			Assert.That (Helper.GetType (prefix + "ObjCRuntime.IntroducedAttribute, " + suffix), Is.Null, "IntroducedAttribute");
+			Assert.That (Helper.GetType (prefix + "ObjCRuntime.DeprecatedAttribute, " + suffix), Is.Null, "DeprecatedAttribute");
+			Assert.That (Helper.GetType (prefix + "ObjCRuntime.ObsoletedAttribute, " + suffix), Is.Null, "ObsoletedAttribute");
+			Assert.That (Helper.GetType (prefix + "ObjCRuntime.UnavailableAttribute, " + suffix), Is.Null, "UnavailableAttribute");
+			Assert.That (Helper.GetType (prefix + "ObjCRuntime.ThreadSafeAttribute, " + suffix), Is.Null, "ThreadSafeAttribute");
+			Assert.That (Helper.GetType ("System.Runtime.Versioning.SupportedOSPlatformAttribute, " + suffix), Is.Null, "SupportedOSPlatformAttribute");
+			Assert.That (Helper.GetType ("System.Runtime.Versioning.UnsupportedOSPlatformAttribute, " + suffix), Is.Null, "UnsupportedOSPlatformAttribute");
 		}
 
 		[Test]
 		public void Assembly_Load ()
 		{
 			Assembly mscorlib = Assembly.Load ("System.Private.CoreLib.dll");
-			Assert.NotNull (mscorlib, "System.Private.CoreLib.dll");
+			Assert.That (mscorlib, Is.Not.Null, "System.Private.CoreLib.dll");
 		}
 
 		string FindAssemblyPath ()
@@ -238,14 +240,14 @@ namespace LinkAll {
 		public void Assembly_LoadFile ()
 		{
 			string filename = FindAssemblyPath ();
-			Assert.NotNull (Assembly.LoadFile (Path.GetFullPath (filename)), "1");
+			Assert.That (Assembly.LoadFile (Path.GetFullPath (filename)), Is.Not.Null, "1");
 		}
 
 		[Test]
 		public void Assembly_LoadFrom ()
 		{
 			string filename = FindAssemblyPath ();
-			Assert.NotNull (Assembly.LoadFrom (filename), "1");
+			Assert.That (Assembly.LoadFrom (filename), Is.Not.Null, "1");
 		}
 
 		[Test]
@@ -268,14 +270,14 @@ namespace LinkAll {
 					using (var img = new UIImage (cgimg)) {
 						UIPasteboard.General.Images = new UIImage [] { img };
 						if (TestRuntime.CheckXcodeVersion (8, 0))
-							Assert.True (UIPasteboard.General.HasImages, "HasImages");
+							Assert.That (UIPasteboard.General.HasImages, Is.True, "HasImages");
 
-						Assert.AreEqual (1, UIPasteboard.General.Images.Length, "a - length");
+						Assert.That (UIPasteboard.General.Images.Length, Is.EqualTo (1), "a - length");
 
 						UIPasteboard.General.Images = new UIImage [] { img, img };
-						Assert.AreEqual (2, UIPasteboard.General.Images.Length, "b - length");
-						Assert.IsNotNull (UIPasteboard.General.Images [0], "b - nonnull[0]");
-						Assert.IsNotNull (UIPasteboard.General.Images [1], "b - nonnull[0]");
+						Assert.That (UIPasteboard.General.Images.Length, Is.EqualTo (2), "b - length");
+						Assert.That (UIPasteboard.General.Images [0], Is.Not.Null, "b - nonnull[0]");
+						Assert.That (UIPasteboard.General.Images [1], Is.Not.Null, "b - nonnull[0]");
 					}
 				}
 			}
@@ -285,7 +287,7 @@ namespace LinkAll {
 		[Test]
 		public void UltimateBindings ()
 		{
-			Assert.IsNotNull (Bindings.Test.UltimateMachine.SharedInstance, "SharedInstance");
+			Assert.That (Bindings.Test.UltimateMachine.SharedInstance, Is.Not.Null, "SharedInstance");
 		}
 
 		#region bug 14456
@@ -371,14 +373,14 @@ namespace LinkAll {
 		{
 			// Parent type is not used - but it's not linked out
 			var p = Helper.GetType ("LinkAll.Parent");
-			Assert.NotNull (p, "Parent");
+			Assert.That (p, Is.Not.Null, "Parent");
 			// because a nested type is a subclass of NSObject (and not part of monotouch.dll)
 			var n = p.GetNestedType ("Derived")!;
-			Assert.NotNull (n, "Derived");
+			Assert.That (n, Is.Not.Null, "Derived");
 			// however other stuff in Parent, like unused methods, will be removed
-			Assert.Null (p.GetMethod ("UnusedMethod"), "unused method");
+			Assert.That (p.GetMethod ("UnusedMethod"), Is.Null, "unused method");
 			// while exported stuff will be present
-			Assert.NotNull (n.GetMethod ("Foo"), "unused Export method");
+			Assert.That (n.GetMethod ("Foo"), Is.Not.Null, "unused Export method");
 		}
 
 		[Test]
@@ -386,7 +388,7 @@ namespace LinkAll {
 		{
 			// testing compile time error
 			CancelEventArgs cea = new CancelEventArgs ();
-			Assert.NotNull (cea, "CancelEventArgs");
+			Assert.That (cea, Is.Not.Null, "CancelEventArgs");
 		}
 
 		string? GetField (object o, string s)
@@ -420,14 +422,14 @@ namespace LinkAll {
 				id = 1234,
 				contentType = "xml"
 			});
-			Assert.Null (result, result);
+			Assert.That (result, Is.Null, result);
 		}
 
 		[Test]
 		public void Events ()
 		{
 			using (var pr = new SKProductsRequest ()) {
-				Assert.Null (pr.WeakDelegate, "none");
+				Assert.That (pr.WeakDelegate, Is.Null, "none");
 				// event on SKProductsRequest itself
 				pr.ReceivedResponse += (object? sender, SKProductsRequestResponseEventArgs e) => { };
 
@@ -435,15 +437,15 @@ namespace LinkAll {
 				Assert.That (t.Name, Is.EqualTo ("_SKProductsRequestDelegate"), "delegate");
 
 				var fi = t.GetField ("receivedResponse", BindingFlags.NonPublic | BindingFlags.Instance)!;
-				Assert.NotNull (fi, "receivedResponse");
+				Assert.That (fi, Is.Not.Null, "receivedResponse");
 				var value = fi.GetValue (pr.WeakDelegate);
-				Assert.NotNull (value, "value");
+				Assert.That (value, Is.Not.Null, "value");
 
 				// and on the SKRequest defined one
 				pr.RequestFailed += (object? sender, SKRequestErrorEventArgs e) => { };
 				// and the existing (initial field) is still set
 				fi = t.GetField ("receivedResponse", BindingFlags.NonPublic | BindingFlags.Instance);
-				Assert.NotNull (fi, "receivedResponse/SKRequest");
+				Assert.That (fi, Is.Not.Null, "receivedResponse/SKRequest");
 			}
 		}
 
@@ -453,7 +455,7 @@ namespace LinkAll {
 			var nix = (from nic in System.Net.NetworkInformation.NetworkInterface.GetAllNetworkInterfaces ()
 					   where nic.Id.StartsWith ("en") || nic.Id.StartsWith ("pdp_ip")
 					   select nic);
-			Assert.NotNull (nix);
+			Assert.That (nix, Is.Not.Null);
 		}
 
 		[Test]
@@ -461,7 +463,7 @@ namespace LinkAll {
 		{
 			// make test work for classic (monotouch) and unified (iOS, tvOS)
 			var fqn = typeof (NSObject).AssemblyQualifiedName!.Replace ("Foundation.NSObject", "Security.Tls.AppleTlsProvider");
-			Assert.Null (Helper.GetType (fqn), "Should NOT be included (no SslStream or Socket support)");
+			Assert.That (Helper.GetType (fqn), Is.Null, "Should NOT be included (no SslStream or Socket support)");
 		}
 
 		[Test]
@@ -470,7 +472,7 @@ namespace LinkAll {
 		{
 			// this test works only because "Link all" does not use WebKit
 			var fqn = typeof (NSObject).AssemblyQualifiedName!.Replace ("Foundation.NSObject", "Foundation.NSProxy");
-			Assert.Null (Helper.GetType (fqn), fqn);
+			Assert.That (Helper.GetType (fqn), Is.Null, fqn);
 		}
 
 		static Type type_Task = typeof (Task);
@@ -482,24 +484,24 @@ namespace LinkAll {
 			CheckAsyncTaskMethodBuilder (typeof (AsyncTaskMethodBuilder<int>));
 			var snfwc = type_Task.GetMethod ("NotifyDebuggerOfWaitCompletion", BindingFlags.Instance | BindingFlags.NonPublic);
 #if DEBUG
-			Assert.NotNull (snfwc, "Task.NotifyDebuggerOfWaitCompletion");
+			Assert.That (snfwc, Is.Not.Null, "Task.NotifyDebuggerOfWaitCompletion");
 #else
 			// something keeps it from being removed
-			// Assert.Null (snfwc, "Task.NotifyDebuggerOfWaitCompletion");
+			// Assert.That (snfwc, Is.Null, "Task.NotifyDebuggerOfWaitCompletion");
 #endif
 		}
 
 		void CheckAsyncTaskMethodBuilder (Type atmb)
 		{
-			Assert.NotNull (atmb, "AsyncTaskMethodBuilder");
+			Assert.That (atmb, Is.Not.Null, "AsyncTaskMethodBuilder");
 			var snfwc = atmb.GetMethod ("SetNotificationForWaitCompletion", BindingFlags.Instance | BindingFlags.NonPublic);
 			var oifd = atmb.GetProperty ("ObjectIdForDebugger", BindingFlags.Instance | BindingFlags.NonPublic);
 #if DEBUG
-			Assert.NotNull (snfwc, atmb.FullName + ".SetNotificationForWaitCompletion");
-			Assert.NotNull (oifd,  atmb.FullName + ".ObjectIdForDebugger");
+			Assert.That (snfwc, Is.Not.Null, atmb.FullName + ".SetNotificationForWaitCompletion");
+			Assert.That (oifd, Is.Not.Null, atmb.FullName + ".ObjectIdForDebugger");
 #else
-			Assert.Null (snfwc, atmb.FullName + ".SetNotificationForWaitCompletion");
-			Assert.Null (oifd, atmb.FullName + ".ObjectIdForDebugger");
+			Assert.That (snfwc, Is.Null, atmb.FullName + ".SetNotificationForWaitCompletion");
+			Assert.That (oifd, Is.Null, atmb.FullName + ".ObjectIdForDebugger");
 #endif
 		}
 
@@ -509,7 +511,7 @@ namespace LinkAll {
 		{
 			// https://github.com/dotnet/macios/issues/3523
 			// This test will fail at build time if it regresses (usually these types of build tests go into monotouch-test, but monotouch-test uses NSSet<T> elsewhere, which this test requires to be linked away).
-			Assert.IsNull (typeof (NSObject).Assembly.GetType (NamespacePrefix + "Foundation.NSSet`1"), "NSSet<T> must be linked away, otherwise this test is useless");
+			Assert.That (typeof (NSObject).Assembly.GetType (NamespacePrefix + "Foundation.NSSet`1"), Is.Null, "NSSet<T> must be linked away, otherwise this test is useless");
 		}
 
 		[Protocol (Name = "ProtocolWithGenericsInOptionalMember", WrapperType = typeof (ProtocolWithGenericsInOptionalMemberWrapper))]
@@ -550,7 +552,7 @@ namespace LinkAll {
 			using var view = new PdfView ();
 			view.Document = new PdfDocument (NSUrl.FromFilename (pdfPath)!);
 			using var page = view.CurrentPage!;
-			Assert.IsNotNull (page.Page, "Page");
+			Assert.That (page.Page, Is.Not.Null, "Page");
 		}
 #endif
 	}

--- a/tests/linker/link all/LinqExpressionTest.cs
+++ b/tests/linker/link all/LinqExpressionTest.cs
@@ -17,7 +17,7 @@ namespace LinkAll.Linq {
 		{
 			var ctor = typeof (LinqExpressionTest).GetConstructor (Type.EmptyTypes)!;
 			var expr = Expression.New (ctor, new Expression [0]);
-			Assert.NotNull (Expression.Lambda (typeof (Bug14863Delegate), expr, null), "Lambda");
+			Assert.That (Expression.Lambda (typeof (Bug14863Delegate), expr, null), Is.Not.Null, "Lambda");
 			// note: reflection is used to create an instance of Expression<TDelegate> using an internal ctor
 			// it can be indirectly "preserved" by other code (in Expression) but it can fail in other cases
 			// ref: https://bugzilla.xamarin.com/show_bug.cgi?id=14863

--- a/tests/linker/link all/PreserveTest.cs
+++ b/tests/linker/link all/PreserveTest.cs
@@ -58,8 +58,8 @@ namespace LinkAll.Attributes {
 		{
 			var t = Type.GetType ("LinkAll.Attributes.TypeWithMembers" + WorkAroundLinkerHeuristics)!;
 			// both type and members are preserved
-			Assert.NotNull (t, "type");
-			Assert.NotNull (t.GetProperty ("Present"), "members");
+			Assert.That (t, Is.Not.Null, "type");
+			Assert.That (t.GetProperty ("Present"), Is.Not.Null, "members");
 		}
 
 		[Test]
@@ -67,9 +67,9 @@ namespace LinkAll.Attributes {
 		{
 			var t = Type.GetType ("LinkAll.Attributes.TypeWithoutMembers" + WorkAroundLinkerHeuristics)!;
 			// type is preserved
-			Assert.NotNull (t, "type");
+			Assert.That (t, Is.Not.Null, "type");
 			// but we did not ask the linker to preserve it's members
-			Assert.Null (t.GetProperty ("Absent"), "members");
+			Assert.That (t.GetProperty ("Absent"), Is.Null, "members");
 		}
 
 		[Test]
@@ -78,7 +78,7 @@ namespace LinkAll.Attributes {
 			TestRuntime.AssertSimulator ("https://github.com/dotnet/macios/issues/10457");
 
 			var klass = Type.GetType ("ObjCRuntime.Runtime, " + AssemblyName)!;
-			Assert.NotNull (klass, "Runtime");
+			Assert.That (klass, Is.Not.Null, "Runtime");
 			// RegisterEntryAssembly is only needed for the simulator (not on devices) so it's only preserved for sim builds
 			var method = klass.GetMethod ("RegisterEntryAssembly", BindingFlags.NonPublic | BindingFlags.Static, null, new [] { typeof (Assembly) }, null);
 #if __MACOS__
@@ -94,81 +94,81 @@ namespace LinkAll.Attributes {
 		{
 			const string klassName = "ObjCRuntime.ObjCException";
 			var klass = Type.GetType (klassName + ", " + AssemblyName);
-			Assert.NotNull (klass, klassName);
+			Assert.That (klass, Is.Not.Null, klassName);
 		}
 
 		[Test]
 		public void Class_Unconditional ()
 		{
 			var klass = Type.GetType ("ObjCRuntime.Class, " + AssemblyName)!;
-			Assert.NotNull (klass, "Class");
+			Assert.That (klass, Is.Not.Null, "Class");
 			// handle is unconditionally preserved
 			var field = klass.GetField ("handle", BindingFlags.NonPublic | BindingFlags.Instance);
-			Assert.NotNull (field, "handle");
+			Assert.That (field, Is.Not.Null, "handle");
 		}
 
 		[Test]
 		public void Runtime_Unconditional ()
 		{
 			var klass = Type.GetType ("ObjCRuntime.Runtime, " + AssemblyName)!;
-			Assert.NotNull (klass, "Runtime");
+			Assert.That (klass, Is.Not.Null, "Runtime");
 			// Initialize and a few other methods are unconditionally preserved
 			var method = klass.GetMethod ("Initialize", BindingFlags.NonPublic | BindingFlags.Static);
-			Assert.NotNull (method, "Initialize");
+			Assert.That (method, Is.Not.Null, "Initialize");
 			method = klass.GetMethod ("RegisterNSObject", BindingFlags.NonPublic | BindingFlags.Static, null, new Type [] { typeof (NSObject), typeof (IntPtr) }, null);
-			Assert.NotNull (method, "RegisterNSObject");
+			Assert.That (method, Is.Not.Null, "RegisterNSObject");
 		}
 
 		[Test]
 		public void Selector_Unconditional ()
 		{
 			var klass = Type.GetType ("ObjCRuntime.Selector, " + AssemblyName)!;
-			Assert.NotNull (klass, "Selector");
+			Assert.That (klass, Is.Not.Null, "Selector");
 			// handle and is unconditionally preserved
 			var field = klass.GetField ("handle", BindingFlags.NonPublic | BindingFlags.Instance);
-			Assert.NotNull (field, "handle");
+			Assert.That (field, Is.Not.Null, "handle");
 			var method = klass.GetMethod ("GetHandle", BindingFlags.Public | BindingFlags.Static);
-			Assert.NotNull (method, "GetHandle");
+			Assert.That (method, Is.Not.Null, "GetHandle");
 		}
 
 		[Test]
 		public void SmartEnumTest ()
 		{
 			var consumer = GetType ().Assembly.GetType ("LinkAll.Attributes.SmartConsumer" + WorkAroundLinkerHeuristics)!;
-			Assert.NotNull (consumer, "SmartConsumer");
-			Assert.NotNull (consumer.GetMethod ("GetSmartEnumValue"), "GetSmartEnumValue");
-			Assert.NotNull (consumer.GetMethod ("SetSmartEnumValue"), "SetSmartEnumValue");
+			Assert.That (consumer, Is.Not.Null, "SmartConsumer");
+			Assert.That (consumer.GetMethod ("GetSmartEnumValue"), Is.Not.Null, "GetSmartEnumValue");
+			Assert.That (consumer.GetMethod ("SetSmartEnumValue"), Is.Not.Null, "SetSmartEnumValue");
 			var smartEnum = GetType ().Assembly.GetType ("LinkAll.Attributes.SmartEnum")!;
-			Assert.NotNull (smartEnum, "SmartEnum");
+			Assert.That (smartEnum, Is.Not.Null, "SmartEnum");
 			var smartExtensions = GetType ().Assembly.GetType ("LinkAll.Attributes.SmartEnumExtensions" + WorkAroundLinkerHeuristics)!;
-			Assert.NotNull (smartExtensions, "SmartEnumExtensions");
-			Assert.NotNull (smartExtensions.GetMethod ("GetConstant"), "GetConstant");
-			Assert.NotNull (smartExtensions.GetMethod ("GetValue"), "GetValue");
+			Assert.That (smartExtensions, Is.Not.Null, "SmartEnumExtensions");
+			Assert.That (smartExtensions.GetMethod ("GetConstant"), Is.Not.Null, "GetConstant");
+			Assert.That (smartExtensions.GetMethod ("GetValue"), Is.Not.Null, "GetValue");
 
 			// Unused smart enums and their extensions should be linked away
-			Assert.IsNull (typeof (NSObject).Assembly.GetType ("AVFoundation.AVMediaTypes"), "AVMediaTypes");
-			Assert.IsNull (typeof (NSObject).Assembly.GetType ("AVFoundation.AVMediaTypesExtensions"), "AVMediaTypesExtensions");
+			Assert.That (typeof (NSObject).Assembly.GetType ("AVFoundation.AVMediaTypes"), Is.Null, "AVMediaTypes");
+			Assert.That (typeof (NSObject).Assembly.GetType ("AVFoundation.AVMediaTypesExtensions"), Is.Null, "AVMediaTypesExtensions");
 		}
 
 		[Test]
 		public void PreserveAllExcludesNestedTypes ()
 		{
 			var parentClass = GetType ().Assembly.GetType ("LinkAll.Attributes.ParentClass" + WorkAroundLinkerHeuristics);
-			Assert.NotNull (parentClass, "ParentClass");
+			Assert.That (parentClass, Is.Not.Null, "ParentClass");
 			var nestedEnum = GetType ().Assembly.GetType ("LinkAll.Attributes.ParentClass.NestedEnum" + WorkAroundLinkerHeuristics);
-			Assert.Null (nestedEnum, "NestedEnum");
+			Assert.That (nestedEnum, Is.Null, "NestedEnum");
 			var nestedStruct = GetType ().Assembly.GetType ("LinkAll.Attributes.ParentClass.NestedStruct" + WorkAroundLinkerHeuristics);
-			Assert.Null (nestedStruct, "NestedStruct");
+			Assert.That (nestedStruct, Is.Null, "NestedStruct");
 			var nestedClass = GetType ().Assembly.GetType ("LinkAll.Attributes.ParentClass.NestedClass" + WorkAroundLinkerHeuristics);
-			Assert.Null (nestedClass, "NestedClass");
+			Assert.That (nestedClass, Is.Null, "NestedClass");
 		}
 
 		[Test]
 		public void PreserveAllKeepsEnumValues ()
 		{
 			var enumType = GetType ().Assembly.GetType ("LinkAll.Attributes.MyEnum" + WorkAroundLinkerHeuristics)!;
-			Assert.NotNull (enumType, "MyEnum");
-			Assert.AreEqual (3, enumType.GetFields (BindingFlags.Public | BindingFlags.Static).Length, "fields");
+			Assert.That (enumType, Is.Not.Null, "MyEnum");
+			Assert.That (enumType.GetFields (BindingFlags.Public | BindingFlags.Static).Length, Is.EqualTo (3), "fields");
 			AssertHasStaticField ("A", 1);
 			AssertHasStaticField ("B", 2);
 			AssertHasStaticField ("C", 4);
@@ -176,8 +176,8 @@ namespace LinkAll.Attributes {
 			void AssertHasStaticField (string name, int value)
 			{
 				var field = enumType.GetField (name, BindingFlags.Public | BindingFlags.Static)!;
-				Assert.NotNull (field, name);
-				Assert.AreEqual (value, (int) field.GetValue (null)!, $"{name} == {value}");
+				Assert.That (field, Is.Not.Null, name);
+				Assert.That ((int) field.GetValue (null)!, Is.EqualTo (value), $"{name} == {value}");
 			}
 		}
 	}

--- a/tests/linker/link all/SealerTest.cs
+++ b/tests/linker/link all/SealerTest.cs
@@ -45,22 +45,22 @@ namespace Linker.Sealer {
 		public void Sealed ()
 		{
 			// this can not be optimized into a sealed type
-			Assert.False (typeof (Unsealable).IsSealed, "Unsealed");
+			Assert.That (typeof (Unsealable).IsSealed, Is.False, "Unsealed");
 #if DEBUG || __MACOS__
 			// this is not a sealed type (in the source)
-			Assert.False (typeof (Sealable).IsSealed, "Sealable");
-			Assert.False (typeof (Base).IsSealed, "Base");
-			Assert.False (typeof (Subclass).IsSealed, "Subclass");
-			Assert.False (typeof (Interface).IsSealed, "Interface");
+			Assert.That (typeof (Sealable).IsSealed, Is.False, "Sealable");
+			Assert.That (typeof (Base).IsSealed, Is.False, "Base");
+			Assert.That (typeof (Subclass).IsSealed, Is.False, "Subclass");
+			Assert.That (typeof (Interface).IsSealed, Is.False, "Interface");
 #else
 			// Sealable can be optimized / sealed as nothing else is (or can) subclass it
-			Assert.True (typeof (Sealable).IsSealed, "Sealable");
+			Assert.That (typeof (Sealable).IsSealed, Is.True, "Sealable");
 			// Base is subclassed so it can't be sealed
-			Assert.False (typeof (Base).IsSealed, "Base");
+			Assert.That (typeof (Base).IsSealed, Is.False, "Base");
 			// Subclass is not subclassed anymore and can be sealed
-			Assert.True (typeof (Subclass).IsSealed, "Subclass");
+			Assert.That (typeof (Subclass).IsSealed, Is.True, "Subclass");
 			// interface can not be sealed
-			Assert.False (typeof (Interface).IsSealed, "Interface");
+			Assert.That (typeof (Interface).IsSealed, Is.False, "Interface");
 #endif
 		}
 
@@ -73,14 +73,14 @@ namespace Linker.Sealer {
 			var c = t.GetMethod ("C")!;
 #if DEBUG || __MACOS__
 			// this is not a sealed (C#) method (in the source)
-			Assert.False (a.IsFinal, "A");
-			Assert.False (b.IsFinal, "B");
-			Assert.False (c.IsFinal, "C");
+			Assert.That (a.IsFinal, Is.False, "A");
+			Assert.That (b.IsFinal, Is.False, "B");
+			Assert.That (c.IsFinal, Is.False, "C");
 #else
 			// but it can be optimized / sealed as nothing else is (or can) overrides it
-			Assert.True (a.IsFinal, "A");
-			Assert.True (b.IsFinal, "B");
-			Assert.False (c.IsFinal, "C"); // devirtualized
+			Assert.That (a.IsFinal, Is.True, "A");
+			Assert.That (b.IsFinal, Is.True, "B");
+			Assert.That (c.IsFinal, Is.False, "C"); // devirtualized
 #endif
 		}
 
@@ -93,16 +93,16 @@ namespace Linker.Sealer {
 			var c = t.GetMethod ("C")!;
 #if DEBUG || __MACOS__
 			// both methods are virtual (both in C# and IL)
-			Assert.True (a.IsVirtual, "A");
-			Assert.True (b.IsVirtual, "B");
-			Assert.True (c.IsVirtual, "C");
+			Assert.That (a.IsVirtual, Is.True, "A");
+			Assert.That (b.IsVirtual, Is.True, "B");
+			Assert.That (c.IsVirtual, Is.True, "C");
 #else
 			// calling A needs dispatch to base type Unsealable
-			Assert.True (a.IsVirtual, "A");
+			Assert.That (a.IsVirtual, Is.True, "A");
 			// B is an override and must remain virtual
-			Assert.True (b.IsVirtual, "B");
+			Assert.That (b.IsVirtual, Is.True, "B");
 			// C has no special requirement and can be de-virtualized
-			Assert.False (c.IsVirtual, "C");
+			Assert.That (c.IsVirtual, Is.False, "C");
 #endif
 		}
 
@@ -112,7 +112,7 @@ namespace Linker.Sealer {
 			var t = typeof (Subclass);
 			var a = t.GetMethod ("A")!;
 			// A cannot be de-virtualized since Concrete must satisfy Interface thru Base
-			Assert.True (a.IsVirtual, "A");
+			Assert.That (a.IsVirtual, Is.True, "A");
 		}
 	}
 }

--- a/tests/linker/link all/SerializationTest.cs
+++ b/tests/linker/link all/SerializationTest.cs
@@ -84,7 +84,7 @@ namespace LinkAll.Serialization {
 			// the serialization attributes only keeps the method(s) if the type was used
 			var t = Helper.GetType ("LinkAll.Serialization.Unused");
 			// since it's not used in the app then it's removed by the linker
-			Assert.Null (t, "type");
+			Assert.That (t, Is.Null, "type");
 		}
 
 		[Test]
@@ -93,9 +93,9 @@ namespace LinkAll.Serialization {
 			// the serialization attributes only keeps the method(s) if the type was used
 			var t = Helper.GetType ("LinkAll.Serialization.Used");
 			// since it's used here...
-			Assert.NotNull (new Used (), "reference");
+			Assert.That (new Used (), Is.Not.Null, "reference");
 			// it's not removed by the linker
-			Assert.NotNull (t, "type");
+			Assert.That (t, Is.Not.Null, "type");
 			// and since it's not the 4 decorated methods are also kept (even if uncalled)
 			Assert.That (t.GetMethods ().Length, Is.EqualTo (4), "4");
 		}

--- a/tests/linker/link all/StructLayoutTest.cs
+++ b/tests/linker/link all/StructLayoutTest.cs
@@ -53,9 +53,9 @@ namespace LinkAll.Layout {
 			var fields = t.GetFields ();
 			Assert.That (fields.Length, Is.EqualTo (2), "Length");
 
-			Assert.False (t.IsAutoLayout, "IsAutoLayout");
-			Assert.False (t.IsExplicitLayout, "IsExplicitLayout");
-			Assert.True (t.IsLayoutSequential, "IsLayoutSequential");
+			Assert.That (t.IsAutoLayout, Is.False, "IsAutoLayout");
+			Assert.That (t.IsExplicitLayout, Is.False, "IsExplicitLayout");
+			Assert.That (t.IsLayoutSequential, Is.True, "IsLayoutSequential");
 		}
 
 		[Test]
@@ -68,9 +68,9 @@ namespace LinkAll.Layout {
 			var fields = t.GetFields ();
 			Assert.That (fields.Length, Is.EqualTo (2), "Length");
 
-			Assert.True (t.IsAutoLayout, "IsAutoLayout");
-			Assert.False (t.IsExplicitLayout, "IsExplicitLayout");
-			Assert.False (t.IsLayoutSequential, "IsLayoutSequential");
+			Assert.That (t.IsAutoLayout, Is.True, "IsAutoLayout");
+			Assert.That (t.IsExplicitLayout, Is.False, "IsExplicitLayout");
+			Assert.That (t.IsLayoutSequential, Is.False, "IsLayoutSequential");
 		}
 
 		[Test]
@@ -83,9 +83,9 @@ namespace LinkAll.Layout {
 			var fields = t.GetFields ();
 			Assert.That (fields.Length, Is.EqualTo (2), "Length");
 
-			Assert.False (t.IsAutoLayout, "IsAutoLayout");
-			Assert.False (t.IsExplicitLayout, "IsExplicitLayout");
-			Assert.True (t.IsLayoutSequential, "IsLayoutSequential");
+			Assert.That (t.IsAutoLayout, Is.False, "IsAutoLayout");
+			Assert.That (t.IsExplicitLayout, Is.False, "IsExplicitLayout");
+			Assert.That (t.IsLayoutSequential, Is.True, "IsLayoutSequential");
 		}
 
 		[Test]
@@ -98,9 +98,9 @@ namespace LinkAll.Layout {
 			var fields = t.GetFields ();
 			Assert.That (fields.Length, Is.EqualTo (3), "Length");
 
-			Assert.False (t.IsAutoLayout, "IsAutoLayout");
-			Assert.True (t.IsExplicitLayout, "IsExplicitLayout");
-			Assert.False (t.IsLayoutSequential, "IsLayoutSequential");
+			Assert.That (t.IsAutoLayout, Is.False, "IsAutoLayout");
+			Assert.That (t.IsExplicitLayout, Is.True, "IsExplicitLayout");
+			Assert.That (t.IsLayoutSequential, Is.False, "IsLayoutSequential");
 		}
 	}
 }

--- a/tests/linker/link sdk/AotBugs.cs
+++ b/tests/linker/link sdk/AotBugs.cs
@@ -40,27 +40,27 @@ namespace LinkSdk.Aot {
 		public void Aot_3285 ()
 		{
 			// called as an extension method (always worked)
-			Assert.False (GetType ().GetInterfaces (typeof (IExpectException)).Select (interf => interf is not null).FirstOrDefault (), "false");
+			Assert.That (GetType ().GetInterfaces (typeof (IExpectException)).Select (interf => interf is not null).FirstOrDefault (), Is.False, "false");
 
 			// workaround for #3285 - similar to previous fix for monotouch/aot
 			// called as a static method (does not change the result - but it was closer to the original test case)
-			Assert.True (AotExtension.GetInterfaces (GetType (), typeof (IAotTest)).Select (interf => interf is not null).FirstOrDefault (delegate { return true; }), "delegate");
+			Assert.That (AotExtension.GetInterfaces (GetType (), typeof (IAotTest)).Select (interf => interf is not null).FirstOrDefault (delegate { return true; }), Is.True, "delegate");
 
 			// actual, failing, test case (fixed by inlining code)
-			Assert.True (GetType ().GetInterfaces (typeof (IAotTest)).Select (interf => interf is not null).FirstOrDefault (), "FirstOrDefault/true");
+			Assert.That (GetType ().GetInterfaces (typeof (IAotTest)).Select (interf => interf is not null).FirstOrDefault (), Is.True, "FirstOrDefault/true");
 
 			// other similar cases (returning bool with optional predicate delegate)
 			var enumerable = GetType ().GetInterfaces (typeof (IAotTest)).Select (interf => interf is not null);
-			Assert.True (enumerable.Any (), "Any");
-			Assert.True (enumerable.ElementAt (0), "ElementAt");
-			Assert.True (enumerable.ElementAtOrDefault (0), "ElementAtOrDefault");
-			Assert.True (enumerable.First (), "First");
-			Assert.True (enumerable.Last (), "Last");                       // failed before fix
-			Assert.True (enumerable.LastOrDefault (), "LastOrDefault");     // failed before fix
-			Assert.True (enumerable.Max (), "Max");
-			Assert.True (enumerable.Min (), "Min");
-			Assert.True (enumerable.Single (), "Single");                   // failed before fix
-			Assert.True (enumerable.SingleOrDefault (), "SingleOrDefault"); // failed before fix
+			Assert.That (enumerable.Any (), Is.True, "Any");
+			Assert.That (enumerable.ElementAt (0), Is.True, "ElementAt");
+			Assert.That (enumerable.ElementAtOrDefault (0), Is.True, "ElementAtOrDefault");
+			Assert.That (enumerable.First (), Is.True, "First");
+			Assert.That (enumerable.Last (), Is.True, "Last");                       // failed before fix
+			Assert.That (enumerable.LastOrDefault (), Is.True, "LastOrDefault");     // failed before fix
+			Assert.That (enumerable.Max (), Is.True, "Max");
+			Assert.That (enumerable.Min (), Is.True, "Min");
+			Assert.That (enumerable.Single (), Is.True, "Single");                   // failed before fix
+			Assert.That (enumerable.SingleOrDefault (), Is.True, "SingleOrDefault"); // failed before fix
 		}
 
 		[Test]
@@ -149,7 +149,7 @@ namespace LinkSdk.Aot {
 			var query = (from wqual in c
 						 join personTable in p on wqual.FK_PERSON equals personTable.Id
 						 select new CounselingWithPerson (wqual, personTable));
-			Assert.NotNull (query.ToList ());
+			Assert.That (query.ToList (), Is.Not.Null);
 			// above throws ExecutionEngineException
 		}
 
@@ -164,7 +164,7 @@ namespace LinkSdk.Aot {
 			var query = (from wqual in c
 						 join personTable in p on wqual.FK_PERSON.ToString () equals personTable.Id.ToString ()
 						 select new CounselingWithPerson (wqual, personTable));
-			Assert.NotNull (query.ToList ());
+			Assert.That (query.ToList (), Is.Not.Null);
 		}
 
 		public class Foo {
@@ -226,7 +226,7 @@ namespace LinkSdk.Aot {
 				Environment.SpecialFolder.ApplicationData,
 				Environment.SpecialFolder.CommonApplicationData
 			};
-			Assert.True (array.Any (folder => folder == Environment.SpecialFolder.ApplicationData));
+			Assert.That (array.Any (folder => folder == Environment.SpecialFolder.ApplicationData), Is.True);
 			// above throws ExecutionEngineException
 			// Attempting to JIT compile method '(wrapper managed-to-managed) System.Environment/SpecialFolder[]:System.Collections.Generic.IEnumerable`1.GetEnumerator ()' while running with --aot-only.
 		}
@@ -239,7 +239,7 @@ namespace LinkSdk.Aot {
 			List<MidpointRounding> list = new List<MidpointRounding> () {
 				MidpointRounding.AwayFromZero
 			};
-			Assert.True (list.Any (rounding => rounding == MidpointRounding.AwayFromZero));
+			Assert.That (list.Any (rounding => rounding == MidpointRounding.AwayFromZero), Is.True);
 		}
 
 		Task<bool> InnerTestB<T> ()
@@ -289,7 +289,7 @@ namespace LinkSdk.Aot {
 						 select q;
 			// note: orderby causing:
 			// Attempting to JIT compile method 'System.Linq.OrderedEnumerable`1<<>__AnonType0`2<MonoTouchFixtures.AotBugsTest/Question, MonoTouchFixtures.AotBugsTest/Section>>:CreateOrderedEnumerable<int> (System.Func`2<<>__AnonType0`2<MonoTouchFixtures.AotBugsTest/Question, MonoTouchFixtures.AotBugsTest/Section>, int>,System.Collections.Generic.IComparer`1<int>,bool)' while running with --aot-only.
-			Assert.NotNull (result);
+			Assert.That (result, Is.Not.Null);
 		}
 
 		[Test]
@@ -302,7 +302,7 @@ namespace LinkSdk.Aot {
 						 where s.BoardId == boardId
 						 orderby q.IsAnswered.ToString (), s.Position.ToString (), q.Position.ToString ()
 						 select q;
-			Assert.NotNull (result);
+			Assert.That (result, Is.Not.Null);
 		}
 
 		[Test]
@@ -316,7 +316,7 @@ namespace LinkSdk.Aot {
 						  select q;
 			// query is ok
 			foreach (var result in results)
-				Assert.NotNull (result);
+				Assert.That (result, Is.Not.Null);
 		}
 
 		[Test]
@@ -329,7 +329,7 @@ namespace LinkSdk.Aot {
 						  where s.BoardId == boardId
 						  select q;
 			foreach (var result in results)
-				Assert.NotNull (result);
+				Assert.That (result, Is.Not.Null);
 		}
 
 		public class VirtualGeneric {
@@ -347,7 +347,7 @@ namespace LinkSdk.Aot {
 		public void Virtual_4114 ()
 		{
 			VirtualGeneric g = new VirtualGeneric ();
-			Assert.NotNull (g.MakeCollectionOfInputs<double> (1.0, 2.0, 3.0));
+			Assert.That (g.MakeCollectionOfInputs<double> (1.0, 2.0, 3.0), Is.Not.Null);
 		}
 
 		public class OverrideGeneric : VirtualGeneric {
@@ -469,7 +469,7 @@ namespace LinkSdk.Aot {
 		{
 			int n = 1;
 			foreach (var e in GetStringList<NSFileManagerItemReplacementOptions> ()) {
-				Assert.NotNull (e, n.ToString ());
+				Assert.That (e, Is.Not.Null, n.ToString ());
 				n++;
 			}
 		}
@@ -479,7 +479,7 @@ namespace LinkSdk.Aot {
 		{
 			int n = 1;
 			foreach (var e in Enum.GetValues (typeof (NSFileManagerItemReplacementOptions)).Cast<NSFileManagerItemReplacementOptions> ().Select (x => x.ToString ())) {
-				Assert.NotNull (e, n.ToString ());
+				Assert.That (e, Is.Not.Null, n.ToString ());
 				n++;
 			}
 		}
@@ -530,10 +530,10 @@ namespace LinkSdk.Aot {
 		[Test]
 		public void Bug12605 ()
 		{
-			Assert.AreEqual ("One", Convert.ToString ((MyEnum8ElementsInInt32) 1), "1");
-			Assert.AreEqual ("One", Convert.ToString ((MyEnum8ElementsInUInt32) 1), "2");
-			Assert.AreEqual ("One", Convert.ToString ((MyEnum7ElementsInUInt16) 1), "3");
-			Assert.AreEqual ("One", Convert.ToString ((MyEnum8ElementsInUInt16) 1), "4");
+			Assert.That (Convert.ToString ((MyEnum8ElementsInInt32) 1), Is.EqualTo ("One"), "1");
+			Assert.That (Convert.ToString ((MyEnum8ElementsInUInt32) 1), Is.EqualTo ("One"), "2");
+			Assert.That (Convert.ToString ((MyEnum7ElementsInUInt16) 1), Is.EqualTo ("One"), "3");
+			Assert.That (Convert.ToString ((MyEnum8ElementsInUInt16) 1), Is.EqualTo ("One"), "4");
 		}
 
 		[Test]
@@ -560,7 +560,7 @@ namespace LinkSdk.Aot {
                 (?:[Ee][+-]?[0-9]+)?           # Optional exponent
                 (?![A-Za-z0-9_])               # Must not be followed by an alphanumeric character
                 )", System.Text.RegularExpressions.RegexOptions.IgnorePatternWhitespace);
-			Assert.NotNull (r); // looking got EEE while executing, on devices, the above code
+			Assert.That (r, Is.Not.Null); // looking got EEE while executing, on devices, the above code
 		}
 
 		[Test]

--- a/tests/linker/link sdk/BitcodeTest.cs
+++ b/tests/linker/link sdk/BitcodeTest.cs
@@ -9,8 +9,8 @@ namespace LinkSdk {
 		{
 			var supported = true;
 			if (supported) {
-				Assert.AreEqual (0, FilterClause (), "Filter me");
-				Assert.AreEqual (10, FilterClauseProperty, "Filter me getter");
+				Assert.That (FilterClause (), Is.EqualTo (0), "Filter me");
+				Assert.That (FilterClauseProperty, Is.EqualTo (10), "Filter me getter");
 				Assert.DoesNotThrow (() => FilterClauseProperty = 20, "Filter me setter");
 			} else {
 				Assert.Throws<NotSupportedException> (() => FilterClause (), "Filter me not supported");
@@ -47,7 +47,7 @@ namespace LinkSdk {
 					throw new Exception ("FilterMe");
 				} catch (Exception e) when (e.Message == "FilterMe") {
 				} catch {
-					Assert.Fail ("Filter failure: {0}", value);
+					Assert.Fail ($"Filter failure: {value}");
 				}
 			}
 		}
@@ -68,12 +68,12 @@ namespace LinkSdk {
 			var body = method.GetMethodBody ();
 			if (body is null)
 				throw new InvalidOperationException ("MoveNext body");
-			Assert.IsTrue (body.ExceptionHandlingClauses.Any ((v) => v.Flags == ExceptionHandlingClauseOptions.Fault), "Any fault clauses");
+			Assert.That (body.ExceptionHandlingClauses.Any ((v) => v.Flags == ExceptionHandlingClauseOptions.Fault), Is.True, "Any fault clauses");
 
 			// Then assert that the method can be called successfully.
 			var rv = FaultClause ().ToArray ();
-			Assert.AreEqual (1, rv.Count (), "Count");
-			Assert.AreEqual (1, rv [0], "Item 1");
+			Assert.That (rv.Count (), Is.EqualTo (1), "Count");
+			Assert.That (rv [0], Is.EqualTo (1), "Item 1");
 
 		}
 

--- a/tests/linker/link sdk/CryptoTest.cs
+++ b/tests/linker/link sdk/CryptoTest.cs
@@ -27,7 +27,7 @@ namespace LinkSdk {
 			// Aes resides in mscorlib.dll but needs to create instance of types that are
 			// located inside System.Core.dll - IOW the linker needs to be aware of this
 			Aes aes = Aes.Create ();
-			Assert.NotNull (aes, "Aes");
+			Assert.That (aes, Is.Not.Null, "Aes");
 			const string prefix = "System.Security.Cryptography, ";
 			Assert.That (aes.GetType ().Assembly.FullName, Does.StartWith (prefix), prefix);
 		}
@@ -47,12 +47,12 @@ namespace LinkSdk {
 						return false;
 					Assert.That (errors, Is.EqualTo (SslPolicyErrors.None), "certificateProblem");
 					X509Certificate2 c2 = X509CertificateLoader.LoadCertificate (cert.GetRawCertData ());
-					Assert.True (chain.Build (c2), "Build");
+					Assert.That (chain.Build (c2), Is.True, "Build");
 					trust_validation_callback++;
 					return true;
 				};
 				WebClient wc = new WebClient ();
-				Assert.IsNotNull (wc.DownloadString (NetworkResources.XamarinUrl));
+				Assert.That (wc.DownloadString (NetworkResources.XamarinUrl), Is.Not.Null);
 				// caching means it will be called at least for the first run, but it might not
 				// be called again in subsequent requests (unless it expires)
 				Assert.That (trust_validation_callback, Is.GreaterThan (0), "validation done");
@@ -101,13 +101,13 @@ namespace LinkSdk {
 						return false;
 					Assert.That (errors, Is.EqualTo (SslPolicyErrors.None), "certificateProblem");
 					X509Certificate2 c2 = X509CertificateLoader.LoadCertificate (cert.GetRawCertData ());
-					Assert.True (chain.Build (c2), "Build");
+					Assert.That (chain.Build (c2), Is.True, "Build");
 					sne_validation_callback++;
 					return true;
 				};
 				ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls;
 				WebClient wc = new WebClient ();
-				Assert.IsNotNull (wc.DownloadString (NetworkResources.StatsUrl));
+				Assert.That (wc.DownloadString (NetworkResources.StatsUrl), Is.Not.Null);
 			} catch (WebException we) {
 				// failing to get data does not mean the SSL/TLS session was not established
 				if (sne_validation_callback == 0) {
@@ -137,16 +137,16 @@ namespace LinkSdk {
 			chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
 			chain.ChainPolicy.CustomTrustStore.Add (rootCert);
 
-			Assert.False (chain.Build (cert), "Online");
-			Assert.True (chain.ChainStatus.Any (s => s.Status.HasFlag (X509ChainStatusFlags.RevocationStatusUnknown)), "Online");
+			Assert.That (chain.Build (cert), Is.False, "Online");
+			Assert.That (chain.ChainStatus.Any (s => s.Status.HasFlag (X509ChainStatusFlags.RevocationStatusUnknown)), Is.True, "Online");
 
 			chain.ChainPolicy.RevocationMode = X509RevocationMode.Offline;
-			Assert.False (chain.Build (cert), "Offline");
-			Assert.True (chain.ChainStatus.Any (s => s.Status.HasFlag (X509ChainStatusFlags.RevocationStatusUnknown)), "Offline");
+			Assert.That (chain.Build (cert), Is.False, "Offline");
+			Assert.That (chain.ChainStatus.Any (s => s.Status.HasFlag (X509ChainStatusFlags.RevocationStatusUnknown)), Is.True, "Offline");
 
 			chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-			Assert.True (chain.Build (cert), "NoCheck");
-			Assert.AreEqual (0, chain.ChainStatus.Length, "NoCheck");
+			Assert.That (chain.Build (cert), Is.True, "NoCheck");
+			Assert.That (chain.ChainStatus.Length, Is.EqualTo (0), "NoCheck");
 		}
 
 		byte [] sha256_data = {
@@ -209,7 +209,7 @@ namespace LinkSdk {
 		{
 			X509Certificate2 c = X509CertificateLoader.LoadCertificate (sha256_data);
 			// can't build is fine - as long as we do not throw
-			Assert.False (new X509Chain (false).Build (c), "Build");
+			Assert.That (new X509Chain (false).Build (c), Is.False, "Build");
 		}
 	}
 }

--- a/tests/linker/link sdk/DllImportTest.cs
+++ b/tests/linker/link sdk/DllImportTest.cs
@@ -34,7 +34,7 @@ namespace LinkSdk {
 		public void ScanForStrip_17327 ()
 		{
 			// note: must be tested on a release (strip'ed) build
-			Assert.NotNull (NestedFirstLevel.NestedSecondLevel.xamarin_get_locale_country_code ());
+			Assert.That (NestedFirstLevel.NestedSecondLevel.xamarin_get_locale_country_code (), Is.Not.Null);
 		}
 
 		[Test]
@@ -89,7 +89,7 @@ namespace LinkSdk {
 			};
 			var timeout = TimeSpan.FromSeconds (10);
 			var tasks = hosts.Select (host => (new Ping ()).SendPingAsync (host, timeout)).ToArray ();
-			Assert.IsTrue (Task.WaitAll (tasks, timeout.Add (TimeSpan.FromSeconds (10))), "One or more of the ping requests timed out.");
+			Assert.That (Task.WaitAll (tasks, timeout.Add (TimeSpan.FromSeconds (10))), Is.True, "One or more of the ping requests timed out.");
 			var results = tasks.Select (task => task.Result.Status).ToArray ();
 			Assert.That (results, Has.Some.EqualTo (IPStatus.Success), "Pong any host");
 		}

--- a/tests/linker/link sdk/HttpClientHandlerTest.cs
+++ b/tests/linker/link sdk/HttpClientHandlerTest.cs
@@ -15,20 +15,20 @@ namespace LinkSdk.Net.Http {
 		public void HttpClient ()
 		{
 			using (var handler = new HttpClientHandler ()) {
-				Assert.True (handler.AllowAutoRedirect, "AllowAutoRedirect");
-				Assert.NotNull (handler.CookieContainer, "CookieContainer");
-				Assert.Null (handler.Credentials, "Credentials");
+				Assert.That (handler.AllowAutoRedirect, Is.True, "AllowAutoRedirect");
+				Assert.That (handler.CookieContainer, Is.Not.Null, "CookieContainer");
+				Assert.That (handler.Credentials, Is.Null, "Credentials");
 				// (so far) not exposed in other, native handlers
 				Assert.That (handler.AutomaticDecompression, Is.EqualTo (DecompressionMethods.None), "AutomaticDecompression");
 				Assert.That (handler.ClientCertificateOptions, Is.EqualTo (ClientCertificateOption.Manual), "ClientCertificateOptions");
 				Assert.That (handler.MaxAutomaticRedirections, Is.EqualTo (50), "MaxAutomaticRedirections");
-				Assert.Null (handler.Proxy, "Proxy");
-				Assert.True (handler.SupportsAutomaticDecompression, "SupportsAutomaticDecompression");
-				Assert.True (handler.SupportsProxy, "SupportsProxy");
-				Assert.True (handler.SupportsRedirectConfiguration, "SupportsRedirectConfiguration");
-				Assert.True (handler.UseCookies, "UseCookies");
-				Assert.False (handler.UseDefaultCredentials, "UseDefaultCredentials");
-				Assert.True (handler.UseProxy, "UseProxy");
+				Assert.That (handler.Proxy, Is.Null, "Proxy");
+				Assert.That (handler.SupportsAutomaticDecompression, Is.True, "SupportsAutomaticDecompression");
+				Assert.That (handler.SupportsProxy, Is.True, "SupportsProxy");
+				Assert.That (handler.SupportsRedirectConfiguration, Is.True, "SupportsRedirectConfiguration");
+				Assert.That (handler.UseCookies, Is.True, "UseCookies");
+				Assert.That (handler.UseDefaultCredentials, Is.False, "UseDefaultCredentials");
+				Assert.That (handler.UseProxy, Is.True, "UseProxy");
 			}
 		}
 
@@ -36,10 +36,10 @@ namespace LinkSdk.Net.Http {
 		public void CFNetwork ()
 		{
 			using (var handler = new CFNetworkHandler ()) {
-				Assert.True (handler.AllowAutoRedirect, "AllowAutoRedirect");
-				Assert.NotNull (handler.CookieContainer, "CookieContainer");
+				Assert.That (handler.AllowAutoRedirect, Is.True, "AllowAutoRedirect");
+				Assert.That (handler.CookieContainer, Is.Not.Null, "CookieContainer");
 				// custom, not in HttpClientHandler
-				Assert.False (handler.UseSystemProxy, "UseSystemProxy");
+				Assert.That (handler.UseSystemProxy, Is.False, "UseSystemProxy");
 			}
 		}
 
@@ -47,10 +47,10 @@ namespace LinkSdk.Net.Http {
 		public void NSUrlSession ()
 		{
 			using (var handler = new NSUrlSessionHandler ()) {
-				Assert.True (handler.AllowAutoRedirect, "AllowAutoRedirect");
-				Assert.Null (handler.Credentials, "Credentials");
+				Assert.That (handler.AllowAutoRedirect, Is.True, "AllowAutoRedirect");
+				Assert.That (handler.Credentials, Is.Null, "Credentials");
 				// custom, not in HttpClientHandler
-				Assert.False (handler.DisableCaching, "DisableCaching");
+				Assert.That (handler.DisableCaching, Is.False, "DisableCaching");
 			}
 		}
 	}

--- a/tests/linker/link sdk/LinkExtraDefsTest.cs
+++ b/tests/linker/link sdk/LinkExtraDefsTest.cs
@@ -27,7 +27,7 @@ namespace LinkSdk {
 		public void Corlib ()
 		{
 			var t = Type.GetType ("System.Security.PermissionSet, " + typeof (int).Assembly.GetName ().Name);
-			Assert.NotNull (t, "System.Security.PermissionSet");
+			Assert.That (t, Is.Not.Null, "System.Security.PermissionSet");
 			if (t is null)
 				throw new InvalidOperationException ("System.Security.PermissionSet");
 		}
@@ -36,11 +36,11 @@ namespace LinkSdk {
 		public void System ()
 		{
 			var t = Type.GetType ("System.Net.Mime.ContentType, System.Net.Mail");
-			Assert.NotNull (t, "System.Net.Mime.ContentType");
+			Assert.That (t, Is.Not.Null, "System.Net.Mime.ContentType");
 			if (t is null)
 				throw new InvalidOperationException ("System.Net.Mime.ContentType");
 			// we asked for ParseValue to be preserved
-			Assert.NotNull (t.GetMethod ("ParseValue", BindingFlags.Instance | BindingFlags.NonPublic), "Parse");
+			Assert.That (t.GetMethod ("ParseValue", BindingFlags.Instance | BindingFlags.NonPublic), Is.Not.Null, "Parse");
 		}
 
 #if !__MACOS__
@@ -48,7 +48,7 @@ namespace LinkSdk {
 		public void MonoTouch ()
 		{
 			var t = Type.GetType ("CoreBluetooth.CBUUID, " + typeof (NSObject).Assembly.ToString ());
-			Assert.NotNull (t, "[MonoTouch.]CoreBluetooth.CBUUID");
+			Assert.That (t, Is.Not.Null, "[MonoTouch.]CoreBluetooth.CBUUID");
 			if (t is null)
 				throw new InvalidOperationException ("CoreBluetooth.CBUUID");
 			// check (generated) fields since we instructed the linker to keep them

--- a/tests/linker/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/link sdk/LinkSdkRegressionTest.cs
@@ -69,7 +69,7 @@ namespace LinkSdk {
 		public void Bug234_Interlocked ()
 		{
 			string? str = null;
-			Assert.Null (Interlocked.Exchange (ref str, "one"), "Exchange");
+			Assert.That (Interlocked.Exchange (ref str, "one"), Is.Null, "Exchange");
 			// the above should not crash with System.ExecutionEngineException
 			Assert.That (str, Is.EqualTo ("one"), "one");
 		}
@@ -82,7 +82,7 @@ namespace LinkSdk {
 			Dictionary<string, DateTime> queued = new Dictionary<string, DateTime> ();
 			KeyValuePair<string, DateTime> valuePair = queued.FirstOrDefault ();
 			// above should not crash with System.ExecutionEngineException
-			Assert.NotNull (valuePair);
+			Assert.That (valuePair, Is.Not.Null);
 		}
 
 		[Test]
@@ -103,7 +103,7 @@ namespace LinkSdk {
 			var tmp = Class.ThrowOnInitFailure;
 			Class.ThrowOnInitFailure = false;
 			try {
-				Assert.NotNull (new MKMapViewDelegate ());
+				Assert.That (new MKMapViewDelegate (), Is.Not.Null);
 				// the above should not throw an Exception
 			} finally {
 				Class.ThrowOnInitFailure = tmp;
@@ -120,12 +120,12 @@ namespace LinkSdk {
 				Assert.Ignore ("NSUrl was fixed with Xcode 15.0");
 
 #pragma warning disable CS8625 // Intentional null test case
-			Assert.False (UIApplication.SharedApplication.CanOpenUrl (null), "null");
+			Assert.That (UIApplication.SharedApplication.CanOpenUrl (null), Is.False, "null");
 #pragma warning restore CS8625
 			// the above should not throw an ArgumentNullException
 			// and that's important because NSUrl.FromString and NSUrl.ctor(string) differs
 			const string bad_tel = "tel://1800 023 009";
-			Assert.Null (NSUrl.FromString (bad_tel), "bad url");
+			Assert.That (NSUrl.FromString (bad_tel), Is.Null, "bad url");
 			// we now throw if `init*` fails
 			Assert.Throws<Exception> (() => new NSUrl (bad_tel), "ctor, bad url");
 		}
@@ -150,9 +150,9 @@ namespace LinkSdk {
 			using (ABPeoplePickerNavigationController picker = new ABPeoplePickerNavigationController ()) {
 				// no NRE should occur
 				if (UIDevice.CurrentDevice.CheckSystemVersion (8, 0))
-					Assert.Null (picker.AddressBook);
+					Assert.That (picker.AddressBook, Is.Null);
 				else
-					Assert.NotNull (picker.AddressBook);
+					Assert.That (picker.AddressBook, Is.Not.Null);
 			}
 		}
 
@@ -168,7 +168,7 @@ namespace LinkSdk {
 			}
 #endif // !__MACOS__
 			TestRuntime.AssertSystemVersion (ApplePlatform.MacCatalyst, 14, 0, throwIfOtherPlatform: false); // The AddressBook framework was introduced in Mac Catalyst 14.0
-			Assert.IsNotNull (ABPersonAddressKey.City, "ABPersonAddressKey");
+			Assert.That (ABPersonAddressKey.City, Is.Not.Null, "ABPersonAddressKey");
 		}
 #endif // HAS_ADDRESSBOOKUI
 
@@ -178,7 +178,7 @@ namespace LinkSdk {
 		public void Bug1387_UIEdgeInsets_ToString ()
 		{
 			var insets = new UIEdgeInsets (1, 2, 3, 4);
-			Assert.False (insets.ToString ().Contains ("UIEdgeInsets"));
+			Assert.That (insets.ToString ().Contains ("UIEdgeInsets"), Is.False);
 		}
 #endif // !__MACOS__
 
@@ -193,8 +193,8 @@ namespace LinkSdk {
 			}
 			// to be valid both getter and setter must be present if [DataMember]
 			if (data_member) {
-				Assert.NotNull (pi.GetGetMethod (true), "get_" + pi.Name);
-				Assert.NotNull (pi.GetSetMethod (true), "set_" + pi.Name);
+				Assert.That (pi.GetGetMethod (true), Is.Not.Null, "get_" + pi.Name);
+				Assert.That (pi.GetSetMethod (true), Is.Not.Null, "set_" + pi.Name);
 			} else {
 				// check well-known [DataMember]
 				switch (pi.Name) {
@@ -203,7 +203,7 @@ namespace LinkSdk {
 				case "Message":
 				case "StackTrace":
 				case "Type":
-					Assert.Fail ("{0} is missing it's [DataMember] attribute", pi.Name);
+					Assert.Fail ($"{pi.Name} is missing it's [DataMember] attribute");
 					break;
 				}
 			}
@@ -242,7 +242,7 @@ namespace LinkSdk {
 			// the simulator has complete file access but the device won't have - i.e. we can't depend on it
 			var hasFileAccess = TestRuntime.IsSimulatorOrDesktop;
 			Assert.That (File.Exists ("/etc/localtime"), Is.EqualTo (hasFileAccess), "/etc/localtime");
-			Assert.NotNull (TimeZoneInfo.Local, "Local");
+			Assert.That (TimeZoneInfo.Local, Is.Not.Null, "Local");
 			// should not throw a TimeZoneNotFoundException on devices
 		}
 
@@ -295,7 +295,7 @@ namespace LinkSdk {
 				NSError error;
 				var c = new NSPersistentStoreCoordinator (model);
 				c.AddPersistentStore (NSPersistentStoreCoordinator.SQLiteStoreType, null, url, null, out error);
-				Assert.IsNull (error, "error");
+				Assert.That (error, Is.Null, "error");
 			} finally {
 				File.Delete (sqlitePath);
 			}
@@ -459,7 +459,7 @@ namespace LinkSdk {
 		// could not be duplicated on iPad2 (rolf), iPad1 (spouliot), iPodTouch4 (spouliot)
 		public void Hardware_SO ()
 		{
-			Assert.NotNull (DeviceHardware.Version, "Hardware");
+			Assert.That (DeviceHardware.Version, Is.Not.Null, "Hardware");
 		}
 
 		public class Location { }
@@ -478,7 +478,7 @@ namespace LinkSdk {
 		public void Synchronized_3904 ()
 		{
 			// crash with LLVM
-			Assert.NotNull (getInstance (), "Location");
+			Assert.That (getInstance (), Is.Not.Null, "Location");
 		}
 
 		[Test]
@@ -492,7 +492,7 @@ namespace LinkSdk {
 		[Test]
 		public void NetworkInterface_4631 ()
 		{
-			Assert.NotNull (NetworkInterface.GetAllNetworkInterfaces ());
+			Assert.That (NetworkInterface.GetAllNetworkInterfaces (), Is.Not.Null);
 		}
 
 		[Test]
@@ -504,7 +504,7 @@ namespace LinkSdk {
 				try {
 					// note: needs to be executed under Instrument to verify it does not leak
 					string s = wc.DownloadString (url);
-					Assert.NotNull (s);
+					Assert.That (s, Is.Not.Null);
 					return; // one url succeeded, that's enough
 				} catch (Exception e) {
 					var msg = $"Url '{url}' failed: {e.ToString ()}";
@@ -520,7 +520,7 @@ namespace LinkSdk {
 		public void WebProxy_Leak ()
 		{
 			// note: needs to be executed under Instrument to verify it does not leak
-			Assert.NotNull (global::CoreFoundation.CFNetwork.GetSystemProxySettings (), "should not leak");
+			Assert.That (global::CoreFoundation.CFNetwork.GetSystemProxySettings (), Is.Not.Null, "should not leak");
 		}
 #endif // !__TVOS__ && !__MACOS__
 
@@ -552,7 +552,7 @@ namespace LinkSdk {
 		public void Pointer_5200 ()
 		{
 			// ensure the linker did not remove the type, which is used by the runtime
-			Assert.NotNull (GetTypeHelper ("System.Reflection.Pointer, " + typeof (int).Assembly.GetName ().Name));
+			Assert.That (GetTypeHelper ("System.Reflection.Pointer, " + typeof (int).Assembly.GetName ().Name), Is.Not.Null);
 		}
 
 		[Test]
@@ -599,13 +599,13 @@ namespace LinkSdk {
 			var typeName = o.FullName;
 			if (string.IsNullOrEmpty (assemblyName) || string.IsNullOrEmpty (typeName))
 				throw new InvalidOperationException ("Unable to create an ObjectHandle.");
-			Assert.NotNull (Activator.CreateInstance (assemblyName, typeName), "ObjectHandle");
+			Assert.That (Activator.CreateInstance (assemblyName, typeName), Is.Not.Null, "ObjectHandle");
 		}
 
 		[Test]
 		public void AttributeUsageAttribute_Persistance ()
 		{
-			Assert.IsFalse (Attribute.IsDefined (GetType (), typeof (SerializableAttribute)));
+			Assert.That (Attribute.IsDefined (GetType (), typeof (SerializableAttribute)), Is.False);
 		}
 
 		[Test]
@@ -644,7 +644,7 @@ namespace LinkSdk {
 		{
 			var arr = new AnEnum [16];
 			var c = new ReadOnlyCollection<AnEnum> (arr);
-			Assert.False (c.Contains (AnEnum.First));
+			Assert.That (c.Contains (AnEnum.First), Is.False);
 		}
 
 		enum MyEnum {
@@ -657,7 +657,7 @@ namespace LinkSdk {
 		{
 			IList<MyEnum> _myValues = new List<MyEnum> { MyEnum.AValue };
 			bool pleaseDontCrash = _myValues.Contains (MyEnum.AnotherValue);
-			Assert.False (pleaseDontCrash);
+			Assert.That (pleaseDontCrash, Is.False);
 		}
 
 		[Test]
@@ -689,9 +689,9 @@ namespace LinkSdk {
 			string file = Path.Combine (path, "temp.txt");
 			try {
 				File.WriteAllText (file, "mine");
-				Assert.False (readOnly, "!readOnly " + folder);
+				Assert.That (readOnly, Is.False, "!readOnly " + folder);
 			} catch {
-				Assert.True (readOnly, "readOnly " + folder);
+				Assert.That (readOnly, Is.True, "readOnly " + folder);
 			} finally {
 				File.Delete (file);
 			}
@@ -895,7 +895,7 @@ namespace LinkSdk {
 			path = TestFolder (Environment.SpecialFolder.Resources, supported: false);
 #else
 			path = TestFolder (Environment.SpecialFolder.Resources, readOnly: tvos && device);
-			Assert.True (path.EndsWith ("/Library", StringComparison.Ordinal), "Resources");
+			Assert.That (path.EndsWith ("/Library", StringComparison.Ordinal), Is.True, "Resources");
 #endif
 		}
 
@@ -904,29 +904,29 @@ namespace LinkSdk {
 		public void Events ()
 		{
 			using (var tv = new UITextView ()) {
-				Assert.Null (tv.WeakDelegate, "none");
+				Assert.That (tv.WeakDelegate, Is.Null, "none");
 				// event on UITextView itself
 				tv.Ended += (object? sender, EventArgs e) => { };
 
 				var weakDelegate = tv.WeakDelegate;
-				Assert.NotNull (weakDelegate, "textview delegate");
+				Assert.That (weakDelegate, Is.Not.Null, "textview delegate");
 				if (weakDelegate is null)
 					throw new InvalidOperationException ("The text view delegate was not created.");
 				var t = weakDelegate.GetType ();
 				Assert.That (t.Name, Is.EqualTo ("_UITextViewDelegate"), "textview");
 
 				var fi = t.GetField ("editingEnded", BindingFlags.NonPublic | BindingFlags.Instance);
-				Assert.NotNull (fi, "editingEnded");
+				Assert.That (fi, Is.Not.Null, "editingEnded");
 				if (fi is null)
 					throw new InvalidOperationException ("The editingEnded field was not found.");
 				var value = fi.GetValue (weakDelegate);
-				Assert.NotNull (value, "value");
+				Assert.That (value, Is.Not.Null, "value");
 
 				// and on the UIScrollView defined one
 				tv.Scrolled += (object? sender, EventArgs e) => { };
 				// and the existing (initial field) is still set
 				fi = t.GetField ("editingEnded", BindingFlags.NonPublic | BindingFlags.Instance);
-				Assert.NotNull (fi, "editingEnded/scrollview");
+				Assert.That (fi, Is.Not.Null, "editingEnded/scrollview");
 				if (fi is null)
 					throw new InvalidOperationException ("The editingEnded field was not found after scroll hookup.");
 			}
@@ -998,14 +998,14 @@ namespace LinkSdk {
 		[Test]
 		public void MonoRuntime34671 ()
 		{
-			Assert.Null (GetTypeHelper ("Mono.Runtime"), "Mono.Runtime");
+			Assert.That (GetTypeHelper ("Mono.Runtime"), Is.Null, "Mono.Runtime");
 		}
 
 		[Test]
 		public void TraceListeners36255 ()
 		{
 			Trace.Close (); // here too
-			Assert.NotNull (Trace.Listeners, "C6 had a SecurityPermission call");
+			Assert.That (Trace.Listeners, Is.Not.Null, "C6 had a SecurityPermission call");
 		}
 
 #if !__MACOS__
@@ -1022,10 +1022,10 @@ namespace LinkSdk {
 					throw new InvalidOperationException ("No assembly qualified name for UISearchController.");
 				var n = a.Replace ("UIKit.UISearchController", "UIKit.UISearchController+__Xamarin_UISearchResultsUpdating");
 				var t = Type.GetType (n);
-				Assert.NotNull (t, "private inner type");
+				Assert.That (t, Is.Not.Null, "private inner type");
 				if (t is null)
 					throw new InvalidOperationException ("The private inner type was not found.");
-				Assert.IsNotNull (t.GetMethod ("UpdateSearchResultsForSearchController"), "preserved");
+				Assert.That (t.GetMethod ("UpdateSearchResultsForSearchController"), Is.Not.Null, "preserved");
 			}
 		}
 #endif // !__MACOS__
@@ -1035,7 +1035,7 @@ namespace LinkSdk {
 		{
 			// make test work for classic (monotouch) and unified (iOS, tvOS)
 			var fqn = GetReplacedNSObjectAssemblyQualifiedName ("Security.Tls.OldTlsProvider");
-			Assert.Null (GetTypeHelper (fqn), "Should not be included");
+			Assert.That (GetTypeHelper (fqn), Is.Null, "Should not be included");
 		}
 
 		[Test]
@@ -1043,7 +1043,7 @@ namespace LinkSdk {
 		{
 			// make test work for classic (monotouch) and unified (iOS, tvOS)
 			var fqn = GetReplacedNSObjectAssemblyQualifiedName ("Security.Tls.AppleTlsProvider");
-			Assert.Null (GetTypeHelper (fqn), "Should be included");
+			Assert.That (GetTypeHelper (fqn), Is.Null, "Should be included");
 		}
 
 #if !__TVOS__ // WebKit isn't available in tvOS
@@ -1053,9 +1053,9 @@ namespace LinkSdk {
 		{
 			// a reference to WKWebView will bring the internal NSProxy type
 			var t = typeof (WKWebView);
-			Assert.NotNull (t, "avoid compiler optimization of unused variable");
+			Assert.That (t, Is.Not.Null, "avoid compiler optimization of unused variable");
 			var fqn = GetReplacedNSObjectAssemblyQualifiedName ("Foundation.NSProxy");
-			Assert.NotNull (GetTypeHelper (fqn), fqn);
+			Assert.That (GetTypeHelper (fqn), Is.Not.Null, fqn);
 		}
 #endif // !__TVOS__
 
@@ -1085,7 +1085,7 @@ namespace LinkSdk {
 			// linker will keep the MTAudioProcessingTap type
 			var mta = typeof (MediaToolbox.MTAudioProcessingTap);
 			// and we check that it still implement INativeObject
-			Assert.IsNotNull (mta.GetInterface ("ObjCRuntime.INativeObject"), "INativeObject");
+			Assert.That (mta.GetInterface ("ObjCRuntime.INativeObject"), Is.Not.Null, "INativeObject");
 		}
 
 		[Test]
@@ -1093,7 +1093,7 @@ namespace LinkSdk {
 		public void AsQueryable_Enumerable ()
 		{
 			var list = new List<string> { "hello hello" };
-			Assert.NotNull (list.AsQueryable ().GroupBy (x => x).FirstOrDefault ()?.FirstOrDefault (), "Enumerable");
+			Assert.That (list.AsQueryable ().GroupBy (x => x).FirstOrDefault ()?.FirstOrDefault (), Is.Not.Null, "Enumerable");
 		}
 
 		public class CustomIdentity : IIdentity {
@@ -1113,7 +1113,7 @@ namespace LinkSdk {
 		{
 			Thread.CurrentPrincipal = new CustomPrincipal ();
 			var identity = Thread.CurrentPrincipal?.Identity;
-			Assert.NotNull (identity, "Identity");
+			Assert.That (identity, Is.Not.Null, "Identity");
 			if (identity is null)
 				throw new InvalidOperationException ("No current principal identity.");
 			Assert.That (identity.Name, Is.EqualTo ("abc"), "Name");

--- a/tests/linker/link sdk/LinkSdkRegressionTest.cs
+++ b/tests/linker/link sdk/LinkSdkRegressionTest.cs
@@ -203,7 +203,7 @@ namespace LinkSdk {
 				case "Message":
 				case "StackTrace":
 				case "Type":
-					Assert.Fail ($"{pi.Name} is missing it's [DataMember] attribute");
+					Assert.Fail ($"{pi.Name} is missing its [DataMember] attribute");
 					break;
 				}
 			}

--- a/tests/linker/link sdk/LinkSdkTest.cs
+++ b/tests/linker/link sdk/LinkSdkTest.cs
@@ -6,8 +6,10 @@ namespace LinkSdkTests {
 		static void Check (string calendarName, bool present)
 		{
 			var type = Type.GetType ("System.Globalization." + calendarName);
-			bool success = present == (type is not null);
-			Assert.AreEqual (present, type is not null, calendarName);
+			if (present)
+				Assert.That (type, Is.Not.Null, calendarName);
+			else
+				Assert.That (type, Is.Null, calendarName);
 		}
 
 		[Test]

--- a/tests/linker/link sdk/LocaleTest.cs
+++ b/tests/linker/link sdk/LocaleTest.cs
@@ -33,13 +33,13 @@ namespace LinkSdk {
 			var n1 = "SEARCHFIELDS";
 			var n2 = "Searchfields";
 
-			Assert.True (string.Equals (n1, n2, StringComparison.OrdinalIgnoreCase), "string equality");
+			Assert.That (string.Equals (n1, n2, StringComparison.OrdinalIgnoreCase), Is.True, "string equality");
 
 			var dict = new Dictionary<string, string> (StringComparer.OrdinalIgnoreCase);
 			dict [n1] = "test";
 
 			string? result;
-			Assert.True (dict.TryGetValue (n2, out result), "dictionary value");
+			Assert.That (dict.TryGetValue (n2, out result), Is.True, "dictionary value");
 		}
 	}
 }

--- a/tests/linker/link sdk/OptimizeGeneratedCodeTest.cs
+++ b/tests/linker/link sdk/OptimizeGeneratedCodeTest.cs
@@ -66,7 +66,7 @@ namespace Linker.Shared {
 		public void IsNewRefcountEnabled ()
 		{
 			using (UIWebView wv = new UIWebView ()) {
-				Assert.Null (wv.Request, "IsNewRefcountEnabled");
+				Assert.That (wv.Request, Is.Null, "IsNewRefcountEnabled");
 			}
 		}
 
@@ -92,7 +92,7 @@ namespace Linker.Shared {
 			using (UIView v = new UIView ())
 			using (UIFont font = UIFont.SystemFontOfSize (12f)!) {
 				var size = "MonoTouch".StringSize (font);
-				Assert.False (size.IsEmpty, "!Empty");
+				Assert.That (size.IsEmpty, Is.False, "!Empty");
 			}
 		}
 #endif // !__TVOS__
@@ -107,7 +107,7 @@ namespace Linker.Shared {
 		{
 			var empty = CGSize.Empty;
 			using (UIView v = new UIView ()) {
-				Assert.True (v.SizeThatFits (empty).IsEmpty, "Empty");
+				Assert.That (v.SizeThatFits (empty).IsEmpty, Is.True, "Empty");
 			}
 		}
 #endif // !__MACOS__
@@ -152,7 +152,7 @@ namespace Linker.Shared {
 
 			// bug #26415
 			FinallyTestMethod ();
-			Assert.IsTrue (finally_invoked);
+			Assert.That (finally_invoked, Is.True);
 		}
 
 		bool finally_invoked;

--- a/tests/linker/link sdk/PclTest.cs
+++ b/tests/linker/link sdk/PclTest.cs
@@ -23,32 +23,32 @@ namespace LinkSdk {
 			const string url = "http://www.google.com";
 			Uri uri = new Uri (url);
 
-			Assert.False (this is ICommand, "ICommand");
+			Assert.That (this is ICommand, Is.False, "ICommand");
 
 			try {
 				HttpWebRequest hwr = WebRequest.CreateHttp (uri);
 				try {
-					Assert.True (hwr.SupportsCookieContainer, "SupportsCookieContainer");
+					Assert.That (hwr.SupportsCookieContainer, Is.True, "SupportsCookieContainer");
 				} catch (NotImplementedException) {
 					// feature is not available, but the symbol itself is needed
 				}
 
 				WebResponse wr = hwr.GetResponse ();
 				try {
-					Assert.True (wr.SupportsHeaders, "SupportsHeaders");
+					Assert.That (wr.SupportsHeaders, Is.True, "SupportsHeaders");
 				} catch (NotImplementedException) {
 					// feature is not available, but the symbol itself is needed
 				}
 				wr.Dispose ();
 
 				try {
-					Assert.NotNull (WebRequest.CreateHttp (url));
+					Assert.That (WebRequest.CreateHttp (url), Is.Not.Null);
 				} catch (NotImplementedException) {
 					// feature is not available, but the symbol itself is needed
 				}
 
 				try {
-					Assert.NotNull (WebRequest.CreateHttp (uri));
+					Assert.That (WebRequest.CreateHttp (uri), Is.Not.Null);
 				} catch (NotImplementedException) {
 					// feature is not available, but the symbol itself is needed
 				}

--- a/tests/linker/link sdk/ReflectionTest.cs
+++ b/tests/linker/link sdk/ReflectionTest.cs
@@ -13,7 +13,7 @@ namespace Linker.Shared.Reflection {
 		{
 			// linker will disable the metadata removal optimization if that property is used by user code
 			// however it's used inside mscorlib.dll (and SDK) so it cannot be checked while testing
-			//Assert.Null (typeof (ParameterInfo).GetProperty ("Name"), "Name");
+			//Assert.That (typeof (ParameterInfo).GetProperty ("Name"), Is.Null, "Name");
 
 			// Call the method we want to test, so that the linker doesn't remove it.
 			// The method needs to be in a different class, because this class has the Preserve attribute,

--- a/tests/linker/link sdk/TaskTest.cs
+++ b/tests/linker/link sdk/TaskTest.cs
@@ -21,12 +21,12 @@ namespace LinkSdk {
 			mre.Set ();
 			contSuccess.Wait (100);
 
-			Assert.True (contSuccess.IsCompleted, "contSuccess.IsCompleted");
-			Assert.True (contFailed.IsCompleted, "contFailed.IsCompleted");
-			Assert.True (contCanceled.IsCompleted, "contCanceled.IsCompleted");
-			Assert.False (contSuccess.IsCanceled, "contSuccess.IsCanceled");
-			Assert.True (contFailed.IsCanceled, "contFailed.IsCanceled");
-			Assert.True (contCanceled.IsCanceled, "contCanceled.IsCanceled");
+			Assert.That (contSuccess.IsCompleted, Is.True, "contSuccess.IsCompleted");
+			Assert.That (contFailed.IsCompleted, Is.True, "contFailed.IsCompleted");
+			Assert.That (contCanceled.IsCompleted, Is.True, "contCanceled.IsCompleted");
+			Assert.That (contSuccess.IsCanceled, Is.False, "contSuccess.IsCanceled");
+			Assert.That (contFailed.IsCanceled, Is.True, "contFailed.IsCanceled");
+			Assert.That (contCanceled.IsCanceled, Is.True, "contCanceled.IsCanceled");
 		}
 
 		[Test]
@@ -45,7 +45,7 @@ namespace LinkSdk {
 			mre.Set ();
 			cont.Wait (200);
 
-			Assert.True (ran, "ran");
+			Assert.That (ran, Is.True, "ran");
 			Assert.That (cont.Status, Is.EqualTo (TaskStatus.RanToCompletion), "Status");
 		}
 	}


### PR DESCRIPTION
Convert classic NUnit assertions (Assert.AreEqual, Assert.IsNotNull,
Assert.IsTrue, etc.) to NUnit v4 constraint-based Assert.That syntax
across all linker test files.