### PR TITLE
[src] Mark MKDistanceFormatter as thread-safe. Fixes #25617.

### DIFF
--- a/src/mapkit.cs
+++ b/src/mapkit.cs
@@ -2067,6 +2067,7 @@ namespace MapKit {
 
 	[BaseType (typeof (NSFormatter))]
 	[MacCatalyst (13, 1)]
+	[ThreadSafe]
 	partial interface MKDistanceFormatter {
 
 		[Export ("stringFromDistance:")]


### PR DESCRIPTION
Fixes https://github.com/dotnet/macios/issues/25617.