### PR TITLE
[net11.0] Keep R2R debug info in Debug for CoreCLR Apple mobile

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -246,6 +246,8 @@
 		<PublishReadyToRunComposite Condition="'$(PublishReadyToRunComposite)' == '' And '$(PublishReadyToRun)' == 'true'">true</PublishReadyToRunComposite>
 		<PublishReadyToRunContainerFormat Condition="'$(PublishReadyToRunContainerFormat)' == '' And '$(PublishReadyToRun)' == 'true'">macho</PublishReadyToRunContainerFormat>
 		<PublishReadyToRunCreateSharedLibrary>false</PublishReadyToRunCreateSharedLibrary>
+		<!-- Keep R2R debug info in Debug so the CoreCLR debugger can bind breakpoints to native offsets. -->
+		<PublishReadyToRunStripDebugInfo Condition="'$(PublishReadyToRunStripDebugInfo)' == '' And '$(Configuration)' == 'Debug'">false</PublishReadyToRunStripDebugInfo>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(UseMonoRuntime)' == 'false' And '$(_PlatformName)' != 'macOS' And '$(PublishReadyToRun)' != 'true'">


### PR DESCRIPTION
The .NET SDK defaults `PublishReadyToRunStripDebugInfo=true` for ios/tvos/iossimulator/tvossimulator/maccatalyst RIDs, so crossgen2 is invoked with `--strip-debug-info` and the composite R2R image ships without a `READYTORUN_SECTION_DEBUG_INFO` section. macios additionally defaults `PublishReadyToRun=true` (composite) for CoreCLR even in Debug, so the user assembly itself is composite-R2R'd with no IL-to-native map.

Under the CoreCLR remote debugger this means `DebuggerJitInfo::LazyInitBounds` never populates `m_sequenceMap`, line-level breakpoints cannot bind to the right native offset (only method entry), and `DebuggerJitInfo::MapILOffsetToNative` dereferences a NULL map entry on the first R2R load that matches an IL primary patch (see dotnet/runtime#128764 for the defensive runtime fix).

Default `PublishReadyToRunStripDebugInfo=false` for the CoreCLR apple-mobile + Debug combination so the re-composited R2R image keeps debug info and the debugger gets accurate IL-to-native mappings. Release builds are unaffected and still strip.
