### PR TITLE
[release/10.0.1xx] [dotnet] Use desktop MSBuild task assemblies in VS for all platforms

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -19,6 +19,9 @@
 	<Import Project="$(_MobilePropsPath)" Condition="Exists('$(_MobilePropsPath)') And ('$(BuildingInsideVisualStudio)' == 'true' Or '$(DesignTimeBuild)' == 'true')" />
 	
 	<PropertyGroup>
+		<!-- Keep using the desktop (netstandard2.0) MSBuild task assemblies when building from within Visual Studio (on Windows), instead of the net assemblies that require a .NET task host (which doesn't work reliably, in particular on Windows ARM64). The iOS Sdk.props sets this earlier because it also drives CoreiOSSdkDirectory; the condition below makes it apply to the other platforms (MacCatalyst, macOS, tvOS) too. -->
+		<_UseDesktopTaskAssemblies Condition="'$(_UseDesktopTaskAssemblies)' == '' And '$(BuildingInsideVisualStudio)' == 'true'">true</_UseDesktopTaskAssemblies>
+
 		<!-- Set to true when using the Microsoft.<platform>.Sdk NuGet. This is used by pre-existing/shared targets to tweak behavior depending on build system -->
 		<UsingAppleNETSdk>true</UsingAppleNETSdk>
 		<!-- This is the location of the Microsoft.<platform>.Sdk NuGet (/usr/local/share/dotnet/sdk/<version>/Sdks/Microsoft.[iOS/tvOS/MacCatalyst/macOS].Sdk) on the platform the build is running from (Mac or Win) -->


### PR DESCRIPTION
## Description

Building a MacCatalyst app inside Visual Studio on Windows ARM64 fails with:

```
error MSB4216: Could not run the "MakeDir" task because MSBuild could not create
or connect to a task host with runtime "NET" and architecture "*".
```

## Root cause

Inside Visual Studio, our MSBuild tasks should run in-process using the `netstandard2.0` assemblies. This is controlled by the `_UseDesktopTaskAssemblies` property. When it is not set, the tasks instead use the `.NET` assemblies, which need a separate .NET task host. That task host does not work reliably from Visual Studio, and fails on Windows ARM64.

#25417 set `_UseDesktopTaskAssemblies` for Visual Studio builds, but only in the iOS SDK. MacCatalyst, macOS and tvOS were missed, so they still try to use the .NET task host and break.

## Fix

Set `_UseDesktopTaskAssemblies` in the shared `Xamarin.Shared.Sdk.props`, which is imported by all four platforms, so the workaround applies everywhere. The iOS SDK keeps setting it earlier (it also needs it for `CoreiOSSdkDirectory`); the `== ''` guard makes the shared copy a no-op for iOS.

Ref: #25418

---------

Co-authored-by: Milos Kotlar <kotlarmilos@gmail.com>
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Backport of #25662.