### PR TITLE
[dotnet] Don't enable InlineClassGetHandle if we're using the static registrar as a custom trimmer step.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -108,7 +108,7 @@
 	</PropertyGroup>
 
 	<!-- Set default value for InlineClassGetHandle based on .NET version -->
-	<PropertyGroup Condition="'$(InlineClassGetHandle)' == '' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '11.0'))">
+	<PropertyGroup Condition="'$(InlineClassGetHandle)' == '' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '11.0')) And !('$(Registrar)' == 'static' And '$(PrepareAssemblies)' != 'true')">
 		<InlineClassGetHandle Condition="'$(_UseNativeAot)' == 'true'">strict</InlineClassGetHandle>
 		<InlineClassGetHandle Condition="'$(InlineClassGetHandle)' == ''">compatibility</InlineClassGetHandle>
 	</PropertyGroup>


### PR DESCRIPTION
The InlineClassGetHandle step runs before marking, and the StaticRegistrar
step runs after sweeping, which causes a problem when the InlineClassGetHandle
step needs the registrar to run first.

This won't be a problem once we've moved out of custom trimmer steps.