### PR TITLE
[devops] Don't clean ACES bots.

### DIFF
--- a/tools/devops/automation/scripts/bash/clean-bot.sh
+++ b/tools/devops/automation/scripts/bash/clean-bot.sh
@@ -6,6 +6,11 @@ if [[ "$BUILD_REVISION" == "" ]] ; then
 	exit 1
 fi
 
+if [[ "$ACES" != "" ]]; then
+	echo "Assuming ACES bots are already clean, so not cleaning anything."
+	exit 0
+fi
+
 # Print disk status before cleaning
 df -h
 


### PR DESCRIPTION
They're already clean.

Looks like this will save ~2 min for every job.