### PR TITLE
[apidiff] Add nullability support to mono-api-info and mono-api-html

### DIFF
--- a/src/Foundation/NSUndoManager.cs
+++ b/src/Foundation/NSUndoManager.cs
@@ -15,7 +15,7 @@ namespace Foundation {
 		/// <summary>Returns the modes governing the types of input handled during a cycle of the run loop.</summary>
 		///         <value>To be added.</value>
 		///         <remarks>To be added.</remarks>
-		public NSRunLoopMode []? RunLoopModes {
+		public NSRunLoopMode [] RunLoopModes {
 			get {
 				var modes = WeakRunLoopModes;
 				if (modes is null)

--- a/src/Foundation/NSUndoManager.cs
+++ b/src/Foundation/NSUndoManager.cs
@@ -15,7 +15,7 @@ namespace Foundation {
 		/// <summary>Returns the modes governing the types of input handled during a cycle of the run loop.</summary>
 		///         <value>To be added.</value>
 		///         <remarks>To be added.</remarks>
-		public NSRunLoopMode [] RunLoopModes {
+		public NSRunLoopMode []? RunLoopModes {
 			get {
 				var modes = WeakRunLoopModes;
 				if (modes is null)

--- a/tools/api-tools/mono-api-html/ApiChange.cs
+++ b/tools/api-tools/mono-api-html/ApiChange.cs
@@ -10,6 +10,7 @@ namespace Mono.ApiTools {
 		public string Header = "";
 		public TextChunk Member = new TextChunk ();
 		public bool AnyChange;
+		public bool IsNullabilityChange;
 		public string SourceDescription;
 		public State State;
 
@@ -61,12 +62,67 @@ namespace Mono.ApiTools {
 			if (!change.AnyChange)
 				return;
 
+			// Detect if this change is nullability-only
+			if (DiffersOnlyByNullability (source, target))
+				change.IsNullabilityChange = true;
+
 			if (!TryGetValue (change.Header, out List<ApiChange>? list)) {
 				list = new List<ApiChange> ();
 				base.Add (change.Header, list);
 			}
 			list.Add (change);
 		}
+
+		static bool DiffersOnlyByNullability (XElement source, XElement target)
+		{
+			// Compare all attributes, stripping nullability from type-related attributes
+			var typeAttributes = new HashSet<string> { "returntype", "fieldtype", "ptype", "eventtype", "type" };
+
+			if (source.Name != target.Name)
+				return false;
+
+			// Check that all non-type-related attributes are the same
+			var srcAttrs = source.Attributes ().ToDictionary (a => a.Name.LocalName, a => a.Value);
+			var tgtAttrs = target.Attributes ().ToDictionary (a => a.Name.LocalName, a => a.Value);
+
+			if (srcAttrs.Count != tgtAttrs.Count)
+				return false;
+
+			bool hasNullabilityDiff = false;
+			foreach (var kvp in srcAttrs) {
+				if (!tgtAttrs.TryGetValue (kvp.Key, out var tgtValue))
+					return false;
+
+				if (kvp.Value == tgtValue)
+					continue;
+
+				if (typeAttributes.Contains (kvp.Key)) {
+					if (Helper.DiffersOnlyByNullability (kvp.Value, tgtValue))
+						hasNullabilityDiff = true;
+					else
+						return false;
+				} else {
+					return false;
+				}
+			}
+
+			if (!hasNullabilityDiff) {
+				// Check child elements recursively
+				var srcChildren = source.Elements ().ToList ();
+				var tgtChildren = target.Elements ().ToList ();
+				if (srcChildren.Count != tgtChildren.Count)
+					return false;
+
+				for (int i = 0; i < srcChildren.Count; i++) {
+					if (XNode.DeepEquals (srcChildren [i], tgtChildren [i]))
+						continue;
+					if (!DiffersOnlyByNullability (srcChildren [i], tgtChildren [i]))
+						return false;
+					hasNullabilityDiff = true;
+				}
+			}
+
+			return hasNullabilityDiff;
+		}
 	}
 }
-

--- a/tools/api-tools/mono-api-html/ApiChange.cs
+++ b/tools/api-tools/mono-api-html/ApiChange.cs
@@ -46,6 +46,75 @@ namespace Mono.ApiTools {
 			AnyChange = true;
 			return this;
 		}
+
+		// Renders a type change: uses inline nullability rendering if the only
+		// difference is '?' annotations, otherwise falls back to full modification.
+		public ApiChange AppendTypeModified (string old, string @new)
+		{
+			if (Helper.DiffersOnlyByNullability (old, @new))
+				return AppendNullabilityModified (old, @new);
+			return AppendModified (old, @new);
+		}
+
+		// Renders a type modification where only nullability annotations ('?') differ.
+		// Only the added/removed '?' characters are highlighted; the rest is plain text.
+		public ApiChange AppendNullabilityModified (string old, string @new)
+		{
+			int si = 0;
+			int ti = 0;
+			while (si < old.Length && ti < @new.Length) {
+				if (old [si] == @new [ti]) {
+					Member.Append (old [si].ToString ());
+					si++;
+					ti++;
+				} else if (old [si] == '?' && IsNullabilitySuffix (old, si)) {
+					State.Formatter.DiffRemoval (Member, "?");
+					AnyChange = true;
+					si++;
+				} else if (@new [ti] == '?' && IsNullabilitySuffix (@new, ti)) {
+					State.Formatter.DiffAddition (Member, "?");
+					AnyChange = true;
+					ti++;
+				} else {
+					// Shouldn't happen for nullability-only diffs, fall back to full modification
+					State.Formatter.DiffModification (Member, old.Substring (si), @new.Substring (ti));
+					AnyChange = true;
+					return this;
+				}
+			}
+			// Handle remaining characters
+			while (si < old.Length) {
+				if (old [si] == '?' && IsNullabilitySuffix (old, si)) {
+					State.Formatter.DiffRemoval (Member, "?");
+					AnyChange = true;
+					si++;
+				} else {
+					Member.Append (old [si].ToString ());
+					si++;
+				}
+			}
+			while (ti < @new.Length) {
+				if (@new [ti] == '?' && IsNullabilitySuffix (@new, ti)) {
+					State.Formatter.DiffAddition (Member, "?");
+					AnyChange = true;
+					ti++;
+				} else {
+					Member.Append (@new [ti].ToString ());
+					ti++;
+				}
+			}
+			return this;
+		}
+
+		static bool IsNullabilitySuffix (string text, int index)
+		{
+			// A '?' is a nullability suffix if it's at the end, or before a type separator
+			if (index + 1 >= text.Length)
+				return true;
+			char next = text [index + 1];
+			// Before ']', ',', '>', '&' (start of &gt; or &amp;), or ' ' (before parameter name)
+			return next == ']' || next == ',' || next == '>' || next == '&' || next == ' ';
+		}
 	}
 
 	class ApiChanges : Dictionary<string, List<ApiChange>> {

--- a/tools/api-tools/mono-api-html/ApiChange.cs
+++ b/tools/api-tools/mono-api-html/ApiChange.cs
@@ -64,7 +64,7 @@ namespace Mono.ApiTools {
 			int ti = 0;
 			while (si < old.Length && ti < @new.Length) {
 				if (old [si] == @new [ti]) {
-					Member.Append (old [si].ToString ());
+					Member.Append (old [si]);
 					si++;
 					ti++;
 				} else if (old [si] == '?' && IsNullabilitySuffix (old, si)) {
@@ -89,7 +89,7 @@ namespace Mono.ApiTools {
 					AnyChange = true;
 					si++;
 				} else {
-					Member.Append (old [si].ToString ());
+					Member.Append (old [si]);
 					si++;
 				}
 			}
@@ -99,7 +99,7 @@ namespace Mono.ApiTools {
 					AnyChange = true;
 					ti++;
 				} else {
-					Member.Append (@new [ti].ToString ());
+					Member.Append (@new [ti]);
 					ti++;
 				}
 			}
@@ -108,11 +108,12 @@ namespace Mono.ApiTools {
 
 		static bool IsNullabilitySuffix (string text, int index)
 		{
-			// A '?' is a nullability suffix if it's at the end, or before a type separator
+			// A '?' is a nullability suffix if it's at the end, or before a type separator.
+			// The input type names are already formatted (via GetTypeName + Formatter), so generic
+			// brackets appear as HTML entities (&lt; / &gt;). A '?' before '&' catches the &gt; case.
 			if (index + 1 >= text.Length)
 				return true;
 			char next = text [index + 1];
-			// Before ']', ',', '>', '&' (start of &gt; or &amp;), or ' ' (before parameter name)
 			return next == ']' || next == ',' || next == '>' || next == '&' || next == ' ';
 		}
 	}
@@ -175,20 +176,19 @@ namespace Mono.ApiTools {
 				}
 			}
 
-			if (!hasNullabilityDiff) {
-				// Check child elements recursively
-				var srcChildren = source.Elements ().ToList ();
-				var tgtChildren = target.Elements ().ToList ();
-				if (srcChildren.Count != tgtChildren.Count)
-					return false;
+			// Always check child elements — a non-nullability child diff means this
+			// is not a nullability-only change, even if the parent attributes differ only by nullability.
+			var srcChildren = source.Elements ().ToList ();
+			var tgtChildren = target.Elements ().ToList ();
+			if (srcChildren.Count != tgtChildren.Count)
+				return false;
 
-				for (int i = 0; i < srcChildren.Count; i++) {
-					if (XNode.DeepEquals (srcChildren [i], tgtChildren [i]))
-						continue;
-					if (!DiffersOnlyByNullability (srcChildren [i], tgtChildren [i]))
-						return false;
-					hasNullabilityDiff = true;
-				}
+			for (int i = 0; i < srcChildren.Count; i++) {
+				if (XNode.DeepEquals (srcChildren [i], tgtChildren [i]))
+					continue;
+				if (!DiffersOnlyByNullability (srcChildren [i], tgtChildren [i]))
+					return false;
+				hasNullabilityDiff = true;
 			}
 
 			return hasNullabilityDiff;

--- a/tools/api-tools/mono-api-html/ConstructorComparer.cs
+++ b/tools/api-tools/mono-api-html/ConstructorComparer.cs
@@ -59,7 +59,7 @@ namespace Mono.ApiTools {
 			var tgtType = target.GetTypeName ("returntype", State);
 
 			if (srcType != tgtType) {
-				change.AppendModified (srcType ?? "", tgtType ?? "");
+				change.AppendTypeModified (srcType ?? "", tgtType ?? "");
 				change.Append (" ");
 			} else if (srcType is not null) {
 				// ctor don't have a return type

--- a/tools/api-tools/mono-api-html/EventComparer.cs
+++ b/tools/api-tools/mono-api-html/EventComparer.cs
@@ -59,7 +59,7 @@ namespace Mono.ApiTools {
 			var tgtEventType = target.GetTypeName ("eventtype", State) ?? "";
 
 			if (srcEventType != tgtEventType) {
-				change.AppendModified (srcEventType, tgtEventType);
+				change.AppendTypeModified (srcEventType, tgtEventType);
 			} else {
 				change.Append (srcEventType);
 			}

--- a/tools/api-tools/mono-api-html/FieldComparer.cs
+++ b/tools/api-tools/mono-api-html/FieldComparer.cs
@@ -146,7 +146,7 @@ namespace Mono.ApiTools {
 				var tgtType = target.GetTypeName ("fieldtype", State) ?? "";
 
 				if (srcType != tgtType) {
-					change.AppendModified (srcType, tgtType);
+					change.AppendTypeModified (srcType, tgtType);
 				} else {
 					change.Append (srcType);
 				}

--- a/tools/api-tools/mono-api-html/Formatter.cs
+++ b/tools/api-tools/mono-api-html/Formatter.cs
@@ -211,6 +211,13 @@ namespace Mono.ApiTools {
 			cachedOutput.Append (value);
 		}
 
+		public void Append (char value)
+		{
+			foreach (var kvp in stringbuilders)
+				kvp.StringBuilder.Append (value);
+			cachedOutput.Append (value);
+		}
+
 		public override string ToString ()
 		{
 			throw new InvalidOperationException ();

--- a/tools/api-tools/mono-api-html/Helpers.cs
+++ b/tools/api-tools/mono-api-html/Helpers.cs
@@ -261,13 +261,12 @@ namespace Mono.ApiTools {
 		{
 			if (type is null)
 				return null;
-			// Remove all '?' that appear before ']', at end of string, or before ','
-			// These are the positions where nullable reference type annotations appear
+			// Remove all '?' that appear before ']', at end of string, before ',',
+			// before '>' or '&' (HTML entities like &gt;), or before ' ' (before param name)
 			var sb = new StringBuilder (type.Length);
 			for (int i = 0; i < type.Length; i++) {
 				if (type [i] == '?') {
-					// Skip '?' if it's at the end, before ']', or before ','
-					if (i + 1 >= type.Length || type [i + 1] == ']' || type [i + 1] == ',')
+					if (i + 1 >= type.Length || type [i + 1] == ']' || type [i + 1] == ',' || type [i + 1] == '>' || type [i + 1] == '&' || type [i + 1] == ' ')
 						continue;
 				}
 				sb.Append (type [i]);

--- a/tools/api-tools/mono-api-html/Helpers.cs
+++ b/tools/api-tools/mono-api-html/Helpers.cs
@@ -127,11 +127,18 @@ namespace Mono.ApiTools {
 
 			StringBuilder sb = null!;
 			bool is_nullable = false;
+			bool is_nullable_ref = false;
 			if (type.StartsWith ("System.Nullable`1[", StringComparison.Ordinal)) {
 				is_nullable = true;
 				sb = new StringBuilder (type, 18, type.Length - 19, 1024);
 			} else {
 				sb = new StringBuilder (type);
+			}
+
+			// Handle nullable reference type annotation (trailing '?' added by mono-api-info)
+			if (!is_nullable && sb.Length > 0 && sb [sb.Length - 1] == '?') {
+				is_nullable_ref = true;
+				sb.Remove (sb.Length - 1, 1);
 			}
 
 			bool is_ref = (sb [sb.Length - 1] == '&');
@@ -158,6 +165,8 @@ namespace Mono.ApiTools {
 			while (array-- > 0)
 				sb.Append ("[]");
 			if (is_nullable)
+				sb.Append ('?');
+			if (is_nullable_ref)
 				sb.Append ('?');
 			if (is_pointer)
 				sb.Append ('*');
@@ -244,6 +253,34 @@ namespace Mono.ApiTools {
 		{
 			var srcAttribs = element.Attribute ("attrib");
 			return (FieldAttributes) (srcAttribs is not null ? Int32.Parse (srcAttribs.Value) : 0);
+		}
+
+		// Strips trailing '?' nullability annotations from a type name for comparison purposes.
+		// Handles both top-level (System.String?) and nested generics (List`1[System.String?]).
+		public static string? StripNullability (string? type)
+		{
+			if (type is null)
+				return null;
+			// Remove all '?' that appear before ']', at end of string, or before ','
+			// These are the positions where nullable reference type annotations appear
+			var sb = new StringBuilder (type.Length);
+			for (int i = 0; i < type.Length; i++) {
+				if (type [i] == '?') {
+					// Skip '?' if it's at the end, before ']', or before ','
+					if (i + 1 >= type.Length || type [i + 1] == ']' || type [i + 1] == ',')
+						continue;
+				}
+				sb.Append (type [i]);
+			}
+			return sb.ToString ();
+		}
+
+		// Returns true if two type names differ only in nullability annotations.
+		public static bool DiffersOnlyByNullability (string? source, string? target)
+		{
+			if (source == target)
+				return false;
+			return StripNullability (source) == StripNullability (target);
 		}
 	}
 }

--- a/tools/api-tools/mono-api-html/MemberComparer.cs
+++ b/tools/api-tools/mono-api-html/MemberComparer.cs
@@ -328,7 +328,7 @@ namespace Mono.ApiTools {
 					}
 
 					if (paramSourceType != paramTargetType) {
-						change.AppendModified (paramSourceType ?? "", paramTargetType ?? "");
+						change.AppendTypeModified (paramSourceType ?? "", paramTargetType ?? "");
 					} else {
 						change.Append (paramSourceType ?? "");
 					}

--- a/tools/api-tools/mono-api-html/MemberComparer.cs
+++ b/tools/api-tools/mono-api-html/MemberComparer.cs
@@ -134,11 +134,24 @@ namespace Mono.ApiTools {
 		void Modify (ApiChanges modified)
 		{
 			foreach (var changes in modified) {
-				Formatter.BeginMemberModification (changes.Key);
-				foreach (var element in changes.Value) {
-					Formatter.Diff (element);
+				var nonNullability = changes.Value.Where (c => !c.IsNullabilityChange).ToList ();
+				var nullabilityOnly = changes.Value.Where (c => c.IsNullabilityChange).ToList ();
+
+				if (nonNullability.Count > 0) {
+					Formatter.BeginMemberModification (changes.Key);
+					foreach (var element in nonNullability) {
+						Formatter.Diff (element);
+					}
+					Formatter.EndMemberModification ();
 				}
-				Formatter.EndMemberModification ();
+
+				if (nullabilityOnly.Count > 0) {
+					Formatter.BeginMemberModification (changes.Key + " (nullability)");
+					foreach (var element in nullabilityOnly) {
+						Formatter.Diff (element);
+					}
+					Formatter.EndMemberModification ();
+				}
 			}
 		}
 

--- a/tools/api-tools/mono-api-html/MethodComparer.cs
+++ b/tools/api-tools/mono-api-html/MethodComparer.cs
@@ -52,7 +52,7 @@ namespace Mono.ApiTools {
 			if (e.GetAttribute ("name") != Source.GetAttribute ("name"))
 				return false;
 
-			if (e.GetAttribute ("returntype") != Source.GetAttribute ("returntype"))
+			if (Helper.StripNullability (e.GetAttribute ("returntype")) != Helper.StripNullability (Source.GetAttribute ("returntype")))
 				return false;
 
 			var eGP = e.Element ("generic-parameters");

--- a/tools/api-tools/mono-api-html/PropertyComparer.cs
+++ b/tools/api-tools/mono-api-html/PropertyComparer.cs
@@ -103,7 +103,7 @@ namespace Mono.ApiTools {
 			if (srcType == tgtType) {
 				change.Append (tgtType);
 			} else {
-				change.AppendModified (srcType, tgtType);
+				change.AppendTypeModified (srcType, tgtType);
 			}
 			change.Append (" ");
 		}
@@ -150,7 +150,7 @@ namespace Mono.ApiTools {
 				if (srcType == tgtType) {
 					change.Append (tgtType);
 				} else {
-					change.AppendModified (srcType, tgtType);
+					change.AppendTypeModified (srcType, tgtType);
 				}
 				change.Append (" ");
 

--- a/tools/api-tools/mono-api-info/mono-api-info.cs
+++ b/tools/api-tools/mono-api-info/mono-api-info.cs
@@ -1014,7 +1014,9 @@ namespace Mono.ApiTools {
 			base.AddExtraAttributes (memberDefinition);
 
 			FieldDefinition field = (FieldDefinition) memberDefinition;
-			AddAttribute ("fieldtype", Utils.CleanupTypeName (field.FieldType));
+			var fieldTypeName = Utils.CleanupTypeName (field.FieldType);
+			fieldTypeName = NullabilityHelper.AppendNullabilityToTypeName (fieldTypeName, field.FieldType, field, field.DeclaringType);
+			AddAttribute ("fieldtype", fieldTypeName);
 
 			if (field.IsLiteral) {
 				object value = field.Constant;//object value = field.GetValue (null);
@@ -1083,7 +1085,9 @@ namespace Mono.ApiTools {
 			base.AddExtraAttributes (memberDefinition);
 
 			PropertyDefinition prop = (PropertyDefinition) memberDefinition;
-			AddAttribute ("ptype", Utils.CleanupTypeName (prop.PropertyType));
+			var ptypeName = Utils.CleanupTypeName (prop.PropertyType);
+			ptypeName = NullabilityHelper.AppendNullabilityToTypeName (ptypeName, prop.PropertyType, prop, prop.DeclaringType);
+			AddAttribute ("ptype", ptypeName);
 
 			bool haveParameters;
 			MethodDefinition []? methods = GetMethods ((PropertyDefinition) memberDefinition, out haveParameters);
@@ -1149,7 +1153,9 @@ namespace Mono.ApiTools {
 			base.AddExtraAttributes (memberDefinition);
 
 			EventDefinition evt = (EventDefinition) memberDefinition;
-			AddAttribute ("eventtype", Utils.CleanupTypeName (evt.EventType));
+			var evtTypeName = Utils.CleanupTypeName (evt.EventType);
+			evtTypeName = NullabilityHelper.AppendNullabilityToTypeName (evtTypeName, evt.EventType, evt, evt.DeclaringType);
+			AddAttribute ("eventtype", evtTypeName);
 		}
 
 		public override string ParentTag {
@@ -1217,8 +1223,10 @@ namespace Mono.ApiTools {
 				AddAttribute ("is-override", "true");
 			}
 			string rettype = Utils.CleanupTypeName (mbase.MethodReturnType.ReturnType);
-			if (rettype != "System.Void" || !mbase.IsConstructor)
+			if (rettype != "System.Void" || !mbase.IsConstructor) {
+				rettype = NullabilityHelper.AppendNullabilityToTypeName (rettype, mbase.MethodReturnType.ReturnType, mbase.MethodReturnType, mbase);
 				AddAttribute ("returntype", (rettype));
+			}
 			//
 			//			if (mbase.MethodReturnType.HasCustomAttributes)
 			//				AttributeData.OutputAttributes (writer, mbase.MethodReturnType);
@@ -1302,7 +1310,7 @@ namespace Mono.ApiTools {
 					pt = brt.ElementType;
 				}
 
-				AddAttribute ("type", Utils.CleanupTypeName (pt));
+				AddAttribute ("type", NullabilityHelper.AppendNullabilityToTypeName (Utils.CleanupTypeName (pt), pt, parameter, parameter.Method as ICustomAttributeProvider));
 
 				if (parameter.IsOptional) {
 					AddAttribute ("optional", "true");
@@ -1454,6 +1462,113 @@ namespace Mono.ApiTools {
 			return signature.ToString ();
 		}
 
+	}
+
+	static class NullabilityHelper {
+		const string NullableAttributeName = "System.Runtime.CompilerServices.NullableAttribute";
+		const string NullableContextAttributeName = "System.Runtime.CompilerServices.NullableContextAttribute";
+
+		// Returns the nullability flag for the top-level type:
+		// 0 = oblivious, 1 = not-null, 2 = nullable
+		public static byte GetTopLevelNullability (ICustomAttributeProvider provider, ICustomAttributeProvider? context)
+		{
+			// Check for NullableAttribute directly on the member/parameter/return type
+			var flag = GetNullableFlagFromProvider (provider);
+			if (flag.HasValue)
+				return flag.Value;
+
+			// Fall back to NullableContextAttribute on the containing method/type
+			if (context is not null) {
+				var contextFlag = GetNullableContextFlag (context);
+				if (contextFlag.HasValue)
+					return contextFlag.Value;
+			}
+
+			return 0; // oblivious
+		}
+
+		// Gets the NullableContextAttribute flag from a method or type
+		public static byte? GetNullableContextFlag (ICustomAttributeProvider provider)
+		{
+			if (provider is null)
+				return null;
+
+			if (!provider.HasCustomAttributes)
+				return GetNullableContextFromParent (provider);
+
+			foreach (var attr in provider.CustomAttributes) {
+				if (attr.AttributeType.FullName != NullableContextAttributeName)
+					continue;
+				if (attr.ConstructorArguments.Count == 1 && attr.ConstructorArguments [0].Value is byte b)
+					return b;
+			}
+
+			return GetNullableContextFromParent (provider);
+		}
+
+		static byte? GetNullableContextFromParent (ICustomAttributeProvider? provider)
+		{
+			if (provider is MethodDefinition method)
+				return GetNullableContextFlag (method.DeclaringType);
+			if (provider is PropertyDefinition prop)
+				return GetNullableContextFlag (prop.DeclaringType);
+			if (provider is FieldDefinition field)
+				return GetNullableContextFlag (field.DeclaringType);
+			if (provider is EventDefinition evt)
+				return GetNullableContextFlag (evt.DeclaringType);
+			if (provider is TypeDefinition type && type.DeclaringType is not null)
+				return GetNullableContextFlag (type.DeclaringType);
+			return null;
+		}
+
+		static byte? GetNullableFlagFromProvider (ICustomAttributeProvider provider)
+		{
+			if (!provider.HasCustomAttributes)
+				return null;
+
+			foreach (var attr in provider.CustomAttributes) {
+				if (attr.AttributeType.FullName != NullableAttributeName)
+					continue;
+				if (attr.ConstructorArguments.Count != 1)
+					continue;
+
+				var arg = attr.ConstructorArguments [0];
+				if (arg.Value is byte b)
+					return b;
+				if (arg.Value is CustomAttributeArgument [] arr && arr.Length > 0 && arr [0].Value is byte b2)
+					return b2;
+			}
+
+			return null;
+		}
+
+		public static bool IsNullableReferenceType (TypeReference type, ICustomAttributeProvider provider, ICustomAttributeProvider? context)
+		{
+			if (type is null)
+				return false;
+
+			// Value types use Nullable<T> for nullability, not annotations
+			if (type.IsValueType)
+				return false;
+
+			// Generic parameters can be nullable
+			// ByReference types: check the element type
+			if (type.IsByReference) {
+				var elementType = ((ByReferenceType) type).ElementType;
+				if (elementType.IsValueType)
+					return false;
+			}
+
+			var flag = GetTopLevelNullability (provider, context);
+			return flag == 2;
+		}
+
+		public static string AppendNullabilityToTypeName (string typeName, TypeReference type, ICustomAttributeProvider provider, ICustomAttributeProvider? context)
+		{
+			if (IsNullableReferenceType (type, provider, context))
+				return typeName + "?";
+			return typeName;
+		}
 	}
 
 	class TypeReferenceComparer : IComparer<TypeReference> {

--- a/tools/api-tools/mono-api-info/mono-api-info.cs
+++ b/tools/api-tools/mono-api-info/mono-api-info.cs
@@ -1516,8 +1516,26 @@ namespace Mono.ApiTools {
 				return GetNullableContextFlag (field.DeclaringType);
 			if (provider is EventDefinition evt)
 				return GetNullableContextFlag (evt.DeclaringType);
-			if (provider is TypeDefinition type && type.DeclaringType is not null)
-				return GetNullableContextFlag (type.DeclaringType);
+			if (provider is TypeDefinition type) {
+				if (type.DeclaringType is not null)
+					return GetNullableContextFlag (type.DeclaringType);
+				// Fall back to module-level NullableContextAttribute
+				return GetNullableContextFlagFromAttributes (type.Module);
+			}
+			return null;
+		}
+
+		static byte? GetNullableContextFlagFromAttributes (ICustomAttributeProvider? provider)
+		{
+			if (provider is null || !provider.HasCustomAttributes)
+				return null;
+
+			foreach (var attr in provider.CustomAttributes) {
+				if (attr.AttributeType.FullName != NullableContextAttributeName)
+					continue;
+				if (attr.ConstructorArguments.Count == 1 && attr.ConstructorArguments [0].Value is byte b)
+					return b;
+			}
 			return null;
 		}
 
@@ -1551,8 +1569,7 @@ namespace Mono.ApiTools {
 			if (type.IsValueType)
 				return false;
 
-			// Generic parameters can be nullable
-			// ByReference types: check the element type
+			// ByReference types (ref/out parameters): check the element type
 			if (type.IsByReference) {
 				var elementType = ((ByReferenceType) type).ElementType;
 				if (elementType.IsValueType)


### PR DESCRIPTION
mono-api-info now reads NullableAttribute and NullableContextAttribute
metadata from assemblies and appends '?' to type names for nullable
reference types in the XML output (parameters, return types, properties,
fields, and events).

mono-api-html now:
- Strips nullability annotations when matching methods (so nullability-
  only changes don't cause false removed/added entries)
- Detects nullability-only changes and renders them under a separate
  '(nullability)' subsection header to indicate they are non-breaking
- Handles the '?' suffix in type name resolution (GetTypeName)