### PR TITLE
[monotouch-test] Add timeouts to all Thread.Join calls

### DIFF
--- a/tests/monotouch-test/CoreAnimation/LayerTest.cs
+++ b/tests/monotouch-test/CoreAnimation/LayerTest.cs
@@ -133,7 +133,7 @@ namespace MonoTouchFixtures.CoreAnimation {
 				}
 			});
 			thread.Start ();
-			thread.Join ();
+			Assert.That (thread.Join (TimeSpan.FromSeconds (10)), Is.True, "Thread.Join timed out");
 
 			var watch = new Stopwatch ();
 			watch.Start ();
@@ -181,7 +181,7 @@ namespace MonoTouchFixtures.CoreAnimation {
 				IsBackground = true,
 			};
 			t.Start ();
-			t.Join ();
+			Assert.That (t.Join (TimeSpan.FromSeconds (5)), Is.True, "Thread.Join timed out");
 			GC.Collect ();
 
 			NSRunLoop.Main.RunUntil (NSDate.Now.AddSeconds (0.1));

--- a/tests/monotouch-test/CoreAnimation/LayerTest.cs
+++ b/tests/monotouch-test/CoreAnimation/LayerTest.cs
@@ -131,7 +131,9 @@ namespace MonoTouchFixtures.CoreAnimation {
 				} catch (Exception e) {
 					ex = e;
 				}
-			});
+			}) {
+				IsBackground = true,
+			};
 			thread.Start ();
 			Assert.That (thread.Join (TimeSpan.FromSeconds (10)), Is.True, "Thread.Join timed out");
 

--- a/tests/monotouch-test/CoreImage/CIKernelTests.cs
+++ b/tests/monotouch-test/CoreImage/CIKernelTests.cs
@@ -153,7 +153,9 @@ namespace MonoTouchFixtures.CoreImage {
 				} catch (Exception ex2) {
 					ex = ex2;
 				}
-			});
+			}) {
+				IsBackground = true,
+			};
 			t.Start ();
 			Assert.That (t.Join (TimeSpan.FromSeconds (30)), Is.True, "Thread.Join timed out");
 			if (ex is not null)

--- a/tests/monotouch-test/CoreImage/CIKernelTests.cs
+++ b/tests/monotouch-test/CoreImage/CIKernelTests.cs
@@ -155,7 +155,7 @@ namespace MonoTouchFixtures.CoreImage {
 				}
 			});
 			t.Start ();
-			t.Join ();
+			Assert.That (t.Join (TimeSpan.FromSeconds (30)), Is.True, "Thread.Join timed out");
 			if (ex is not null)
 				throw ex;
 		}

--- a/tests/monotouch-test/Foundation/NSStreamTest.cs
+++ b/tests/monotouch-test/Foundation/NSStreamTest.cs
@@ -63,7 +63,9 @@ namespace MonoTouchFixtures.Foundation {
 				return;
 			}
 
-			var listenThread = new Thread (new ParameterizedThreadStart (DebugListener));
+			var listenThread = new Thread (new ParameterizedThreadStart (DebugListener)) {
+				IsBackground = true,
+			};
 			listenThread.Start (listener);
 			NSStream.CreatePairWithSocketToHost (new IPEndPoint (IPAddress.Loopback, port), out read, out write);
 			read.Open ();

--- a/tests/monotouch-test/Foundation/NSStreamTest.cs
+++ b/tests/monotouch-test/Foundation/NSStreamTest.cs
@@ -74,7 +74,7 @@ namespace MonoTouchFixtures.Foundation {
 			Assert.That (read.Read (result, 5), Is.EqualTo ((nint) 5));
 			for (int i = 0; i < 5; i++)
 				Assert.That (result [i], Is.EqualTo (send [i] * 10));
-			listenThread.Join ();
+			Assert.That (listenThread.Join (TimeSpan.FromSeconds (10)), Is.True, "listenThread.Join timed out");
 			listener.Stop ();
 			read.Close ();
 			write.Close ();

--- a/tests/monotouch-test/Foundation/NotificationCenter.cs
+++ b/tests/monotouch-test/Foundation/NotificationCenter.cs
@@ -140,7 +140,7 @@ namespace MonoTouchFixtures.Foundation {
 			// OK, we're done now, time to stop.
 			stopSignal.Set ();
 			for (var i = 0; i < threadCount; i++) {
-				threads [i].Join ();
+				Assert.That (threads [i].Join (TimeSpan.FromSeconds (5)), Is.True, $"Thread {i} failed to join within 5 seconds");
 			}
 			Assert.That (ex, Is.Null, "Exception");
 		}

--- a/tests/monotouch-test/Foundation/ThreadTest.cs
+++ b/tests/monotouch-test/Foundation/ThreadTest.cs
@@ -40,7 +40,7 @@ namespace MonoTouchFixtures.Foundation {
 				IsBackground = true,
 			};
 			t.Start ();
-			t.Join ();
+			Assert.That (t.Join (TimeSpan.FromSeconds (5)), Is.True, "Thread.Join timed out");
 			Assert.That (rv, Is.EqualTo (0));
 		}
 

--- a/tests/monotouch-test/Foundation/TimerTest.cs
+++ b/tests/monotouch-test/Foundation/TimerTest.cs
@@ -42,7 +42,7 @@ namespace MonoTouchFixtures.Foundation {
 				thread.Start ();
 
 				Assert.That (evt.Wait (TimeSpan.FromSeconds (5)), Is.True, "Not signalled twice in 5s");
-				thread.Join ();
+				Assert.That (thread.Join (TimeSpan.FromSeconds (10)), Is.True, "Thread.Join timed out");
 			}
 		}
 
@@ -70,7 +70,7 @@ namespace MonoTouchFixtures.Foundation {
 				thread.Start ();
 
 				Assert.That (evt.Wait (TimeSpan.FromSeconds (5)), Is.True, "Not signalled twice in 5s");
-				thread.Join ();
+				Assert.That (thread.Join (TimeSpan.FromSeconds (10)), Is.True, "Thread.Join timed out");
 			}
 		}
 
@@ -101,7 +101,7 @@ namespace MonoTouchFixtures.Foundation {
 
 				Assert.That (evt.WaitOne (TimeSpan.FromSeconds (5)), Is.True, "WaitOne");
 				Assert.That (result, Is.True, "result");
-				thread.Join ();
+				Assert.That (thread.Join (TimeSpan.FromSeconds (10)), Is.True, "Thread.Join timed out");
 			}
 		}
 	}

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2124,7 +2124,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				}
 			});
 			thread.Start ();
-			thread.Join ();
+			Assert.That (thread.Join (TimeSpan.FromSeconds (30)), Is.True, "Thread.Join timed out");
 			GC.Collect ();
 			GC.WaitForPendingFinalizers ();
 			TestRuntime.RunAsync (TimeSpan.FromSeconds (30), () => { }, () => ObjCBlockTester.FreedBlockCount > initialFreedCount);

--- a/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RegistrarTest.cs
@@ -2122,7 +2122,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				} catch (Exception e) {
 					ex = e;
 				}
-			});
+			}) {
+				IsBackground = true,
+			};
 			thread.Start ();
 			Assert.That (thread.Join (TimeSpan.FromSeconds (30)), Is.True, "Thread.Join timed out");
 			GC.Collect ();

--- a/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
@@ -198,7 +198,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				IsBackground = true,
 			};
 			t.Start ();
-			t.Join ();
+			Assert.That (t.Join (TimeSpan.FromSeconds (5)), Is.True, "Thread.Join timed out");
 
 			// Now we have a handle to an object that may be garbage collected at any time.
 			int counter = 0;
@@ -297,7 +297,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 				IsBackground = true
 			};
 			thread.Start ();
-			thread.Join ();
+			Assert.That (thread.Join (TimeSpan.FromSeconds (5)), Is.True, "Thread.Join timed out");
 
 			var getter1 = new Func<string, string> ((key) => dict [key] as NSString);
 			var getter2 = new Func<string, NSString> ((key) => dict [key] as NSString);
@@ -557,7 +557,7 @@ namespace MonoTouchFixtures.ObjCRuntime {
 					Messaging.bool_objc_msgSend_IntPtr_int (invokerClassHandle, Selector.GetHandle ("invokeMe:wait:"), objects [i], 0);
 			});
 			t1.Start ();
-			t1.Join ();
+			Assert.That (t1.Join (TimeSpan.FromSeconds (5)), Is.True, "Thread.Join timed out");
 
 			// Collect all those managed wrappers, and make sure their finalizers are executed.
 			GC.Collect ();

--- a/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
+++ b/tests/monotouch-test/ObjCRuntime/RuntimeTest.cs
@@ -555,7 +555,9 @@ namespace MonoTouchFixtures.ObjCRuntime {
 			var t1 = new Thread (() => {
 				for (int i = 0; i < objects.Length; i++)
 					Messaging.bool_objc_msgSend_IntPtr_int (invokerClassHandle, Selector.GetHandle ("invokeMe:wait:"), objects [i], 0);
-			});
+			}) {
+				IsBackground = true,
+			};
 			t1.Start ();
 			Assert.That (t1.Join (TimeSpan.FromSeconds (5)), Is.True, "Thread.Join timed out");
 

--- a/tests/monotouch-test/SystemConfiguration/NetworkReachabilityTest.cs
+++ b/tests/monotouch-test/SystemConfiguration/NetworkReachabilityTest.cs
@@ -220,7 +220,9 @@ namespace MonoTouchFixtures.SystemConfiguration {
 					// Dispose to ensure GCHandle is freed
 					reachability.Dispose ();
 				}
-			});
+			}) {
+				IsBackground = true,
+			};
 
 			thread.Start ();
 			Assert.That (thread.Join (TimeSpan.FromSeconds (5)), Is.True, "Thread.Join timed out");
@@ -263,7 +265,9 @@ namespace MonoTouchFixtures.SystemConfiguration {
 					// Store weak reference to track if object is collected
 					weakRefs [i] = new WeakReference (reachability);
 				}
-			});
+			}) {
+				IsBackground = true,
+			};
 
 			thread.Start ();
 			Assert.That (thread.Join (TimeSpan.FromSeconds (5)), Is.True, "Thread.Join timed out");

--- a/tests/monotouch-test/SystemConfiguration/NetworkReachabilityTest.cs
+++ b/tests/monotouch-test/SystemConfiguration/NetworkReachabilityTest.cs
@@ -223,7 +223,7 @@ namespace MonoTouchFixtures.SystemConfiguration {
 			});
 
 			thread.Start ();
-			thread.Join ();
+			Assert.That (thread.Join (TimeSpan.FromSeconds (5)), Is.True, "Thread.Join timed out");
 
 			// Force garbage collection
 			GC.Collect ();
@@ -266,7 +266,7 @@ namespace MonoTouchFixtures.SystemConfiguration {
 			});
 
 			thread.Start ();
-			thread.Join ();
+			Assert.That (thread.Join (TimeSpan.FromSeconds (5)), Is.True, "Thread.Join timed out");
 
 			// Force garbage collection
 			GC.Collect ();


### PR DESCRIPTION
Replace all `Thread.Join()` calls (no timeout) in monotouch-test with `Thread.Join(TimeSpan)` + `Assert.That` to fail the test if the thread does not complete within a reasonable time, instead of hanging indefinitely.

Additionally, all affected threads are marked as background threads (`IsBackground = true`) so that if a Join times out, the orphaned thread does not keep the test process alive.

Timeouts are chosen based on the work each thread does:

- **5s** for simple/fast operations (object creation, property checks)
- **10s** for I/O or RunLoop-based threads (timers, network listeners, sublayer creation)
- **30s** for heavy workloads (10k iterations, GPU image processing)

🤖 Pull request created by Copilot