### PR TITLE
[dotnet] Use desktop MSBuild task assemblies in VS for all platforms, not just iOS

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -19,6 +19,9 @@
 	<Import Project="$(_MobilePropsPath)" Condition="Exists('$(_MobilePropsPath)') And ('$(BuildingInsideVisualStudio)' == 'true' Or '$(DesignTimeBuild)' == 'true')" />
 	
 	<PropertyGroup>
+		<!-- Keep using the desktop (netstandard2.0) MSBuild task assemblies when building from within Visual Studio (on Windows), instead of the net assemblies that require a .NET task host (which doesn't work reliably, in particular on Windows ARM64). The iOS Sdk.props sets this earlier because it also drives CoreiOSSdkDirectory; the condition below makes it apply to the other platforms (MacCatalyst, macOS, tvOS) too. -->
+		<_UseDesktopTaskAssemblies Condition="'$(_UseDesktopTaskAssemblies)' == '' And '$(BuildingInsideVisualStudio)' == 'true'">true</_UseDesktopTaskAssemblies>
+
 		<!-- Set to true when using the Microsoft.<platform>.Sdk NuGet. This is used by pre-existing/shared targets to tweak behavior depending on build system -->
 		<UsingAppleNETSdk>true</UsingAppleNETSdk>
 		<!-- This is the location of the Microsoft.<platform>.Sdk NuGet (/usr/local/share/dotnet/sdk/<version>/Sdks/Microsoft.[iOS/tvOS/MacCatalyst/macOS].Sdk) on the platform the build is running from (Mac or Win) -->


### PR DESCRIPTION
## Summary

Building a `net*-maccatalyst` project inside Visual Studio on **Windows ARM64** fails with:

```
error MSB4216: Could not run the "MakeDir" task because MSBuild could not create
or connect to a task host with runtime "NET" and architecture "*".
```

### Root cause

When building inside VS, our MSBuild tasks (including the built-in tasks we override, e.g. `MakeDir`) are registered in `Xamarin.Shared.Sdk.targets` with `Runtime="$(_TaskRuntime)"`. `_TaskRuntime` is `NET` (using the `net` task assemblies, which require a .NET task host) unless `_UseDesktopTaskAssemblies=true`, in which case it is `CurrentRuntime` (using the `netstandard2.0` assemblies in-process).

The .NET task host does not work reliably from VS, and fails outright on Windows ARM64.

#25417 worked around this by setting `_UseDesktopTaskAssemblies=true` when `BuildingInsideVisualStudio=true`, but only added it to `Microsoft.iOS.Sdk.props`. MacCatalyst, macOS and tvOS were left out, so those platforms still use `Runtime="NET"` in VS and break on Windows ARM64. The attached binlog from the work item confirms the iOS inner build resolves `_TaskRuntime=CurrentRuntime` while the MacCatalyst inner build resolves `_TaskRuntime=NET`.

### Fix

Move the `_UseDesktopTaskAssemblies` guard into the shared `Xamarin.Shared.Sdk.props` (imported by all four platform SDKs) so the workaround applies to MacCatalyst, macOS and tvOS as well. `Microsoft.iOS.Sdk.props` keeps setting it earlier (it also drives `CoreiOSSdkDirectory`), and the `'$(_UseDesktopTaskAssemblies)' == ''` guard makes the shared copy idempotent.

All platform packs ship both the `netstandard2.0` and `net` task assemblies (`msbuild/Makefile` installs them uniformly for every platform), so the `netstandard2.0` path resolves to a real file.