### PR TITLE
Fix 'dotnet checkout' typos in docs/guides/HowToBranch.md

### DIFF
--- a/docs/guides/HowToBranch.md
+++ b/docs/guides/HowToBranch.md
@@ -20,8 +20,8 @@ sequence of events would be:
 3. `dotnet/macios` branches `release/10.0.1xx-preview42` from `net10.0`:
 
 	```shell
-	$ dotnet checkout net10.0
-	$ dotnet checkout -b release/10.0.1xx-preview42
+	$ git checkout net10.0
+	$ git checkout -b release/10.0.1xx-preview42
 	```
 
 	Note that release candidates will use values such as `rc.1`, `rc.2`, etc.


### PR DESCRIPTION
## Summary

Lines 23-24 of `docs/guides/HowToBranch.md` incorrectly use `dotnet checkout` instead of `git checkout`. The `dotnet` CLI has no `checkout` subcommand, so anyone following the guide literally would get an error. Later commands in the same document correctly use `git`, confirming this was a typo.

## Changes

- Line 23: `$ dotnet checkout net10.0` → `$ git checkout net10.0`
- Line 24: `$ dotnet checkout -b release/10.0.1xx-preview42` → `$ git checkout -b release/10.0.1xx-preview42`

Markdown-only change — no build or test impact.