### PR TITLE
[tests] Fix introspection ApiTypoTest TypoTest failures on macOS

### DIFF
--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -107,7 +107,6 @@ namespace Introspection {
 			{ "Applei", All },
 			{ "Aps", ApplePlatform.MacOSX },
 			{ "Apv", ApplePlatform.MacOSX },
-			{ "Arae", ApplePlatform.MacOSX },
 			{ "Arcball", All },
 			{ "Argb", All },
 			{ "Arraycollation", All & ~ApplePlatform.MacOSX },
@@ -450,7 +449,7 @@ namespace Introspection {
 			{ "Lzfse", All }, // acronym
 			{ "Lzma", All }, // acronym
 			{ "Lzw", ApplePlatform.MacOSX },
-			{ "Mada", All & ~ApplePlatform.TVOS }, // payment system
+			{ "Mada", ApplePlatform.iOS | ApplePlatform.MacCatalyst }, // payment system
 			{ "Matchingcoalesce", All },
 			{ "Mcp", All }, // metacarpophalangeal (hand)
 			{ "Mebibits", All },
@@ -501,7 +500,7 @@ namespace Introspection {
 			{ "Muxed", All },
 			{ "Nacs", ApplePlatform.iOS | ApplePlatform.MacCatalyst },
 			{ "Nai", ApplePlatform.iOS | ApplePlatform.MacCatalyst },
-			{ "Nanaco", All & ~ApplePlatform.TVOS },
+			{ "Nanaco", ApplePlatform.iOS | ApplePlatform.MacCatalyst },
 			{ "Nand", All },
 			{ "Nanograms", All },
 			{ "Nanowatts", All },
@@ -543,7 +542,7 @@ namespace Introspection {
 			{ "Organisation", All }, // kCGImagePropertyIPTCExtRegistryOrganisationID in Xcode9.3-b1
 			{ "Orth", All },
 			{ "Osa", All }, // Open Scripting Architecture
-			{ "Otsu", All }, // threshold for image binarization
+			{ "Otsu", All & ~ApplePlatform.MacOSX }, // threshold for image binarization
 			{ "ove", All },
 			{ "Overline", All & ~ApplePlatform.TVOS },
 			{ "Paeth", All }, // PNG filter
@@ -579,7 +578,7 @@ namespace Introspection {
 			{ "Polylines", All },
 			{ "Popularimeter", All },
 			{ "Postback", ApplePlatform.iOS | ApplePlatform.MacCatalyst },
-			{ "Ppd", ApplePlatform.MacOSX }, // PostScript Printer Description
+			{ "Ppd", ApplePlatform.MacOSX }, // PostScript Printer Description (PDEPanel / PDEPlugInCallback - macOS only)
 			{ "Ppk", All },
 			{ "Preauthentication", ApplePlatform.MacOSX },
 			{ "Preds", All },
@@ -587,6 +586,7 @@ namespace Introspection {
 			{ "Prereleased", All },
 			{ "Prerolls", All },
 			{ "Preseti", All },
+			{ "Prev", All }, // abbreviation for "previous" (MTLFXFrameInterpolator)
 			{ "Previewable", ApplePlatform.MacOSX },
 			{ "Prf", All & ~ApplePlatform.TVOS },
 			{ "Propogate", All },
@@ -694,7 +694,7 @@ namespace Introspection {
 			{ "Subpixel", All },
 			{ "Subresources", All },
 			{ "Subsec", All },
-			{ "Suica", All & ~ApplePlatform.TVOS }, // Japanese contactless smart card type
+			{ "Suica", ApplePlatform.iOS | ApplePlatform.MacCatalyst }, // Japanese contactless smart card type
 			{ "Superentity", All },
 			{ "Supertype", All },
 			{ "Supertypes", All },
@@ -720,6 +720,7 @@ namespace Introspection {
 			{ "Thumbstick", All },
 			{ "Thumbsticks", ApplePlatform.iOS },
 			{ "Timecodes", All & ~ApplePlatform.TVOS },
+			{ "Timelapse", All & ~ApplePlatform.TVOS }, // Apple's spelling (PHPickerFilter / MediaLibrary)
 			{ "Tls", All },
 			{ "Tlv", All },
 			{ "Tmoney", All & ~ApplePlatform.TVOS },
@@ -776,7 +777,7 @@ namespace Introspection {
 			{ "Voronoi", All },
 			{ "Vpn", All },
 			{ "Vtt", All },
-			{ "Waon", All & ~ApplePlatform.TVOS },
+			{ "Waon", ApplePlatform.iOS | ApplePlatform.MacCatalyst },
 			{ "Warichu", All },
 			{ "Warpable", All },
 			{ "Wcdma", All },


### PR DESCRIPTION
Clean up the allowed-typo list to resolve the shared TypoTest regression affecting macOS introspection runs (#25397):

- PKPaymentNetwork words removed from the macOS 26 SDK were still flagged as "unnecessary allowed typo" on macOS. Remove "Arae"; restrict "Mada", "Nanaco", "Suica" and "Waon" to iOS|MacCatalyst; and exclude macOS from "Otsu".
- Allow the method-name typos that were being reported: add "Prev" (MTLFXFrameInterpolatorBase.PrevColorTexture, all platforms) and "Timelapse" (PHPickerFilter / MediaLibrary, all platforms except tvOS).
- Expand the "Ppd" comment to document its macOS-only source.