### PR TITLE
Test NuGet MSI conversion template update

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -45,7 +45,7 @@ resources:
     - repository: yaml-templates
       type: git
       name: xamarin.yaml-templates
-      ref: e30b445c2ffcbebe75efdd69546d7196a20c5a43
+      ref: refs/heads/deps/update-nuget-msi-convert-wix
 
     - repository: CustomPipelineTemplates
       type: git

--- a/tools/devops/automation/templates/pipelines/build-pipeline.yml
+++ b/tools/devops/automation/templates/pipelines/build-pipeline.yml
@@ -59,7 +59,7 @@ resources:
   - repository: yaml-templates
     type: git
     name: xamarin.yaml-templates
-    ref: e30b445c2ffcbebe75efdd69546d7196a20c5a43
+    ref: refs/heads/deps/update-nuget-msi-convert-wix
 
 variables:
 - ${{ if eq(parameters.isPR, false) }}:


### PR DESCRIPTION
## Summary

Temporarily points the macios build pipeline YAML template resource at the `Xamarin.yaml-templates` branch containing the NuGet MSI conversion template update.

This follows the existing release-test validation pattern so the appropriate macios checks run before the template change is merged.
