### PR TITLE
[docs] Improve XML docs for SystemConfigurationException

### DIFF
--- a/src/SystemConfiguration/SystemConfigurationException.cs
+++ b/src/SystemConfiguration/SystemConfigurationException.cs
@@ -11,21 +11,18 @@
 
 namespace SystemConfiguration {
 
-	/// <summary>An exception relating to network reachability. The cause of the exception is specified by the <see cref="SystemConfiguration.SystemConfigurationException.StatusErrorCode" /> property.</summary>
-	///     <remarks>To be added.</remarks>
+	/// <summary>An exception relating to network reachability. The cause of the exception is specified by the <see cref="StatusErrorCode" /> property.</summary>
 	public class SystemConfigurationException : Exception {
-		/// <param name="statusErrorCode">To be added.</param>
-		///         <summary>Creates a new <see cref="SystemConfiguration.SystemConfigurationException" /> wrapping the <paramref name="statusErrorCode" />.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Creates a new <see cref="SystemConfigurationException" /> wrapping the specified <paramref name="statusErrorCode" />.</summary>
+		/// <param name="statusErrorCode">The <see cref="StatusCode" /> that caused this exception.</param>
 		public SystemConfigurationException (StatusCode statusErrorCode)
 			: base (StatusCodeError.GetErrorDescription (statusErrorCode))
 		{
 			StatusErrorCode = statusErrorCode;
 		}
 
-		/// <summary>The <see cref="SystemConfiguration.StatusCode" /> wrapped in this <see cref="SystemConfiguration.SystemConfigurationException" />.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets the <see cref="StatusCode" /> that describes the cause of this exception.</summary>
+		/// <value>The status code associated with this exception.</value>
 		public StatusCode StatusErrorCode { get; private set; }
 
 		internal static SystemConfigurationException FromMostRecentCall ()


### PR DESCRIPTION
Improve XML documentation for the `SystemConfigurationException` type:

- Remove "To be added." placeholder entries
- Add meaningful `<param>` and `<value>` descriptions
- Simplify `<see cref>` references (remove redundant namespace qualifiers)
- Reorder XML doc elements to standard order (summary, value, param)
- Remove empty `<remarks>` nodes

🤖 Pull request created by Copilot