### PR TITLE
[net11.0] Bundle DynamicLibrary publish items added after _ComputePublishLocation

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -280,6 +280,7 @@
 			_CompileNativeExecutable;
 			_LinkNativeExecutable;
 			_ComputePublishLocation;
+			_BundleLateDynamicLibrariesToPublish;
 			_ComputeCodesignItems;
 			CopyFilesToPublishDirectory;
 			_CopyDirectoriesToBundle;
@@ -2223,6 +2224,22 @@
 			_ComputeMonoComponents;
 		</_ComputePublishLocationDependsOn>
 	</PropertyGroup>
+
+	<Target Name="_BundleLateDynamicLibrariesToPublish"
+	        DependsOnTargets="_ComputeVariables;_ComputePublishLocation;ComputeFilesToPublish"
+	        Condition="'$(_CanOutputAppBundle)' == 'true'">
+		<ItemGroup>
+			<_LateBundleDylib Include="@(ResolvedFileToPublish)" Condition="('%(ResolvedFileToPublish.PublishFolderType)' == 'DynamicLibrary' Or '%(ResolvedFileToPublish.PublishFolderType)' == 'PluginLibrary') And '%(ResolvedFileToPublish.CopyToAppBundle)' != 'false' And !$([System.String]::Copy('%(ResolvedFileToPublish.RelativePath)').StartsWith('$(_RelativeAppBundlePath)'))" />
+
+			<ResolvedFileToPublish Remove="@(_LateBundleDylib)" />
+
+			<ResolvedFileToPublish Include="@(_LateBundleDylib)">
+				<RelativePath Condition="'%(_LateBundleDylib.RelativePath)' == ''">$(_DylibPublishDir)\%(Filename)%(Extension)</RelativePath>
+				<RelativePath Condition="'%(_LateBundleDylib.RelativePath)' != ''">$(_RelativeAppBundlePath)\%(_LateBundleDylib.RelativePath)</RelativePath>
+				<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+			</ResolvedFileToPublish>
+		</ItemGroup>
+	</Target>
 
 	<Target Name="_ComputePublishLocation"
 		DependsOnTargets="$(_ComputePublishLocationDependsOn)"


### PR DESCRIPTION
## Description

`_ComputePublishLocation` resolves the final `RelativePath` for `DynamicLibrary` items in `ResolvedFileToPublish`, but on iOS, tvOS, and MacCatalyst it runs early as a dependency of `_CreateRuntimeConfiguration`. Any item added later by an extension hooking the documented `BeforeTargets="ComputeFilesToPublish"` extension point keeps its raw `RelativePath` and lands in `bin/.../publish/` instead of the signed `.app` bundle, because the second `_ComputePublishLocation` invocation is cached and skipped. This breaks the VS Code MAUI extension's CoreCLR remote-debugger flow.

The fix is to add `_BundleLateDynamicLibrariesToPublish` to `CreateAppBundleDependsOn`, between `_ComputePublishLocation` and `_ComputeCodesignItems`.