### PR TITLE
[Foundation] Simplify memory management of NSObjectData for CoreCLR.

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -213,10 +213,6 @@ monoobject_dict_free_value (CFAllocatorRef allocator, const void *value)
  * Ref: https://github.com/dotnet/designs/blob/1bb5844c165195e2f633cb1dbe042c4b92aefc4d/accepted/2021/objectivec-interop.md
  */
 
-struct TrackedObjectInfo {
-	struct NSObjectData* data;
-};
-
 void
 xamarin_bridge_setup ()
 {
@@ -296,10 +292,10 @@ xamarin_coreclr_reference_tracking_is_referenced_callback (void* ptr)
 	// But we can access the native memory given to us when the object was toggled
 	// (and which is passed as the 'ptr' argument), so let's get the data we need from there.
 	int rv = 0;
-	struct TrackedObjectInfo *info = (struct TrackedObjectInfo *) ptr;
-	enum NSObjectFlags flags = (enum NSObjectFlags) info->data->flags;
+	struct NSObjectData *data = (struct NSObjectData *) ptr;
+	enum NSObjectFlags flags = (enum NSObjectFlags) data->flags;
 	bool isRegisteredToggleRef = (flags & NSObjectFlagsRegisteredToggleRef) == NSObjectFlagsRegisteredToggleRef;
-	id handle = info->data->handle;
+	id handle = data->handle;
 	MonoToggleRefStatus res = (MonoToggleRefStatus) 0;
 
 	if (isRegisteredToggleRef) {
@@ -337,9 +333,9 @@ xamarin_coreclr_reference_tracking_is_referenced_callback (void* ptr)
 void
 xamarin_coreclr_reference_tracking_tracked_object_entered_finalization (void* ptr)
 {
-	struct TrackedObjectInfo *info = (struct TrackedObjectInfo *) ptr;
-	info->data->flags = (enum NSObjectFlags) (info->data->flags | NSObjectFlagsInFinalizerQueue);
-	LOG_CORECLR (stderr, "%s (%p) flags: %i\n", __func__, ptr, (int) info->flags);
+	struct NSObjectData *data = (struct NSObjectData *) ptr;
+	data->flags = (enum NSObjectFlags) (data->flags | NSObjectFlagsInFinalizerQueue);
+	LOG_CORECLR (stderr, "%s (%p) flags: %i\n", __func__, ptr, (int) data->flags);
 }
 
 void

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -120,7 +120,7 @@ namespace Foundation {
 #if !COREBUILD
 	// Allocated in native memory, so that it can be accessed from native code without having to deal with the GC.
 	// This is mirrored in runtime.h and the definition needs to be in sync.
-	struct NSObjectData {
+	internal struct NSObjectData {
 		public NativeHandle handle;
 		public NSObject.Flags flags;
 	}
@@ -228,18 +228,24 @@ namespace Foundation {
 			if (data != IntPtr.Zero)
 				return (NSObjectData*) data;
 
-			var data_handle = new NSObjectDataHandle ();
-			var existing_data = Interlocked.CompareExchange (ref __data, (IntPtr) data_handle.Data, IntPtr.Zero);
-			if (existing_data != IntPtr.Zero) {
-				// return the existing data, the GC will collect the other one we just created
-				return (NSObjectData*) existing_data;
+			if (Runtime.IsCoreCLR) {
+				data = (IntPtr) Runtime.GetTaggedMemory (this);
+				__data = data; // Runtime.GetTaggedMemory will always return the same pointer for the same object, so no synchronization is needed here (redundant writes are benign).
+				return (NSObjectData*) data;
+			} else {
+				var data_handle = new NSObjectDataHandle ();
+				var existing_data = Interlocked.CompareExchange (ref __data, (IntPtr) data_handle.Data, IntPtr.Zero);
+				if (existing_data != IntPtr.Zero) {
+					// return the existing data, the GC will collect the other one we just created
+					return (NSObjectData*) existing_data;
+				}
+				// tell the data handle we just created to track us
+				data_handle.CreateHandle (this);
+				// make sure the data isn't freed before this NSObject is collected, but also
+				// that it is freed after this NSObject is collected.
+				data_table.Add (this, data_handle);
+				return data_handle.Data;
 			}
-			// tell the data handle we just created to track us
-			data_handle.CreateHandle (this);
-			// make sure the data isn't freed before this NSObject is collected, but also
-			// that it is freed after this NSObject is collected.
-			data_table.Add (this, data_handle);
-			return data_handle.Data;
 		}
 
 		unsafe Flags flags {
@@ -417,7 +423,8 @@ namespace Foundation {
 
 		internal static NativeHandle Initialize ()
 		{
-			data_table = new ConditionalWeakTable<NSObject, NSObjectDataHandle> ();
+			if (!Runtime.IsCoreCLR)
+				data_table = new ConditionalWeakTable<NSObject, NSObjectDataHandle> ();
 			super_map = new ConditionalWeakTable<NSObject, TrackedMemory> ();
 			return class_ptr;
 		}

--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -205,26 +205,33 @@ namespace ObjCRuntime {
 				ExceptionHandling.RaiseAppDomainUnhandledExceptionEvent (exception);
 		}
 
-		// Size: 2 pointers
-		internal struct TrackedObjectInfo {
-			public unsafe NSObjectData* Data;
-		}
-
 		[SupportedOSPlatform ("macos")]
 		internal static GCHandle CreateTrackingGCHandle (NSObject obj, IntPtr handle)
 		{
 			var gchandle = ObjectiveCMarshal.CreateReferenceTrackingHandle (obj, out var info);
 
 			unsafe {
-				TrackedObjectInfo* tracked_info;
 				fixed (void* ptr = info)
-					tracked_info = (TrackedObjectInfo*) ptr;
-				tracked_info->Data = obj.GetData ();
-
-				log_coreclr ($"GetOrCreateTrackingGCHandle ({obj.GetType ().FullName}, 0x{handle.ToString ("x")}) => Info=0x{((IntPtr) tracked_info).ToString ("x")} Data=0x{(IntPtr) tracked_info->Data:x} Created new");
+					log_coreclr ($"GetOrCreateTrackingGCHandle ({obj.GetType ().FullName}, 0x{handle.ToString ("x")}) => 0x{((IntPtr) ptr).ToString ("x")} Created new");
 			}
 
 			return gchandle;
+		}
+
+		internal unsafe static void* GetTaggedMemory (NSObject obj)
+		{
+			// If https://github.com/dotnet/runtime/issues/128476 is accepted and implemented,
+			// can just call that new API instead of calling ObjectiveCMarshal.CreateReferenceTrackingHandle and
+			// freeing the returned handle.
+
+			var gchandle = ObjectiveCMarshal.CreateReferenceTrackingHandle (obj, out var info);
+			// We only care about the tagged memory ('info'), so just free the GCHandle.
+			// We might want to request an API to just get the tagged memory at some point.
+			gchandle.Free ();
+			// The tagged memory pointer is guaranteed to be the same for every call to ObjectiveCMarshal.CreateReferenceTrackingHandle,
+			// and it will automatically be freed once the 'obj' is freed by the GC (in particular _once the instance is freed_,
+			// not _once the instance is collectible_, which is a very important distinction for us).
+			return Unsafe.AsPointer (ref info.GetPinnableReference ());
 		}
 
 		// See  "Toggle-ref support for CoreCLR" in coreclr-bridge.m for more information.


### PR DESCRIPTION
On CoreCLR, the tagged memory returned by ObjectiveCMarshal.CreateReferenceTrackingHandle
is guaranteed to be stable (same pointer per object) and its lifetime is tied to the GC
freeing the instance. This means we can use it directly as our NSObjectData storage,
removing the need for:

- The TrackedObjectInfo indirection struct (both in C# and native code).
- The ConditionalWeakTable<NSObject, NSObjectDataHandle> used to prevent premature
  collection of separately-allocated native memory.
- The Interlocked.CompareExchange synchronization (since the pointer is always the same).