### PR TITLE
[dotnet] Quote MlaunchPath in generated mobile run scripts

### DIFF
--- a/dotnet/targets/Microsoft.Sdk.Mobile.targets
+++ b/dotnet/targets/Microsoft.Sdk.Mobile.targets
@@ -70,7 +70,7 @@
 
 		<WriteLinesToFile
 			File="$(MlaunchInstallScript)"
-			Lines="$(MlaunchPath) $(MlaunchInstallArguments)"
+			Lines="'$(MlaunchPath)' $(MlaunchInstallArguments)"
 			Overwrite="true"
 			WriteOnlyWhenDifferent="true"
 			Condition="'$(MlaunchInstallScript)' != ''"
@@ -128,14 +128,14 @@
 
 		<WriteLinesToFile
 			File="$(MlaunchRunScript)"
-			Lines="$(MlaunchPath) $(MlaunchRunArguments)"
+			Lines="'$(MlaunchPath)' $(MlaunchRunArguments)"
 			Overwrite="true"
 			WriteOnlyWhenDifferent="true"
 			Condition="'$(MlaunchRunScript)' != ''"
 			 />
 
 		<PropertyGroup>
-			<RunCommand>$(MlaunchPath)</RunCommand>
+			<RunCommand>'$(MlaunchPath)'</RunCommand>
 			<RunArguments>$(MlaunchRunArguments) -- </RunArguments>
 		</PropertyGroup>
 	</Target>

--- a/tests/dotnet/UnitTests/MlaunchTest.cs
+++ b/tests/dotnet/UnitTests/MlaunchTest.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Tests {
 			Assert.That (mlaunchInstallArguments, Is.EqualTo (expectedArguments.ToString ()));
 
 			var scriptContents = File.ReadAllText (outputPath).Trim ('\n');
-			var expectedScriptContents = mlaunchPath + " " + expectedArguments.ToString ();
+			var expectedScriptContents = $"'{mlaunchPath}' " + expectedArguments.ToString ();
 			Assert.That (scriptContents, Is.EqualTo (expectedScriptContents), "Script contents");
 		}
 
@@ -96,6 +96,10 @@ namespace Xamarin.Tests {
 				Assert.Fail ("Could not find the property 'MlaunchPath' in the binlog.");
 			Assert.That (mlaunchPath, Does.Exist, "mlaunch existence");
 
+			if (!BinLog.TryFindPropertyValue (rv.BinLogPath, "RunCommand", out var runCommand))
+				Assert.Fail ("Could not find the property 'RunCommand' in the binlog.");
+			Assert.That (runCommand, Is.EqualTo ($"'{mlaunchPath}'"), "Run command");
+
 			var expectedArguments = new StringBuilder ();
 			var isSim = runtimeIdentifiers.Contains ("simulator");
 			expectedArguments.Append (isSim ? "--launchsim " : "--launchdev ");
@@ -108,7 +112,7 @@ namespace Xamarin.Tests {
 			Assert.That (mlaunchRunArguments, Does.Match (expectedArguments.ToString ()), "arguments");
 
 			var scriptContents = File.ReadAllText (outputPath).Trim ('\n');
-			var expectedScriptContents = mlaunchPath + " " + expectedArguments.ToString ();
+			var expectedScriptContents = $"'{mlaunchPath}' " + expectedArguments.ToString ();
 			Assert.That (scriptContents, Does.Match (expectedScriptContents), "Script contents");
 		}
 	}


### PR DESCRIPTION
## Summary

This restores the quoting fix for `MlaunchPath` on the `11.0` preview line.

The regression is in `Microsoft.Sdk.Mobile.targets`: the direct `Exec` path is quoted, but the generated install/run scripts and `RunCommand` were emitted without shell-safe quoting. When the SDK lives under a path containing a space, `dotnet build -t:Run` fails before `mlaunch` starts.

## Changes

- quote `$(MlaunchPath)` in generated install scripts
- quote `$(MlaunchPath)` in generated run scripts
- quote `RunCommand`
- update `MlaunchTest` expectations for the quoted script content / run command

## Validation so far

- temporary pack-swap validation succeeded: replacing the installed `Microsoft.Sdk.Mobile.targets` with this patched file made `dotnet build -t:Run -f net11.0-ios` launch a MAUI sample app successfully when the SDK path contained a space

Ref: https://github.com/dotnet/macios/issues/22481

This PR is recreated from #25673 (because our CI won't build from forks).