### PR TITLE
[make] Allow configuring the Xcode path

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -212,13 +212,7 @@ MACCATALYST_NUGET_VERSION_FULL=$(MACCATALYST_NUGET_VERSION_NO_METADATA)$(NUGET_B
 XCODE_VERSION=26.5
 XCODE_URL=https://bosstoragemirror.blob.core.windows.net/internal-files/xcodes/Xcode_26.5.xip
 ifndef NO_XCODE
-ifndef XCODE_DEVELOPER_ROOT
-ifneq ($(CONFIGURED_XCODE_DEVELOPER_ROOT),)
-XCODE_DEVELOPER_ROOT := $(CONFIGURED_XCODE_DEVELOPER_ROOT)
-else
-XCODE_DEVELOPER_ROOT=/Applications/Xcode_26.5.0.app/Contents/Developer
-endif
-endif
+XCODE_DEVELOPER_ROOT?=/Applications/Xcode_26.5.0.app/Contents/Developer
 ifneq (OK,$(shell test -d $(abspath $(XCODE_DEVELOPER_ROOT)) && echo OK))
 NO_XCODE=1
 $(warning The required Xcode ($(XCODE_VERSION)) is not installed in $(XCODE_DEVELOPER_ROOT) - this directory does not exist. Any parts of the build that require Xcode will be disabled.)

--- a/Make.config
+++ b/Make.config
@@ -206,11 +206,19 @@ MACCATALYST_NUGET_VERSION_PATCH=$(word 3, $(subst ., ,$(MACCATALYST_NUGET_VERSIO
 MACCATALYST_NUGET_VERSION_NO_METADATA=$(MACCATALYST_NUGET_VERSION)$(NUGET_PRERELEASE_IDENTIFIER)
 MACCATALYST_NUGET_VERSION_FULL=$(MACCATALYST_NUGET_VERSION_NO_METADATA)$(NUGET_BUILD_METADATA)
 
+-include $(TOP)/configure.inc
+
 # Xcode version should have both a major and a minor version (even if the minor version is 0)
 XCODE_VERSION=26.5
 XCODE_URL=https://bosstoragemirror.blob.core.windows.net/internal-files/xcodes/Xcode_26.5.xip
 ifndef NO_XCODE
+ifndef XCODE_DEVELOPER_ROOT
+ifneq ($(CONFIGURED_XCODE_DEVELOPER_ROOT),)
+XCODE_DEVELOPER_ROOT := $(CONFIGURED_XCODE_DEVELOPER_ROOT)
+else
 XCODE_DEVELOPER_ROOT=/Applications/Xcode_26.5.0.app/Contents/Developer
+endif
+endif
 ifneq (OK,$(shell test -d $(abspath $(XCODE_DEVELOPER_ROOT)) && echo OK))
 NO_XCODE=1
 $(warning The required Xcode ($(XCODE_VERSION)) is not installed in $(XCODE_DEVELOPER_ROOT) - this directory does not exist. Any parts of the build that require Xcode will be disabled.)

--- a/configure
+++ b/configure
@@ -29,6 +29,11 @@ Usage: configure [options]
 
     --custom-dotnet=[dotnet/runtime] Use a locally built version of dotnet/runtime. Pass the path to an already build checkout of dotnet/runtime. See docs/CORECLR.md for detailed instructions about how to build dotnet/runtime from source.
 
+    --xcode=[path]          Select the Xcode app or developer root to use for the build.
+    --xcode-root=[path]     Select the Xcode app to use for the build.
+    --xcode-developer-root=[path]
+                            Select the Xcode developer root to use for the build.
+
     --ignore-unknown-params  alters the default behavior to not return an non-zero exit code when an unknown parameter is provided.
 
     --no-xcode               Only do things that don't require Xcode. This won't produce anything useful, but might come in handy once in a blue moon when testing something that doesn't require Xcode somewhere Xcode can't be installed (Linux, older macOS devices, etc.)
@@ -39,6 +44,39 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 CONFIGURED_FILE=configure.inc
 IGNORE_UNKNOWN_PARAMS=false
 UNKNOWN_PARAMETERS=
+NO_XCODE_FLAG=
+XCODE_ARG=
+
+function fail_configure () {
+    echo "configure: $1" >&2
+    rm -f "$CONFIGURED_FILE"
+    exit 1
+}
+
+function set_xcode_arg () {
+    local value="$1"
+    local option="$2"
+
+    while [[ "$value" == */ ]]; do
+        value="${value%/}"
+    done
+
+    if [[ -z "$value" ]]; then
+        fail_configure "$option requires a non-empty path"
+    fi
+
+    if [[ ! "$value" =~ ^/[A-Za-z0-9._+/-]+$ ]]; then
+        fail_configure "$option path contains unsupported characters: '$value'"
+    fi
+
+    if [[ "$value" == *.app ]]; then
+        value="$value/Contents/Developer"
+    elif [[ "$value" != */Contents/Developer ]]; then
+        fail_configure "$option must point to an Xcode .app bundle or Contents/Developer directory"
+    fi
+
+    XCODE_ARG="$value"
+}
 
 rm -f $CONFIGURED_FILE
 
@@ -130,6 +168,17 @@ while test "x$1" != x; do
         echo "DOTNET_RUNTIME_PATH=$2" >> "$CONFIGURED_FILE"
         shift 2
         ;;
+    --xcode=*|--xcode-root=*|--xcode-developer-root=*)
+        set_xcode_arg "${1#*=}" "${1%%=*}"
+        shift
+        ;;
+    --xcode|--xcode-root|--xcode-developer-root)
+        if [[ $# -lt 2 ]] || [[ "$2" == --* ]]; then
+            fail_configure "$1 requires a value"
+        fi
+        set_xcode_arg "$2" "$1"
+        shift 2
+        ;;
     --disable-device)
         echo "INCLUDE_DEVICE=" >> "$CONFIGURED_FILE"
         shift
@@ -153,6 +202,7 @@ while test "x$1" != x; do
         ;;
     --no-xcode)
         echo "Ignoring Xcode requirement"
+        NO_XCODE_FLAG=1
         echo "NO_XCODE=1" >> "$CONFIGURED_FILE"
         shift
         ;;
@@ -168,12 +218,21 @@ while test "x$1" != x; do
     esac
 done
 
+if [[ -n "$NO_XCODE_FLAG" && -n "$XCODE_ARG" ]]; then
+    fail_configure "--no-xcode cannot be combined with --xcode, --xcode-root, or --xcode-developer-root"
+fi
+
 if [[ "$IGNORE_UNKNOWN_PARAMS" = false ]] && [[ -n "$UNKNOWN_PARAMETERS" ]]; then
     exit 1
 fi
 
 if [[ "$IGNORE_UNKNOWN_PARAMS" = true ]] && [[ -n "$UNKNOWN_PARAMETERS" ]]; then
     echo "The following parameters were ignored: $UNKNOWN_PARAMETERS"
+fi
+
+if [[ -n "$XCODE_ARG" ]]; then
+    echo "CONFIGURED_XCODE_DEVELOPER_ROOT=$XCODE_ARG" >> "$CONFIGURED_FILE"
+    echo "Xcode developer root set to $XCODE_ARG"
 fi
 
 exit 0

--- a/configure
+++ b/configure
@@ -231,7 +231,7 @@ if [[ "$IGNORE_UNKNOWN_PARAMS" = true ]] && [[ -n "$UNKNOWN_PARAMETERS" ]]; then
 fi
 
 if [[ -n "$XCODE_ARG" ]]; then
-    echo "CONFIGURED_XCODE_DEVELOPER_ROOT=$XCODE_ARG" >> "$CONFIGURED_FILE"
+    echo "XCODE_DEVELOPER_ROOT=$XCODE_ARG" >> "$CONFIGURED_FILE"
     echo "Xcode developer root set to $XCODE_ARG"
 fi
 

--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -53,13 +53,13 @@ function get_xcode_developer_root ()
 			return
 		fi
 
-		if test -n "${CONFIGURED_XCODE_DEVELOPER_ROOT:-}"; then
-			echo "$CONFIGURED_XCODE_DEVELOPER_ROOT"
+		if XCODE_DEVELOPER_ROOT_ASSIGNMENT=$(grep "^XCODE_DEVELOPER_ROOT=" configure.inc 2>/dev/null); then
+			echo "${XCODE_DEVELOPER_ROOT_ASSIGNMENT#*=}"
 			return
 		fi
 	fi
 
-	grep "^XCODE${suffix}_DEVELOPER_ROOT=" Make.config | sed 's/.*=//'
+	grep "^XCODE${suffix}_DEVELOPER_ROOT[?:]*=" Make.config | sed 's/^[^=]*=//'
 }
 
 # parse command-line arguments

--- a/system-dependencies.sh
+++ b/system-dependencies.sh
@@ -43,6 +43,25 @@ if test -f configure.inc; then
 	fi
 fi
 
+function get_xcode_developer_root ()
+{
+	local suffix="${1:-}"
+
+	if test -z "$suffix"; then
+		if test -n "${XCODE_DEVELOPER_ROOT:-}"; then
+			echo "$XCODE_DEVELOPER_ROOT"
+			return
+		fi
+
+		if test -n "${CONFIGURED_XCODE_DEVELOPER_ROOT:-}"; then
+			echo "$CONFIGURED_XCODE_DEVELOPER_ROOT"
+			return
+		fi
+	fi
+
+	grep "^XCODE${suffix}_DEVELOPER_ROOT=" Make.config | sed 's/.*=//'
+}
+
 # parse command-line arguments
 while ! test -z $1; do
 	case $1 in
@@ -219,6 +238,12 @@ while ! test -z $1; do
 	esac
 done
 
+if test -z "${NO_XCODE:-}"; then
+	XCODE_DEVELOPER_ROOT=$(get_xcode_developer_root)
+	export XCODE_DEVELOPER_ROOT
+	export DEVELOPER_DIR="$XCODE_DEVELOPER_ROOT"
+fi
+
 # reporting functions
 COLOR_RED=$(tput setaf 1 2>/dev/null || true)
 COLOR_ORANGE=$(tput setaf 3 2>/dev/null || true)
@@ -351,7 +376,7 @@ function xcodebuild_download_selected_platforms ()
 	local TVOS_NUGET_OS_VERSION
 	local TVOS_BUILD_VERSION
 
-	XCODE_DEVELOPER_ROOT=$(grep XCODE_DEVELOPER_ROOT= Make.config | sed 's/.*=//')
+	XCODE_DEVELOPER_ROOT=$(get_xcode_developer_root)
 	XCODE_NAME=$(basename "$(dirname "$(dirname "$XCODE_DEVELOPER_ROOT")")")
 	# we use the same logic here as in Make.config to determine whether we're using a stable version of Xcode or not (search for XCODE_IS_STABLE/XCODE_IS_PREVIEW)
 	XCODE_IS_STABLE=$(echo "$XCODE_NAME" | sed -e 's@^Xcode[_0-9.]*[.]app$@YES@')
@@ -592,7 +617,7 @@ function install_coresimulator ()
 	local TARGET_CORESIMULATOR_VERSION
 	local CURRENT_CORESIMULATOR_VERSION
 
-	XCODE_DEVELOPER_ROOT=$(grep XCODE_DEVELOPER_ROOT= Make.config | sed 's/.*=//')
+	XCODE_DEVELOPER_ROOT=$(get_xcode_developer_root)
 	XCODE_ROOT=$(dirname "$(dirname "$XCODE_DEVELOPER_ROOT")")
 	CORESIMULATOR_PKG=$XCODE_ROOT/Contents/Resources/Packages/XcodeSystemResources.pkg
 
@@ -658,9 +683,13 @@ function install_coresimulator ()
 }
 
 function check_specific_xcode () {
-	local XCODE_DEVELOPER_ROOT=`grep XCODE$1_DEVELOPER_ROOT= Make.config | sed 's/.*=//'`
-	local XCODE_VERSION=`grep XCODE$1_VERSION= Make.config | sed 's/.*=//'`
-	local XCODE_ROOT=$(dirname `dirname $XCODE_DEVELOPER_ROOT`)
+	local XCODE_DEVELOPER_ROOT
+	local XCODE_VERSION
+	local XCODE_ROOT
+
+	XCODE_DEVELOPER_ROOT=$(get_xcode_developer_root "$1")
+	XCODE_VERSION=$(grep "XCODE$1_VERSION=" Make.config | sed 's/.*=//')
+	XCODE_ROOT=$(dirname "$(dirname "$XCODE_DEVELOPER_ROOT")")
 	
 	if ! test -d $XCODE_DEVELOPER_ROOT; then
 		if ! test -z $PROVISION_XCODE; then
@@ -698,11 +727,13 @@ function check_xcode () {
 	if ! test -z $IGNORE_XCODE; then return; fi
 
 	# must have latest Xcode in /Applications/Xcode<version>.app
-	check_specific_xcode
+	check_specific_xcode ""
 	install_coresimulator
 
 	local IOS_SDK_VERSION MACOS_SDK_VERSION TVOS_SDK_VERSION
-	local XCODE_DEVELOPER_ROOT=`grep ^XCODE_DEVELOPER_ROOT= Make.config | sed 's/.*=//'`
+	local XCODE_DEVELOPER_ROOT
+
+	XCODE_DEVELOPER_ROOT=$(get_xcode_developer_root)
 	IOS_SDK_VERSION=$(grep ^IOS_NUGET_OS_VERSION= Make.versions | sed -e 's/.*=//')
 	MACOS_SDK_VERSION=$(grep ^MACOS_NUGET_OS_VERSION= Make.versions | sed -e 's/.*=//')
 	TVOS_SDK_VERSION=$(grep ^TVOS_NUGET_OS_VERSION= Make.versions | sed -e 's/.*=//')
@@ -928,7 +959,7 @@ function check_old_simulators ()
 	local XCODE
 	local XCODE_DEVELOPER_ROOT
 
-	XCODE_DEVELOPER_ROOT=$(grep XCODE$1_DEVELOPER_ROOT= Make.config | sed 's/.*=//')
+	XCODE_DEVELOPER_ROOT=$(get_xcode_developer_root "$1")
 
 	IFS=' ' read -r -a EXTRA_SIMULATORS <<< "$(grep ^EXTRA_SIMULATORS= Make.config | sed 's/.*=//')"
 	XCODE=$(dirname "$(dirname "$XCODE_DEVELOPER_ROOT")")
@@ -1006,4 +1037,3 @@ else
 	echo "System check failed"
 	exit 1
 fi
-


### PR DESCRIPTION
Add a configure-time option for selecting the Xcode installation used by the build.

Some build images install Xcode 26.5 as:

    /Applications/Xcode_26.5.app

while the repository default points at:

    /Applications/Xcode_26.5.0.app

Xcode does not behave well when accessed through symlinks, so make the path explicit instead of requiring machines to provide an alternate app bundle name.

The configure options accept either the Xcode app bundle path or the developer root path:

    ./configure --xcode=/Applications/Xcode_26.5.app
    ./configure --xcode=/Applications/Xcode_26.5.app/Contents/Developer
    ./configure --xcode-root=/Applications/Xcode_26.5.app
    ./configure --xcode-developer-root=/Applications/Xcode_26.5.app/Contents/Developer

Based on PR review feedback, `configure` now writes the selected path directly to `configure.inc` as `XCODE_DEVELOPER_ROOT`. `Make.config` includes `configure.inc` before resolving the Xcode block and uses `?=` for the existing default path:

    XCODE_DEVELOPER_ROOT?=/Applications/Xcode_26.5.0.app/Contents/Developer

This keeps the behavior simple and consistent with the other configure options: an explicitly configured Xcode path wins, while the existing `.0.app` path remains the default when no path is configured.

`system-dependencies.sh` now also checks `configure.inc` for `XCODE_DEVELOPER_ROOT` before falling back to the `Make.config` default, and direct invocations export `DEVELOPER_DIR` from the resolved Xcode root so the script and Make agree on the selected Xcode.

No pipeline- or agent-specific logic is added. CI can opt into the shorter app bundle name by running:

    ./configure --xcode=/Applications/Xcode_26.5.app

Local developers with `Xcode_26.5.0.app` can continue using the default configuration unchanged.
