### PR TITLE
[net11.0][runtime] Fix CoreCLR VM init by satisfying BindToSystem CoreLib fallback gate

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2413,6 +2413,55 @@ xamarin_get_native_code_data (const struct host_runtime_contract_native_code_con
 
 	return true;
 }
+
+// dotnet/runtime#128278 (.NET 11 preview 5) gates the BindToSystem CoreLib fallback on
+// Bundle::AppIsBundle () && Bundle::AppBundle->HasExtractedFiles (). Register a no-op
+// bundle_probe so AppBundle is non-null, and answer BUNDLE_EXTRACTION_PATH with the
+// directory containing System.Private.CoreLib.dll so the fallback finds it.
+static bool xamarin_coreclr_bundle_probe(const char *path, int64_t *offset, int64_t *size, int64_t *compressed_size)
+{
+	return false;
+}
+
+static const char *xamarin_compute_corelib_directory(void)
+{
+	static char *cached = NULL;
+
+	if (cached)
+		return cached;
+
+	const char *bundle_path = xamarin_get_bundle_path ();
+	NSFileManager *manager = [NSFileManager defaultManager];
+	NSString *candidates [] = {
+		[NSString stringWithUTF8String: bundle_path],
+		[NSString stringWithFormat: @"%s/.xamarin/%s", bundle_path, RUNTIMEIDENTIFIER],
+	};
+	for (size_t i = 0; i < sizeof (candidates) / sizeof (candidates [0]); i++) {
+		NSString *probe = [candidates [i] stringByAppendingPathComponent: @"System.Private.CoreLib.dll"];
+		if ([manager fileExistsAtPath: probe]) {
+			cached = strdup ([candidates [i] UTF8String]);
+			break;
+		}
+	}
+
+	return cached;
+}
+
+static size_t xamarin_coreclr_get_runtime_property(const char *key, char *value_buffer, size_t value_buffer_size, void *contract_context)
+{
+	if (strcmp (key, HOST_PROPERTY_BUNDLE_EXTRACTION_PATH) != 0)
+		return (size_t) -1;
+
+	const char *dir = xamarin_compute_corelib_directory ();
+	if (dir == NULL)
+		return (size_t) -1;
+
+	size_t len = strlen (dir);
+	size_t required = len + 1; // include null terminator
+	if (value_buffer != NULL && value_buffer_size >= required)
+		memcpy (value_buffer, dir, required);
+	return required;
+}
 #endif // defined (CORECLR_RUNTIME)
 
 void
@@ -2421,6 +2470,8 @@ xamarin_vm_initialize ()
 #if defined (CORECLR_RUNTIME)
 	struct host_runtime_contract host_contract = {
 		.size = sizeof (struct host_runtime_contract),
+		.get_runtime_property = &xamarin_coreclr_get_runtime_property,
+		.bundle_probe = &xamarin_coreclr_bundle_probe,
 		.pinvoke_override = &xamarin_pinvoke_override,
 		.get_native_code_data = &xamarin_get_native_code_data
 	};


### PR DESCRIPTION
Fixes #25542.

## Problem

dotnet/runtime#128278 (.NET 11 preview 5) tightened `AssemblyBinderCommon::BindToSystem` so its CoreLib fallback only runs when

```cpp
Bundle::AppIsBundle () && Bundle::AppBundle->HasExtractedFiles ()
```

macios doesn't bundle assemblies and never registered a `bundle_probe` callback nor a `BUNDLE_EXTRACTION_PATH` property on `host_runtime_contract`, so the gate fails. On iOS/tvOS device, libcoreclr ships inside `Frameworks/libcoreclr.framework/libcoreclr` while `System.Private.CoreLib.dll` lives at the app bundle root, so `BindToSystem`'s primary lookup (next to libcoreclr) also fails. Result: `coreclr_initialize` returns false and `xamarin_vm_initialize` aborts with `Microsoft.iOS: Failed to initialize the VM` on startup.

## Fix

Three small statics added to `runtime/runtime.m` and wired into the contract in `xamarin_vm_initialize`:

- `xamarin_coreclr_bundle_probe` — always returns false. We don't actually bundle assemblies; registering this callback is what causes CoreCLR to set `Bundle::AppBundle != nullptr`.
- `xamarin_compute_corelib_directory` — probes `<bundle>` then `<bundle>/.xamarin/<RID>` for `System.Private.CoreLib.dll` (same order as `xamarin_compute_trusted_platform_assemblies`), result cached.
- `xamarin_coreclr_get_runtime_property` — answers only `HOST_PROPERTY_BUNDLE_EXTRACTION_PATH` with that directory; returns -1 for everything else. This sets `Bundle::m_extractionPath` so `HasExtractedFiles ()` returns true.

With both callbacks present the gate passes, and `BindToSystem` loads CoreLib from `Bundle::AppBundle->ExtractionPath () + "System.Private.CoreLib.dll"`.

## Verification

Reproduced and verified on iPhone 13 / iOS 26.5 using a published `dotnet new ios` app with `libcoreclr.dylib` and `System.Private.CoreLib.dll` substituted to preview.6.26277.104:

| Config | Result |
|---|---|
| Unfixed runtime | ❌ `Microsoft.iOS: Failed to initialize the VM` / SIGABRT (matches #25542) |
| Fixed runtime | ✅ VM initialized; `Program.Main` executes |
| Fixed runtime, stock preview.5 libcoreclr (pre-regression) | ✅ Runs (no regression) |