### PR TITLE
[msbuild] Make inlined dlfcn native symbol references weak + dlsym fallback

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/PostTrimmingProcessing.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/PostTrimmingProcessing.cs
@@ -246,11 +246,33 @@ namespace Xamarin.MacDev.Tasks {
 			// The generated C code uses 'extern void*' declarations and returns the address of the symbol.
 			// This is intentional: it allows the native linker to resolve the symbol at link time, which
 			// is the whole point of this optimization (avoiding dlsym at runtime).
+			//
+			// The symbols are declared with __attribute__((weak_import)), and we fall back to dlsym if the
+			// direct reference turns out to be null at runtime. There are two reasons for this:
+			//
+			// * The symbol might not exist at runtime even though it existed in the SDK we built against
+			//   (for example when the app runs on an older OS than the one it was built with). Without
+			//   weak_import a missing symbol makes dyld abort at launch; with it the reference resolves to
+			//   null instead.
+			//
+			// * A symbol can be exported by more than one framework in the SDK (for example
+			//   UIFontTextStyleBody is exported by both UIKit and AppKit in the macOS SDK). In that case the
+			//   native linker binds our reference to one of them (the order isn't specified), which might not
+			//   be the framework that actually exports the symbol at runtime on older OSes. When the bound
+			//   framework doesn't have it, we use dlsym (RTLD_DEFAULT) to find it in whichever loaded
+			//   framework does, restoring the behavior of the non-inlined dlfcn code path.
+			//
+			// The fast path (a direct reference when the symbol is present) is unchanged, and the managed
+			// caller caches the result, so the dlsym fallback runs at most once per symbol.
+			sb.AppendLine ("#include <dlfcn.h>");
+			sb.AppendLine ();
+			sb.AppendLine ("static void* xamarin_dlfcn_fallback (void* ptr, const char* symbol) { return ptr ? ptr : dlsym (RTLD_DEFAULT, symbol); }");
+			sb.AppendLine ();
 			foreach (var field in survivingSymbols.OrderBy (s => s)) {
 				// Using 'void*' as a stand-in type since we only need the address
-				sb.AppendLine ($"extern void* {field};");
+				sb.AppendLine ($"extern void* {field} __attribute__((weak_import));");
 				sb.AppendLine ($"void* xamarin_Dlfcn_{field}_Native ();");
-				sb.AppendLine ($"void* xamarin_Dlfcn_{field}_Native () {{ return &{field}; }}");
+				sb.AppendLine ($"void* xamarin_Dlfcn_{field}_Native () {{ return xamarin_dlfcn_fallback (&{field}, \"{field}\"); }}");
 				sb.AppendLine ();
 			}
 


### PR DESCRIPTION
The inline-dlfcn optimization replaces runtime dlsym lookups of [Field] symbols with a direct native reference, generated by PostTrimmingProcessing.GenerateInlinedDlfcnNativeCode as:

    extern void* UIFontTextStyleBody;
    void* xamarin_Dlfcn_UIFontTextStyleBody_Native () { return &UIFontTextStyleBody; }

This direct reference is non-weak and not scoped to any framework, which breaks when a symbol that exists in the SDK we built against isn't present in the framework the native linker happened to bind it to at runtime.

This started crashing the Mac Catalyst monotouch-test app at launch on macOS 26 in the configurations that use inlined dlfcn (NativeAOT and "strict inline dlfcn"):

    dyld: Symbol not found: _UIFontTextStyleBody
    Referenced from: .../monotouchtest.app/Contents/MacOS/monotouchtest
    Expected in:     /System/Library/Frameworks/AppKit.framework/.../AppKit
    -> SIGABRT at launch (exit code 134)

Root cause:

* In the Xcode 27 SDK, _UIFontTextStyleBody is exported by both UIKit (iOSSupport) and AppKit (it's a UIFoundation symbol re-exported through both). In earlier SDKs only UIKit exported it.

* We pass -framework flags to the native linker from an unordered HashSet (CompilerFlags.Frameworks), so the two-level-namespace library ordinal for the symbol can be bound to AppKit.

* AppKit only began exporting the symbol at runtime in macOS 27, so on macOS < 27 the bound library doesn't have it. Because the reference is non-weak, dyld aborts at launch instead of tolerating the missing symbol.

The non-inlined dlfcn code path doesn't have this problem because it looks the symbol up with dlsym scoped to a specific library handle (e.g. UIKit); the inlining lost that scoping.

This affects more than the test: for .NET 11+ InlineDlfcnMethods defaults to "strict" (NativeAOT) or "compatibility" (everything else), and compatibility inlines [Field] symbols, so any .NET 11+ Mac Catalyst app referencing such a dual-homed symbol would crash at launch on macOS < 27.

Fix: generate the symbol references with __attribute__((weak_import)) and fall back to dlsym (RTLD_DEFAULT) when the direct reference is null at runtime:

    #include <dlfcn.h>
    static void* xamarin_dlfcn_fallback (void* ptr, const char* symbol) { return ptr ? ptr : dlsym (RTLD_DEFAULT, symbol); }

    extern void* UIFontTextStyleBody __attribute__((weak_import));
    void* xamarin_Dlfcn_UIFontTextStyleBody_Native () { return xamarin_dlfcn_fallback (&UIFontTextStyleBody, "UIFontTextStyleBody"); }

* weak_import means a symbol that's missing from the bound framework at runtime resolves to NULL instead of aborting at launch. This matches what the sibling Class.GetHandle generator already does for possibly-missing Objective-C classes in this same file.

* The dlsym (RTLD_DEFAULT) fallback finds the symbol in whichever loaded framework actually exports it (e.g. UIKit), restoring parity with the non-inlined dlfcn path so the value is correct, not just non-crashing.

* The fast path (a direct reference when the symbol is present) is unchanged, and the managed accessor caches the result, so the dlsym fallback runs at most once per symbol -- there is no per-access overhead.

* A shared fallback helper keeps the additional per-symbol generated code (and the binary-size cost of the symbol name strings) to a minimum.

The change is confined to the generated native stub, so it doesn't affect the post-trim surviving-symbol detection (which keys off the xamarin_Dlfcn_*_Native function name), nor the static-library retention scenario (a [Field] symbol defined at link time still resolves to a non-null direct reference, so the fallback never fires for it).

Verified on macOS 26.5 (arm64) with the Xcode 27 SDK: the previous generated code aborts at launch with the signature above, while the new generated code compiles cleanly (-Wall -Wextra -Werror), binds the symbol weakly to AppKit, and returns the correct UIKit value via the dlsym fallback at runtime.