### PR TITLE
[tools] Keep track of removed/unavailable frameworks in our list of frameworks.

### DIFF
--- a/scripts/generate-frameworks-constants/generate-frameworks-constants.cs
+++ b/scripts/generate-frameworks-constants/generate-frameworks-constants.cs
@@ -32,7 +32,7 @@ namespace GenerateFrameworksConstants {
 
 		static int Fix (ApplePlatform platform, string output)
 		{
-			var frameworks = Frameworks.GetFrameworks (platform, false)!.Values.Where (v => !v.Unavailable);
+			var frameworks = Frameworks.GetFrameworks (platform, false)!.Values.Where (v => !v.IsFrameworkUnavailable ());
 			var sb = new StringBuilder ();
 
 			sb.AppendLine ("namespace ObjCRuntime {");

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -771,12 +771,12 @@ namespace Xamarin.Bundler {
 		}
 #endif // !LEGACY_TOOLS
 
-		public bool IsFrameworkAvailableInSimulator (string framework)
+		public bool IsFrameworkUnavailable (string @namespace)
 		{
-			if (!Driver.GetFrameworks (this).TryGetValue (framework, out var fw))
-				return true; // Unknown framework, assume it's valid for the simulator
+			if (!Driver.GetFrameworks (this).TryGetValue (@namespace, out var fw))
+				return false; // Unknown framework, assume it's valid
 
-			return fw.IsFrameworkAvailableInSimulator (this);
+			return fw.IsFrameworkUnavailable (this);
 		}
 
 #if !LEGACY_TOOLS

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -490,8 +490,8 @@ namespace Xamarin.Bundler {
 
 					string file = Path.GetFileNameWithoutExtension (name);
 
-					if (App.IsSimulatorBuild && !App.IsFrameworkAvailableInSimulator (file)) {
-						Driver.Log (3, "Not linking with {0} (referenced by a module reference in {1}) because it's not available in the simulator.", file, FileName);
+					if (App.IsFrameworkUnavailable (file)) {
+						Driver.Log (3, "Not linking with {0} (referenced by a module reference in {1}) because it's not available in the current SDK.", file, FileName);
 						continue;
 					}
 

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -437,7 +437,7 @@ namespace Xamarin.Bundler {
 		void AddFramework (string file)
 		{
 			if (Driver.GetFrameworks (App).TryGetValue (file, out var framework)) {
-				if (framework.Unavailable) {
+				if (framework.IsFrameworkUnavailable (App)) {
 					ErrorHelper.Warning (182, Errors.MX0182 /* Not linking with the framework {0} (referenced by a module reference in {1}) because it's not available on the current platform ({2}). */, framework.Name, FileName, App.PlatformName);
 					return;
 				}

--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -23,6 +23,7 @@ public class Framework {
 	public Version? VersionAvailableInSimulator { get; set; }
 	public bool AlwaysWeakLinked { get; set; }
 	public bool Unavailable { get; set; }
+	public Version? VersionUnavailable { get; set; }
 
 	public string LibraryPath {
 		get {
@@ -35,7 +36,7 @@ public class Framework {
 	}
 
 #if LEGACY_TOOLS || BUNDLER
-	public bool IsFrameworkAvailableInSimulator (Application app)
+	bool IsFrameworkAvailableInSimulator (Application app)
 	{
 		if (VersionAvailableInSimulator is null)
 			return false;
@@ -44,6 +45,20 @@ public class Framework {
 			return false;
 
 		return true;
+	}
+
+	public bool IsFrameworkUnavailable (Application app)
+	{
+		if (app.IsSimulatorBuild && !IsFrameworkAvailableInSimulator (app))
+			return true;
+
+		if (!Unavailable)
+			return false;
+
+		if (VersionUnavailable is null)
+			return true;
+		
+		return app.SdkVersion >= VersionUnavailable;
 	}
 #endif
 }
@@ -89,7 +104,7 @@ public class Frameworks : Dictionary<string, Framework> {
 		Add (@namespace, framework, new Version (major_version, minor_version, build_version));
 	}
 
-	public void Add (string @namespace, string framework, Version version, Version? version_available_in_simulator = null, bool alwaysWeakLink = false, string? subFramework = null)
+	public void Add (string @namespace, string framework, Version version, Version? version_available_in_simulator = null, bool alwaysWeakLink = false, string? subFramework = null, Version? version_unavailable = null)
 	{
 		var fr = new Framework () {
 			Namespace = @namespace,
@@ -98,6 +113,8 @@ public class Frameworks : Dictionary<string, Framework> {
 			VersionAvailableInSimulator = version_available_in_simulator ?? version,
 			AlwaysWeakLinked = alwaysWeakLink,
 			SubFramework = subFramework,
+			Unavailable = version_unavailable is not null,
+			VersionUnavailable = version_unavailable,
 		};
 		base.Add (fr.Namespace, fr);
 	}
@@ -338,6 +355,7 @@ public class Frameworks : Dictionary<string, Framework> {
 				{ "UIKit", "UIKit", 3 },
 
 				{ "Accelerate", "Accelerate", 4 },
+				{ "AssetsLibrary", "AssetsLibrary", new Version (4, 0), null, false, null, /* version_unavailable = */ new Version (17, 4) },
 				{ "EventKit", "EventKit", 4 },
 				{ "EventKitUI", "EventKitUI", 4 },
 				{ "CoreMotion", "CoreMotion", 4 },
@@ -351,6 +369,7 @@ public class Frameworks : Dictionary<string, Framework> {
 
 				{ "Accounts", "Accounts", 5 },
 				{ "GLKit", "GLKit", 5 },
+				{ "NewsstandKit", "NewsstandKit", new Version (5, 0), null, false, null, /* version_unavailable = */ new Version (17, 0) },
 				{ "CoreImage", "CoreImage", 5 },
 				{ "CoreBluetooth", "CoreBluetooth", 5 },
 				{ "Twitter", "Twitter", 5 },
@@ -652,7 +671,6 @@ public class Frameworks : Dictionary<string, Framework> {
 				// These frameworks are not available on Mac Catalyst
 				case "DeviceDiscoveryUI": // xtro and introspection says it's not in Mac Catalyst, Apple's website says it is. For now, listen to xtro and introspection, until proven otherwise.
 				case "OpenGLES":
-				case "NewsstandKit":
 				case "NotificationCenter":
 				case "GLKit":
 				case "VideoSubscriberAccount":
@@ -664,7 +682,6 @@ public class Frameworks : Dictionary<string, Framework> {
 				// headers-based xtro reporting those are *all* unknown API for Catalyst
 				case "AddressBookUI":
 				case "ARKit":
-				case "AssetsLibrary":
 				case "BrowserEngineCore":
 				case "CarPlay":
 				case "WatchConnectivity":
@@ -706,10 +723,13 @@ public class Frameworks : Dictionary<string, Framework> {
 		}
 	}
 
-#if BUNDLER
-	public static bool TryGetFramework (Application app, TypeDefinition td, [NotNullWhen (true)] out string? framework)
+#if BUNDLER || LEGACY_TOOLS
+	public static bool TryGetFramework (Application app, TypeDefinition? td, [NotNullWhen (true)] out string? framework)
 	{
 		framework = null;
+
+		if (td is null)
+			return false;
 
 		if (td.HasCustomAttributes) {
 			foreach (var attrib in td.CustomAttributes) {
@@ -725,16 +745,21 @@ public class Frameworks : Dictionary<string, Framework> {
 			}
 		}
 
+#if !LEGACY_TOOLS
 		if (!app.Profile.IsProductAssembly (td.Module.Assembly))
 			return false;
+#endif
 
 		framework = td.Namespace;
 		return framework is not null;
 	}
 
-	public static bool TryGetFramework (Application app, TypeDefinition td, [NotNullWhen (true)] out Framework? framework)
+	public static bool TryGetFramework (Application app, TypeDefinition? td, [NotNullWhen (true)] out Framework? framework)
 	{
 		framework = null;
+
+		if (td is null)
+			return false;
 
 		if (!TryGetFramework (app, td, out string? frameworkName))
 			return false;
@@ -752,12 +777,16 @@ public class Frameworks : Dictionary<string, Framework> {
 		// Process our product assembly + any assembly with the [ObjectiveCFramework] attribute, and collect all the namespaces that are used in those assemblies.
 		// For non-product assemblies, we only look at types with the [ObjectiveCFramework] attribute.
 		foreach (var assembly in assemblies) {
+#if LEGACY_TOOLS
+			var hasObjectiveCFrameworkAttribute = true;
+#else
 			var hasObjectiveCFrameworkAttribute = false;
 			if (!app.Profile.IsProductAssembly (assembly)) {
 				hasObjectiveCFrameworkAttribute = assembly.MainModule.HasTypeReference ("ObjCRuntime.ObjectiveCFrameworkAttribute");
 				if (!hasObjectiveCFrameworkAttribute)
 					continue;
 			}
+#endif
 
 			// Collect all the namespaces.
 			foreach (var md in assembly.Modules) {
@@ -789,7 +818,7 @@ public class Frameworks : Dictionary<string, Framework> {
 				continue;
 			}
 
-			if (app.IsSimulatorBuild && !framework.IsFrameworkAvailableInSimulator (app))
+			if (framework.IsFrameworkUnavailable (app))
 				continue;
 
 			var weak_link = framework.AlwaysWeakLinked || app.DeploymentTarget < framework.Version;
@@ -804,34 +833,20 @@ public class Frameworks : Dictionary<string, Framework> {
 
 	static bool FilterFrameworks (Application app, Framework framework)
 	{
-		var xcodeVersion = Driver.XcodeVersion;
-		if (xcodeVersion is not null && framework.Name == "NewsstandKit" && xcodeVersion.Major >= 15) {
-			Driver.Log (3, "Not linking with the framework {0} because it's not available when using Xcode 15+.", framework.Name);
+		if (framework.IsFrameworkUnavailable (app)) {
+			Driver.Log (3, "Not linking with the framework {0} because it's not available in the current SDK.", framework.Name);
 			return false;
 		}
 
 		switch (app.Platform) {
 		case ApplePlatform.iOS:
-			switch (framework.Name) {
-			case "GameKit":
-				break;
-			case "NewsstandKit":
-				if (xcodeVersion is not null && xcodeVersion.Major >= 15) {
-					Driver.Log (3, "Not linking with the framework {0} because it's been removed from Xcode 15+.", framework.Name);
-					return false;
-				}
-				break;
-			}
-			break;
 		case ApplePlatform.TVOS:
 		case ApplePlatform.MacCatalyst:
-			break; // Include all frameworks by default
 		case ApplePlatform.MacOSX:
-			return true;
+			return true; // Include all frameworks by default
 		default:
 			throw ErrorHelper.CreateError (71, Errors.MX0071 /* "Unknown platform: {0}. This usually indicates a bug in {1}; please file a bug report at https://github.com/dotnet/macios/issues/new with a test case." */, app.Platform, app.ProductName);
 		}
-		return true;
 	}
 
 	public static void Gather (Application app, IEnumerable<AssemblyDefinition> assemblies, HashSet<string> frameworks, HashSet<string> weak_frameworks)

--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -46,7 +46,9 @@ public class Framework {
 
 		return true;
 	}
+#endif
 
+#if LEGACY_TOOLS || BUNDLER
 	public bool IsFrameworkUnavailable (Application app)
 	{
 		if (app.IsSimulatorBuild && !IsFrameworkAvailableInSimulator (app))
@@ -59,6 +61,11 @@ public class Framework {
 			return true;
 
 		return app.SdkVersion >= VersionUnavailable;
+	}
+#else
+	public bool IsFrameworkUnavailable ()
+	{
+		return Unavailable;
 	}
 #endif
 }

--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -22,8 +22,8 @@ public class Framework {
 	public required Version Version { get; set; }
 	public Version? VersionAvailableInSimulator { get; set; }
 	public bool AlwaysWeakLinked { get; set; }
-	public bool Unavailable { get; set; }
-	public Version? VersionUnavailable { get; set; }
+	public bool Unavailable { private get; set; } // Call IsFrameworkUnavailable () to determine if a framework is available or not
+	public Version? VersionUnavailable { get; set; } // if null, always unavailable (if Unavailable=true)
 
 	public string LibraryPath {
 		get {

--- a/tools/common/Frameworks.cs
+++ b/tools/common/Frameworks.cs
@@ -57,7 +57,7 @@ public class Framework {
 
 		if (VersionUnavailable is null)
 			return true;
-		
+
 		return app.SdkVersion >= VersionUnavailable;
 	}
 #endif

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -2101,10 +2101,7 @@ namespace Registrar {
 
 			namespaces.Add (ns);
 
-			if (App.IsSimulatorBuild && !App.IsFrameworkAvailableInSimulator (ns)) {
-				Driver.Log (5, "Not importing the framework {0} in the generated registrar code because it's not available in the simulator.", ns);
-				return;
-			} else if (Frameworks.GetFrameworks (App.Platform, false)?.TryGetValue (ns, out var fw) == true && fw.Unavailable) {
+			if (Frameworks.GetFrameworks (App.Platform, false)?.TryGetValue (ns, out var fw) == true && fw.IsFrameworkUnavailable (App)) {
 				Driver.Log (5, "Not importing the framework {0} in the generated registrar code because it's not available in the current platform.", ns);
 				return;
 			}
@@ -2631,12 +2628,6 @@ namespace Registrar {
 		static bool IsIntentsType (ObjCType type) => IsTypeCore (type, "Intents");
 		static bool IsExternalAccessoryType (ObjCType type) => IsTypeCore (type, "ExternalAccessory");
 
-		bool IsTypeAllowedInSimulator (ObjCType type)
-		{
-			var ns = type.Type.Namespace;
-			return App.IsFrameworkAvailableInSimulator (ns);
-		}
-
 		class ProtocolInfo {
 			public uint TokenReference;
 			public ObjCType Protocol;
@@ -2688,24 +2679,13 @@ namespace Registrar {
 				return all_types;
 			var allTypes = new List<ObjCType> ();
 			foreach (var @class in Types.Values) {
+				if (@class.Type is null)
+					continue;
+
 				if (!string.IsNullOrEmpty (single_assembly) && single_assembly != @class.Type.Module.Assembly.Name.Name)
 					continue;
 
-				if (App.Platform != ApplePlatform.MacOSX) {
-					var isPlatformType = IsPlatformType (@class.Type);
-					if (isPlatformType && IsSimulatorOrDesktop && !IsTypeAllowedInSimulator (@class)) {
-						Driver.Log (5, "The static registrar won't generate code for {0} because its framework is not supported in the simulator.", @class.ExportedName);
-						continue; // Some types are not supported in the simulator.
-					}
-				}
-
-				// Xcode 15 removed NewsstandKit
 				if (Driver.XcodeVersion.Major >= 15) {
-					if (IsTypeCore (@class, "NewsstandKit")) {
-						exceptions.Add (ErrorHelper.CreateWarning (4178, $"The class '{@class.Type.FullName}' will not be registered because the NewsstandKit framework has been removed from the {App.Platform} SDK."));
-						continue;
-					}
-
 					if (@class.Type.Is ("PassKit", "PKDisbursementAuthorizationControllerDelegate") || @class.Type.Is ("PassKit", "IPKDisbursementAuthorizationControllerDelegate")) {
 						exceptions.Add (ErrorHelper.CreateWarning (4189, $"The class '{@class.Type.FullName}' will not be registered it has been removed from the {App.Platform} SDK."));
 						continue;
@@ -2715,21 +2695,11 @@ namespace Registrar {
 						exceptions.Add (ErrorHelper.CreateWarning (4189, $"The class '{@class.Type.FullName}' will not be registered it has been removed from the {App.Platform} SDK."));
 						continue;
 					}
-
-					if (Driver.XcodeVersion.Minor >= 3 || Driver.XcodeVersion.Major >= 16) {
-						// Xcode 15.3+ will remove AssetsLibrary
-						if (IsTypeCore (@class, "AssetsLibrary")) {
-							exceptions.Add (ErrorHelper.CreateWarning (4178, $"The class '{@class.Type.FullName}' will not be registered because the AssetsLibrary framework has been removed from the {App.Platform} SDK."));
-							continue;
-						}
-					}
 				}
 
-				if (Driver.XcodeVersion.Major >= 16) {
-					if (@class.Type.Namespace == "AssetsLibrary") {
-						exceptions.Add (ErrorHelper.CreateWarning (4190, $"The class '{@class.Type.FullName}' will not be registered because the {@class.Type.Namespace} framework has been deprecated from the {App.Platform} SDK."));
-						continue;
-					}
+				if (Frameworks.TryGetFramework (App, @class.Type.Resolve (), out Framework? framework) && framework.IsFrameworkUnavailable (App)) {
+					exceptions.Add (ErrorHelper.CreateWarning (4178, $"The class '{@class.Type.FullName}' will not be registered because the {framework.Name} framework has been removed from the {App.Platform} SDK."));
+					continue;
 				}
 
 				if (@class.IsFakeProtocol)

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -2101,7 +2101,7 @@ namespace Registrar {
 
 			namespaces.Add (ns);
 
-			if (Frameworks.GetFrameworks (App.Platform, false)?.TryGetValue (ns, out var fw) == true && fw.IsFrameworkUnavailable (App)) {
+			if (Driver.GetFrameworks (App).TryGetValue (ns, out var fw) && fw.IsFrameworkUnavailable (App)) {
 				Driver.Log (5, "Not importing the framework {0} in the generated registrar code because it's not available in the current platform.", ns);
 				return;
 			}

--- a/tools/dotnet-linker/Steps/InlineDlfcnMethodsStep.cs
+++ b/tools/dotnet-linker/Steps/InlineDlfcnMethodsStep.cs
@@ -39,8 +39,8 @@ public class InlineDlfcnMethodsStep : AssemblyModifierStep {
 	{
 		var modified = false;
 		if (type.HasMethods) {
-			if (Frameworks.TryGetFramework (App, type, out Framework? framework) && App.IsSimulatorBuild && !framework.IsFrameworkAvailableInSimulator (App)) {
-				Driver.Log (3, $"Type {type.FullName} appears to be part of the '{framework.Name}' framework, which is not available in the simulator. Skipping inlining Dlfcn calls for this type.");
+			if (Frameworks.TryGetFramework (App, type, out Framework? framework) && !framework.IsFrameworkUnavailable (App)) {
+				Driver.Log (3, $"Type {type.FullName} appears to be part of the '{framework.Name}' framework, which is not available in the current SDK. Skipping inlining Dlfcn calls for this type.");
 				return modified;
 			}
 

--- a/tools/dotnet-linker/Steps/InlineDlfcnMethodsStep.cs
+++ b/tools/dotnet-linker/Steps/InlineDlfcnMethodsStep.cs
@@ -39,7 +39,7 @@ public class InlineDlfcnMethodsStep : AssemblyModifierStep {
 	{
 		var modified = false;
 		if (type.HasMethods) {
-			if (Frameworks.TryGetFramework (App, type, out Framework? framework) && !framework.IsFrameworkUnavailable (App)) {
+			if (Frameworks.TryGetFramework (App, type, out Framework? framework) && framework.IsFrameworkUnavailable (App)) {
 				Driver.Log (3, $"Type {type.FullName} appears to be part of the '{framework.Name}' framework, which is not available in the current SDK. Skipping inlining Dlfcn calls for this type.");
 				return modified;
 			}


### PR DESCRIPTION
This simplifies some code, and also makes it easier to determine what to do with
some bindings we still have for some of these frameworks.