### PR TITLE
[tests] Fix flaky BasicAuthWorksWhenBearerIsAdvertisedFirst test. Fixes #25597

### DIFF
--- a/tests/monotouch-test/System.Net.Http/NSUrlSessionHandlerTest.cs
+++ b/tests/monotouch-test/System.Net.Http/NSUrlSessionHandlerTest.cs
@@ -286,14 +286,27 @@ namespace MonoTests.System.Net.Http {
 					using var handler = new NSUrlSessionHandler ();
 					handler.Credentials = new NetworkCredential (username, password);
 					using var client = new HttpClient (handler);
-					using var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{listeningPort}/test");
+					// Use 127.0.0.1 instead of localhost to avoid IPv6 resolution
+					// issues where NSUrlSession may connect to ::1 while
+					// HttpListener only binds to IPv4.
+					using var request = new HttpRequestMessage (HttpMethod.Get, $"http://127.0.0.1:{listeningPort}/test");
 					var response = await client.SendAsync (request).ConfigureAwait (false);
 					statusCode = response.StatusCode;
 					responseBody = await response.Content.ReadAsStringAsync ().ConfigureAwait (false);
 				}, out var ex);
 
-				Assert.That (done, Is.True, "Request timed out");
+				if (!done) {
+					TestRuntime.IgnoreInCI ("Transient localhost server failure - ignore in CI");
+					Assert.Inconclusive ("Request timed out.");
+				}
+				TestRuntime.IgnoreInCIIfBadNetwork (ex);
 				Assert.That (ex, Is.Null, $"Exception: {ex}");
+				// If no request reached the server, the failure is an infrastructure
+				// issue (e.g. port conflict), not a code bug.
+				if (Volatile.Read (ref requestIndex) == 0 && statusCode == HttpStatusCode.NotFound) {
+					TestRuntime.IgnoreInCI ($"Server received no requests and got status {statusCode} - infrastructure issue, ignore in CI");
+					Assert.Inconclusive ($"Server received no requests; status was {statusCode}. Likely a port/binding issue.");
+				}
 				Assert.That (statusCode, Is.EqualTo (HttpStatusCode.OK), "Expected 200 OK after Basic auth negotiation");
 				Assert.That (responseBody, Is.EqualTo ("authenticated"), "Response body");
 				Assert.That (firstUnauthenticatedIndex, Is.GreaterThan (0), "Server should have received an unauthenticated request");
@@ -316,7 +329,7 @@ namespace MonoTests.System.Net.Http {
 
 			for (var port = MinPort; port < MaxPort; port++) {
 				var listener = new HttpListener ();
-				listener.Prefixes.Add ($"http://*:{port}/");
+				listener.Prefixes.Add ($"http://127.0.0.1:{port}/");
 				try {
 					listener.Start ();
 					listeningPort = port;


### PR DESCRIPTION
The test was getting HTTP 404 on a CI bot, but the local HttpListener
server never returns 404. The likely cause is localhost resolving to
::1 (IPv6) on certain macOS bots while HttpListener with http://*:port/
only binds to IPv4. The request reaches something else and gets 404.

Fix:
- Use 127.0.0.1 explicitly in both the HttpListener prefix and the
  request URL to avoid IPv6/hostname resolution mismatches.
- Add CI tolerance: if the server received zero requests and the status
  is 404, mark the test as inconclusive (infrastructure issue, not a
  code bug).
- Add IgnoreInCIIfBadNetwork and timeout handling consistent with other
  tests in this file.