### PR TITLE
[dotnet] Fix the .NET 10 MSI minor-version computation for Xcode 27 and later

### DIFF
--- a/scripts/generate-vs-workload/generate-vs-workload.cs
+++ b/scripts/generate-vs-workload/generate-vs-workload.cs
@@ -105,10 +105,30 @@ using (TextWriter writer = new StreamWriter (outputPath)) {
 			// So implement a custom version scheme for .NET 10 (in .NET 11 the inserted
 			// package name will be different, so we can use any version number we want,
 			// so we'll use the correct one).
+			//
+			// The scheme keeps the major fixed at 255 and uses the commit distance as the build component, and
+			// encodes the Xcode version into the minor component so the MSI version increases monotonically every
+			// time the Xcode major/minor increases (a newer Xcode must produce a higher MSI version), while staying
+			// just above the last bad version (255.220.39248) and below the MSI minor ceiling of 255.
+			//
+			// The minor bump is computed from the Xcode version as:
+			//     minorVersionBump = (Xcode major - 26) * 10 + Xcode minor
+			// Xcode 26 is the first Xcode that uses Apple's year-based version numbers, so subtracting 26 gives 0
+			// for the 26.x series, 1 for 27.x, 2 for 28.x, etc. Multiplying by 10 and adding the (single-digit)
+			// Xcode minor yields a value that strictly increases with the Xcode version:
+			//     26.5 => 5 (MSI minor 225), 27.0 => 10 (230), 27.5 => 15 (235), 28.0 => 20 (240), ...
+			// The final MSI minor is 220 + minorVersionBump. For Xcode 27.x and 28.x (and any 26.x with a non-zero
+			// minor) this is > 220, so the version exceeds the 255.220.39248 baseline on the minor component alone,
+			// regardless of the build component (only Xcode 26.0 would map to exactly 220, where the build component
+			// would instead have to exceed 39248). The minor stays <= 255 across .NET 10's supported Xcode range
+			// (26-28; 28.9 => 249) and would first overflow the 255 ceiling at Xcode 29.6 (=> 256), which is one
+			// reason this scheme is .NET-10-only. This relies on the Xcode minor being a single digit, which has
+			// always held.
+			//
+			// Note: this was previously written as (26 - Xcode major), which is negative for Xcode 27 and later
+			// and threw in the System.Version constructor (it rejects negative components), breaking the build.
 			var minimumVersion = new Version (255, 220, 39248); // This is the last incorrect MSI version, we need to produce something higher than this.
-																// bump minor version according to current Xcode version:
-																// minor = minimumVersion.Minor + (26 - Major Xcode version) * 10 + (Minor Xcode version)
-			var minorVersionBump = int.Parse (new Version (26 - Version.Parse (xcodeVersion).Major, Version.Parse (xcodeVersion).Minor).ToString ().Replace (".", ""));
+			var minorVersionBump = (Version.Parse (xcodeVersion).Major - 26) * 10 + Version.Parse (xcodeVersion).Minor;
 			// just use the commit distance for the build version, our minor version will be higher than the minimum version, so we can use any build version.
 			var buildVersionBump = commitDistances [platform];
 			var msiVersion = new Version (minimumVersion.Major, minimumVersion.Minor + minorVersionBump, buildVersionBump);


### PR DESCRIPTION
The .NET 10 custom MSI version scheme in generate-vs-workload bumped the minor version using:

    int.Parse (new Version (26 - xcodeMajor, xcodeMinor).ToString ().Replace (".", ""))

For Xcode 27 and later, (26 - xcodeMajor) is negative, and the System.Version constructor rejects negative components, so this threw and broke VS workload generation.

Compute the bump arithmetically instead:

    minorVersionBump = (xcodeMajor - 26) * 10 + xcodeMinor

This is equivalent to the old expression for the Xcode 26.x series (single-digit minor) and keeps the MSI minor monotonically increasing with the Xcode version while staying above the 255.220.39248 baseline and below the 255 minor ceiling across .NET 10's supported Xcode range. A detailed explanation of the scheme is added as a comment.

Standalone backport of the generate-vs-workload.cs change from the Xcode 27 update (dotnet/macios #25665, commit 0dc3ce93ac), as suggested in code review; it is independent of the Xcode 27 bump itself.