### PR TITLE
Fix missing 'don't' in docs/os-onboarding.md that reverses sentence meaning

### DIFF
--- a/docs/os-onboarding.md
+++ b/docs/os-onboarding.md
@@ -20,7 +20,7 @@ This involves:
 
 ### Bind new APIs
 
-This is technically optional, because we can release support for a new OS version even if we bind any of the new APIs.
+This is technically optional, because we can release support for a new OS version even if we don't bind any of the new APIs.
 
 Yet we try to bind most of new APIs, because it's hard to predict what users will need.
 


### PR DESCRIPTION
## Summary

Line 23 of `docs/os-onboarding.md` was missing the word "don't", which reversed the intended meaning of the sentence.

**Before:** "even if we bind any of the new APIs"
**After:** "even if we **don't** bind any of the new APIs"

The sentence explains that releasing support for a new OS version is technically optional because bindings aren't strictly required — the missing negation made it say the opposite.

## Changes

- `docs/os-onboarding.md`: Inserted missing "don't" on line 23

Single-word typo fix, no functional code changes.