### PR TITLE
[NSUrlSessionHandler] Reject unsupported auth methods to allow fallback to Basic. Fixes #25485.

### DIFF
--- a/src/Foundation/NSUrlSessionHandler.cs
+++ b/src/Foundation/NSUrlSessionHandler.cs
@@ -1175,15 +1175,19 @@ namespace Foundation {
 					authenticationType = "basic";
 				} else if (protectionSpace.AuthenticationMethod == NSUrlProtectionSpace.AuthenticationMethodHTTPDigest) {
 					authenticationType = "digest";
-				} else if (protectionSpace.AuthenticationMethod == NSUrlProtectionSpace.AuthenticationMethodNegotiate ||
-					protectionSpace.AuthenticationMethod == NSUrlProtectionSpace.AuthenticationMethodHTMLForm) {
-					// Want to reject this authentication type to allow the next authentication method in the request to
-					// be used.
-					authenticationType = RejectProtectionSpaceAuthType;
-				} else {
-					// ServerTrust, ClientCertificate or Default.
+				} else if (protectionSpace.AuthenticationMethod == NSUrlProtectionSpace.AuthenticationMethodServerTrust ||
+					protectionSpace.AuthenticationMethod == NSUrlProtectionSpace.AuthenticationMethodClientCertificate) {
+					// ServerTrust and ClientCertificate are handled earlier in DidReceiveChallengeImpl,
+					// so we should not reach here for these types. Return false just in case.
 					authenticationType = null;
 					return false;
+				} else {
+					// For any other authentication method (Negotiate, HTMLForm, Bearer, etc.),
+					// reject this protection space to allow the next authentication method in the
+					// request to be tried. This is important when the server advertises multiple
+					// WWW-Authenticate challenges (e.g. Bearer before Basic) - rejecting unsupported
+					// methods allows fallback to one we can handle.
+					authenticationType = RejectProtectionSpaceAuthType;
 				}
 				return true;
 			}

--- a/tests/monotouch-test/System.Net.Http/NSUrlSessionHandlerTest.cs
+++ b/tests/monotouch-test/System.Net.Http/NSUrlSessionHandlerTest.cs
@@ -3,7 +3,11 @@
 //
 
 using System;
+using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Foundation;
 using NUnit.Framework;
@@ -215,6 +219,108 @@ namespace MonoTests.System.Net.Http {
 				return;
 
 			Assert.Ignore ("The background service is in use by another process.");
+		}
+
+		// https://github.com/dotnet/macios/issues/25485
+		[Test]
+		public void BasicAuthWorksWhenBearerIsAdvertisedFirst ()
+		{
+			if (!HttpListener.IsSupported) {
+				Assert.Inconclusive ("HttpListener is not supported");
+			}
+
+			const string username = "admin";
+			const string password = "secret";
+			var expectedBasicValue = Convert.ToBase64String (Encoding.UTF8.GetBytes ($"{username}:{password}"));
+
+			var serverReady = new SemaphoreSlim (0, 1);
+
+			var httpListener = StartListenerOnAvailablePort (out var listeningPort);
+			if (httpListener is null) {
+				Assert.Inconclusive ("Could not find an available port for the test server.");
+				return;
+			}
+
+			var serverTask = Task.Run (async () => {
+				serverReady.Release ();
+				try {
+					while (httpListener.IsListening) {
+						var context = await httpListener.GetContextAsync ().ConfigureAwait (false);
+						var request = context.Request;
+						var response = context.Response;
+
+						var authHeader = request.Headers ["Authorization"];
+						if (authHeader is not null && authHeader == $"Basic {expectedBasicValue}") {
+							// Authenticated - return success
+							response.StatusCode = 200;
+							var body = Encoding.UTF8.GetBytes ("authenticated");
+							response.ContentLength64 = body.Length;
+							response.OutputStream.Write (body, 0, body.Length);
+						} else {
+							// Return 401 with Bearer first, then Basic
+							response.StatusCode = 401;
+							response.AddHeader ("WWW-Authenticate", "Bearer realm=\"test\", charset=\"UTF-8\"");
+							response.AppendHeader ("WWW-Authenticate", "Basic realm=\"test\", charset=\"UTF-8\"");
+						}
+						response.Close ();
+					}
+				} catch (ObjectDisposedException) {
+					// listener was stopped
+				} catch (HttpListenerException) {
+					// listener was stopped
+				}
+			});
+
+			HttpStatusCode? statusCode = null;
+			string responseBody = null;
+
+			try {
+				var done = TestRuntime.TryRunAsync (TimeSpan.FromSeconds (30), async () => {
+					await serverReady.WaitAsync ().ConfigureAwait (false);
+
+					using var handler = new NSUrlSessionHandler ();
+					handler.Credentials = new NetworkCredential (username, password);
+					using var client = new HttpClient (handler);
+					using var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{listeningPort}/test");
+					var response = await client.SendAsync (request).ConfigureAwait (false);
+					statusCode = response.StatusCode;
+					responseBody = await response.Content.ReadAsStringAsync ().ConfigureAwait (false);
+				}, out var ex);
+
+				Assert.That (done, Is.True, "Request timed out");
+				Assert.That (ex, Is.Null, $"Exception: {ex}");
+				Assert.That (statusCode, Is.EqualTo (HttpStatusCode.OK), "Expected 200 OK after Basic auth negotiation");
+				Assert.That (responseBody, Is.EqualTo ("authenticated"), "Response body");
+
+				if (serverTask.IsFaulted)
+					Assert.Fail ($"Server task failed: {serverTask.Exception}");
+			} finally {
+				httpListener.Stop ();
+				httpListener.Close ();
+			}
+		}
+
+		static HttpListener? StartListenerOnAvailablePort (out int listeningPort)
+		{
+			// IANA suggested range for dynamic or private ports
+			const int MinPort = 49215;
+			const int MaxPort = 65535;
+
+			for (var port = MinPort; port < MaxPort; port++) {
+				var listener = new HttpListener ();
+				listener.Prefixes.Add ($"http://*:{port}/");
+				try {
+					listener.Start ();
+					listeningPort = port;
+					return listener;
+				} catch {
+					// port in use, try next
+					listener.Close ();
+				}
+			}
+
+			listeningPort = -1;
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
When a server advertises multiple WWW-Authenticate challenges (e.g. Bearer
before Basic), the handler would call PerformDefaultHandling for unrecognized
methods like Bearer. This prevented the system from trying subsequent methods.

Fix by rejecting unrecognized HTTP auth protection spaces, which allows the
URL loading system to try the next advertised authentication method.

Fixes https://github.com/dotnet/macios/issues/25485.