### PR TITLE
[devops] Fan the linker tests out per platform.

### DIFF
--- a/tools/devops/README.md
+++ b/tools/devops/README.md
@@ -301,7 +301,7 @@ testConfigurations:
   - label: framework      # Framework tests
   - label: generator      # Binding generator tests
   - label: introspection  # Runtime introspection tests
-  - label: linker         # Linker tests
+  - label: linker         # Linker tests (split by platform)
   - label: monotouch      # MonoTouch tests (split by platform)
   - label: msbuild        # MSBuild tests
   - label: sharpie        # Sharpie tests

--- a/tools/devops/automation/templates/common/configure.yml
+++ b/tools/devops/automation/templates/common/configure.yml
@@ -69,7 +69,8 @@ parameters:
     },
     {
       label: linker,
-      splitByPlatforms: false,
+      splitByPlatforms: true,
+      needsMultiplePlatforms: false,
       testPrefix: 'simulator_tests',
     },
     {


### PR DESCRIPTION
The linker tests are now our longest-running tests (a bit over an hour), so
fan them out to run on separate bots on a per-platform basis to speed them
up.