### PR TITLE
[release/10.0.1xx] [tests] Treat missing expected cookie as transient network failure in TestNSurlSessionHandlerCookieContainerSetCookie

### DIFF
--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -195,13 +195,14 @@ namespace MonoTests.System.Net.Http {
 				nativeCookieResult = await nativeResponse.Content.ReadAsStringAsync ();
 			}, out var ex);
 
-			if (!completed)
+			var cookiesFromServer = cookieContainer.GetCookies (new Uri (url));
+			var hasExpectedCookie = cookiesFromServer.Cast<Cookie> ().Any (v => v.Name == "cookie" && v.Value == "chocolate-chip");
+			if (!completed || !hasExpectedCookie)
 				TestRuntime.IgnoreInCI ("Transient network failure - ignore in CI");
 			Assert.IsTrue (completed, "Network request completed");
 			Assert.IsNull (ex, "Exception");
 			Assert.IsNotNull (nativeCookieResult, "Native cookies result");
-			var cookiesFromServer = cookieContainer.GetCookies (new Uri (url));
-			Assert.That (cookiesFromServer.Cast<Cookie> ().Any (v => v.Name == "cookie" && v.Value == "chocolate-chip"), Is.True, "Cookies received from server.");
+			Assert.That (hasExpectedCookie, Is.True, "Cookies received from server.");
 		}
 
 		[Test]

--- a/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
+++ b/tests/monotouch-test/System.Net.Http/MessageHandlers.cs
@@ -195,13 +195,15 @@ namespace MonoTests.System.Net.Http {
 				nativeCookieResult = await nativeResponse.Content.ReadAsStringAsync ();
 			}, out var ex);
 
-			var cookiesFromServer = cookieContainer.GetCookies (new Uri (url));
-			var hasExpectedCookie = cookiesFromServer.Cast<Cookie> ().Any (v => v.Name == "cookie" && v.Value == "chocolate-chip");
-			if (!completed || !hasExpectedCookie)
+			if (!completed)
 				TestRuntime.IgnoreInCI ("Transient network failure - ignore in CI");
 			Assert.IsTrue (completed, "Network request completed");
 			Assert.IsNull (ex, "Exception");
 			Assert.IsNotNull (nativeCookieResult, "Native cookies result");
+			var cookiesFromServer = cookieContainer.GetCookies (new Uri (url));
+			var hasExpectedCookie = cookiesFromServer.Cast<Cookie> ().Any (v => v.Name == "cookie" && v.Value == "chocolate-chip");
+			if (!hasExpectedCookie)
+				TestRuntime.IgnoreInCI ("Transient network failure - ignore in CI");
 			Assert.That (hasExpectedCookie, Is.True, "Cookies received from server.");
 		}
 


### PR DESCRIPTION
- [x] Fix `TestNSurlSessionHandlerCookieContainerSetCookie` to treat missing expected cookie as transient network failure (ignore in CI)
- [x] Address race condition: move `CookieContainer` inspection after `!completed` guard to avoid concurrent access
- [x] Address exception masking: separate `!completed` and `!hasExpectedCookie` CI-ignore guards so real exceptions still fail the test

Fixes https://github.com/dotnet/macios/issues/25385.

---------

Co-authored-by: rolfbjarne <249268+rolfbjarne@users.noreply.github.com>

Backport of #25420.