### PR TITLE
[tests] Don't strip symbols on any platform.

### DIFF
--- a/tests/monotouch-test/dotnet/shared.csproj
+++ b/tests/monotouch-test/dotnet/shared.csproj
@@ -13,7 +13,7 @@
     <MonoTouchTestDirectory>$(RootTestsDirectory)\monotouch-test</MonoTouchTestDirectory>
 
     <!-- Don't remove native symbols, because it makes debugging native crashes harder -->
-    <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
+    <NoSymbolStrip>true</NoSymbolStrip>
 
     <DefineConstants Condition="'$(Configuration)' == 'Debug'">$(DefineConstants);DEBUG</DefineConstants>
 


### PR DESCRIPTION
`MtouchNoSymbolStrip` doesn't do anything on macOS, so use `NoSymbolStrip` instead.