### PR TITLE
[tests] Update MSBuild.StructuredLogger to 2.2.243

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<!-- Disables the transitive restore of packages like Microsoft.AspNetCore.App.Ref, Microsoft.WindowsDesktop.App.Ref -->
 		<DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
-		<MSBuildStructuredLoggerPackageVersion>2.2.158</MSBuildStructuredLoggerPackageVersion>
+		<MSBuildStructuredLoggerPackageVersion>2.2.243</MSBuildStructuredLoggerPackageVersion>
 		<MicrosoftBuildPackageVersion>17.13.26</MicrosoftBuildPackageVersion>
 		<MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
 		<MicrosoftBuildTasksCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildTasksCorePackageVersion>


### PR DESCRIPTION
## Summary
- update `MSBuild.StructuredLogger` from `2.2.158` to `2.2.243`
- pick the smallest verified bump that fixes the local binlog parser crash

## Why
Local Apple test binlogs can record an empty `CurrentUICulture=` event under `LANG=C.UTF-8`.

With `MSBuild.StructuredLogger` `2.2.158`, the reader synthesizes `PropertyReassignment` messages from localized string resources, but those resources are only initialized after a non-empty culture event. When the binlog reaches the first `PropertyReassignment`, `Strings.PropertyReassignment` can still be null, which crashes parsing with `ArgumentNullException("format")` instead of reporting the actual build result.

`2.2.243` already contains the upfront string initialization that avoids that failure, so the same local binlogs parse successfully without needing a larger package jump.

## Validation
- built `tests/dotnet/UnitTests/DotNetUnitTests.csproj` on current `main`
- re-ran the standalone binlog repro against a previously failing successful local Apple binlog and `2.2.243` parsed property reassignments successfully
