### PR TITLE
[net11.0] Keep R2R debug info in Debug for CoreCLR Apple mobile

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -246,6 +246,15 @@
 		<PublishReadyToRunComposite Condition="'$(PublishReadyToRunComposite)' == '' And '$(PublishReadyToRun)' == 'true'">true</PublishReadyToRunComposite>
 		<PublishReadyToRunContainerFormat Condition="'$(PublishReadyToRunContainerFormat)' == '' And '$(PublishReadyToRun)' == 'true'">macho</PublishReadyToRunContainerFormat>
 		<PublishReadyToRunCreateSharedLibrary>false</PublishReadyToRunCreateSharedLibrary>
+		<!--
+			The .NET SDK defaults PublishReadyToRunStripDebugInfo=true for apple-mobile RIDs,
+			which passes --strip-debug-info to crossgen2 and drops READYTORUN_SECTION_DEBUG_INFO
+			from the composite R2R image. Without that section, DebuggerJitInfo::m_sequenceMap
+			stays NULL for every R2R method, line-level breakpoints cannot bind to a native
+			offset, and the CoreCLR remote debugger experience is degraded. Keep the debug info
+			in Debug builds at the cost of a larger R2R image; release builds still strip it.
+		-->
+		<PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' And '$(Configuration)' == 'Debug'">false</PublishReadyToRunStripDebugInfo>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(UseMonoRuntime)' == 'false' And '$(_PlatformName)' != 'macOS' And '$(PublishReadyToRun)' != 'true'">


### PR DESCRIPTION
The .NET SDK defaults `PublishReadyToRunStripDebugInfo=true` for ios/tvos/iossimulator/tvossimulator/maccatalyst RIDs, so crossgen2 is invoked with `--strip-debug-info` and the composite R2R image ships without a `READYTORUN_SECTION_DEBUG_INFO` section. macios additionally defaults `PublishReadyToRun=true` (composite) for CoreCLR even in Debug, so the user assembly itself is composite-R2R'd with no IL-to-native map.

Under the CoreCLR remote debugger this means `DebuggerJitInfo::LazyInitBounds` never populates `m_sequenceMap`, line-level breakpoints cannot bind to the right native offset (only method entry), and `DebuggerJitInfo::MapILOffsetToNative` dereferences a NULL map entry on the first R2R load that matches an IL primary patch (see dotnet/runtime#128764 for the defensive runtime fix).

Default `PublishReadyToRunStripDebugInfo=false` for the CoreCLR apple-mobile + Debug combination so the re-composited R2R image keeps debug info and the debugger gets accurate IL-to-native mappings. Release builds are unaffected and still strip.
