### PR TITLE
[src] Remove NSPrintPreviewGraphicsContext.

### DIFF
--- a/src/AppKit/NSPrintPreviewGraphicsContext.cs
+++ b/src/AppKit/NSPrintPreviewGraphicsContext.cs
@@ -10,6 +10,7 @@ namespace AppKit {
 	[UnsupportedOSPlatform ("maccatalyst")]
 	[UnsupportedOSPlatform ("macos")]
 	[Obsolete ("This class does not form part of the public API in macOS, and will be removed in the future.")]
+	[EditorBrowsable (EditorBrowsableState.Never)]
 	public partial class NSPrintPreviewGraphicsContext : NSGraphicsContext {
 
 		public override NativeHandle ClassHandle { get { return default; } }

--- a/src/AppKit/NSPrintPreviewGraphicsContext.cs
+++ b/src/AppKit/NSPrintPreviewGraphicsContext.cs
@@ -13,6 +13,7 @@ namespace AppKit {
 	[EditorBrowsable (EditorBrowsableState.Never)]
 	public partial class NSPrintPreviewGraphicsContext : NSGraphicsContext {
 
+		[EditorBrowsable (EditorBrowsableState.Never)]
 		public override NativeHandle ClassHandle { get { return default; } }
 
 		[EditorBrowsable (EditorBrowsableState.Never)]

--- a/src/AppKit/NSPrintPreviewGraphicsContext.cs
+++ b/src/AppKit/NSPrintPreviewGraphicsContext.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel;
+
+#if __MACOS__ && !__XAMCORE_5_0__
+
+namespace AppKit {
+	[UnsupportedOSPlatform ("maccatalyst")]
+	[UnsupportedOSPlatform ("macos")]
+	[Obsolete ("This class does not form part of the public API in macOS, and will be removed in the future.")]
+	public partial class NSPrintPreviewGraphicsContext : NSGraphicsContext {
+
+		public override NativeHandle ClassHandle { get { return default; } }
+
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		protected NSPrintPreviewGraphicsContext (NSObjectFlag t) : base (t)
+		{
+		}
+
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		protected internal NSPrintPreviewGraphicsContext (NativeHandle handle) : base (handle)
+		{
+		}
+	} /* class NSPrintPreviewGraphicsContext */
+}
+
+#endif // __MACOS__ && !__XAMCORE_5_0__

--- a/src/AppKit/NSPrintPreviewGraphicsContext.cs
+++ b/src/AppKit/NSPrintPreviewGraphicsContext.cs
@@ -4,7 +4,7 @@
 using System;
 using System.ComponentModel;
 
-#if __MACOS__ && !__XAMCORE_5_0__
+#if __MACOS__ && !XAMCORE_5_0
 
 namespace AppKit {
 	[UnsupportedOSPlatform ("maccatalyst")]
@@ -27,4 +27,4 @@ namespace AppKit {
 	} /* class NSPrintPreviewGraphicsContext */
 }
 
-#endif // __MACOS__ && !__XAMCORE_5_0__
+#endif // __MACOS__ && !XAMCORE_5_0

--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -32,6 +32,7 @@
 #nullable enable
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics;
 using System.ComponentModel;
 using CoreGraphics;
@@ -8701,7 +8702,11 @@ namespace AppKit {
 		NSGraphicsContext FromGraphicsPort (IntPtr graphicsPort, bool initialFlippedState);
 
 		[Static, Export ("currentContext"), NullAllowed]
-		NSGraphicsContext CurrentContext { get; set; }
+		NSGraphicsContext CurrentContext {
+			[DynamicDependency (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors, "Foundation.NSProxy", "Microsoft.macOS")] // https://github.com/xamarin/bugzilla-archives/blob/main/16/16505/bug.html
+			get;
+			set;
+		}
 
 		[Static, Export ("currentContextDrawingToScreen")]
 		bool IsCurrentContextDrawingToScreen { get; }
@@ -8962,12 +8967,6 @@ namespace AppKit {
 
 		[Export ("customPlacementConstraints", ArgumentSemantic.Copy)]
 		NSLayoutConstraint [] CustomPlacementConstraints { get; set; }
-	}
-
-	[NoMacCatalyst]
-	[BaseType (typeof (NSGraphicsContext))]
-	[DisableDefaultCtor]
-	interface NSPrintPreviewGraphicsContext {
 	}
 
 	[NoMacCatalyst]

--- a/src/bgen/AttributeManager.cs
+++ b/src/bgen/AttributeManager.cs
@@ -15,6 +15,7 @@ public class AttributeManager {
 		"System.Runtime.CompilerServices.NullableAttribute",
 		"System.Runtime.CompilerServices.NullableContextAttribute",
 		"System.Runtime.CompilerServices.NativeIntegerAttribute",
+		"System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute",
 	};
 
 	TypeCache TypeCache { get; }

--- a/src/bgen/Generator.cs
+++ b/src/bgen/Generator.cs
@@ -2805,7 +2805,7 @@ public partial class Generator : IMemberGatherer {
 		string name = GetMethodName (minfo, is_async);
 
 		// Some codepaths already write preservation info
-		PrintAttributes (minfo.mi, preserve: !alreadyPreserved, advice: true, bindAs: true, requiresSuper: true);
+		PrintAttributes (minfo.mi, preserve: !alreadyPreserved, advice: true, bindAs: true, requiresSuper: true, dynamicDependency: true);
 
 		if (minfo.is_ctor && minfo.is_protocol_member) {
 			sb.Append ("T? ");
@@ -4104,7 +4104,7 @@ public partial class Generator : IMemberGatherer {
 					pi.Name.GetSafeParamName ());
 			indent++;
 			if (generate_getter) {
-				PrintAttributes (pi.GetGetMethod ()!, platform: true, preserve: true, advice: true);
+				PrintAttributes (pi.GetGetMethod ()!, platform: true, preserve: true, advice: true, dynamicDependency: true);
 				print ("get {");
 				indent++;
 
@@ -4123,7 +4123,7 @@ public partial class Generator : IMemberGatherer {
 				print ("}");
 			}
 			if (generate_setter) {
-				PrintAttributes (pi.GetSetMethod ()!, platform: true, preserve: true, advice: true);
+				PrintAttributes (pi.GetSetMethod ()!, platform: true, preserve: true, advice: true, dynamicDependency: true);
 				print ("set {");
 				indent++;
 
@@ -4197,7 +4197,7 @@ public partial class Generator : IMemberGatherer {
 			// If property getter or setter has its own WrapAttribute we let the user do whatever their heart desires
 			if (generate_getter) {
 				PrintAttributes (pi, platform: true);
-				PrintAttributes (pi.GetGetMethod (), platform: true, preserve: true, advice: true);
+				PrintAttributes (pi.GetGetMethod (), platform: true, preserve: true, advice: true, dynamicDependency: true);
 				print ("get {");
 				indent++;
 
@@ -4237,7 +4237,7 @@ public partial class Generator : IMemberGatherer {
 				PrintExport (minfo, sel, export!.ArgumentSemantic);
 			}
 
-			PrintAttributes (pi.GetGetMethod (), platform: true, preserve: true, advice: true, notImplemented: true, inlinedType: inlinedType);
+			PrintAttributes (pi.GetGetMethod (), platform: true, preserve: true, advice: true, notImplemented: true, inlinedType: inlinedType, dynamicDependency: true);
 			if (minfo.is_protocol_member && !minfo.is_static) {
 				print ("get {");
 				print ($"\treturn _Get{pi.Name.GetSafeParamName ()} (this);");
@@ -4293,7 +4293,7 @@ public partial class Generator : IMemberGatherer {
 			if (not_implemented_attr is null && (!minfo.is_sealed || !minfo.is_wrapper))
 				PrintExport (minfo, sel, export!.ArgumentSemantic);
 
-			PrintAttributes (pi.GetSetMethod (), platform: true, preserve: true, advice: true, notImplemented: true, inlinedType: inlinedType);
+			PrintAttributes (pi.GetSetMethod (), platform: true, preserve: true, advice: true, notImplemented: true, inlinedType: inlinedType, dynamicDependency: true);
 			if (minfo.is_protocol_member && !minfo.is_static) {
 				print ("set {");
 				print ($"\t_Set{pi.Name.GetSafeParamName ()} (this, value);");
@@ -5576,7 +5576,7 @@ public partial class Generator : IMemberGatherer {
 	// Not adding the experimental attribute is bad (it would mean that an API
 	// we meant to be experimental ended up being released as stable), so it's
 	// opt-out instead of opt-in.
-	public void PrintAttributes (ICustomAttributeProvider? mi, bool platform = false, bool preserve = false, bool advice = false, bool notImplemented = false, bool bindAs = false, bool requiresSuper = false, Type? inlinedType = null, bool experimental = true, bool obsolete = false, bool objectiveCFramework = false, bool simulatorAvailability = true)
+	public void PrintAttributes (ICustomAttributeProvider? mi, bool platform = false, bool preserve = false, bool advice = false, bool notImplemented = false, bool bindAs = false, bool requiresSuper = false, Type? inlinedType = null, bool experimental = true, bool obsolete = false, bool objectiveCFramework = false, bool simulatorAvailability = true, bool dynamicDependency = false)
 	{
 		if (platform)
 			PrintPlatformAttributes (mi as MemberInfo, inlinedType);
@@ -5598,6 +5598,70 @@ public partial class Generator : IMemberGatherer {
 			PrintObjectiveCFrameworkAttribute (mi);
 		if (simulatorAvailability)
 			PrintSimulatorAvailabilityAttributes (mi);
+		if (dynamicDependency)
+			PrintDynamicDependencyAttributes (mi);
+	}
+
+	public void PrintDynamicDependencyAttributes (ICustomAttributeProvider? mi)
+	{
+		if (mi is not MemberInfo memberInfo)
+			return;
+
+		var allAttribs = memberInfo.GetCustomAttributesData ();
+		foreach (var attrib in allAttribs) {
+			if (attrib.GetAttributeType ().FullName != "System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute")
+				continue;
+			var args = attrib.ConstructorArguments;
+			var parts = new List<string> ();
+			foreach (var arg in args) {
+				if (arg.Value is string stringValue) {
+					parts.Add ($"\"{stringValue}\"");
+				} else if (arg.Value is int intValue) {
+					parts.Add (FormatDynamicallyAccessedMemberTypes (intValue));
+				} else if (arg.Value is Type typeValue) {
+					parts.Add ($"typeof ({typeValue})");
+				} else {
+					exceptions.Add (ErrorHelper.CreateError (99, $"Unexpected attribute argument value for DynamicDependency attribute: {arg.ArgumentType.FullName} => {arg.Value}"));
+				}
+			}
+			print ($"[DynamicDependency ({string.Join (", ", parts)})]");
+		}
+	}
+
+	static string FormatDynamicallyAccessedMemberTypes (int memberTypes)
+	{
+		if (memberTypes == -1) // All
+			return "DynamicallyAccessedMemberTypes.All";
+		if (memberTypes == 0) // None
+			return "DynamicallyAccessedMemberTypes.None";
+
+		// Use the composite values first to match the original source
+		var flagValues = new (int value, string name) [] {
+			(3, "PublicConstructors"), // 3 includes PublicParameterlessConstructor
+			(1, "PublicParameterlessConstructor"),
+			(4, "NonPublicConstructors"),
+			(8, "PublicMethods"),
+			(16, "NonPublicMethods"),
+			(32, "PublicFields"),
+			(64, "NonPublicFields"),
+			(128, "PublicNestedTypes"),
+			(256, "NonPublicNestedTypes"),
+			(512, "PublicProperties"),
+			(1024, "NonPublicProperties"),
+			(2048, "PublicEvents"),
+			(4096, "NonPublicEvents"),
+			(8192, "Interfaces"),
+		};
+
+		var parts = new List<string> ();
+		var remaining = memberTypes;
+		foreach (var (value, name) in flagValues) {
+			if (value != 0 && (remaining & value) == value) {
+				parts.Add ($"DynamicallyAccessedMemberTypes.{name}");
+				remaining &= ~value;
+			}
+		}
+		return string.Join (" | ", parts);
 	}
 
 	public void PrintExperimentalAttribute (ICustomAttributeProvider? mi)

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -130,6 +130,7 @@ APPKIT_SOURCES = \
 	AppKit/NSPopUpButtonCell.cs \
 	AppKit/NSPredicateEditorRowTemplate.cs \
 	AppKit/NSPrintInfo.cs \
+	AppKit/NSPrintPreviewGraphicsContext.cs \
 	AppKit/NSScreen.cs \
 	AppKit/NSSegmentedControl.cs \
 	AppKit/NSSharingService.cs \

--- a/tests/bgen/BGenTests.cs
+++ b/tests/bgen/BGenTests.cs
@@ -1156,6 +1156,64 @@ namespace GeneratorTests {
 		}
 
 		[Test]
+		public void DynamicDependencyAttribute ()
+		{
+			var bgen = BuildFile (Profile.macOSMobile, "dynamic-dependency-attribute.cs");
+
+			var type = bgen.ApiAssembly.MainModule.Types.First (v => v.Name == "MyClass");
+			var getter = type.Methods.First (v => v.Name == "get_CurrentContext");
+			var setter = type.Methods.First (v => v.Name == "set_CurrentContext");
+			var doSomething = type.Methods.First (v => v.Name == "DoSomething");
+			var doSomethingElse = type.Methods.First (v => v.Name == "DoSomethingElse");
+			var doAnother = type.Methods.First (v => v.Name == "DoAnother");
+			var doYetAnother = type.Methods.First (v => v.Name == "DoYetAnother");
+			var doAll = type.Methods.First (v => v.Name == "DoAll");
+
+			// (DynamicallyAccessedMemberTypes, string, string) on property getter
+			var getterDDA = getter.CustomAttributes.Where (ca => ca.AttributeType.Name == "DynamicDependencyAttribute").ToArray ();
+			Assert.That (getterDDA.Length, Is.EqualTo (1), "Getter DynamicDependency count");
+			Assert.That ((int) getterDDA [0].ConstructorArguments [0].Value, Is.EqualTo (7), "Getter DynamicDependency MemberTypes (PublicConstructors | NonPublicConstructors)");
+			Assert.That (getterDDA [0].ConstructorArguments [1].Value, Is.EqualTo ("Foundation.NSProxy"), "Getter DynamicDependency TypeName");
+			Assert.That (getterDDA [0].ConstructorArguments [2].Value, Is.EqualTo ("Microsoft.macOS"), "Getter DynamicDependency AssemblyName");
+
+			// Setter should not have it
+			var setterDDA = setter.CustomAttributes.Where (ca => ca.AttributeType.Name == "DynamicDependencyAttribute").ToArray ();
+			Assert.That (setterDDA.Length, Is.EqualTo (0), "Setter DynamicDependency count");
+
+			// (string, string, string) on method
+			var methodDDA = doSomething.CustomAttributes.Where (ca => ca.AttributeType.Name == "DynamicDependencyAttribute").ToArray ();
+			Assert.That (methodDDA.Length, Is.EqualTo (1), "DoSomething DynamicDependency count");
+			Assert.That (methodDDA [0].ConstructorArguments [0].Value, Is.EqualTo ("Create"), "DoSomething DynamicDependency MemberSignature");
+			Assert.That (methodDDA [0].ConstructorArguments [1].Value, Is.EqualTo ("NS.MyClass"), "DoSomething DynamicDependency TypeName");
+			Assert.That (methodDDA [0].ConstructorArguments [2].Value, Is.EqualTo ("api0"), "DoSomething DynamicDependency AssemblyName");
+
+			// (string) - single member signature
+			var elseDDA = doSomethingElse.CustomAttributes.Where (ca => ca.AttributeType.Name == "DynamicDependencyAttribute").ToArray ();
+			Assert.That (elseDDA.Length, Is.EqualTo (1), "DoSomethingElse DynamicDependency count");
+			Assert.That (elseDDA [0].ConstructorArguments.Count, Is.EqualTo (1), "DoSomethingElse DynamicDependency arg count");
+			Assert.That (elseDDA [0].ConstructorArguments [0].Value, Is.EqualTo ("Activate"), "DoSomethingElse DynamicDependency MemberSignature");
+
+			// (DynamicallyAccessedMemberTypes, Type)
+			var anotherDDA = doAnother.CustomAttributes.Where (ca => ca.AttributeType.Name == "DynamicDependencyAttribute").ToArray ();
+			Assert.That (anotherDDA.Length, Is.EqualTo (1), "DoAnother DynamicDependency count");
+			Assert.That ((int) anotherDDA [0].ConstructorArguments [0].Value, Is.EqualTo (8 | 512), "DoAnother DynamicDependency MemberTypes (PublicMethods | PublicProperties)");
+			Assert.That (((Mono.Cecil.TypeReference) anotherDDA [0].ConstructorArguments [1].Value).Name, Is.EqualTo ("NSObject"), "DoAnother DynamicDependency Type");
+
+			// (string, Type)
+			var yetAnotherDDA = doYetAnother.CustomAttributes.Where (ca => ca.AttributeType.Name == "DynamicDependencyAttribute").ToArray ();
+			Assert.That (yetAnotherDDA.Length, Is.EqualTo (1), "DoYetAnother DynamicDependency count");
+			Assert.That (yetAnotherDDA [0].ConstructorArguments [0].Value, Is.EqualTo ("Create"), "DoYetAnother DynamicDependency MemberSignature");
+			Assert.That (((Mono.Cecil.TypeReference) yetAnotherDDA [0].ConstructorArguments [1].Value).Name, Is.EqualTo ("NSObject"), "DoYetAnother DynamicDependency Type");
+
+			// (DynamicallyAccessedMemberTypes.All, string, string)
+			var allDDA = doAll.CustomAttributes.Where (ca => ca.AttributeType.Name == "DynamicDependencyAttribute").ToArray ();
+			Assert.That (allDDA.Length, Is.EqualTo (1), "DoAll DynamicDependency count");
+			Assert.That ((int) allDDA [0].ConstructorArguments [0].Value, Is.EqualTo (-1), "DoAll DynamicDependency MemberTypes (All)");
+			Assert.That (allDDA [0].ConstructorArguments [1].Value, Is.EqualTo ("NS.MyClass"), "DoAll DynamicDependency TypeName");
+			Assert.That (allDDA [0].ConstructorArguments [2].Value, Is.EqualTo ("api0"), "DoAll DynamicDependency AssemblyName");
+		}
+
+		[Test]
 		[TestCase (Profile.iOS)]
 		public void NewerAvailabilityInInlinedProtocol (Profile profile)
 		{

--- a/tests/bgen/tests/dynamic-dependency-attribute.cs
+++ b/tests/bgen/tests/dynamic-dependency-attribute.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Foundation;
+using ObjCRuntime;
+
+namespace NS {
+	[BaseType (typeof (NSObject))]
+	interface MyClass {
+		[Static, Export ("currentContext"), NullAllowed]
+		NSObject CurrentContext {
+			// (DynamicallyAccessedMemberTypes, string, string)
+			[DynamicDependency (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors, "Foundation.NSProxy", "Microsoft.macOS")]
+			get;
+			set;
+		}
+
+		// (string, string, string)
+		[Export ("doSomething")]
+		[DynamicDependency ("Create", "NS.MyClass", "api0")]
+		void DoSomething ();
+
+		// (string) - single member signature
+		[Export ("doSomethingElse")]
+		[DynamicDependency ("Activate")]
+		void DoSomethingElse ();
+
+		// (DynamicallyAccessedMemberTypes, Type)
+		[Export ("doAnother")]
+		[DynamicDependency (DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties, typeof (NSObject))]
+		void DoAnother ();
+
+		// (string, Type)
+		[Export ("doYetAnother")]
+		[DynamicDependency ("Create", typeof (NSObject))]
+		void DoYetAnother ();
+
+		// (DynamicallyAccessedMemberTypes.All, string, string)
+		[Export ("doAll")]
+		[DynamicDependency (DynamicallyAccessedMemberTypes.All, "NS.MyClass", "api0")]
+		void DoAll ();
+	}
+}

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -25152,7 +25152,6 @@ T:AppKit.NSPrintingPageOrder
 T:AppKit.NSPrintingPaginationMode
 T:AppKit.NSPrintPanelOptions
 T:AppKit.NSPrintPanelResult
-T:AppKit.NSPrintPreviewGraphicsContext
 T:AppKit.NSPrintRenderingQuality
 T:AppKit.NSProgressIndicatorStyle
 T:AppKit.NSProgressIndicatorThickness

--- a/tests/linker/link all/LinkAllMacTest.cs
+++ b/tests/linker/link all/LinkAllMacTest.cs
@@ -79,6 +79,8 @@ namespace LinkAllTests {
 		[Test]
 		public void PrintPreview_NSGraphicsContextCurrentContext ()
 		{
+			TestRuntime.AssertXcodeVersion (26, 0);
+
 			// Verify that accessing NSGraphicsContext.CurrentContext during print preview
 			// doesn't crash due to the linker trimming NSPrintPreviewGraphicsContext.
 			var printableView = new PrintableView (new CoreGraphics.CGRect (0, 0, 100, 100));

--- a/tests/linker/link all/LinkAllMacTest.cs
+++ b/tests/linker/link all/LinkAllMacTest.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Serialization;
 
@@ -72,6 +73,73 @@ namespace LinkAllTests {
 			{
 				SetMe = 1;
 			}
+		}
+
+		// https://github.com/xamarin/bugzilla-archives/blob/main/16/16505/bug.html
+		[Test]
+		public void PrintPreview_NSGraphicsContextCurrentContext ()
+		{
+			// Verify that accessing NSGraphicsContext.CurrentContext during print preview
+			// doesn't crash due to the linker trimming NSPrintPreviewGraphicsContext.
+			var printableView = new PrintableView (new CoreGraphics.CGRect (0, 0, 100, 100));
+
+			var printInfo = (NSPrintInfo) NSPrintInfo.SharedPrintInfo.Copy ();
+			printInfo.JobDisposition = "NSPrintPreviewJob";
+
+			var printOp = NSPrintOperation.FromView (printableView, printInfo);
+			printOp.ShowsPrintPanel = true; // this is required to trigger the bug
+			printOp.ShowsProgressPanel = true;
+
+			var closedPreview = false;
+			var closeAction = new Action (() => {
+				if (closedPreview)
+					return;
+				NSApplication.SharedApplication.AbortModal ();
+				closedPreview = true;
+			});
+
+			printableView.TaskCompletionSource.Task.ContinueWith (task => {
+				closeAction ();
+			}, TaskScheduler.FromCurrentSynchronizationContext ());
+
+			// Auto-close after 3 seconds in case something goes wrong
+			var timer = NSTimer.CreateScheduledTimer (3.0, (t) => closeAction ());
+			NSRunLoop.Current.AddTimer (timer, NSRunLoopMode.ModalPanel);
+
+			printOp.RunOperation ();
+
+			Assert.That (printableView.TaskCompletionSource.Task.IsCompletedSuccessfully, Is.True, "DrawPageBorder was called successfully");
+			var context = printableView.TaskCompletionSource.Task.Result;
+			Assert.That (context, Is.Not.Null, "NSGraphicsContext.CurrentContext was not null during print preview");
+		}
+	}
+
+	class PrintableView : NSView {
+		public PrintableView (CoreGraphics.CGRect frame) : base (frame) { }
+
+		public TaskCompletionSource<NSGraphicsContext?> TaskCompletionSource = new ();
+
+		public override void DrawPageBorder (CoreGraphics.CGSize borderSize)
+		{
+			try {
+				var context = NSGraphicsContext.CurrentContext;
+				base.DrawPageBorder (borderSize);
+				TaskCompletionSource.TrySetResult (context);
+			} catch (Exception e) {
+				Console.WriteLine ($"Unexpected exception occurred: {e}");
+				TaskCompletionSource.TrySetException (e);
+			}
+		}
+
+		public override bool KnowsPageRange (ref Foundation.NSRange range)
+		{
+			range = new Foundation.NSRange (1, 1);
+			return true;
+		}
+
+		public override CoreGraphics.CGRect RectForPage (nint pageNumber)
+		{
+			return Bounds;
 		}
 	}
 }

--- a/tests/linker/link all/LinkAllTest.cs
+++ b/tests/linker/link all/LinkAllTest.cs
@@ -466,15 +466,6 @@ namespace LinkAll {
 			Assert.That (Helper.GetType (fqn), Is.Null, "Should NOT be included (no SslStream or Socket support)");
 		}
 
-		[Test]
-		// https://bugzilla.xamarin.com/show_bug.cgi?id=59247
-		public void WebKit_NSProxy ()
-		{
-			// this test works only because "Link all" does not use WebKit
-			var fqn = typeof (NSObject).AssemblyQualifiedName!.Replace ("Foundation.NSObject", "Foundation.NSProxy");
-			Assert.That (Helper.GetType (fqn), Is.Null, fqn);
-		}
-
 		static Type type_Task = typeof (Task);
 
 		[Test]

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
@@ -1,9 +1,6 @@
 ## https://bugzilla.xamarin.com/show_bug.cgi?id=30717
 !duplicate-register! _NSDatePickerCellDelegate exists as both AppKit.NSDatePickerCell/_NSDatePickerCellDelegate and AppKit.NSDatePicker/_NSDatePickerCellDelegate
 
-## Proxy class for NSGraphicsContext internal to AppKit
-!unknown-type! NSPrintPreviewGraphicsContext bound
-
 ## In header as old style unnamaed enum
 !unknown-native-enum! NSModalResponse bound
 !unknown-native-enum! NSWindowLevel bound


### PR DESCRIPTION
NSPrintPreviewGraphicsContext existed in our bindings because we sometimes get instances of this type, and since its parent type is NSProxy, it causes problems at runtime when we try to figure out which managed type to instantiate.

In particular, when:

* The app is trimmed
* The NSProxy type is trimmed away

This happens:

    MarshalManagedException: ObjCRuntime.RuntimeException: The ObjectiveC class 'NSPrintPreviewGraphicsContext' could not be registered, it does not seem to derive from any known ObjectiveC class (including NSObject).
       at Registrar.DynamicRegistrar.Lookup(IntPtr class, Boolean throw_on_error) in /Users/builder/azdo/_work/1/s/macios/src/ObjCRuntime/DynamicRegistrar.cs:line 1069
       at ObjCRuntime.Class.Lookup(IntPtr klass, Boolean throw_on_error) in /Users/builder/azdo/_work/1/s/macios/src/ObjCRuntime/Class.cs:line 291
       at ObjCRuntime.Class.Lookup(IntPtr klass) in /Users/builder/azdo/_work/1/s/macios/src/ObjCRuntime/Class.cs:line 272
       at ObjCRuntime.Runtime.GetNSObject[T](IntPtr ptr, IntPtr sel, RuntimeMethodHandle method_handle, Boolean evenInFinalizerQueue, Boolean typeSafe) in /Users/builder/azdo/_work/1/s/macios/src/ObjCRuntime/Runtime.cs:line 1893
       at ObjCRuntime.Runtime.GetNSObject[T](IntPtr ptr) in /Users/builder/azdo/_work/1/s/macios/src/ObjCRuntime/Runtime.cs:line 1844
       at ObjCRuntime.Runtime.GetNSObject[T](IntPtr ptr, Boolean owns) in /Users/builder/azdo/_work/1/s/macios/src/ObjCRuntime/Runtime.cs:line 1930
       at AppKit.NSGraphicsContext.get_CurrentContext() in /Users/builder/azdo/_work/1/s/macios/src/build/dotnet/macos/generated-sources/AppKit/NSGraphicsContext.g.cs:line 411
       at PrintableView.DrawPageBorder(CGSize borderSize) in /Users/rolf/test/dotnet/macos-printpreview/Program.cs:line 97

because `NSProxy` doesn't subclass `NSObject`, we can't find a managed type to instantiate.

In the Xamarin days we had custom linker support to keep `NSPrintPreviewGraphicsContext` (https://github.com/xamarin/maccore/commit/d047ee123f3bfc28126bb9258878fccfed8d1c7a), but this was never ported to .NET, so this has been broken since forever in .NET.

So fix this by:

* Removing the `NSPrintPreviewGraphicsContext` binding, it causes problems when inlining calls to Class.GetHandle, because it's not part of the public API.
* Ensure `NSProxy` is not trimmed away when `NSGraphicsContext.CurrentContext` is used, this way we'll return an `NSProxy` instance when the native instance is an actual `NSPrintPreviewGraphicsContext`. This required adding support for copying `[DynamicDependency]` attributes from binding code to the generated code.
* Also add unit tests.

This required removing the WebKit_NSProxy unit test, because it doesn't work anymore (it asserts that the `NSProxy` type is trimmed away, but one of the new tests depends on `NSProxy` not being trimmed away).

References:

* https://github.com/xamarin/bugzilla-archives/blob/main/16/16505/bug.html
* https://github.com/xamarin/maccore/commit/d047ee123f3bfc28126bb9258878fccfed8d1c7a