### PR TITLE
[net11.0] [builds] Fix .NET SDK installation on Windows for .NET 11+

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -27,7 +27,7 @@ downloads/$(DOTNET_INSTALL_NAME): $(DOTNET_INSTALL_SCRIPT)
 	$(Q) echo "Downloading and installing .NET $(DOTNET_VERSION) ($(DOTNET_ARCH)) into $@..."
 ifeq ($(OS),Windows_NT)
 	rm -Rf "$@"
-	pwsh -ExecutionPolicy ByPass -NoProfile -Command '& ./$(DOTNET_INSTALL_SCRIPT) -Version "$(DOTNET_VERSION)" -InstallDir "$@.tmp" -Verbose'
+	pwsh -ExecutionPolicy ByPass -NoProfile -Command '& ./$(DOTNET_INSTALL_SCRIPT) -Version "$(DOTNET_VERSION)" -InstallDir "$@.tmp" -ZipPath "downloads/$(DOTNET_FILENAME)" -Verbose'
 	mv "$@.tmp" "$@"
 else
 	$(Q) if test -f $(DOTNET_CACHE_FILENAME); then \


### PR DESCRIPTION
The dotnet-install.ps1 script now prefers .tar.gz over .zip on Windows
for .NET 11.0+. It downloads the tarball to a temp path in
C:\Users\...\Temp\ and passes that path to MSYS /usr/bin/tar. GNU tar
interprets 'C:' in the path as a remote host specification, causing:

    tar (child): Cannot connect to C: resolve failed

Fix this by passing -ZipPath with a relative path (no drive letter) so
that tar receives a colon-free path it can handle correctly.