### PR TITLE
[tests] Await async cancellation in SecProtocolMetadataTest to avoid a hang

### DIFF
--- a/tests/monotouch-test/Security/SecProtocolMetadataTest.cs
+++ b/tests/monotouch-test/Security/SecProtocolMetadataTest.cs
@@ -25,6 +25,7 @@ namespace MonoTouchFixtures.Security {
 
 				var ready = new ManualResetEvent (false);
 				var anyStateChange = new ManualResetEvent (false);
+				var done = new ManualResetEvent (false);
 				connection.SetStateChangeHandler ((state, error) => {
 					Console.WriteLine (state);
 					anyStateChange.Set ();
@@ -33,6 +34,7 @@ namespace MonoTouchFixtures.Security {
 					case NWConnectionState.Failed:
 						// We can't dispose until the connection has been closed or it failed.
 						connection.Dispose ();
+						done.Set ();
 						break;
 					case NWConnectionState.Invalid:
 					case NWConnectionState.Preparing:
@@ -49,42 +51,60 @@ namespace MonoTouchFixtures.Security {
 				connection.SetQueue (queue);
 				connection.Start ();
 
-				// Wait until the connection is ready.
-				if (!ready.WaitOne (TimeSpan.FromSeconds (10))) {
-					// If we're in CI, and didn't get _any_ callbacks, then ignore the failure, since it's likely a network hiccup.
-					if (!anyStateChange.WaitOne (0))
-						TestRuntime.IgnoreInCI ("Transient network failure - ignore in CI");
-					Assert.Fail ("Connection is ready");
-				}
-
-				using (var m = connection.GetProtocolMetadata<NWTlsMetadata> (NWProtocolDefinition.CreateTlsDefinition ())) {
-					var s = m.SecProtocolMetadata;
-					Assert.That (s.EarlyDataAccepted, Is.False, "EarlyDataAccepted");
-					Assert.That (s.NegotiatedProtocol, Is.Null, "NegotiatedProtocol");
-					Assert.That (s.NegotiatedProtocolVersion, Is.EqualTo (SslProtocol.Tls_1_2).Or.EqualTo (SslProtocol.Tls_1_3), "NegotiatedProtocolVersion");
-					Assert.That (s.PeerPublicKey, Is.Null.Or.Not.Null, "PeerPublicKey");
-
-					Assert.That (SecProtocolMetadata.ChallengeParametersAreEqual (s, s), Is.True, "ChallengeParametersAreEqual");
-					Assert.That (SecProtocolMetadata.PeersAreEqual (s, s), Is.True, "PeersAreEqual");
-
-					if (TestRuntime.CheckXcodeVersion (11, 0)) {
-						using (var d = s.CreateSecret ("Xamarin", 128)) {
-							Assert.That (d.Size, Is.EqualTo ((nuint) 128), "CreateSecret-1");
-						}
-						using (var d = s.CreateSecret ("Microsoft", new byte [1], 256)) {
-							Assert.That (d.Size, Is.EqualTo ((nuint) 256), "CreateSecret-2");
-						}
-
-						Assert.That (s.NegotiatedTlsProtocolVersion, Is.EqualTo (TlsProtocolVersion.Tls12).Or.EqualTo (TlsProtocolVersion.Tls13), "NegotiatedTlsProtocolVersion");
-						// we want to test the binding/API - not the exact value which can vary depending on the negotiation between the client (OS) and server...
-						Assert.That (s.NegotiatedTlsCipherSuite, Is.Not.EqualTo (0), "NegotiatedTlsCipherSuite");
-						Assert.That (s.ServerName, Is.EqualTo ("www.microsoft.com"), "ServerName");
-						// we don't have a TLS-PSK enabled server to test this
-						Assert.That (s.AccessPreSharedKeys ((psk, pskId) => { }), Is.False, "AccessPreSharedKeys");
+				try {
+					// Wait until the connection is ready.
+					if (!ready.WaitOne (TimeSpan.FromSeconds (10))) {
+						// If we're in CI, and didn't get _any_ callbacks, then ignore the failure, since it's likely a network hiccup.
+						if (!anyStateChange.WaitOne (0))
+							TestRuntime.IgnoreInCI ("Transient network failure - ignore in CI");
+						Assert.Fail ("Connection is ready");
 					}
-				}
 
-				connection.Cancel ();
+					using (var m = connection.GetProtocolMetadata<NWTlsMetadata> (NWProtocolDefinition.CreateTlsDefinition ())) {
+						var s = m.SecProtocolMetadata;
+						Assert.That (s.EarlyDataAccepted, Is.False, "EarlyDataAccepted");
+						Assert.That (s.NegotiatedProtocol, Is.Null, "NegotiatedProtocol");
+						Assert.That (s.NegotiatedProtocolVersion, Is.EqualTo (SslProtocol.Tls_1_2).Or.EqualTo (SslProtocol.Tls_1_3), "NegotiatedProtocolVersion");
+						Assert.That (s.PeerPublicKey, Is.Null.Or.Not.Null, "PeerPublicKey");
+
+						Assert.That (SecProtocolMetadata.ChallengeParametersAreEqual (s, s), Is.True, "ChallengeParametersAreEqual");
+						Assert.That (SecProtocolMetadata.PeersAreEqual (s, s), Is.True, "PeersAreEqual");
+
+						if (TestRuntime.CheckXcodeVersion (11, 0)) {
+							using (var d = s.CreateSecret ("Xamarin", 128)) {
+								Assert.That (d.Size, Is.EqualTo ((nuint) 128), "CreateSecret-1");
+							}
+							using (var d = s.CreateSecret ("Microsoft", new byte [1], 256)) {
+								Assert.That (d.Size, Is.EqualTo ((nuint) 256), "CreateSecret-2");
+							}
+
+							Assert.That (s.NegotiatedTlsProtocolVersion, Is.EqualTo (TlsProtocolVersion.Tls12).Or.EqualTo (TlsProtocolVersion.Tls13), "NegotiatedTlsProtocolVersion");
+							// we want to test the binding/API - not the exact value which can vary depending on the negotiation between the client (OS) and server...
+							Assert.That (s.NegotiatedTlsCipherSuite, Is.Not.EqualTo (0), "NegotiatedTlsCipherSuite");
+							Assert.That (s.ServerName, Is.EqualTo ("www.microsoft.com"), "ServerName");
+							// we don't have a TLS-PSK enabled server to test this
+							Assert.That (s.AccessPreSharedKeys ((psk, pskId) => { }), Is.False, "AccessPreSharedKeys");
+						}
+					}
+				} finally {
+					// Cancel the connection and wait for the asynchronous cancellation to complete before
+					// leaving this scope. The state-change handler (which disposes the connection) runs on
+					// 'queue', so if we let the 'using (queue)' block dispose the queue while a Cancelled/
+					// Failed callback is still pending, that callback is left to run on a disposed queue and
+					// can fire long after the test finished - wedging the process. Doing this in a 'finally'
+					// also guarantees deterministic teardown on every path (the Assert.Fail above, an
+					// assertion failure inside the inner 'using', or the IgnoreInCI case).
+					try {
+						connection.Cancel ();
+					} catch (ObjectDisposedException) {
+						// The connection already reached a terminal state (Failed/Cancelled) and was disposed
+						// by the state-change handler; 'done' is (or is about to be) set by that handler, so the
+						// wait below still completes. Swallowing this keeps the original failure - if any - from
+						// being masked by an ObjectDisposedException.
+					}
+					if (!done.WaitOne (TimeSpan.FromSeconds (10)))
+						connection.Dispose ();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
SecProtocolMetadataTest.TlsDefaults starts an NWConnection on a DispatchQueue created with a 'using' block and registers a state-change handler that disposes the connection when it reaches the Cancelled/Failed state. The handler runs on that queue, but the test disposed the queue (leaving the 'using' scope) without waiting for the asynchronous cancellation to complete, and skipped the trailing Cancel () entirely whenever Assert.Fail / IgnoreInCI threw. The cancellation callback could therefore still be pending - and run on a disposed queue - long after the test finished, contributing to a process-wide hang on the macOS test run (observed as a ~20 minute timeout / "Test run crashed").

Wrap the body in try/finally and signal a ManualResetEvent from the Cancelled/Failed branch of the handler. The finally cancels the connection and waits (bounded to 10s) for that event before the queue is disposed, on every path (success, the Assert.Fail, an assertion failure inside the inner 'using', and the IgnoreInCI case). Cancel () is guarded against ObjectDisposedException so that, if the connection already failed on its own and the handler disposed it, the original test failure is preserved instead of being masked.