### PR TITLE
Expose application artifacts

### DIFF
--- a/docs/building-apps/build-items.md
+++ b/docs/building-apps/build-items.md
@@ -249,9 +249,9 @@ An item group that contains environment variables that will be set when the app 
 > [!NOTE]
 > This only applies when launching the app from the command line (`dotnet run` or `dotnet build -t:Run`), not when launching from the IDE.
 
-## MaciOSArtifactOutput
+## ApplePackageOutput
 
-An item group that contains final app artifacts produced by the build. This can include:
+An item group that contains final Apple app artifacts produced by the build or publish. This can include:
 
 * `.app` app bundles for iOS, tvOS, macOS, and Mac Catalyst apps.
 * `.ipa` packages when [BuildIpa](build-properties.md#buildipa) is enabled.
@@ -260,44 +260,25 @@ An item group that contains final app artifacts produced by the build. This can 
 
 The following metadata is set:
 
-* `ArtifactKind`: The artifact kind. Possible values are `AppBundle`, `Package`, and `Archive`.
 * `PackageFormat`: The artifact format. Possible values are `app`, `ipa`, `pkg`, and `xcarchive`.
 * `IsDirectory`: `true` for `.app` and `.xcarchive` outputs; `false` for `.ipa` and `.pkg` outputs.
 * `PlatformName`: The Apple platform name, such as `iOS`, `tvOS`, `macOS`, or `MacCatalyst`.
-* `TargetPlatformIdentifier`: The target platform identifier, such as `ios`, `tvos`, `macos`, or `maccatalyst`.
-* `TargetFramework`: The target framework.
-* `RuntimeIdentifier`: The runtime identifier when building with `RuntimeIdentifier`.
-* `RuntimeIdentifiers`: The runtime identifiers when building with `RuntimeIdentifiers`.
-* `Configuration`: The build configuration.
-* `RelativePath`: The artifact file or directory name.
 * `AppBundlePath`: The app bundle path associated with the artifact.
 * `BundleIdentifier`: The resolved app bundle identifier.
-* `CodeSigned`: Whether the app bundle was code signed.
-* `PackageSigned`: Whether a `.pkg` installer package was signed. This metadata is only set for `.pkg` outputs.
-* `BuildIpa`: The effective [BuildIpa](build-properties.md#buildipa) value.
-* `CreatePackage`: The effective [CreatePackage](build-properties.md#createpackage) value.
-* `ArchiveOnBuild`: The effective [ArchiveOnBuild](build-properties.md#archiveonbuild) value.
+* `Signed`: `true` when the app or package output is signed; otherwise `false`.
 
 Example:
 
 ```xml
-<Target Name="WriteMaciOSArtifacts" AfterTargets="Build">
+<Target Name="WriteApplePackages" AfterTargets="Build">
     <WriteLinesToFile
-        File="$(OutputPath)macios-artifacts.txt"
-        Lines="%(MaciOSArtifactOutput.Identity)|%(MaciOSArtifactOutput.ArtifactKind)|%(MaciOSArtifactOutput.PackageFormat)"
+        File="$(OutputPath)apple-packages.txt"
+        Lines="%(ApplePackageOutput.Identity)|%(ApplePackageOutput.PackageFormat)|%(ApplePackageOutput.Signed)"
         Overwrite="true" />
 </Target>
 ```
 
-See also the [GetMaciOSArtifactOutputs](build-targets.md#getmaciosartifactoutputs) target.
-
-## MaciOSPublishedArtifactOutput
-
-An item group that contains the `@(MaciOSArtifactOutput)` items produced by the `Publish` target.
-
-This item group has the same metadata as [MaciOSArtifactOutput](#maciosartifactoutput), plus:
-
-* `OriginalPath`: The corresponding path from `@(MaciOSArtifactOutput)`.
+See also the [GetApplePackageOutputs](build-targets.md#getapplepackageoutputs) target.
 
 ## NativeReference
 

--- a/docs/building-apps/build-items.md
+++ b/docs/building-apps/build-items.md
@@ -265,8 +265,6 @@ The following metadata is set:
 * `PlatformName`: The Apple platform name, such as `iOS`, `tvOS`, `macOS`, or `MacCatalyst`.
 * `AppBundlePath`: The app bundle path associated with the artifact.
 * `BundleIdentifier`: The resolved app bundle identifier.
-* `Signed`: `true` when the app bundle associated with the output is code signed; otherwise `false`.
-* `PackageSigned`: For `.pkg` outputs, `true` when installer package signing is enabled; otherwise `false`. This metadata is not set for other formats.
 
 Example:
 
@@ -274,7 +272,7 @@ Example:
 <Target Name="WriteApplePackages" AfterTargets="Build">
     <WriteLinesToFile
         File="$(OutputPath)apple-packages.txt"
-        Lines="%(ApplePackageOutput.Identity)|%(ApplePackageOutput.PackageFormat)|%(ApplePackageOutput.Signed)|%(ApplePackageOutput.PackageSigned)"
+        Lines="%(ApplePackageOutput.Identity)|%(ApplePackageOutput.PackageFormat)"
         Overwrite="true" />
 </Target>
 ```

--- a/docs/building-apps/build-items.md
+++ b/docs/building-apps/build-items.md
@@ -265,7 +265,8 @@ The following metadata is set:
 * `PlatformName`: The Apple platform name, such as `iOS`, `tvOS`, `macOS`, or `MacCatalyst`.
 * `AppBundlePath`: The app bundle path associated with the artifact.
 * `BundleIdentifier`: The resolved app bundle identifier.
-* `Signed`: `true` when the app or package output is signed; otherwise `false`.
+* `Signed`: `true` when the app bundle associated with the output is code signed; otherwise `false`.
+* `PackageSigned`: For `.pkg` outputs, `true` when installer package signing is enabled; otherwise `false`. This metadata is not set for other formats.
 
 Example:
 
@@ -273,7 +274,7 @@ Example:
 <Target Name="WriteApplePackages" AfterTargets="Build">
     <WriteLinesToFile
         File="$(OutputPath)apple-packages.txt"
-        Lines="%(ApplePackageOutput.Identity)|%(ApplePackageOutput.PackageFormat)|%(ApplePackageOutput.Signed)"
+        Lines="%(ApplePackageOutput.Identity)|%(ApplePackageOutput.PackageFormat)|%(ApplePackageOutput.Signed)|%(ApplePackageOutput.PackageSigned)"
         Overwrite="true" />
 </Target>
 ```

--- a/docs/building-apps/build-items.md
+++ b/docs/building-apps/build-items.md
@@ -263,7 +263,6 @@ The following metadata is set:
 * `PackageFormat`: The artifact format. Possible values are `app`, `ipa`, `pkg`, and `xcarchive`.
 * `IsDirectory`: `true` for `.app` and `.xcarchive` outputs; `false` for `.ipa` and `.pkg` outputs.
 * `PlatformName`: The Apple platform name, such as `iOS`, `tvOS`, `macOS`, or `MacCatalyst`.
-* `AppBundlePath`: The app bundle path associated with the artifact.
 * `BundleIdentifier`: The resolved app bundle identifier.
 
 Example:

--- a/docs/building-apps/build-items.md
+++ b/docs/building-apps/build-items.md
@@ -249,9 +249,9 @@ An item group that contains environment variables that will be set when the app 
 > [!NOTE]
 > This only applies when launching the app from the command line (`dotnet run` or `dotnet build -t:Run`), not when launching from the IDE.
 
-## ApplePackageOutput
+## ApplicationArtifact
 
-An item group that contains final Apple app artifacts produced by the build or publish. This can include:
+An item group that contains final application artifacts produced by Apple platform builds and publishes. The item identity is the path to the artifact. This can include:
 
 * `.app` app bundles for iOS, tvOS, macOS, and Mac Catalyst apps.
 * `.ipa` packages when [BuildIpa](build-properties.md#buildipa) is enabled.
@@ -268,15 +268,15 @@ The following metadata is set:
 Example:
 
 ```xml
-<Target Name="WriteApplePackages" AfterTargets="Build">
+<Target Name="WriteApplicationArtifacts" AfterTargets="Build">
     <WriteLinesToFile
-        File="$(OutputPath)apple-packages.txt"
-        Lines="%(ApplePackageOutput.Identity)|%(ApplePackageOutput.PackageFormat)"
+        File="$(OutputPath)application-artifacts.txt"
+        Lines="%(ApplicationArtifact.Identity)|%(ApplicationArtifact.PackageFormat)"
         Overwrite="true" />
 </Target>
 ```
 
-See also the [GetApplePackageOutputs](build-targets.md#getapplepackageoutputs) target.
+See also the [GetApplicationArtifacts](build-targets.md#getapplicationartifacts) target.
 
 ## NativeReference
 

--- a/docs/building-apps/build-items.md
+++ b/docs/building-apps/build-items.md
@@ -249,6 +249,56 @@ An item group that contains environment variables that will be set when the app 
 > [!NOTE]
 > This only applies when launching the app from the command line (`dotnet run` or `dotnet build -t:Run`), not when launching from the IDE.
 
+## MaciOSArtifactOutput
+
+An item group that contains final app artifacts produced by the build. This can include:
+
+* `.app` app bundles for iOS, tvOS, macOS, and Mac Catalyst apps.
+* `.ipa` packages when [BuildIpa](build-properties.md#buildipa) is enabled.
+* `.pkg` installer packages when [CreatePackage](build-properties.md#createpackage) is enabled.
+* `.xcarchive` directories when [ArchiveOnBuild](build-properties.md#archiveonbuild) is enabled.
+
+The following metadata is set:
+
+* `ArtifactKind`: The artifact kind. Possible values are `AppBundle`, `Package`, and `Archive`.
+* `PackageFormat`: The artifact format. Possible values are `app`, `ipa`, `pkg`, and `xcarchive`.
+* `IsDirectory`: `true` for `.app` and `.xcarchive` outputs; `false` for `.ipa` and `.pkg` outputs.
+* `PlatformName`: The Apple platform name, such as `iOS`, `tvOS`, `macOS`, or `MacCatalyst`.
+* `TargetPlatformIdentifier`: The target platform identifier, such as `ios`, `tvos`, `macos`, or `maccatalyst`.
+* `TargetFramework`: The target framework.
+* `RuntimeIdentifier`: The runtime identifier when building with `RuntimeIdentifier`.
+* `RuntimeIdentifiers`: The runtime identifiers when building with `RuntimeIdentifiers`.
+* `Configuration`: The build configuration.
+* `RelativePath`: The artifact file or directory name.
+* `AppBundlePath`: The app bundle path associated with the artifact.
+* `BundleIdentifier`: The resolved app bundle identifier.
+* `CodeSigned`: Whether the app bundle was code signed.
+* `PackageSigned`: Whether a `.pkg` installer package was signed. This metadata is only set for `.pkg` outputs.
+* `BuildIpa`: The effective [BuildIpa](build-properties.md#buildipa) value.
+* `CreatePackage`: The effective [CreatePackage](build-properties.md#createpackage) value.
+* `ArchiveOnBuild`: The effective [ArchiveOnBuild](build-properties.md#archiveonbuild) value.
+
+Example:
+
+```xml
+<Target Name="WriteMaciOSArtifacts" AfterTargets="Build">
+    <WriteLinesToFile
+        File="$(OutputPath)macios-artifacts.txt"
+        Lines="%(MaciOSArtifactOutput.Identity)|%(MaciOSArtifactOutput.ArtifactKind)|%(MaciOSArtifactOutput.PackageFormat)"
+        Overwrite="true" />
+</Target>
+```
+
+See also the [GetMaciOSArtifactOutputs](build-targets.md#getmaciosartifactoutputs) target.
+
+## MaciOSPublishedArtifactOutput
+
+An item group that contains the `@(MaciOSArtifactOutput)` items produced by the `Publish` target.
+
+This item group has the same metadata as [MaciOSArtifactOutput](#maciosartifactoutput), plus:
+
+* `OriginalPath`: The corresponding path from `@(MaciOSArtifactOutput)`.
+
 ## NativeReference
 
 An item group that contains any native references that should be linked into

--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -550,7 +550,9 @@ the platform build has collected `@(ApplicationArtifact)` items and before
 `GetApplicationArtifacts` or `Publish` returns them.
 
 This can be used by SDKs such as .NET MAUI to add shared application metadata
-to platform-produced artifacts.
+to platform-produced artifacts. Extension targets should update existing
+`@(ApplicationArtifact)` items to add metadata; they should only add new items
+when introducing additional artifacts.
 
 Example:
 

--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -544,10 +544,10 @@ Where the generated source from the generator are saved.
 ## GetApplicationArtifactsDependsOn
 
 A semi-colon delimited property that can be used to extend the
-[GetApplicationArtifacts](build-targets.md#getapplicationartifacts) target.
-MSBuild targets added to this property will execute after the platform build
-has collected `@(ApplicationArtifact)` items and before `GetApplicationArtifacts`
-returns them.
+[GetApplicationArtifacts](build-targets.md#getapplicationartifacts) and
+`Publish` targets. MSBuild targets added to this property will execute after
+the platform build has collected `@(ApplicationArtifact)` items and before
+`GetApplicationArtifacts` or `Publish` returns them.
 
 This can be used by SDKs such as .NET MAUI to add shared application metadata
 to platform-produced artifacts.

--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -545,7 +545,8 @@ Where the generated source from the generator are saved.
 
 A semi-colon delimited property that can be used to extend the
 [GetApplicationArtifacts](build-targets.md#getapplicationartifacts) and
-`Publish` targets. MSBuild targets added to this property will execute after
+`Publish` targets. The platform build is a mandatory dependency of
+`GetApplicationArtifacts`; MSBuild targets added to this property execute after
 the platform build has collected `@(ApplicationArtifact)` items and before
 `GetApplicationArtifacts` or `Publish` returns them.
 

--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -541,6 +541,33 @@ Default: true
 
 Where the generated source from the generator are saved.
 
+## GetApplicationArtifactsDependsOn
+
+A semi-colon delimited property that can be used to extend the
+[GetApplicationArtifacts](build-targets.md#getapplicationartifacts) target.
+MSBuild targets added to this property will execute after the platform build
+has collected `@(ApplicationArtifact)` items and before `GetApplicationArtifacts`
+returns them.
+
+This can be used by SDKs such as .NET MAUI to add shared application metadata
+to platform-produced artifacts.
+
+Example:
+
+```xml
+<PropertyGroup>
+  <GetApplicationArtifactsDependsOn>$(GetApplicationArtifactsDependsOn);AddApplicationArtifactMetadata</GetApplicationArtifactsDependsOn>
+</PropertyGroup>
+
+<Target Name="AddApplicationArtifactMetadata">
+  <ItemGroup>
+    <ApplicationArtifact Update="@(ApplicationArtifact)">
+      <ApplicationTitle>$(ApplicationTitle)</ApplicationTitle>
+    </ApplicationArtifact>
+  </ItemGroup>
+</Target>
+```
+
 ## IBToolPath
 
 The full path to the `ibtool` tool.

--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -109,7 +109,7 @@ Only applicable to iOS projects (since only iOS projects can be built remotely f
 
 If an Xcode archive should be created at the end of the build.
 
-Created archives are exposed in the [MaciOSArtifactOutput](build-items.md#maciosartifactoutput) item group.
+Created archives are exposed in the [ApplePackageOutput](build-items.md#applepackageoutput) item group.
 
 ## BGenEmitDebugInformation
 
@@ -141,7 +141,7 @@ Only applicable to iOS and tvOS projects.
 
 See [CreatePackage](#createpackage) for macOS and Mac Catalyst projects.
 
-Created IPA packages are exposed in the [MaciOSArtifactOutput](build-items.md#maciosartifactoutput) item group.
+Created IPA packages are exposed in the [ApplePackageOutput](build-items.md#applepackageoutput) item group.
 
 ## BundleCreateDump
 
@@ -354,7 +354,7 @@ Only applicable to macOS and Mac Catalyst projects.
 
 See [BuildIpa](#buildipa) for iOS and tvOS projects.
 
-Created PKG packages are exposed in the [MaciOSArtifactOutput](build-items.md#maciosartifactoutput) item group.
+Created PKG packages are exposed in the [ApplePackageOutput](build-items.md#applepackageoutput) item group.
 
 ## Device
 
@@ -675,7 +675,7 @@ Specifies the path to the resulting .ipa file when creating an IPA package (see 
 
 Only applicable to iOS and tvOS projects.
 
-The resulting IPA is exposed in the [MaciOSArtifactOutput](build-items.md#maciosartifactoutput) item group.
+The resulting IPA is exposed in the [ApplePackageOutput](build-items.md#applepackageoutput) item group.
 
 ## IsAppExtension
 
@@ -1147,7 +1147,7 @@ Specifies the path to the resulting .pkg file when creating a package (see [Crea
 
 Only applicable to macOS and Mac Catalyst apps.
 
-The resulting PKG is exposed in the [MaciOSArtifactOutput](build-items.md#maciosartifactoutput) item group.
+The resulting PKG is exposed in the [ApplePackageOutput](build-items.md#applepackageoutput) item group.
 
 ## PlutilPath
 

--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -109,6 +109,8 @@ Only applicable to iOS projects (since only iOS projects can be built remotely f
 
 If an Xcode archive should be created at the end of the build.
 
+Created archives are exposed in the [MaciOSArtifactOutput](build-items.md#maciosartifactoutput) item group.
+
 ## BGenEmitDebugInformation
 
 Whether the `bgen` tool (the binding generator) should emit debug information or not.
@@ -138,6 +140,8 @@ If a package (.ipa) should be created for the app bundle at the end of the build
 Only applicable to iOS and tvOS projects.
 
 See [CreatePackage](#createpackage) for macOS and Mac Catalyst projects.
+
+Created IPA packages are exposed in the [MaciOSArtifactOutput](build-items.md#maciosartifactoutput) item group.
 
 ## BundleCreateDump
 
@@ -349,6 +353,8 @@ If a package (.pkg) should be created for the app bundle at the end of the build
 Only applicable to macOS and Mac Catalyst projects.
 
 See [BuildIpa](#buildipa) for iOS and tvOS projects.
+
+Created PKG packages are exposed in the [MaciOSArtifactOutput](build-items.md#maciosartifactoutput) item group.
 
 ## Device
 
@@ -668,6 +674,8 @@ Only applicable to iOS and tvOS projects.
 Specifies the path to the resulting .ipa file when creating an IPA package (see [BuildIpa](#buildipa)).
 
 Only applicable to iOS and tvOS projects.
+
+The resulting IPA is exposed in the [MaciOSArtifactOutput](build-items.md#maciosartifactoutput) item group.
 
 ## IsAppExtension
 
@@ -1138,6 +1146,8 @@ Only applicable to macOS and Mac Catalyst apps.
 Specifies the path to the resulting .pkg file when creating a package (see [CreatePackage](#createpackage)).
 
 Only applicable to macOS and Mac Catalyst apps.
+
+The resulting PKG is exposed in the [MaciOSArtifactOutput](build-items.md#maciosartifactoutput) item group.
 
 ## PlutilPath
 

--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -109,7 +109,7 @@ Only applicable to iOS projects (since only iOS projects can be built remotely f
 
 If an Xcode archive should be created at the end of the build.
 
-Created archives are exposed in the [ApplePackageOutput](build-items.md#applepackageoutput) item group.
+Created archives are exposed in the [ApplicationArtifact](build-items.md#applicationartifact) item group.
 
 ## BGenEmitDebugInformation
 
@@ -141,7 +141,7 @@ Only applicable to iOS and tvOS projects.
 
 See [CreatePackage](#createpackage) for macOS and Mac Catalyst projects.
 
-Created IPA packages are exposed in the [ApplePackageOutput](build-items.md#applepackageoutput) item group.
+Created IPA packages are exposed in the [ApplicationArtifact](build-items.md#applicationartifact) item group.
 
 ## BundleCreateDump
 
@@ -354,7 +354,7 @@ Only applicable to macOS and Mac Catalyst projects.
 
 See [BuildIpa](#buildipa) for iOS and tvOS projects.
 
-Created PKG packages are exposed in the [ApplePackageOutput](build-items.md#applepackageoutput) item group.
+Created PKG packages are exposed in the [ApplicationArtifact](build-items.md#applicationartifact) item group.
 
 ## Device
 
@@ -675,7 +675,7 @@ Specifies the path to the resulting .ipa file when creating an IPA package (see 
 
 Only applicable to iOS and tvOS projects.
 
-The resulting IPA is exposed in the [ApplePackageOutput](build-items.md#applepackageoutput) item group.
+The resulting IPA is exposed in the [ApplicationArtifact](build-items.md#applicationartifact) item group.
 
 ## IsAppExtension
 
@@ -1147,7 +1147,7 @@ Specifies the path to the resulting .pkg file when creating a package (see [Crea
 
 Only applicable to macOS and Mac Catalyst apps.
 
-The resulting PKG is exposed in the [ApplePackageOutput](build-items.md#applepackageoutput) item group.
+The resulting PKG is exposed in the [ApplicationArtifact](build-items.md#applicationartifact) item group.
 
 ## PlutilPath
 

--- a/docs/building-apps/build-targets.md
+++ b/docs/building-apps/build-targets.md
@@ -44,6 +44,29 @@ $ dotnet run --device UDID
 
 Added in .NET 11.
 
+## GetMaciOSArtifactOutputs
+
+Builds the project and returns the `@(MaciOSArtifactOutput)` item group. This
+target can be used by custom build scripts to query final `.app`, `.ipa`,
+`.pkg`, and `.xcarchive` artifacts without invoking the `Publish` target.
+
+```shell
+$ dotnet build -t:GetMaciOSArtifactOutputs
+```
+
+See [MaciOSArtifactOutput](build-items.md#maciosartifactoutput) for supported metadata.
+
+## GetMaciOSPublishedArtifactOutputs
+
+Publishes the project and returns the `@(MaciOSPublishedArtifactOutput)` item
+group.
+
+```shell
+$ dotnet publish -t:GetMaciOSPublishedArtifactOutputs
+```
+
+See [MaciOSPublishedArtifactOutput](build-items.md#maciospublishedartifactoutput) for supported metadata.
+
 ## Run
 
 Builds the source code within a project and all dependencies, and then deploys and runs it

--- a/docs/building-apps/build-targets.md
+++ b/docs/building-apps/build-targets.md
@@ -44,28 +44,18 @@ $ dotnet run --device UDID
 
 Added in .NET 11.
 
-## GetMaciOSArtifactOutputs
+## GetApplePackageOutputs
 
-Builds the project and returns the `@(MaciOSArtifactOutput)` item group. This
+Builds the project and returns the `@(ApplePackageOutput)` item group. This
 target can be used by custom build scripts to query final `.app`, `.ipa`,
-`.pkg`, and `.xcarchive` artifacts without invoking the `Publish` target.
+`.pkg`, and `.xcarchive` artifacts. The `Publish` target also populates the
+same item group for packages it creates.
 
 ```shell
-$ dotnet build -t:GetMaciOSArtifactOutputs
+$ dotnet build -t:GetApplePackageOutputs
 ```
 
-See [MaciOSArtifactOutput](build-items.md#maciosartifactoutput) for supported metadata.
-
-## GetMaciOSPublishedArtifactOutputs
-
-Publishes the project and returns the `@(MaciOSPublishedArtifactOutput)` item
-group.
-
-```shell
-$ dotnet publish -t:GetMaciOSPublishedArtifactOutputs
-```
-
-See [MaciOSPublishedArtifactOutput](build-items.md#maciospublishedartifactoutput) for supported metadata.
+See [ApplePackageOutput](build-items.md#applepackageoutput) for supported metadata.
 
 ## Run
 

--- a/docs/building-apps/build-targets.md
+++ b/docs/building-apps/build-targets.md
@@ -48,8 +48,8 @@ Added in .NET 11.
 
 Builds the project and returns the `@(ApplicationArtifact)` item group. This
 target can be used by custom build scripts to query final `.app`, `.ipa`,
-`.pkg`, and `.xcarchive` artifacts. The `Publish` target also populates the
-same item group for artifacts it creates.
+`.pkg`, and `.xcarchive` artifacts. The `Publish` target returns the same item
+group for artifacts it creates.
 
 ```shell
 $ dotnet build -t:GetApplicationArtifacts
@@ -58,7 +58,7 @@ $ dotnet build -t:GetApplicationArtifacts
 See [ApplicationArtifact](build-items.md#applicationartifact) for supported metadata.
 
 Targets that need to add or update `@(ApplicationArtifact)` metadata before
-`GetApplicationArtifacts` returns can append to
+`GetApplicationArtifacts` or `Publish` returns can append to
 [GetApplicationArtifactsDependsOn](build-properties.md#getapplicationartifactsdependson).
 
 ## Run

--- a/docs/building-apps/build-targets.md
+++ b/docs/building-apps/build-targets.md
@@ -44,18 +44,18 @@ $ dotnet run --device UDID
 
 Added in .NET 11.
 
-## GetApplePackageOutputs
+## GetApplicationArtifacts
 
-Builds the project and returns the `@(ApplePackageOutput)` item group. This
+Builds the project and returns the `@(ApplicationArtifact)` item group. This
 target can be used by custom build scripts to query final `.app`, `.ipa`,
 `.pkg`, and `.xcarchive` artifacts. The `Publish` target also populates the
-same item group for packages it creates.
+same item group for artifacts it creates.
 
 ```shell
-$ dotnet build -t:GetApplePackageOutputs
+$ dotnet build -t:GetApplicationArtifacts
 ```
 
-See [ApplePackageOutput](build-items.md#applepackageoutput) for supported metadata.
+See [ApplicationArtifact](build-items.md#applicationartifact) for supported metadata.
 
 ## Run
 

--- a/docs/building-apps/build-targets.md
+++ b/docs/building-apps/build-targets.md
@@ -57,6 +57,10 @@ $ dotnet build -t:GetApplicationArtifacts
 
 See [ApplicationArtifact](build-items.md#applicationartifact) for supported metadata.
 
+Targets that need to add or update `@(ApplicationArtifact)` metadata before
+`GetApplicationArtifacts` returns can append to
+[GetApplicationArtifactsDependsOn](build-properties.md#getapplicationartifactsdependson).
+
 ## Run
 
 Builds the source code within a project and all dependencies, and then deploys and runs it

--- a/docs/building-apps/build-targets.md
+++ b/docs/building-apps/build-targets.md
@@ -47,9 +47,10 @@ Added in .NET 11.
 ## GetApplicationArtifacts
 
 Builds the project and returns the `@(ApplicationArtifact)` item group. This
-target can be used by custom build scripts to query final `.app`, `.ipa`,
-`.pkg`, and `.xcarchive` artifacts. The `Publish` target returns the same item
-group for artifacts it creates.
+target always runs the platform build first so `.app`, `.ipa`, `.pkg`, and
+`.xcarchive` artifacts are populated before any custom metadata extension
+targets run. The `Publish` target returns the same item group for artifacts it
+creates.
 
 ```shell
 $ dotnet build -t:GetApplicationArtifacts

--- a/docs/building-apps/build-targets.md
+++ b/docs/building-apps/build-targets.md
@@ -53,7 +53,8 @@ targets run. The `Publish` target returns the same item group for artifacts it
 creates.
 
 ```shell
-$ dotnet build -t:GetApplicationArtifacts
+$ dotnet build MyApp.csproj -t:GetApplicationArtifacts -getTargetResult:GetApplicationArtifacts
+$ dotnet build MyApp.csproj -t:Publish -getTargetResult:Publish
 ```
 
 See [ApplicationArtifact](build-items.md#applicationartifact) for supported metadata.

--- a/dotnet/targets/Xamarin.Shared.Sdk.Publish.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.Publish.targets
@@ -20,7 +20,7 @@
 			Condition="$(RuntimeIdentifiers.Contains('iossimulator-')) Or $(RuntimeIdentifiers.Contains('tvossimulator-'))"
 		/>
 	</Target>
-	<Target Name="Publish" DependsOnTargets="_PrePublish;Build" Returns="@(ApplePackageOutput)">
+	<Target Name="Publish" DependsOnTargets="_PrePublish;Build" Returns="@(ApplicationArtifact)">
 		<Message Importance="high" Text="Created the package: $(IpaPackagePath)" Condition="'$(BuildIpa)' == 'true' And '$(SdkIsMobile)' == 'true'" />
 		<Message Importance="high" Text="Created the package: $(PkgPackagePath)" Condition="'$(CreatePackage)' == 'true' And '$(SdkIsDesktop)' == 'true'" />
 	</Target>

--- a/dotnet/targets/Xamarin.Shared.Sdk.Publish.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.Publish.targets
@@ -20,14 +20,8 @@
 			Condition="$(RuntimeIdentifiers.Contains('iossimulator-')) Or $(RuntimeIdentifiers.Contains('tvossimulator-'))"
 		/>
 	</Target>
-	<Target Name="Publish" DependsOnTargets="_PrePublish;Build">
-		<ItemGroup>
-			<MaciOSPublishedArtifactOutput Include="@(MaciOSArtifactOutput)" Condition="'@(MaciOSArtifactOutput)' != ''">
-				<OriginalPath>%(MaciOSArtifactOutput.Identity)</OriginalPath>
-			</MaciOSPublishedArtifactOutput>
-		</ItemGroup>
+	<Target Name="Publish" DependsOnTargets="_PrePublish;Build" Returns="@(ApplePackageOutput)">
 		<Message Importance="high" Text="Created the package: $(IpaPackagePath)" Condition="'$(BuildIpa)' == 'true' And '$(SdkIsMobile)' == 'true'" />
 		<Message Importance="high" Text="Created the package: $(PkgPackagePath)" Condition="'$(CreatePackage)' == 'true' And '$(SdkIsDesktop)' == 'true'" />
 	</Target>
-	<Target Name="GetMaciOSPublishedArtifactOutputs" DependsOnTargets="Publish" Returns="@(MaciOSPublishedArtifactOutput)" />
 </Project>

--- a/dotnet/targets/Xamarin.Shared.Sdk.Publish.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.Publish.targets
@@ -21,7 +21,13 @@
 		/>
 	</Target>
 	<Target Name="Publish" DependsOnTargets="_PrePublish;Build">
+		<ItemGroup>
+			<MaciOSPublishedArtifactOutput Include="@(MaciOSArtifactOutput)" Condition="'@(MaciOSArtifactOutput)' != ''">
+				<OriginalPath>%(MaciOSArtifactOutput.Identity)</OriginalPath>
+			</MaciOSPublishedArtifactOutput>
+		</ItemGroup>
 		<Message Importance="high" Text="Created the package: $(IpaPackagePath)" Condition="'$(BuildIpa)' == 'true' And '$(SdkIsMobile)' == 'true'" />
 		<Message Importance="high" Text="Created the package: $(PkgPackagePath)" Condition="'$(CreatePackage)' == 'true' And '$(SdkIsDesktop)' == 'true'" />
 	</Target>
+	<Target Name="GetMaciOSPublishedArtifactOutputs" DependsOnTargets="Publish" Returns="@(MaciOSPublishedArtifactOutput)" />
 </Project>

--- a/dotnet/targets/Xamarin.Shared.Sdk.Publish.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.Publish.targets
@@ -20,7 +20,7 @@
 			Condition="$(RuntimeIdentifiers.Contains('iossimulator-')) Or $(RuntimeIdentifiers.Contains('tvossimulator-'))"
 		/>
 	</Target>
-	<Target Name="Publish" DependsOnTargets="_PrePublish;Build" Returns="@(ApplicationArtifact)">
+	<Target Name="Publish" DependsOnTargets="_PrePublish;GetApplicationArtifacts" Returns="@(ApplicationArtifact)">
 		<Message Importance="high" Text="Created the package: $(IpaPackagePath)" Condition="'$(BuildIpa)' == 'true' And '$(SdkIsMobile)' == 'true'" />
 		<Message Importance="high" Text="Created the package: $(PkgPackagePath)" Condition="'$(CreatePackage)' == 'true' And '$(SdkIsDesktop)' == 'true'" />
 	</Target>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -3428,13 +3428,18 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			_PackageOnDemandResources;
 			_ZipIpa
 		</CreateIpaDependsOn>
+
+		<GetApplicationArtifactsDependsOn>
+			Build;
+			$(GetApplicationArtifactsDependsOn)
+		</GetApplicationArtifactsDependsOn>
 	</PropertyGroup>
 
 	<Target Name="_BeforeCreateIpaForDistribution" Condition="'$(IsAppDistribution)' == 'true'" DependsOnTargets="$(_BeforeCreateIpaForDistributionDependsOn)" />
 
 	<Target Name="CreateIpa" Condition="'$(_CanArchive)' == 'true' And '$(SdkIsDesktop)' != 'true'" DependsOnTargets="$(CreateIpaDependsOn)" />
 
-	<Target Name="GetApplicationArtifacts" DependsOnTargets="Build" Returns="@(ApplicationArtifact)" />
+	<Target Name="GetApplicationArtifacts" DependsOnTargets="$(GetApplicationArtifactsDependsOn)" Returns="@(ApplicationArtifact)" />
 
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Shared.ObjCBinding.targets" Condition="'$(IsBindingProject)' == 'true'" />
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -3401,8 +3401,10 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 				<PlatformName>$(_PlatformName)</PlatformName>
 				<AppBundlePath>$(AppBundleDir)</AppBundlePath>
 				<BundleIdentifier>$(_BundleIdentifier)</BundleIdentifier>
-				<Signed Condition="'$(_CodeSigningKey)' != '' Or '$(EnablePackageSigning)' == 'true'">true</Signed>
-				<Signed Condition="'$(_CodeSigningKey)' == '' And '$(EnablePackageSigning)' != 'true'">false</Signed>
+				<Signed Condition="'$(_CodeSigningKey)' != ''">true</Signed>
+				<Signed Condition="'$(_CodeSigningKey)' == ''">false</Signed>
+				<PackageSigned Condition="'$(EnablePackageSigning)' == 'true'">true</PackageSigned>
+				<PackageSigned Condition="'$(EnablePackageSigning)' != 'true'">false</PackageSigned>
 			</ApplePackageOutput>
 		</ItemGroup>
 	</Target>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -3429,17 +3429,13 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			_ZipIpa
 		</CreateIpaDependsOn>
 
-		<GetApplicationArtifactsDependsOn>
-			Build;
-			$(GetApplicationArtifactsDependsOn)
-		</GetApplicationArtifactsDependsOn>
 	</PropertyGroup>
 
 	<Target Name="_BeforeCreateIpaForDistribution" Condition="'$(IsAppDistribution)' == 'true'" DependsOnTargets="$(_BeforeCreateIpaForDistributionDependsOn)" />
 
 	<Target Name="CreateIpa" Condition="'$(_CanArchive)' == 'true' And '$(SdkIsDesktop)' != 'true'" DependsOnTargets="$(CreateIpaDependsOn)" />
 
-	<Target Name="GetApplicationArtifacts" DependsOnTargets="$(GetApplicationArtifactsDependsOn)" Returns="@(ApplicationArtifact)" />
+	<Target Name="GetApplicationArtifacts" DependsOnTargets="Build;$(GetApplicationArtifactsDependsOn)" Returns="@(ApplicationArtifact)" />
 
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Shared.ObjCBinding.targets" Condition="'$(IsBindingProject)' == 'true'" />
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2377,7 +2377,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 				<PackageFormat>app</PackageFormat>
 				<IsDirectory>true</IsDirectory>
 				<PlatformName>$(_PlatformName)</PlatformName>
-				<AppBundlePath>$(AppBundleDir)</AppBundlePath>
 				<BundleIdentifier>$(_BundleIdentifier)</BundleIdentifier>
 			</ApplePackageOutput>
 		</ItemGroup>
@@ -3278,7 +3277,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 				<PackageFormat>xcarchive</PackageFormat>
 				<IsDirectory>true</IsDirectory>
 				<PlatformName>$(_PlatformName)</PlatformName>
-				<AppBundlePath>$(AppBundleDir)</AppBundlePath>
 				<BundleIdentifier>$(_BundleIdentifier)</BundleIdentifier>
 			</ApplePackageOutput>
 		</ItemGroup>
@@ -3395,7 +3393,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 				<PackageFormat>pkg</PackageFormat>
 				<IsDirectory>false</IsDirectory>
 				<PlatformName>$(_PlatformName)</PlatformName>
-				<AppBundlePath>$(AppBundleDir)</AppBundlePath>
 				<BundleIdentifier>$(_BundleIdentifier)</BundleIdentifier>
 			</ApplePackageOutput>
 		</ItemGroup>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2379,8 +2379,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 				<PlatformName>$(_PlatformName)</PlatformName>
 				<AppBundlePath>$(AppBundleDir)</AppBundlePath>
 				<BundleIdentifier>$(_BundleIdentifier)</BundleIdentifier>
-				<Signed Condition="'$(_CodeSigningKey)' != ''">true</Signed>
-				<Signed Condition="'$(_CodeSigningKey)' == ''">false</Signed>
 			</ApplePackageOutput>
 		</ItemGroup>
 	</Target>
@@ -3282,8 +3280,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 				<PlatformName>$(_PlatformName)</PlatformName>
 				<AppBundlePath>$(AppBundleDir)</AppBundlePath>
 				<BundleIdentifier>$(_BundleIdentifier)</BundleIdentifier>
-				<Signed Condition="'$(_CodeSigningKey)' != ''">true</Signed>
-				<Signed Condition="'$(_CodeSigningKey)' == ''">false</Signed>
 			</ApplePackageOutput>
 		</ItemGroup>
 	</Target>
@@ -3401,10 +3397,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 				<PlatformName>$(_PlatformName)</PlatformName>
 				<AppBundlePath>$(AppBundleDir)</AppBundlePath>
 				<BundleIdentifier>$(_BundleIdentifier)</BundleIdentifier>
-				<Signed Condition="'$(_CodeSigningKey)' != ''">true</Signed>
-				<Signed Condition="'$(_CodeSigningKey)' == ''">false</Signed>
-				<PackageSigned Condition="'$(EnablePackageSigning)' == 'true'">true</PackageSigned>
-				<PackageSigned Condition="'$(EnablePackageSigning)' != 'true'">false</PackageSigned>
 			</ApplePackageOutput>
 		</ItemGroup>
 	</Target>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2369,6 +2369,32 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 	<Target Name="Codesign" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="$(CodesignDependsOn)" />
 
+	<Target Name="_CollectMaciOSAppBundleOutput"
+		Condition="'$(_CanOutputAppBundle)' == 'true' And '$(OutputType)' == 'Exe' And '$(IsAppExtension)' != 'true' And '$(IsWatchApp)' != 'true' And Exists('$(AppBundleDir)')"
+		AfterTargets="Codesign">
+		<ItemGroup>
+			<MaciOSArtifactOutput Include="$(AppBundleDir)">
+				<ArtifactKind>AppBundle</ArtifactKind>
+				<PackageFormat>app</PackageFormat>
+				<IsDirectory>true</IsDirectory>
+				<PlatformName>$(_PlatformName)</PlatformName>
+				<TargetPlatformIdentifier>$(TargetPlatformIdentifier)</TargetPlatformIdentifier>
+				<TargetFramework>$(TargetFramework)</TargetFramework>
+				<RuntimeIdentifier>$(RuntimeIdentifier)</RuntimeIdentifier>
+				<RuntimeIdentifiers>$(RuntimeIdentifiers)</RuntimeIdentifiers>
+				<Configuration>$(Configuration)</Configuration>
+				<RelativePath>%(Filename)%(Extension)</RelativePath>
+				<AppBundlePath>$(AppBundleDir)</AppBundlePath>
+				<BundleIdentifier>$(_BundleIdentifier)</BundleIdentifier>
+				<CodeSigned Condition="'$(_CodeSigningKey)' != ''">true</CodeSigned>
+				<CodeSigned Condition="'$(_CodeSigningKey)' == ''">false</CodeSigned>
+				<BuildIpa>$(BuildIpa)</BuildIpa>
+				<CreatePackage>$(CreatePackage)</CreatePackage>
+				<ArchiveOnBuild>$(ArchiveOnBuild)</ArchiveOnBuild>
+			</MaciOSArtifactOutput>
+		</ItemGroup>
+	</Target>
+
 	<!--
 
 		Code signing
@@ -3256,6 +3282,32 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		</Archive>
 	</Target>
 
+	<Target Name="_CollectMaciOSArchiveOutput"
+		Condition="'$(ArchiveOnBuild)' == 'true' And '$(ArchiveDir)' != '' And Exists('$(ArchiveDir)')"
+		AfterTargets="_CoreArchive">
+		<ItemGroup>
+			<MaciOSArtifactOutput Include="$(ArchiveDir)">
+				<ArtifactKind>Archive</ArtifactKind>
+				<PackageFormat>xcarchive</PackageFormat>
+				<IsDirectory>true</IsDirectory>
+				<PlatformName>$(_PlatformName)</PlatformName>
+				<TargetPlatformIdentifier>$(TargetPlatformIdentifier)</TargetPlatformIdentifier>
+				<TargetFramework>$(TargetFramework)</TargetFramework>
+				<RuntimeIdentifier>$(RuntimeIdentifier)</RuntimeIdentifier>
+				<RuntimeIdentifiers>$(RuntimeIdentifiers)</RuntimeIdentifiers>
+				<Configuration>$(Configuration)</Configuration>
+				<RelativePath>%(Filename)%(Extension)</RelativePath>
+				<AppBundlePath>$(AppBundleDir)</AppBundlePath>
+				<BundleIdentifier>$(_BundleIdentifier)</BundleIdentifier>
+				<CodeSigned Condition="'$(_CodeSigningKey)' != ''">true</CodeSigned>
+				<CodeSigned Condition="'$(_CodeSigningKey)' == ''">false</CodeSigned>
+				<BuildIpa>$(BuildIpa)</BuildIpa>
+				<CreatePackage>$(CreatePackage)</CreatePackage>
+				<ArchiveOnBuild>$(ArchiveOnBuild)</ArchiveOnBuild>
+			</MaciOSArtifactOutput>
+		</ItemGroup>
+	</Target>
+
 	<Target Name="_GenerateBundleName" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="_ComputeTargetArchitectures;_ParseBundlerArguments">
 		<PropertyGroup Condition="'$(AppBundleDir)' == ''">
 			<_AppContainerDir Condition="'$(IsAppDistribution)' != 'true'">$(DeviceSpecificOutputPath)</_AppContainerDir>
@@ -3359,6 +3411,33 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		</CreateInstallerPackage>
 	</Target>
 
+	<Target Name="_CollectMaciOSPkgOutput"
+		Condition="'$(CreatePackage)' == 'true' And '$(PkgPackagePath)' != '' And Exists('$(PkgPackagePath)')"
+		AfterTargets="_CreateInstaller">
+		<ItemGroup>
+			<MaciOSArtifactOutput Include="$(PkgPackagePath)">
+				<ArtifactKind>Package</ArtifactKind>
+				<PackageFormat>pkg</PackageFormat>
+				<IsDirectory>false</IsDirectory>
+				<PlatformName>$(_PlatformName)</PlatformName>
+				<TargetPlatformIdentifier>$(TargetPlatformIdentifier)</TargetPlatformIdentifier>
+				<TargetFramework>$(TargetFramework)</TargetFramework>
+				<RuntimeIdentifier>$(RuntimeIdentifier)</RuntimeIdentifier>
+				<RuntimeIdentifiers>$(RuntimeIdentifiers)</RuntimeIdentifiers>
+				<Configuration>$(Configuration)</Configuration>
+				<RelativePath>%(Filename)%(Extension)</RelativePath>
+				<AppBundlePath>$(AppBundleDir)</AppBundlePath>
+				<BundleIdentifier>$(_BundleIdentifier)</BundleIdentifier>
+				<CodeSigned Condition="'$(_CodeSigningKey)' != ''">true</CodeSigned>
+				<CodeSigned Condition="'$(_CodeSigningKey)' == ''">false</CodeSigned>
+				<PackageSigned>$(EnablePackageSigning)</PackageSigned>
+				<BuildIpa>$(BuildIpa)</BuildIpa>
+				<CreatePackage>$(CreatePackage)</CreatePackage>
+				<ArchiveOnBuild>$(ArchiveOnBuild)</ArchiveOnBuild>
+			</MaciOSArtifactOutput>
+		</ItemGroup>
+	</Target>
+
 	<!-- 
 		Creates a plist with the entitlements used to sign the App bundle.
 		MacCatalyst apps don't have a compiled entitlements file in the app bundle, 
@@ -3394,6 +3473,8 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<Target Name="_BeforeCreateIpaForDistribution" Condition="'$(IsAppDistribution)' == 'true'" DependsOnTargets="$(_BeforeCreateIpaForDistributionDependsOn)" />
 
 	<Target Name="CreateIpa" Condition="'$(_CanArchive)' == 'true' And '$(SdkIsDesktop)' != 'true'" DependsOnTargets="$(CreateIpaDependsOn)" />
+
+	<Target Name="GetMaciOSArtifactOutputs" DependsOnTargets="Build" Returns="@(MaciOSArtifactOutput)" />
 
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Shared.ObjCBinding.targets" Condition="'$(IsBindingProject)' == 'true'" />
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2373,12 +2373,12 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		Condition="'$(_CanOutputAppBundle)' == 'true' And '$(OutputType)' == 'Exe' And '$(IsAppExtension)' != 'true' And '$(IsWatchApp)' != 'true' And Exists('$(AppBundleDir)')"
 		AfterTargets="Codesign">
 		<ItemGroup>
-			<ApplePackageOutput Include="$(AppBundleDir)">
+			<ApplicationArtifact Include="$(AppBundleDir)">
 				<PackageFormat>app</PackageFormat>
 				<IsDirectory>true</IsDirectory>
 				<PlatformName>$(_PlatformName)</PlatformName>
 				<BundleIdentifier>$(_BundleIdentifier)</BundleIdentifier>
-			</ApplePackageOutput>
+			</ApplicationArtifact>
 		</ItemGroup>
 	</Target>
 
@@ -3273,12 +3273,12 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		Condition="'$(ArchiveOnBuild)' == 'true' And '$(ArchiveDir)' != '' And Exists('$(ArchiveDir)')"
 		AfterTargets="_CoreArchive">
 		<ItemGroup>
-			<ApplePackageOutput Include="$(ArchiveDir)">
+			<ApplicationArtifact Include="$(ArchiveDir)">
 				<PackageFormat>xcarchive</PackageFormat>
 				<IsDirectory>true</IsDirectory>
 				<PlatformName>$(_PlatformName)</PlatformName>
 				<BundleIdentifier>$(_BundleIdentifier)</BundleIdentifier>
-			</ApplePackageOutput>
+			</ApplicationArtifact>
 		</ItemGroup>
 	</Target>
 
@@ -3389,12 +3389,12 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		Condition="'$(CreatePackage)' == 'true' And '$(PkgPackagePath)' != '' And Exists('$(PkgPackagePath)')"
 		AfterTargets="_CreateInstaller">
 		<ItemGroup>
-			<ApplePackageOutput Include="$(PkgPackagePath)">
+			<ApplicationArtifact Include="$(PkgPackagePath)">
 				<PackageFormat>pkg</PackageFormat>
 				<IsDirectory>false</IsDirectory>
 				<PlatformName>$(_PlatformName)</PlatformName>
 				<BundleIdentifier>$(_BundleIdentifier)</BundleIdentifier>
-			</ApplePackageOutput>
+			</ApplicationArtifact>
 		</ItemGroup>
 	</Target>
 
@@ -3434,7 +3434,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 	<Target Name="CreateIpa" Condition="'$(_CanArchive)' == 'true' And '$(SdkIsDesktop)' != 'true'" DependsOnTargets="$(CreateIpaDependsOn)" />
 
-	<Target Name="GetApplePackageOutputs" DependsOnTargets="Build" Returns="@(ApplePackageOutput)" />
+	<Target Name="GetApplicationArtifacts" DependsOnTargets="Build" Returns="@(ApplicationArtifact)" />
 
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Shared.ObjCBinding.targets" Condition="'$(IsBindingProject)' == 'true'" />
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2369,29 +2369,19 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 	<Target Name="Codesign" Condition="'$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="$(CodesignDependsOn)" />
 
-	<Target Name="_CollectMaciOSAppBundleOutput"
+	<Target Name="_CollectAppleAppBundleOutput"
 		Condition="'$(_CanOutputAppBundle)' == 'true' And '$(OutputType)' == 'Exe' And '$(IsAppExtension)' != 'true' And '$(IsWatchApp)' != 'true' And Exists('$(AppBundleDir)')"
 		AfterTargets="Codesign">
 		<ItemGroup>
-			<MaciOSArtifactOutput Include="$(AppBundleDir)">
-				<ArtifactKind>AppBundle</ArtifactKind>
+			<ApplePackageOutput Include="$(AppBundleDir)">
 				<PackageFormat>app</PackageFormat>
 				<IsDirectory>true</IsDirectory>
 				<PlatformName>$(_PlatformName)</PlatformName>
-				<TargetPlatformIdentifier>$(TargetPlatformIdentifier)</TargetPlatformIdentifier>
-				<TargetFramework>$(TargetFramework)</TargetFramework>
-				<RuntimeIdentifier>$(RuntimeIdentifier)</RuntimeIdentifier>
-				<RuntimeIdentifiers>$(RuntimeIdentifiers)</RuntimeIdentifiers>
-				<Configuration>$(Configuration)</Configuration>
-				<RelativePath>%(Filename)%(Extension)</RelativePath>
 				<AppBundlePath>$(AppBundleDir)</AppBundlePath>
 				<BundleIdentifier>$(_BundleIdentifier)</BundleIdentifier>
-				<CodeSigned Condition="'$(_CodeSigningKey)' != ''">true</CodeSigned>
-				<CodeSigned Condition="'$(_CodeSigningKey)' == ''">false</CodeSigned>
-				<BuildIpa>$(BuildIpa)</BuildIpa>
-				<CreatePackage>$(CreatePackage)</CreatePackage>
-				<ArchiveOnBuild>$(ArchiveOnBuild)</ArchiveOnBuild>
-			</MaciOSArtifactOutput>
+				<Signed Condition="'$(_CodeSigningKey)' != ''">true</Signed>
+				<Signed Condition="'$(_CodeSigningKey)' == ''">false</Signed>
+			</ApplePackageOutput>
 		</ItemGroup>
 	</Target>
 
@@ -3282,29 +3272,19 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		</Archive>
 	</Target>
 
-	<Target Name="_CollectMaciOSArchiveOutput"
+	<Target Name="_CollectAppleArchiveOutput"
 		Condition="'$(ArchiveOnBuild)' == 'true' And '$(ArchiveDir)' != '' And Exists('$(ArchiveDir)')"
 		AfterTargets="_CoreArchive">
 		<ItemGroup>
-			<MaciOSArtifactOutput Include="$(ArchiveDir)">
-				<ArtifactKind>Archive</ArtifactKind>
+			<ApplePackageOutput Include="$(ArchiveDir)">
 				<PackageFormat>xcarchive</PackageFormat>
 				<IsDirectory>true</IsDirectory>
 				<PlatformName>$(_PlatformName)</PlatformName>
-				<TargetPlatformIdentifier>$(TargetPlatformIdentifier)</TargetPlatformIdentifier>
-				<TargetFramework>$(TargetFramework)</TargetFramework>
-				<RuntimeIdentifier>$(RuntimeIdentifier)</RuntimeIdentifier>
-				<RuntimeIdentifiers>$(RuntimeIdentifiers)</RuntimeIdentifiers>
-				<Configuration>$(Configuration)</Configuration>
-				<RelativePath>%(Filename)%(Extension)</RelativePath>
 				<AppBundlePath>$(AppBundleDir)</AppBundlePath>
 				<BundleIdentifier>$(_BundleIdentifier)</BundleIdentifier>
-				<CodeSigned Condition="'$(_CodeSigningKey)' != ''">true</CodeSigned>
-				<CodeSigned Condition="'$(_CodeSigningKey)' == ''">false</CodeSigned>
-				<BuildIpa>$(BuildIpa)</BuildIpa>
-				<CreatePackage>$(CreatePackage)</CreatePackage>
-				<ArchiveOnBuild>$(ArchiveOnBuild)</ArchiveOnBuild>
-			</MaciOSArtifactOutput>
+				<Signed Condition="'$(_CodeSigningKey)' != ''">true</Signed>
+				<Signed Condition="'$(_CodeSigningKey)' == ''">false</Signed>
+			</ApplePackageOutput>
 		</ItemGroup>
 	</Target>
 
@@ -3411,30 +3391,19 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		</CreateInstallerPackage>
 	</Target>
 
-	<Target Name="_CollectMaciOSPkgOutput"
+	<Target Name="_CollectApplePkgOutput"
 		Condition="'$(CreatePackage)' == 'true' And '$(PkgPackagePath)' != '' And Exists('$(PkgPackagePath)')"
 		AfterTargets="_CreateInstaller">
 		<ItemGroup>
-			<MaciOSArtifactOutput Include="$(PkgPackagePath)">
-				<ArtifactKind>Package</ArtifactKind>
+			<ApplePackageOutput Include="$(PkgPackagePath)">
 				<PackageFormat>pkg</PackageFormat>
 				<IsDirectory>false</IsDirectory>
 				<PlatformName>$(_PlatformName)</PlatformName>
-				<TargetPlatformIdentifier>$(TargetPlatformIdentifier)</TargetPlatformIdentifier>
-				<TargetFramework>$(TargetFramework)</TargetFramework>
-				<RuntimeIdentifier>$(RuntimeIdentifier)</RuntimeIdentifier>
-				<RuntimeIdentifiers>$(RuntimeIdentifiers)</RuntimeIdentifiers>
-				<Configuration>$(Configuration)</Configuration>
-				<RelativePath>%(Filename)%(Extension)</RelativePath>
 				<AppBundlePath>$(AppBundleDir)</AppBundlePath>
 				<BundleIdentifier>$(_BundleIdentifier)</BundleIdentifier>
-				<CodeSigned Condition="'$(_CodeSigningKey)' != ''">true</CodeSigned>
-				<CodeSigned Condition="'$(_CodeSigningKey)' == ''">false</CodeSigned>
-				<PackageSigned>$(EnablePackageSigning)</PackageSigned>
-				<BuildIpa>$(BuildIpa)</BuildIpa>
-				<CreatePackage>$(CreatePackage)</CreatePackage>
-				<ArchiveOnBuild>$(ArchiveOnBuild)</ArchiveOnBuild>
-			</MaciOSArtifactOutput>
+				<Signed Condition="'$(_CodeSigningKey)' != '' Or '$(EnablePackageSigning)' == 'true'">true</Signed>
+				<Signed Condition="'$(_CodeSigningKey)' == '' And '$(EnablePackageSigning)' != 'true'">false</Signed>
+			</ApplePackageOutput>
 		</ItemGroup>
 	</Target>
 
@@ -3474,7 +3443,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 	<Target Name="CreateIpa" Condition="'$(_CanArchive)' == 'true' And '$(SdkIsDesktop)' != 'true'" DependsOnTargets="$(CreateIpaDependsOn)" />
 
-	<Target Name="GetMaciOSArtifactOutputs" DependsOnTargets="Build" Returns="@(MaciOSArtifactOutput)" />
+	<Target Name="GetApplePackageOutputs" DependsOnTargets="Build" Returns="@(ApplePackageOutput)" />
 
 	<Import Project="$(MSBuildThisFileDirectory)Xamarin.Shared.ObjCBinding.targets" Condition="'$(IsBindingProject)' == 'true'" />
 

--- a/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
@@ -498,8 +498,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 				<PlatformName>$(_PlatformName)</PlatformName>
 				<AppBundlePath>$(AppBundleDir)</AppBundlePath>
 				<BundleIdentifier>$(_BundleIdentifier)</BundleIdentifier>
-				<Signed Condition="'$(_CodeSigningKey)' != ''">true</Signed>
-				<Signed Condition="'$(_CodeSigningKey)' == ''">false</Signed>
 			</ApplePackageOutput>
 		</ItemGroup>
 	</Target>

--- a/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
@@ -496,7 +496,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 				<PackageFormat>ipa</PackageFormat>
 				<IsDirectory>false</IsDirectory>
 				<PlatformName>$(_PlatformName)</PlatformName>
-				<AppBundlePath>$(AppBundleDir)</AppBundlePath>
 				<BundleIdentifier>$(_BundleIdentifier)</BundleIdentifier>
 			</ApplePackageOutput>
 		</ItemGroup>

--- a/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
@@ -488,6 +488,32 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</Zip>
 	</Target>
 
+	<Target Name="_CollectMaciOSIpaOutput"
+		Condition="'$(BuildIpa)' == 'true' And '$(IpaPackagePath)' != '' And Exists('$(IpaPackagePath)')"
+		AfterTargets="_ZipIpa">
+		<ItemGroup>
+			<MaciOSArtifactOutput Include="$(IpaPackagePath)">
+				<ArtifactKind>Package</ArtifactKind>
+				<PackageFormat>ipa</PackageFormat>
+				<IsDirectory>false</IsDirectory>
+				<PlatformName>$(_PlatformName)</PlatformName>
+				<TargetPlatformIdentifier>$(TargetPlatformIdentifier)</TargetPlatformIdentifier>
+				<TargetFramework>$(TargetFramework)</TargetFramework>
+				<RuntimeIdentifier>$(RuntimeIdentifier)</RuntimeIdentifier>
+				<RuntimeIdentifiers>$(RuntimeIdentifiers)</RuntimeIdentifiers>
+				<Configuration>$(Configuration)</Configuration>
+				<RelativePath>%(Filename)%(Extension)</RelativePath>
+				<AppBundlePath>$(AppBundleDir)</AppBundlePath>
+				<BundleIdentifier>$(_BundleIdentifier)</BundleIdentifier>
+				<CodeSigned Condition="'$(_CodeSigningKey)' != ''">true</CodeSigned>
+				<CodeSigned Condition="'$(_CodeSigningKey)' == ''">false</CodeSigned>
+				<BuildIpa>$(BuildIpa)</BuildIpa>
+				<CreatePackage>$(CreatePackage)</CreatePackage>
+				<ArchiveOnBuild>$(ArchiveOnBuild)</ArchiveOnBuild>
+			</MaciOSArtifactOutput>
+		</ItemGroup>
+	</Target>
+
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets')"/>
 		

--- a/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
@@ -488,29 +488,19 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		</Zip>
 	</Target>
 
-	<Target Name="_CollectMaciOSIpaOutput"
+	<Target Name="_CollectAppleIpaOutput"
 		Condition="'$(BuildIpa)' == 'true' And '$(IpaPackagePath)' != '' And Exists('$(IpaPackagePath)')"
 		AfterTargets="_ZipIpa">
 		<ItemGroup>
-			<MaciOSArtifactOutput Include="$(IpaPackagePath)">
-				<ArtifactKind>Package</ArtifactKind>
+			<ApplePackageOutput Include="$(IpaPackagePath)">
 				<PackageFormat>ipa</PackageFormat>
 				<IsDirectory>false</IsDirectory>
 				<PlatformName>$(_PlatformName)</PlatformName>
-				<TargetPlatformIdentifier>$(TargetPlatformIdentifier)</TargetPlatformIdentifier>
-				<TargetFramework>$(TargetFramework)</TargetFramework>
-				<RuntimeIdentifier>$(RuntimeIdentifier)</RuntimeIdentifier>
-				<RuntimeIdentifiers>$(RuntimeIdentifiers)</RuntimeIdentifiers>
-				<Configuration>$(Configuration)</Configuration>
-				<RelativePath>%(Filename)%(Extension)</RelativePath>
 				<AppBundlePath>$(AppBundleDir)</AppBundlePath>
 				<BundleIdentifier>$(_BundleIdentifier)</BundleIdentifier>
-				<CodeSigned Condition="'$(_CodeSigningKey)' != ''">true</CodeSigned>
-				<CodeSigned Condition="'$(_CodeSigningKey)' == ''">false</CodeSigned>
-				<BuildIpa>$(BuildIpa)</BuildIpa>
-				<CreatePackage>$(CreatePackage)</CreatePackage>
-				<ArchiveOnBuild>$(ArchiveOnBuild)</ArchiveOnBuild>
-			</MaciOSArtifactOutput>
+				<Signed Condition="'$(_CodeSigningKey)' != ''">true</Signed>
+				<Signed Condition="'$(_CodeSigningKey)' == ''">false</Signed>
+			</ApplePackageOutput>
 		</ItemGroup>
 	</Target>
 

--- a/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
@@ -492,12 +492,12 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		Condition="'$(BuildIpa)' == 'true' And '$(IpaPackagePath)' != '' And Exists('$(IpaPackagePath)')"
 		AfterTargets="_ZipIpa">
 		<ItemGroup>
-			<ApplePackageOutput Include="$(IpaPackagePath)">
+			<ApplicationArtifact Include="$(IpaPackagePath)">
 				<PackageFormat>ipa</PackageFormat>
 				<IsDirectory>false</IsDirectory>
 				<PlatformName>$(_PlatformName)</PlatformName>
 				<BundleIdentifier>$(_BundleIdentifier)</BundleIdentifier>
-			</ApplePackageOutput>
+			</ApplicationArtifact>
 		</ItemGroup>
 	</Target>
 

--- a/tests/dotnet/UnitTests/PostBuildTest.cs
+++ b/tests/dotnet/UnitTests/PostBuildTest.cs
@@ -103,6 +103,42 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
+		public void GetApplicationArtifactsDependsOnTest ()
+		{
+			var project = "MySimpleApp";
+			var platform = ApplePlatform.iOS;
+			var runtimeIdentifiers = "ios-arm64";
+			var configuration = "Release";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath, configuration: configuration);
+			Clean (project_path);
+			var existingProjectContent = File.ReadAllText (project_path);
+			var newProjectContent = existingProjectContent.Replace ("</Project>", @"
+	<PropertyGroup>
+		<GetApplicationArtifactsDependsOn>$(GetApplicationArtifactsDependsOn);AddMauiApplicationArtifactMetadata</GetApplicationArtifactsDependsOn>
+	</PropertyGroup>
+	<Target Name=""AddMauiApplicationArtifactMetadata"">
+		<ItemGroup>
+			<ApplicationArtifact Update=""@(ApplicationArtifact)"">
+				<ApplicationTitle>My MAUI App</ApplicationTitle>
+			</ApplicationArtifact>
+		</ItemGroup>
+	</Target>
+</Project>");
+			File.WriteAllText (project_path, newProjectContent);
+
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["BuildIpa"] = "true";
+			properties ["Configuration"] = configuration;
+
+			var outputs = GetApplicationArtifacts (project_path, properties);
+			var appOutput = AssertApplicationArtifact (outputs, appPath, platform, "app", isDirectory: true);
+			Assert.That (GetMetadata (appOutput, "ApplicationTitle"), Is.EqualTo ("My MAUI App"), "ApplicationTitle");
+		}
+
+		[Test]
 		[TestCase (ApplePlatform.iOS, "ios-arm64")]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
 		public void GetApplicationArtifactsArchiveTest (ApplePlatform platform, string runtimeIdentifiers)

--- a/tests/dotnet/UnitTests/PostBuildTest.cs
+++ b/tests/dotnet/UnitTests/PostBuildTest.cs
@@ -45,6 +45,7 @@ namespace Xamarin.Tests {
 			Assert.That (archiveDirs.Count, Is.GreaterThan (0), "ArchiveDir");
 			var archiveDir = archiveDirs [0]!.Trim ();
 			Assert.That (archiveDir, Does.Exist, "Archive directory existence");
+			AssertMaciOSArtifactOutput (result.BinLogPath, archiveDir, platform, "Archive", "xcarchive", isDirectory: true);
 			AssertDSymDirectory (appPath);
 		}
 
@@ -64,10 +65,12 @@ namespace Xamarin.Tests {
 			properties ["BuildIpa"] = "true";
 			properties ["Configuration"] = configuration;
 
-			DotNet.AssertBuild (project_path, properties);
+			var result = DotNet.AssertBuild (project_path, properties);
 
 			var pkgPath = Path.Combine (appPath, "..", $"{project}.ipa");
 			Assert.That (pkgPath, Does.Exist, "pkg creation");
+			AssertMaciOSArtifactOutput (result.BinLogPath, appPath, platform, "AppBundle", "app", isDirectory: true);
+			AssertMaciOSArtifactOutput (result.BinLogPath, pkgPath, platform, "Package", "ipa", isDirectory: false);
 
 			AssertBundleAssembliesStripStatus (appPath, true);
 			AssertDSymDirectory (appPath);
@@ -137,10 +140,12 @@ namespace Xamarin.Tests {
 			var properties = GetDefaultProperties (runtimeIdentifiers);
 			properties ["CreatePackage"] = "true";
 
-			DotNet.AssertBuild (project_path, properties);
+			var result = DotNet.AssertBuild (project_path, properties);
 
 			var pkgPath = Path.Combine (appPath, "..", $"{project}-{projectVersion}.pkg");
 			Assert.That (pkgPath, Does.Exist, "pkg creation");
+			AssertMaciOSArtifactOutput (result.BinLogPath, appPath, platform, "AppBundle", "app", isDirectory: true);
+			AssertMaciOSArtifactOutput (result.BinLogPath, pkgPath, platform, "Package", "pkg", isDirectory: false);
 		}
 
 		[TestCase (ApplePlatform.iOS, "ios-arm64")]
@@ -180,9 +185,11 @@ namespace Xamarin.Tests {
 			var properties = GetDefaultProperties (runtimeIdentifiers);
 			properties [pathVariable] = pkgPath;
 
-			DotNet.AssertPublish (project_path, properties);
+			var result = DotNet.AssertPublish (project_path, properties);
 
 			Assert.That (pkgPath, Does.Exist, "ipa/pkg creation");
+			AssertMaciOSArtifactOutput (result.BinLogPath, pkgPath, platform, "Package", packageExtension, isDirectory: false);
+			AssertMaciOSPublishedArtifactOutput (result.BinLogPath, pkgPath, platform, "Package", packageExtension, isDirectory: false);
 		}
 
 
@@ -374,7 +381,39 @@ namespace Xamarin.Tests {
 			Assert.That (staticFrameworkItems, Is.Empty, $"Static framework XStaticArTest should not be in post-processing items. All items:\n\t{string.Join ("\n\t", postProcessingItems.Select (i => i.ItemSpec))}");
 		}
 
+		static ITaskItem AssertMaciOSArtifactOutput (string binLogPath, string path, ApplePlatform platform, string artifactKind, string packageFormat, bool isDirectory)
+		{
+			return AssertMaciOSOutput (GetItems (binLogPath, "MaciOSArtifactOutput"), path, platform, artifactKind, packageFormat, isDirectory);
+		}
+
+		static ITaskItem AssertMaciOSPublishedArtifactOutput (string binLogPath, string path, ApplePlatform platform, string artifactKind, string packageFormat, bool isDirectory)
+		{
+			var output = AssertMaciOSOutput (GetItems (binLogPath, "MaciOSPublishedArtifactOutput"), path, platform, artifactKind, packageFormat, isDirectory);
+			Assert.That (Path.GetFullPath (output.GetMetadata ("OriginalPath")), Is.EqualTo (Path.GetFullPath (path)), "OriginalPath");
+			return output;
+		}
+
+		static ITaskItem AssertMaciOSOutput (List<ITaskItem> outputs, string path, ApplePlatform platform, string artifactKind, string packageFormat, bool isDirectory)
+		{
+			var fullPath = Path.GetFullPath (path);
+			var output = outputs.SingleOrDefault (v => Path.GetFullPath (v.GetMetadata ("FullPath")) == fullPath);
+			Assert.That (output, Is.Not.Null, $"Could not find {artifactKind} output for {fullPath}. All outputs:\n\t{string.Join ("\n\t", outputs.Select (v => v.GetMetadata ("FullPath")))}");
+			Assert.That (output!.GetMetadata ("ArtifactKind"), Is.EqualTo (artifactKind), "ArtifactKind");
+			Assert.That (output.GetMetadata ("PackageFormat"), Is.EqualTo (packageFormat), "PackageFormat");
+			Assert.That (output.GetMetadata ("IsDirectory"), Is.EqualTo (isDirectory ? "true" : "false"), "IsDirectory");
+			Assert.That (output.GetMetadata ("PlatformName"), Is.EqualTo (platform.AsString ()), "PlatformName");
+			Assert.That (output.GetMetadata ("RelativePath"), Is.EqualTo (Path.GetFileName (path)), "RelativePath");
+			Assert.That (output.GetMetadata ("Configuration"), Is.Not.Empty, "Configuration");
+			Assert.That (output.GetMetadata ("TargetFramework"), Is.Not.Empty, "TargetFramework");
+			return output;
+		}
+
 		static List<ITaskItem> GetPostProcessingItems (string binLogPath)
+		{
+			return GetItems (binLogPath, "_PostProcessingItem");
+		}
+
+		static List<ITaskItem> GetItems (string binLogPath, string itemType)
 		{
 			var items = new Dictionary<string, ITaskItem> ();
 			foreach (var args in BinLog.ReadBuildEvents (binLogPath)) {
@@ -382,7 +421,7 @@ namespace Xamarin.Tests {
 					continue;
 				if (tpea.Kind != TaskParameterMessageKind.AddItem)
 					continue;
-				if (tpea.ItemType != "_PostProcessingItem")
+				if (tpea.ItemType != itemType)
 					continue;
 				foreach (var item in tpea.Items) {
 					if (item is ITaskItem taskItem)

--- a/tests/dotnet/UnitTests/PostBuildTest.cs
+++ b/tests/dotnet/UnitTests/PostBuildTest.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging.StructuredLogger;
 using Mono.Cecil;
@@ -77,6 +79,50 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
+		[TestCase (ApplePlatform.iOS, "ios-arm64")]
+		[TestCase (ApplePlatform.TVOS, "tvos-arm64")]
+		public void GetApplePackageOutputsIpaTest (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			var project = "MySimpleApp";
+			var configuration = "Release";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath, configuration: configuration);
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["BuildIpa"] = "true";
+			properties ["Configuration"] = configuration;
+
+			var outputs = GetApplePackageOutputs (project_path, properties);
+			var pkgPath = Path.Combine (appPath, "..", $"{project}.ipa");
+
+			Assert.That (pkgPath, Does.Exist, "pkg creation");
+			AssertApplePackageOutput (outputs, appPath, platform, "app", isDirectory: true);
+			AssertApplePackageOutput (outputs, pkgPath, platform, "ipa", isDirectory: false);
+		}
+
+		[Test]
+		[TestCase (ApplePlatform.iOS, "ios-arm64")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
+		public void GetApplePackageOutputsArchiveTest (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			var project = "MySimpleApp";
+			var configuration = "Release";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers, platform, out _, configuration: configuration);
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["ArchiveOnBuild"] = "true";
+			properties ["Configuration"] = configuration;
+
+			var outputs = GetApplePackageOutputs (project_path, properties);
+			AssertApplePackageOutput (outputs, platform, "xcarchive", isDirectory: true);
+		}
+
+		[Test]
 		[TestCase ("MySimpleApp", ApplePlatform.iOS, "ios-arm64", true)]
 		[TestCase ("MySimpleApp", ApplePlatform.iOS, "ios-arm64", false)]
 		[TestCase ("MySimpleAppWithSatelliteReference", ApplePlatform.iOS, "ios-arm64", true)]
@@ -146,6 +192,29 @@ namespace Xamarin.Tests {
 			Assert.That (pkgPath, Does.Exist, "pkg creation");
 			AssertApplePackageOutput (result.BinLogPath, appPath, platform, "app", isDirectory: true);
 			AssertApplePackageOutput (result.BinLogPath, pkgPath, platform, "pkg", isDirectory: false);
+		}
+
+		[Test]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
+		[TestCase (ApplePlatform.MacOSX, "osx-x64")]
+		public void GetApplePackageOutputsPkgTest (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			var project = "MySimpleApp";
+			var projectVersion = "3.14";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["CreatePackage"] = "true";
+
+			var outputs = GetApplePackageOutputs (project_path, properties);
+			var pkgPath = Path.Combine (appPath, "..", $"{project}-{projectVersion}.pkg");
+
+			Assert.That (pkgPath, Does.Exist, "pkg creation");
+			AssertApplePackageOutput (outputs, appPath, platform, "app", isDirectory: true);
+			AssertApplePackageOutput (outputs, pkgPath, platform, "pkg", isDirectory: false);
 		}
 
 		[TestCase (ApplePlatform.iOS, "ios-arm64")]
@@ -396,6 +465,46 @@ namespace Xamarin.Tests {
 			Assert.That (output.GetMetadata ("Signed"), Is.Empty, "Signed");
 			Assert.That (output.GetMetadata ("PackageSigned"), Is.Empty, "PackageSigned");
 			return output;
+		}
+
+		static JsonElement [] GetApplePackageOutputs (string projectPath, Dictionary<string, string> properties)
+		{
+			using var document = JsonDocument.Parse (DotNet.GetItems (projectPath, "ApplePackageOutput", target: "GetApplePackageOutputs", properties: properties));
+			var outputs = document.RootElement.GetProperty ("Items").GetProperty ("ApplePackageOutput").EnumerateArray ().Select (v => v.Clone ()).ToArray ();
+			Assert.That (outputs, Is.Not.Empty, "ApplePackageOutput items");
+			return outputs;
+		}
+
+		static JsonElement AssertApplePackageOutput (JsonElement [] outputs, string path, ApplePlatform platform, string packageFormat, bool isDirectory)
+		{
+			var fullPath = Path.GetFullPath (path);
+			var output = outputs.SingleOrDefault (v => Path.GetFullPath (GetMetadata (v, "FullPath")) == fullPath);
+			Assert.That (output.ValueKind, Is.Not.EqualTo (JsonValueKind.Undefined), $"Could not find {packageFormat} output for {fullPath}. All outputs:\n\t{string.Join ("\n\t", outputs.Select (v => GetMetadata (v, "FullPath")))}");
+			Assert.That (GetMetadata (output, "PackageFormat"), Is.EqualTo (packageFormat), "PackageFormat");
+			Assert.That (GetMetadata (output, "IsDirectory"), Is.EqualTo (isDirectory ? "true" : "false"), "IsDirectory");
+			Assert.That (GetMetadata (output, "PlatformName"), Is.EqualTo (platform.AsString ()), "PlatformName");
+			Assert.That (GetMetadata (output, "BundleIdentifier"), Is.Not.Empty, "BundleIdentifier");
+			Assert.That (GetMetadata (output, "ArtifactKind"), Is.Empty, "ArtifactKind");
+			Assert.That (GetMetadata (output, "AppBundlePath"), Is.Empty, "AppBundlePath");
+			Assert.That (GetMetadata (output, "CodeSigned"), Is.Empty, "CodeSigned");
+			Assert.That (GetMetadata (output, "Signed"), Is.Empty, "Signed");
+			Assert.That (GetMetadata (output, "PackageSigned"), Is.Empty, "PackageSigned");
+			return output;
+		}
+
+		static JsonElement AssertApplePackageOutput (JsonElement [] outputs, ApplePlatform platform, string packageFormat, bool isDirectory)
+		{
+			var matchingOutputs = outputs.Where (v => GetMetadata (v, "PackageFormat") == packageFormat).ToArray ();
+			Assert.That (matchingOutputs, Has.Length.EqualTo (1), $"Expected one {packageFormat} output. All outputs:\n\t{string.Join ("\n\t", outputs.Select (v => GetMetadata (v, "FullPath")))}");
+
+			var fullPath = GetMetadata (matchingOutputs [0], "FullPath");
+			Assert.That (fullPath, Does.Exist, packageFormat);
+			return AssertApplePackageOutput (outputs, fullPath, platform, packageFormat, isDirectory);
+		}
+
+		static string GetMetadata (JsonElement item, string name)
+		{
+			return item.TryGetProperty (name, out var value) ? value.GetString () ?? "" : "";
 		}
 
 		static List<ITaskItem> GetPostProcessingItems (string binLogPath)

--- a/tests/dotnet/UnitTests/PostBuildTest.cs
+++ b/tests/dotnet/UnitTests/PostBuildTest.cs
@@ -117,7 +117,7 @@ namespace Xamarin.Tests {
 			var existingProjectContent = File.ReadAllText (project_path);
 			var newProjectContent = existingProjectContent.Replace ("</Project>", @"
 	<PropertyGroup>
-		<GetApplicationArtifactsDependsOn>$(GetApplicationArtifactsDependsOn);AddMauiApplicationArtifactMetadata</GetApplicationArtifactsDependsOn>
+		<GetApplicationArtifactsDependsOn>AddMauiApplicationArtifactMetadata</GetApplicationArtifactsDependsOn>
 	</PropertyGroup>
 	<Target Name=""AddMauiApplicationArtifactMetadata"">
 		<ItemGroup>
@@ -325,7 +325,7 @@ namespace Xamarin.Tests {
 			var existingProjectContent = File.ReadAllText (project_path);
 			var newProjectContent = existingProjectContent.Replace ("</Project>", @"
 	<PropertyGroup>
-		<GetApplicationArtifactsDependsOn>$(GetApplicationArtifactsDependsOn);AddMauiPublishApplicationArtifactMetadata</GetApplicationArtifactsDependsOn>
+		<GetApplicationArtifactsDependsOn>AddMauiPublishApplicationArtifactMetadata</GetApplicationArtifactsDependsOn>
 	</PropertyGroup>
 	<Target Name=""AddMauiPublishApplicationArtifactMetadata"">
 		<ItemGroup>

--- a/tests/dotnet/UnitTests/PostBuildTest.cs
+++ b/tests/dotnet/UnitTests/PostBuildTest.cs
@@ -47,7 +47,7 @@ namespace Xamarin.Tests {
 			Assert.That (archiveDirs.Count, Is.GreaterThan (0), "ArchiveDir");
 			var archiveDir = archiveDirs [0]!.Trim ();
 			Assert.That (archiveDir, Does.Exist, "Archive directory existence");
-			AssertApplePackageOutput (result.BinLogPath, archiveDir, platform, "xcarchive", isDirectory: true);
+			AssertApplicationArtifact (result.BinLogPath, archiveDir, platform, "xcarchive", isDirectory: true);
 			AssertDSymDirectory (appPath);
 		}
 
@@ -71,8 +71,8 @@ namespace Xamarin.Tests {
 
 			var pkgPath = Path.Combine (appPath, "..", $"{project}.ipa");
 			Assert.That (pkgPath, Does.Exist, "pkg creation");
-			AssertApplePackageOutput (result.BinLogPath, appPath, platform, "app", isDirectory: true);
-			AssertApplePackageOutput (result.BinLogPath, pkgPath, platform, "ipa", isDirectory: false);
+			AssertApplicationArtifact (result.BinLogPath, appPath, platform, "app", isDirectory: true);
+			AssertApplicationArtifact (result.BinLogPath, pkgPath, platform, "ipa", isDirectory: false);
 
 			AssertBundleAssembliesStripStatus (appPath, true);
 			AssertDSymDirectory (appPath);
@@ -81,7 +81,7 @@ namespace Xamarin.Tests {
 		[Test]
 		[TestCase (ApplePlatform.iOS, "ios-arm64")]
 		[TestCase (ApplePlatform.TVOS, "tvos-arm64")]
-		public void GetApplePackageOutputsIpaTest (ApplePlatform platform, string runtimeIdentifiers)
+		public void GetApplicationArtifactsIpaTest (ApplePlatform platform, string runtimeIdentifiers)
 		{
 			var project = "MySimpleApp";
 			var configuration = "Release";
@@ -94,18 +94,18 @@ namespace Xamarin.Tests {
 			properties ["BuildIpa"] = "true";
 			properties ["Configuration"] = configuration;
 
-			var outputs = GetApplePackageOutputs (project_path, properties);
+			var outputs = GetApplicationArtifacts (project_path, properties);
 			var pkgPath = Path.Combine (appPath, "..", $"{project}.ipa");
 
 			Assert.That (pkgPath, Does.Exist, "pkg creation");
-			AssertApplePackageOutput (outputs, appPath, platform, "app", isDirectory: true);
-			AssertApplePackageOutput (outputs, pkgPath, platform, "ipa", isDirectory: false);
+			AssertApplicationArtifact (outputs, appPath, platform, "app", isDirectory: true);
+			AssertApplicationArtifact (outputs, pkgPath, platform, "ipa", isDirectory: false);
 		}
 
 		[Test]
 		[TestCase (ApplePlatform.iOS, "ios-arm64")]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
-		public void GetApplePackageOutputsArchiveTest (ApplePlatform platform, string runtimeIdentifiers)
+		public void GetApplicationArtifactsArchiveTest (ApplePlatform platform, string runtimeIdentifiers)
 		{
 			var project = "MySimpleApp";
 			var configuration = "Release";
@@ -118,8 +118,8 @@ namespace Xamarin.Tests {
 			properties ["ArchiveOnBuild"] = "true";
 			properties ["Configuration"] = configuration;
 
-			var outputs = GetApplePackageOutputs (project_path, properties);
-			AssertApplePackageOutput (outputs, platform, "xcarchive", isDirectory: true);
+			var outputs = GetApplicationArtifacts (project_path, properties);
+			AssertApplicationArtifact (outputs, platform, "xcarchive", isDirectory: true);
 		}
 
 		[Test]
@@ -190,14 +190,14 @@ namespace Xamarin.Tests {
 
 			var pkgPath = Path.Combine (appPath, "..", $"{project}-{projectVersion}.pkg");
 			Assert.That (pkgPath, Does.Exist, "pkg creation");
-			AssertApplePackageOutput (result.BinLogPath, appPath, platform, "app", isDirectory: true);
-			AssertApplePackageOutput (result.BinLogPath, pkgPath, platform, "pkg", isDirectory: false);
+			AssertApplicationArtifact (result.BinLogPath, appPath, platform, "app", isDirectory: true);
+			AssertApplicationArtifact (result.BinLogPath, pkgPath, platform, "pkg", isDirectory: false);
 		}
 
 		[Test]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64")]
-		public void GetApplePackageOutputsPkgTest (ApplePlatform platform, string runtimeIdentifiers)
+		public void GetApplicationArtifactsPkgTest (ApplePlatform platform, string runtimeIdentifiers)
 		{
 			var project = "MySimpleApp";
 			var projectVersion = "3.14";
@@ -209,12 +209,12 @@ namespace Xamarin.Tests {
 			var properties = GetDefaultProperties (runtimeIdentifiers);
 			properties ["CreatePackage"] = "true";
 
-			var outputs = GetApplePackageOutputs (project_path, properties);
+			var outputs = GetApplicationArtifacts (project_path, properties);
 			var pkgPath = Path.Combine (appPath, "..", $"{project}-{projectVersion}.pkg");
 
 			Assert.That (pkgPath, Does.Exist, "pkg creation");
-			AssertApplePackageOutput (outputs, appPath, platform, "app", isDirectory: true);
-			AssertApplePackageOutput (outputs, pkgPath, platform, "pkg", isDirectory: false);
+			AssertApplicationArtifact (outputs, appPath, platform, "app", isDirectory: true);
+			AssertApplicationArtifact (outputs, pkgPath, platform, "pkg", isDirectory: false);
 		}
 
 		[TestCase (ApplePlatform.iOS, "ios-arm64")]
@@ -257,7 +257,7 @@ namespace Xamarin.Tests {
 			var result = DotNet.AssertPublish (project_path, properties);
 
 			Assert.That (pkgPath, Does.Exist, "ipa/pkg creation");
-			AssertApplePackageOutput (result.BinLogPath, pkgPath, platform, packageExtension, isDirectory: false);
+			AssertApplicationArtifact (result.BinLogPath, pkgPath, platform, packageExtension, isDirectory: false);
 		}
 
 
@@ -449,9 +449,9 @@ namespace Xamarin.Tests {
 			Assert.That (staticFrameworkItems, Is.Empty, $"Static framework XStaticArTest should not be in post-processing items. All items:\n\t{string.Join ("\n\t", postProcessingItems.Select (i => i.ItemSpec))}");
 		}
 
-		static ITaskItem AssertApplePackageOutput (string binLogPath, string path, ApplePlatform platform, string packageFormat, bool isDirectory)
+		static ITaskItem AssertApplicationArtifact (string binLogPath, string path, ApplePlatform platform, string packageFormat, bool isDirectory)
 		{
-			var outputs = GetItems (binLogPath, "ApplePackageOutput");
+			var outputs = GetItems (binLogPath, "ApplicationArtifact");
 			var fullPath = Path.GetFullPath (path);
 			var output = outputs.SingleOrDefault (v => Path.GetFullPath (v.GetMetadata ("FullPath")) == fullPath);
 			Assert.That (output, Is.Not.Null, $"Could not find {packageFormat} output for {fullPath}. All outputs:\n\t{string.Join ("\n\t", outputs.Select (v => v.GetMetadata ("FullPath")))}");
@@ -467,15 +467,15 @@ namespace Xamarin.Tests {
 			return output;
 		}
 
-		static JsonElement [] GetApplePackageOutputs (string projectPath, Dictionary<string, string> properties)
+		static JsonElement [] GetApplicationArtifacts (string projectPath, Dictionary<string, string> properties)
 		{
-			using var document = JsonDocument.Parse (DotNet.GetItems (projectPath, "ApplePackageOutput", target: "GetApplePackageOutputs", properties: properties));
-			var outputs = document.RootElement.GetProperty ("Items").GetProperty ("ApplePackageOutput").EnumerateArray ().Select (v => v.Clone ()).ToArray ();
-			Assert.That (outputs, Is.Not.Empty, "ApplePackageOutput items");
+			using var document = JsonDocument.Parse (DotNet.GetItems (projectPath, "ApplicationArtifact", target: "GetApplicationArtifacts", properties: properties));
+			var outputs = document.RootElement.GetProperty ("Items").GetProperty ("ApplicationArtifact").EnumerateArray ().Select (v => v.Clone ()).ToArray ();
+			Assert.That (outputs, Is.Not.Empty, "ApplicationArtifact items");
 			return outputs;
 		}
 
-		static JsonElement AssertApplePackageOutput (JsonElement [] outputs, string path, ApplePlatform platform, string packageFormat, bool isDirectory)
+		static JsonElement AssertApplicationArtifact (JsonElement [] outputs, string path, ApplePlatform platform, string packageFormat, bool isDirectory)
 		{
 			var fullPath = Path.GetFullPath (path);
 			var output = outputs.SingleOrDefault (v => Path.GetFullPath (GetMetadata (v, "FullPath")) == fullPath);
@@ -492,14 +492,14 @@ namespace Xamarin.Tests {
 			return output;
 		}
 
-		static JsonElement AssertApplePackageOutput (JsonElement [] outputs, ApplePlatform platform, string packageFormat, bool isDirectory)
+		static JsonElement AssertApplicationArtifact (JsonElement [] outputs, ApplePlatform platform, string packageFormat, bool isDirectory)
 		{
 			var matchingOutputs = outputs.Where (v => GetMetadata (v, "PackageFormat") == packageFormat).ToArray ();
 			Assert.That (matchingOutputs, Has.Length.EqualTo (1), $"Expected one {packageFormat} output. All outputs:\n\t{string.Join ("\n\t", outputs.Select (v => GetMetadata (v, "FullPath")))}");
 
 			var fullPath = GetMetadata (matchingOutputs [0], "FullPath");
 			Assert.That (fullPath, Does.Exist, packageFormat);
-			return AssertApplePackageOutput (outputs, fullPath, platform, packageFormat, isDirectory);
+			return AssertApplicationArtifact (outputs, fullPath, platform, packageFormat, isDirectory);
 		}
 
 		static string GetMetadata (JsonElement item, string name)

--- a/tests/dotnet/UnitTests/PostBuildTest.cs
+++ b/tests/dotnet/UnitTests/PostBuildTest.cs
@@ -103,11 +103,11 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
-		public void GetApplicationArtifactsDependsOnTest ()
+		[TestCase (ApplePlatform.iOS, "ios-arm64", "ipa")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64", "pkg")]
+		public void GetApplicationArtifactsDependsOnTest (ApplePlatform platform, string runtimeIdentifiers, string packageFormat)
 		{
 			var project = "MySimpleApp";
-			var platform = ApplePlatform.iOS;
-			var runtimeIdentifiers = "ios-arm64";
 			var configuration = "Release";
 			Configuration.IgnoreIfIgnoredPlatform (platform);
 			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
@@ -121,21 +121,36 @@ namespace Xamarin.Tests {
 	</PropertyGroup>
 	<Target Name=""AddMauiApplicationArtifactMetadata"">
 		<ItemGroup>
+			<_MauiObservedAppArtifact Include=""@(ApplicationArtifact)"" Condition=""'%(ApplicationArtifact.PackageFormat)' == 'app'"" />
+			<_MauiObservedPackageArtifact Include=""@(ApplicationArtifact)"" Condition=""'%(ApplicationArtifact.PackageFormat)' == '$(ExpectedAugmentedPackageFormat)'"" />
 			<ApplicationArtifact Update=""@(ApplicationArtifact)"">
 				<ApplicationTitle>My MAUI App</ApplicationTitle>
+				<MauiObservedPackageFormat>%(ApplicationArtifact.PackageFormat)</MauiObservedPackageFormat>
 			</ApplicationArtifact>
 		</ItemGroup>
+		<Error Condition=""'@(_MauiObservedAppArtifact)' == ''"" Text=""Expected app ApplicationArtifact items before MAUI metadata is added."" />
+		<Error Condition=""'@(_MauiObservedPackageArtifact)' == ''"" Text=""Expected $(ExpectedAugmentedPackageFormat) ApplicationArtifact items before MAUI metadata is added."" />
 	</Target>
 </Project>");
 			File.WriteAllText (project_path, newProjectContent);
 
-			var properties = GetDefaultProperties (runtimeIdentifiers);
-			properties ["BuildIpa"] = "true";
-			properties ["Configuration"] = configuration;
+			try {
+				var properties = GetDefaultProperties (runtimeIdentifiers);
+				properties ["BuildIpa"] = packageFormat == "ipa" ? "true" : "false";
+				properties ["CreatePackage"] = packageFormat == "pkg" ? "true" : "false";
+				properties ["Configuration"] = configuration;
+				properties ["ExpectedAugmentedPackageFormat"] = packageFormat;
 
-			var outputs = GetApplicationArtifacts (project_path, properties);
-			var appOutput = AssertApplicationArtifact (outputs, appPath, platform, "app", isDirectory: true);
-			Assert.That (GetMetadata (appOutput, "ApplicationTitle"), Is.EqualTo ("My MAUI App"), "ApplicationTitle");
+				var outputs = GetApplicationArtifacts (project_path, properties);
+				var appOutput = AssertApplicationArtifact (outputs, appPath, platform, "app", isDirectory: true);
+				var packageOutput = AssertApplicationArtifact (outputs, platform, packageFormat, isDirectory: false);
+				Assert.That (GetMetadata (appOutput, "ApplicationTitle"), Is.EqualTo ("My MAUI App"), "ApplicationTitle");
+				Assert.That (GetMetadata (appOutput, "MauiObservedPackageFormat"), Is.EqualTo ("app"), "MauiObservedPackageFormat");
+				Assert.That (GetMetadata (packageOutput, "ApplicationTitle"), Is.EqualTo ("My MAUI App"), "ApplicationTitle");
+				Assert.That (GetMetadata (packageOutput, "MauiObservedPackageFormat"), Is.EqualTo (packageFormat), "MauiObservedPackageFormat");
+			} finally {
+				File.WriteAllText (project_path, existingProjectContent);
+			}
 		}
 
 		[Test]

--- a/tests/dotnet/UnitTests/PostBuildTest.cs
+++ b/tests/dotnet/UnitTests/PostBuildTest.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Tests {
 			Assert.That (archiveDirs.Count, Is.GreaterThan (0), "ArchiveDir");
 			var archiveDir = archiveDirs [0]!.Trim ();
 			Assert.That (archiveDir, Does.Exist, "Archive directory existence");
-			AssertMaciOSArtifactOutput (result.BinLogPath, archiveDir, platform, "Archive", "xcarchive", isDirectory: true);
+			AssertApplePackageOutput (result.BinLogPath, archiveDir, platform, "xcarchive", isDirectory: true);
 			AssertDSymDirectory (appPath);
 		}
 
@@ -69,8 +69,8 @@ namespace Xamarin.Tests {
 
 			var pkgPath = Path.Combine (appPath, "..", $"{project}.ipa");
 			Assert.That (pkgPath, Does.Exist, "pkg creation");
-			AssertMaciOSArtifactOutput (result.BinLogPath, appPath, platform, "AppBundle", "app", isDirectory: true);
-			AssertMaciOSArtifactOutput (result.BinLogPath, pkgPath, platform, "Package", "ipa", isDirectory: false);
+			AssertApplePackageOutput (result.BinLogPath, appPath, platform, "app", isDirectory: true);
+			AssertApplePackageOutput (result.BinLogPath, pkgPath, platform, "ipa", isDirectory: false);
 
 			AssertBundleAssembliesStripStatus (appPath, true);
 			AssertDSymDirectory (appPath);
@@ -144,8 +144,8 @@ namespace Xamarin.Tests {
 
 			var pkgPath = Path.Combine (appPath, "..", $"{project}-{projectVersion}.pkg");
 			Assert.That (pkgPath, Does.Exist, "pkg creation");
-			AssertMaciOSArtifactOutput (result.BinLogPath, appPath, platform, "AppBundle", "app", isDirectory: true);
-			AssertMaciOSArtifactOutput (result.BinLogPath, pkgPath, platform, "Package", "pkg", isDirectory: false);
+			AssertApplePackageOutput (result.BinLogPath, appPath, platform, "app", isDirectory: true);
+			AssertApplePackageOutput (result.BinLogPath, pkgPath, platform, "pkg", isDirectory: false);
 		}
 
 		[TestCase (ApplePlatform.iOS, "ios-arm64")]
@@ -188,8 +188,7 @@ namespace Xamarin.Tests {
 			var result = DotNet.AssertPublish (project_path, properties);
 
 			Assert.That (pkgPath, Does.Exist, "ipa/pkg creation");
-			AssertMaciOSArtifactOutput (result.BinLogPath, pkgPath, platform, "Package", packageExtension, isDirectory: false);
-			AssertMaciOSPublishedArtifactOutput (result.BinLogPath, pkgPath, platform, "Package", packageExtension, isDirectory: false);
+			AssertApplePackageOutput (result.BinLogPath, pkgPath, platform, packageExtension, isDirectory: false);
 		}
 
 
@@ -381,30 +380,21 @@ namespace Xamarin.Tests {
 			Assert.That (staticFrameworkItems, Is.Empty, $"Static framework XStaticArTest should not be in post-processing items. All items:\n\t{string.Join ("\n\t", postProcessingItems.Select (i => i.ItemSpec))}");
 		}
 
-		static ITaskItem AssertMaciOSArtifactOutput (string binLogPath, string path, ApplePlatform platform, string artifactKind, string packageFormat, bool isDirectory)
+		static ITaskItem AssertApplePackageOutput (string binLogPath, string path, ApplePlatform platform, string packageFormat, bool isDirectory)
 		{
-			return AssertMaciOSOutput (GetItems (binLogPath, "MaciOSArtifactOutput"), path, platform, artifactKind, packageFormat, isDirectory);
-		}
-
-		static ITaskItem AssertMaciOSPublishedArtifactOutput (string binLogPath, string path, ApplePlatform platform, string artifactKind, string packageFormat, bool isDirectory)
-		{
-			var output = AssertMaciOSOutput (GetItems (binLogPath, "MaciOSPublishedArtifactOutput"), path, platform, artifactKind, packageFormat, isDirectory);
-			Assert.That (Path.GetFullPath (output.GetMetadata ("OriginalPath")), Is.EqualTo (Path.GetFullPath (path)), "OriginalPath");
-			return output;
-		}
-
-		static ITaskItem AssertMaciOSOutput (List<ITaskItem> outputs, string path, ApplePlatform platform, string artifactKind, string packageFormat, bool isDirectory)
-		{
+			var outputs = GetItems (binLogPath, "ApplePackageOutput");
 			var fullPath = Path.GetFullPath (path);
 			var output = outputs.SingleOrDefault (v => Path.GetFullPath (v.GetMetadata ("FullPath")) == fullPath);
-			Assert.That (output, Is.Not.Null, $"Could not find {artifactKind} output for {fullPath}. All outputs:\n\t{string.Join ("\n\t", outputs.Select (v => v.GetMetadata ("FullPath")))}");
-			Assert.That (output!.GetMetadata ("ArtifactKind"), Is.EqualTo (artifactKind), "ArtifactKind");
-			Assert.That (output.GetMetadata ("PackageFormat"), Is.EqualTo (packageFormat), "PackageFormat");
+			Assert.That (output, Is.Not.Null, $"Could not find {packageFormat} output for {fullPath}. All outputs:\n\t{string.Join ("\n\t", outputs.Select (v => v.GetMetadata ("FullPath")))}");
+			Assert.That (output!.GetMetadata ("PackageFormat"), Is.EqualTo (packageFormat), "PackageFormat");
 			Assert.That (output.GetMetadata ("IsDirectory"), Is.EqualTo (isDirectory ? "true" : "false"), "IsDirectory");
 			Assert.That (output.GetMetadata ("PlatformName"), Is.EqualTo (platform.AsString ()), "PlatformName");
-			Assert.That (output.GetMetadata ("RelativePath"), Is.EqualTo (Path.GetFileName (path)), "RelativePath");
-			Assert.That (output.GetMetadata ("Configuration"), Is.Not.Empty, "Configuration");
-			Assert.That (output.GetMetadata ("TargetFramework"), Is.Not.Empty, "TargetFramework");
+			Assert.That (output.GetMetadata ("AppBundlePath"), Is.Not.Empty, "AppBundlePath");
+			Assert.That (output.GetMetadata ("BundleIdentifier"), Is.Not.Empty, "BundleIdentifier");
+			Assert.That (output.GetMetadata ("Signed"), Is.AnyOf ("true", "false"), "Signed");
+			Assert.That (output.GetMetadata ("ArtifactKind"), Is.Empty, "ArtifactKind");
+			Assert.That (output.GetMetadata ("CodeSigned"), Is.Empty, "CodeSigned");
+			Assert.That (output.GetMetadata ("PackageSigned"), Is.Empty, "PackageSigned");
 			return output;
 		}
 

--- a/tests/dotnet/UnitTests/PostBuildTest.cs
+++ b/tests/dotnet/UnitTests/PostBuildTest.cs
@@ -394,7 +394,11 @@ namespace Xamarin.Tests {
 			Assert.That (output.GetMetadata ("Signed"), Is.AnyOf ("true", "false"), "Signed");
 			Assert.That (output.GetMetadata ("ArtifactKind"), Is.Empty, "ArtifactKind");
 			Assert.That (output.GetMetadata ("CodeSigned"), Is.Empty, "CodeSigned");
-			Assert.That (output.GetMetadata ("PackageSigned"), Is.Empty, "PackageSigned");
+			if (packageFormat == "pkg") {
+				Assert.That (output.GetMetadata ("PackageSigned"), Is.AnyOf ("true", "false"), "PackageSigned");
+			} else {
+				Assert.That (output.GetMetadata ("PackageSigned"), Is.Empty, "PackageSigned");
+			}
 			return output;
 		}
 

--- a/tests/dotnet/UnitTests/PostBuildTest.cs
+++ b/tests/dotnet/UnitTests/PostBuildTest.cs
@@ -389,9 +389,9 @@ namespace Xamarin.Tests {
 			Assert.That (output!.GetMetadata ("PackageFormat"), Is.EqualTo (packageFormat), "PackageFormat");
 			Assert.That (output.GetMetadata ("IsDirectory"), Is.EqualTo (isDirectory ? "true" : "false"), "IsDirectory");
 			Assert.That (output.GetMetadata ("PlatformName"), Is.EqualTo (platform.AsString ()), "PlatformName");
-			Assert.That (output.GetMetadata ("AppBundlePath"), Is.Not.Empty, "AppBundlePath");
 			Assert.That (output.GetMetadata ("BundleIdentifier"), Is.Not.Empty, "BundleIdentifier");
 			Assert.That (output.GetMetadata ("ArtifactKind"), Is.Empty, "ArtifactKind");
+			Assert.That (output.GetMetadata ("AppBundlePath"), Is.Empty, "AppBundlePath");
 			Assert.That (output.GetMetadata ("CodeSigned"), Is.Empty, "CodeSigned");
 			Assert.That (output.GetMetadata ("Signed"), Is.Empty, "Signed");
 			Assert.That (output.GetMetadata ("PackageSigned"), Is.Empty, "PackageSigned");

--- a/tests/dotnet/UnitTests/PostBuildTest.cs
+++ b/tests/dotnet/UnitTests/PostBuildTest.cs
@@ -311,6 +311,58 @@ namespace Xamarin.Tests {
 			AssertApplicationArtifact (result.BinLogPath, pkgPath, platform, packageExtension, isDirectory: false);
 		}
 
+		[TestCase (ApplePlatform.iOS, "ios-arm64", "ipa", "IpaPackagePath")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64", "pkg", "PkgPackagePath")]
+		public void PublishApplicationArtifactsDependsOnTest (ApplePlatform platform, string runtimeIdentifiers, string packageFormat, string pathVariable)
+		{
+			var project = "MySimpleApp";
+			var configuration = "Release";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers, platform: platform, out var appPath, configuration: configuration);
+			Clean (project_path);
+			var existingProjectContent = File.ReadAllText (project_path);
+			var newProjectContent = existingProjectContent.Replace ("</Project>", @"
+	<PropertyGroup>
+		<GetApplicationArtifactsDependsOn>$(GetApplicationArtifactsDependsOn);AddMauiPublishApplicationArtifactMetadata</GetApplicationArtifactsDependsOn>
+	</PropertyGroup>
+	<Target Name=""AddMauiPublishApplicationArtifactMetadata"">
+		<ItemGroup>
+			<_MauiObservedPublishAppArtifact Include=""@(ApplicationArtifact)"" Condition=""'%(ApplicationArtifact.PackageFormat)' == 'app'"" />
+			<_MauiObservedPublishPackageArtifact Include=""@(ApplicationArtifact)"" Condition=""'%(ApplicationArtifact.PackageFormat)' == '$(ExpectedAugmentedPackageFormat)'"" />
+			<ApplicationArtifact Update=""@(ApplicationArtifact)"">
+				<ApplicationTitle>My Published MAUI App</ApplicationTitle>
+				<MauiPublishObservedPackageFormat>%(ApplicationArtifact.PackageFormat)</MauiPublishObservedPackageFormat>
+			</ApplicationArtifact>
+		</ItemGroup>
+		<Error Condition=""'@(_MauiObservedPublishAppArtifact)' == ''"" Text=""Expected app ApplicationArtifact items before publish metadata is added."" />
+		<Error Condition=""'@(_MauiObservedPublishPackageArtifact)' == ''"" Text=""Expected $(ExpectedAugmentedPackageFormat) ApplicationArtifact items before publish metadata is added."" />
+	</Target>
+</Project>");
+			File.WriteAllText (project_path, newProjectContent);
+
+			try {
+				var tmpdir = Cache.CreateTemporaryDirectory ();
+				var pkgPath = Path.Combine (tmpdir, $"MyPackage.{packageFormat}");
+
+				var properties = GetDefaultProperties (runtimeIdentifiers);
+				properties [pathVariable] = pkgPath;
+				properties ["Configuration"] = configuration;
+				properties ["ExpectedAugmentedPackageFormat"] = packageFormat;
+
+				var outputs = GetApplicationArtifacts (project_path, properties, target: "Publish");
+				var appOutput = AssertApplicationArtifact (outputs, appPath, platform, "app", isDirectory: true);
+				var packageOutput = AssertApplicationArtifact (outputs, pkgPath, platform, packageFormat, isDirectory: false);
+				Assert.That (GetMetadata (appOutput, "ApplicationTitle"), Is.EqualTo ("My Published MAUI App"), "ApplicationTitle");
+				Assert.That (GetMetadata (appOutput, "MauiPublishObservedPackageFormat"), Is.EqualTo ("app"), "MauiPublishObservedPackageFormat");
+				Assert.That (GetMetadata (packageOutput, "ApplicationTitle"), Is.EqualTo ("My Published MAUI App"), "ApplicationTitle");
+				Assert.That (GetMetadata (packageOutput, "MauiPublishObservedPackageFormat"), Is.EqualTo (packageFormat), "MauiPublishObservedPackageFormat");
+			} finally {
+				File.WriteAllText (project_path, existingProjectContent);
+			}
+		}
+
 
 		[TestCase (ApplePlatform.iOS, "iossimulator-x64")]
 		[TestCase (ApplePlatform.iOS, "iossimulator-x64;iossimulator-x64")]
@@ -518,9 +570,9 @@ namespace Xamarin.Tests {
 			return output;
 		}
 
-		static JsonElement [] GetApplicationArtifacts (string projectPath, Dictionary<string, string> properties)
+		static JsonElement [] GetApplicationArtifacts (string projectPath, Dictionary<string, string> properties, string target = "GetApplicationArtifacts")
 		{
-			using var document = JsonDocument.Parse (DotNet.GetItems (projectPath, "ApplicationArtifact", target: "GetApplicationArtifacts", properties: properties));
+			using var document = JsonDocument.Parse (DotNet.GetItems (projectPath, "ApplicationArtifact", target: target, properties: properties));
 			var outputs = document.RootElement.GetProperty ("Items").GetProperty ("ApplicationArtifact").EnumerateArray ().Select (v => v.Clone ()).ToArray ();
 			Assert.That (outputs, Is.Not.Empty, "ApplicationArtifact items");
 			return outputs;

--- a/tests/dotnet/UnitTests/PostBuildTest.cs
+++ b/tests/dotnet/UnitTests/PostBuildTest.cs
@@ -391,14 +391,10 @@ namespace Xamarin.Tests {
 			Assert.That (output.GetMetadata ("PlatformName"), Is.EqualTo (platform.AsString ()), "PlatformName");
 			Assert.That (output.GetMetadata ("AppBundlePath"), Is.Not.Empty, "AppBundlePath");
 			Assert.That (output.GetMetadata ("BundleIdentifier"), Is.Not.Empty, "BundleIdentifier");
-			Assert.That (output.GetMetadata ("Signed"), Is.AnyOf ("true", "false"), "Signed");
 			Assert.That (output.GetMetadata ("ArtifactKind"), Is.Empty, "ArtifactKind");
 			Assert.That (output.GetMetadata ("CodeSigned"), Is.Empty, "CodeSigned");
-			if (packageFormat == "pkg") {
-				Assert.That (output.GetMetadata ("PackageSigned"), Is.AnyOf ("true", "false"), "PackageSigned");
-			} else {
-				Assert.That (output.GetMetadata ("PackageSigned"), Is.Empty, "PackageSigned");
-			}
+			Assert.That (output.GetMetadata ("Signed"), Is.Empty, "Signed");
+			Assert.That (output.GetMetadata ("PackageSigned"), Is.Empty, "PackageSigned");
 			return output;
 		}
 


### PR DESCRIPTION
Apple platform builds and publishes now expose final artifacts through the shared `@(ApplicationArtifact)` item group. This gives custom targets and CI a stable way to discover `.app`, `.ipa`, `.pkg`, and `.xcarchive` outputs without parsing scalar properties, while leaving room for other platforms to use the same item group name.

## Changes

- Add `@(ApplicationArtifact)` collectors for app bundles, IPA packages, PKG installers, and Xcode archives.
- Route `Publish` through `GetApplicationArtifacts` after `_PrePublish`, so publish-created artifacts run the same metadata extension path before `Publish` returns `@(ApplicationArtifact)`.
- Add `GetApplicationArtifactsDependsOn` so later SDK layers such as .NET MAUI can enrich `@(ApplicationArtifact)` metadata before `GetApplicationArtifacts` or `Publish` returns.
- Route `GetApplicationArtifacts` through a mandatory private `_CreateApplicationArtifacts` target before extension targets run. That target runs `Build` plus the Apple app/package/archive producer targets so compiled outputs and platform artifacts exist before metadata enrichment.
- Keep the producer targets condition-gated by the existing Apple properties and target conditions such as `BuildIpa`, `CreatePackage`, `ArchiveOnBuild`, `_CanArchive`, and `SdkIsDesktop`, so querying artifacts does not unconditionally force IPA, PKG, or archive creation.
- Clarify that extension targets should update platform-created `@(ApplicationArtifact)` items when adding metadata, and only add new items for additional artifacts.
- Limit platform metadata to `PackageFormat`, `IsDirectory`, `PlatformName`, and `BundleIdentifier`.
- Update unit test assertions and in-repo build item/property/target docs for the new contract.
- Use `dotnet build ... -getTargetResult` examples for querying `GetApplicationArtifacts` and `Publish` results from the command line.
- Add direct item-query tests for IPA, PKG, app bundle, xcarchive outputs, extension metadata, publish-target metadata augmentation, overwritten `GetApplicationArtifactsDependsOn` behavior, and target dependency/condition-gate shape.

## Validation

- `xmllint --noout msbuild/Xamarin.Shared/Xamarin.Shared.targets msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets dotnet/targets/Xamarin.Shared.Sdk.Publish.targets`
- `git diff --check`
- `make -C tests/dotnet/UnitTests build`
- Attempted filtered extension-order tests locally; execution is blocked by missing Xcode/runtime/workload setup in this checkout.