### PR TITLE
[net11.0] [runtime] Register host_runtime_contract callbacks so CoreCLR finds System.Private.CoreLib.dll

### DIFF
--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2473,7 +2473,7 @@ static bool xamarin_coreclr_bundle_probe(const char *path, int64_t *offset, int6
 	return false;
 }
 
-static const char *xamarin_compute_corelib_directory(void)
+static const char *xamarin_compute_corelib_directory (void)
 {
 	static char *cached = NULL;
 

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2468,7 +2468,7 @@ xamarin_get_native_code_data (const struct host_runtime_contract_native_code_con
 // Bundle::AppIsBundle () && Bundle::AppBundle->HasExtractedFiles (). Register a no-op
 // bundle_probe so AppBundle is non-null, and answer BUNDLE_EXTRACTION_PATH with the
 // directory containing System.Private.CoreLib.dll so the fallback finds it.
-static bool xamarin_coreclr_bundle_probe(const char *path, int64_t *offset, int64_t *size, int64_t *compressed_size)
+static bool xamarin_coreclr_bundle_probe (const char *path, int64_t *offset, int64_t *size, int64_t *compressed_size)
 {
 	return false;
 }

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2463,6 +2463,55 @@ xamarin_get_native_code_data (const struct host_runtime_contract_native_code_con
 
 	return true;
 }
+
+// dotnet/runtime#128278 (.NET 11 preview 5) gates the BindToSystem CoreLib fallback on
+// Bundle::AppIsBundle () && Bundle::AppBundle->HasExtractedFiles (). Register a no-op
+// bundle_probe so AppBundle is non-null, and answer BUNDLE_EXTRACTION_PATH with the
+// directory containing System.Private.CoreLib.dll so the fallback finds it.
+static bool xamarin_coreclr_bundle_probe(const char *path, int64_t *offset, int64_t *size, int64_t *compressed_size)
+{
+	return false;
+}
+
+static const char *xamarin_compute_corelib_directory(void)
+{
+	static char *cached = NULL;
+
+	if (cached)
+		return cached;
+
+	const char *bundle_path = xamarin_get_bundle_path ();
+	NSFileManager *manager = [NSFileManager defaultManager];
+	NSString *candidates [] = {
+		[NSString stringWithUTF8String: bundle_path],
+		[NSString stringWithFormat: @"%s/.xamarin/%s", bundle_path, RUNTIMEIDENTIFIER],
+	};
+	for (size_t i = 0; i < sizeof (candidates) / sizeof (candidates [0]); i++) {
+		NSString *probe = [candidates [i] stringByAppendingPathComponent: @"System.Private.CoreLib.dll"];
+		if ([manager fileExistsAtPath: probe]) {
+			cached = strdup ([candidates [i] UTF8String]);
+			break;
+		}
+	}
+
+	return cached;
+}
+
+static size_t xamarin_coreclr_get_runtime_property(const char *key, char *value_buffer, size_t value_buffer_size, void *contract_context)
+{
+	if (strcmp (key, HOST_PROPERTY_BUNDLE_EXTRACTION_PATH) != 0)
+		return (size_t) -1;
+
+	const char *dir = xamarin_compute_corelib_directory ();
+	if (dir == NULL)
+		return (size_t) -1;
+
+	size_t len = strlen (dir);
+	size_t required = len + 1; // include null terminator
+	if (value_buffer != NULL && value_buffer_size >= required)
+		memcpy (value_buffer, dir, required);
+	return required;
+}
 #endif // defined (CORECLR_RUNTIME)
 
 void
@@ -2471,6 +2520,8 @@ xamarin_vm_initialize ()
 #if defined (CORECLR_RUNTIME)
 	struct host_runtime_contract host_contract = {
 		.size = sizeof (struct host_runtime_contract),
+		.get_runtime_property = &xamarin_coreclr_get_runtime_property,
+		.bundle_probe = &xamarin_coreclr_bundle_probe,
 		.pinvoke_override = &xamarin_pinvoke_override,
 		.get_native_code_data = &xamarin_get_native_code_data
 	};

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2497,7 +2497,7 @@ static const char *xamarin_compute_corelib_directory(void)
 	return cached;
 }
 
-static size_t xamarin_coreclr_get_runtime_property(const char *key, char *value_buffer, size_t value_buffer_size, void *contract_context)
+static size_t xamarin_coreclr_get_runtime_property (const char *key, char *value_buffer, size_t value_buffer_size, void *contract_context)
 {
 	if (strcmp (key, HOST_PROPERTY_BUNDLE_EXTRACTION_PATH) != 0)
 		return (size_t) -1;


### PR DESCRIPTION
### Description

When CoreCLR starts, AssemblyBinderCommon::BindToSystem loads System.Private.CoreLib.dll. It first looks next to libcoreclr, and if that fails it runs a fallback path. In .NET 11 preview 5, dotnet/runtime#128278 changed the fallback to read CoreLib from the single-file bundle's extraction directory, and gated it on Bundle::AppIsBundle() && Bundle::AppBundle->HasExtractedFiles().

Those two flags are set from the host. AppIsBundle() requires the host to register a bundle_probe callback on host_runtime_contract, and HasExtractedFiles() requires the host to return a path from the BUNDLE_EXTRACTION_PATH runtime property. The primary lookup fails on Apple mobile device, because libcoreclr ships inside Frameworks/libcoreclr.framework/libcoreclr while System.Private.CoreLib.dll lives at the app bundle root, so CoreLib is never next to libcoreclr.

### Fix

Register a no-op bundle_probe and provide BUNDLE_EXTRACTION_PATH with the directory containing System.Private.CoreLib.dll (app bundle root, then .xamarin/<RID>), so the gate passes and BindToSystem resolves CoreLib from that directory.

Fixes https://github.com/dotnet/macios/issues/25542