### PR TITLE
[bgen] Propagate simulator availability attributes to smart-enum field accessors

### DIFF
--- a/src/bgen/Enums.cs
+++ b/src/bgen/Enums.cs
@@ -260,6 +260,7 @@ public partial class Generator {
 				var fa = kvp.Value;
 				// the attributes (availability and field) are important for our tests
 				PrintPlatformAttributes (f);
+				PrintSimulatorAvailabilityAttributes (f);
 				string? libPath = null;
 				if (library_name is not null)
 					libraries.TryGetValue (library_name, out libPath);

--- a/tests/bgen/BGenTests.cs
+++ b/tests/bgen/BGenTests.cs
@@ -1722,7 +1722,7 @@ namespace GeneratorTests {
 		public void SimulatorAvailabilityAttributes (Profile profile)
 		{
 			Configuration.IgnoreIfIgnoredPlatform (profile.AsPlatform ());
-			var bgen = BuildFile (profile, "simulator-availability-attributes.cs");
+			var bgen = BuildFile (profile, true, true, "simulator-availability-attributes.cs");
 			bgen.AssertNoWarnings ();
 
 			var module = bgen.ApiAssembly.MainModule;
@@ -1762,6 +1762,24 @@ namespace GeneratorTests {
 				.Where (a => a.AttributeType.Name == "UnsupportedSimulatorAttribute" || a.AttributeType.Name == "SupportedSimulatorAttribute")
 				.ToArray ();
 			Assert.That (simulatorAttrs.Length, Is.EqualTo (0), "NoSimulatorAttributes: no simulator attributes");
+
+			// Verify a [SupportedSimulator] on a smart-enum [Field] member is propagated to the generated accessor
+			var smartExtensions = module.GetType ("NS", "SmartEnumWithSimulatorFieldExtensions");
+			Assert.That (smartExtensions, Is.Not.Null, "SmartEnumWithSimulatorFieldExtensions: generated");
+			var supportedAccessor = smartExtensions.Properties.Single (p => p.Name == "SupportedSmartField");
+			var accessorAttrs = supportedAccessor.CustomAttributes
+				.Where (a => a.AttributeType.Name == "SupportedSimulatorAttribute")
+				.ToArray ();
+			Assert.That (accessorAttrs.Length, Is.EqualTo (1), "SupportedSmartField accessor: one SupportedSimulator attribute");
+			var expectedSmartVersion = profile == Profile.iOS ? "ios17.0" : "tvos17.0";
+			Assert.That ((string) accessorAttrs [0].ConstructorArguments [0].Value, Is.EqualTo (expectedSmartVersion), "SupportedSmartField accessor platform name");
+
+			// And a smart-enum member without simulator attributes must not gain any
+			var plainAccessor = smartExtensions.Properties.Single (p => p.Name == "PlainSmartField");
+			var plainAccessorAttrs = plainAccessor.CustomAttributes
+				.Where (a => a.AttributeType.Name == "SupportedSimulatorAttribute" || a.AttributeType.Name == "UnsupportedSimulatorAttribute")
+				.ToArray ();
+			Assert.That (plainAccessorAttrs.Length, Is.EqualTo (0), "PlainSmartField accessor: no simulator attributes");
 		}
 
 		[Test]
@@ -1770,7 +1788,7 @@ namespace GeneratorTests {
 		public void SimulatorAvailabilityAttributes_NotEmittedForMacPlatforms (Profile profile)
 		{
 			Configuration.IgnoreIfIgnoredPlatform (profile.AsPlatform ());
-			var bgen = BuildFile (profile, "simulator-availability-attributes.cs");
+			var bgen = BuildFile (profile, true, true, "simulator-availability-attributes.cs");
 			bgen.AssertNoWarnings ();
 
 			var module = bgen.ApiAssembly.MainModule;
@@ -1780,6 +1798,16 @@ namespace GeneratorTests {
 					.Where (a => a.AttributeType.Name == "UnsupportedSimulatorAttribute" || a.AttributeType.Name == "SupportedSimulatorAttribute")
 					.ToArray ();
 				Assert.That (simulatorAttrs.Length, Is.EqualTo (0), $"{typeName}: no simulator attributes on Mac platforms");
+			}
+
+			// The smart-enum field accessor must not carry simulator attributes on Mac platforms either
+			var smartExtensions = module.GetType ("NS", "SmartEnumWithSimulatorFieldExtensions");
+			Assert.That (smartExtensions, Is.Not.Null, "SmartEnumWithSimulatorFieldExtensions: generated");
+			foreach (var property in smartExtensions.Properties) {
+				var accessorAttrs = property.CustomAttributes
+					.Where (a => a.AttributeType.Name == "UnsupportedSimulatorAttribute" || a.AttributeType.Name == "SupportedSimulatorAttribute")
+					.ToArray ();
+				Assert.That (accessorAttrs.Length, Is.EqualTo (0), $"{property.Name} accessor: no simulator attributes on Mac platforms");
 			}
 		}
 	}

--- a/tests/bgen/tests/simulator-availability-attributes.cs
+++ b/tests/bgen/tests/simulator-availability-attributes.cs
@@ -27,4 +27,17 @@ namespace NS {
 	[BaseType (typeof (NSObject))]
 	interface NoSimulatorAttributes {
 	}
+
+	// A simulator attribute placed on a smart-enum [Field] member must be propagated
+	// to the generated *Extensions field accessor (e.g. CMSampleBufferAttachmentKey.Hdr10PlusPerFrameData).
+	[iOS (16, 0), TV (16, 0), Mac (13, 0), MacCatalyst (16, 0)]
+	enum SmartEnumWithSimulatorField {
+		[SupportedSimulator ("ios17.0")]
+		[SupportedSimulator ("tvos17.0")]
+		[Field ("SupportedSmartField", "__Internal")]
+		Supported,
+
+		[Field ("PlainSmartField", "__Internal")]
+		Plain,
+	}
 }


### PR DESCRIPTION
When a smart-enum member carries a [SupportedSimulator] or [UnsupportedSimulator] attribute, bgen emitted the platform availability attributes on the generated *Extensions field accessor but dropped the simulator availability attributes. The attribute therefore never reached the generated API, so the introspection simulator-availability test could not see it.

This surfaced with CoreMedia's kCMSampleAttachmentKey_HDR10PlusPerFrameData, which is declared available at iOS/tvOS 16.0 but is only present in the simulator runtimes of a later release: the [SupportedSimulator] annotation on the smart-enum member was silently discarded.

Emit PrintSimulatorAvailabilityAttributes (f) alongside the existing PrintPlatformAttributes (f) call in the smart-enum field-accessor loop so the simulator attributes are propagated like the platform ones.

Add a regression test: a smart enum with a [SupportedSimulator]-annotated [Field] member asserts the attribute lands on the generated *Extensions accessor for the active profile (iOS -> ios17.0, tvOS -> tvos17.0), that a plain member gets none, and that Mac profiles emit none. The test fails (Expected 1 / But was 0) without the one-line generator change.