### PR TITLE
[runtime] Use method_getTypeEncoding instead of the deprecated method_getDescription

### DIFF
--- a/runtime/trampolines.m
+++ b/runtime/trampolines.m
@@ -283,9 +283,12 @@ get_method_description (Class cls, SEL sel)
 	Method method = class_getInstanceMethod (cls, sel);
 	if (!method)
 		return NULL;
-	struct objc_method_description* m_desc;
-	m_desc = method_getDescription (method);
-	return m_desc ? m_desc->types : NULL;
+	// Read the method's Objective-C type encoding. We use method_getTypeEncoding instead of
+	// method_getDescription (method)->types: both yield the same type-encoding string (we only ever
+	// consumed the 'types' field), but method_getDescription is deprecated - the <objc/runtime.h>
+	// annotation reads "first deprecated in macOS 11.0 - Use method_getName and
+	// method_getTypeEncoding" - so method_getTypeEncoding is the exact, non-deprecated replacement.
+	return method_getTypeEncoding (method);
 }
 
 static int


### PR DESCRIPTION
get_method_description () read a method's Objective-C type-encoding string via method_getDescription (method)->types. method_getDescription is deprecated: the <objc/runtime.h> annotation reads "first deprecated in macOS 11.0 - Use method_getName and method_getTypeEncoding". Since the only field we ever consumed was 'types', method_getTypeEncoding returns exactly that same string and is the non-deprecated, future-proof replacement.

Standalone backport of the runtime/trampolines.m change from the Xcode 27 update (dotnet/macios #25665, commit 0dc3ce93ac), as suggested in code review; it is independent of the Xcode 27 bump itself.