### PR TITLE
[src] Add opt-in to build the platform assemblies serially.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -435,6 +435,15 @@ $($(2)_DOTNET_BUILD_DIR)/Microsoft.$(1).rsp: Makefile frameworks.sources $(RSP_D
 $($(2)_DOTNET_BUILD_DIR)/$(4)/Microsoft.$(1)%dll $($(2)_DOTNET_BUILD_DIR)/$(4)/Microsoft.$(1)%pdb $($(2)_DOTNET_BUILD_DIR)/ref/Microsoft.$(1)%dll $($(2)_DOTNET_BUILD_DIR)/ref/Microsoft.$(1)%xml: $$($(2)_DOTNET_PLATFORM_ASSEMBLY_DEPENDENCIES) $$(ROSLYN_GENERATOR) $$(ROSLYN_ANALYZER) | $$($(2)_DOTNET_PLATFORM_ASSEMBLY_DIR_DEPENDENCIES)
 	$$(call Q_PROF_CSC,dotnet) $(DOTNET_CSC) @$($(2)_DOTNET_BUILD_DIR)/Microsoft.$(1).rsp
 
+ifdef SERIALIZE_CSC
+# This is to serialize the csc commands for the platform assembly. The platform assembly takes a while to compile (maxing out the CPU), and csc is already multi-threaded, which
+# means that if we're running multiple long csc tasks simultaneously, the CPU of the machine will get absolutely thrashed. csc (aka Roslyn) isn't exactly a cheapskate with memory either...
+# It looks a bit weird, but the idea is that in this template, every platform assembly depends on the assembly from the previous template expansion.
+# It's opt-in, because it slows down the build a bit.
+$($(2)_DOTNET_BUILD_DIR)/$(4)/Microsoft.$(1).dll: $(LAST_DLL)
+LAST_DLL=$($(2)_DOTNET_BUILD_DIR)/$(4)/Microsoft.$(1).dll
+endif
+
 dotnet-$(3):: $($(2)_DOTNET_BUILD_DIR)/$(4)/Microsoft.$(1).dll
 
 DOTNET_TARGETS_$(3) += \


### PR DESCRIPTION
The platform assemblies are rather big, and take a while to compile. This also
means the C# compiler (csc) uses a lot of computational resources during the
process.

Each csc process is multi-threaded, and then if make also runs multiple csc
processes in parallel, the build may completely thrash the CPU, and csc (aka
Roslyn) isn't particularly easy on the memory either, causing any other use of
the machine to suffer signicantly.

So with this change we optionally build the platform assemblies serially.

It looks a bit weird, but the idea is that in the make template, every
platform assembly depends on the assembly from the previous template
expansion.

It slows down the build somewhat (src/ builds in ~5:30 instead of ~3:45 on my
9-year old iMac Pro), so it's opt-in instead of on by default.