### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 14411: Build ID 14405986

### DIFF
--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.cs.resx
@@ -1311,4 +1311,9 @@
         <comment>Shown when the tool reports a simulator runtime version mismatch.
 {0} - The platform name (e.g. "iOS" or "tvOS").</comment>
     </data>
+  <data name="E7178" xml:space="preserve">
+        <value>Console.StandardOutput or Console.StandardError was accessed during a build task. This should not happen, use the MSBuild logging infrastructure instead. Stack trace: {0}</value>
+        <comment>Shown when an MSBuild task writes to the console instead of using MSBuild logging.
+{0} - The stack trace of the offending call.</comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.de.resx
@@ -1311,4 +1311,9 @@
         <comment>Shown when the tool reports a simulator runtime version mismatch.
 {0} - The platform name (e.g. "iOS" or "tvOS").</comment>
     </data>
+  <data name="E7178" xml:space="preserve">
+        <value>Console.StandardOutput or Console.StandardError was accessed during a build task. This should not happen, use the MSBuild logging infrastructure instead. Stack trace: {0}</value>
+        <comment>Shown when an MSBuild task writes to the console instead of using MSBuild logging.
+{0} - The stack trace of the offending call.</comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.es.resx
@@ -1311,4 +1311,9 @@
         <comment>Shown when the tool reports a simulator runtime version mismatch.
 {0} - The platform name (e.g. "iOS" or "tvOS").</comment>
     </data>
+  <data name="E7178" xml:space="preserve">
+        <value>Console.StandardOutput or Console.StandardError was accessed during a build task. This should not happen, use the MSBuild logging infrastructure instead. Stack trace: {0}</value>
+        <comment>Shown when an MSBuild task writes to the console instead of using MSBuild logging.
+{0} - The stack trace of the offending call.</comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.fr.resx
@@ -1311,4 +1311,9 @@
         <comment>Shown when the tool reports a simulator runtime version mismatch.
 {0} - The platform name (e.g. "iOS" or "tvOS").</comment>
     </data>
+  <data name="E7178" xml:space="preserve">
+        <value>Console.StandardOutput or Console.StandardError was accessed during a build task. This should not happen, use the MSBuild logging infrastructure instead. Stack trace: {0}</value>
+        <comment>Shown when an MSBuild task writes to the console instead of using MSBuild logging.
+{0} - The stack trace of the offending call.</comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.it.resx
@@ -1311,4 +1311,9 @@
         <comment>Shown when the tool reports a simulator runtime version mismatch.
 {0} - The platform name (e.g. "iOS" or "tvOS").</comment>
     </data>
+  <data name="E7178" xml:space="preserve">
+        <value>Console.StandardOutput or Console.StandardError was accessed during a build task. This should not happen, use the MSBuild logging infrastructure instead. Stack trace: {0}</value>
+        <comment>Shown when an MSBuild task writes to the console instead of using MSBuild logging.
+{0} - The stack trace of the offending call.</comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ja.resx
@@ -1311,4 +1311,9 @@
         <comment>Shown when the tool reports a simulator runtime version mismatch.
 {0} - The platform name (e.g. "iOS" or "tvOS").</comment>
     </data>
+  <data name="E7178" xml:space="preserve">
+        <value>Console.StandardOutput or Console.StandardError was accessed during a build task. This should not happen, use the MSBuild logging infrastructure instead. Stack trace: {0}</value>
+        <comment>Shown when an MSBuild task writes to the console instead of using MSBuild logging.
+{0} - The stack trace of the offending call.</comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ko.resx
@@ -1311,4 +1311,9 @@
         <comment>Shown when the tool reports a simulator runtime version mismatch.
 {0} - The platform name (e.g. "iOS" or "tvOS").</comment>
     </data>
+  <data name="E7178" xml:space="preserve">
+        <value>Console.StandardOutput or Console.StandardError was accessed during a build task. This should not happen, use the MSBuild logging infrastructure instead. Stack trace: {0}</value>
+        <comment>Shown when an MSBuild task writes to the console instead of using MSBuild logging.
+{0} - The stack trace of the offending call.</comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pl.resx
@@ -1311,4 +1311,9 @@
         <comment>Shown when the tool reports a simulator runtime version mismatch.
 {0} - The platform name (e.g. "iOS" or "tvOS").</comment>
     </data>
+  <data name="E7178" xml:space="preserve">
+        <value>Console.StandardOutput or Console.StandardError was accessed during a build task. This should not happen, use the MSBuild logging infrastructure instead. Stack trace: {0}</value>
+        <comment>Shown when an MSBuild task writes to the console instead of using MSBuild logging.
+{0} - The stack trace of the offending call.</comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.pt-BR.resx
@@ -1311,4 +1311,9 @@
         <comment>Shown when the tool reports a simulator runtime version mismatch.
 {0} - The platform name (e.g. "iOS" or "tvOS").</comment>
     </data>
+  <data name="E7178" xml:space="preserve">
+        <value>Console.StandardOutput or Console.StandardError was accessed during a build task. This should not happen, use the MSBuild logging infrastructure instead. Stack trace: {0}</value>
+        <comment>Shown when an MSBuild task writes to the console instead of using MSBuild logging.
+{0} - The stack trace of the offending call.</comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.ru.resx
@@ -1311,4 +1311,9 @@
         <comment>Shown when the tool reports a simulator runtime version mismatch.
 {0} - The platform name (e.g. "iOS" or "tvOS").</comment>
     </data>
+  <data name="E7178" xml:space="preserve">
+        <value>Console.StandardOutput or Console.StandardError was accessed during a build task. This should not happen, use the MSBuild logging infrastructure instead. Stack trace: {0}</value>
+        <comment>Shown when an MSBuild task writes to the console instead of using MSBuild logging.
+{0} - The stack trace of the offending call.</comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.tr.resx
@@ -1311,4 +1311,9 @@
         <comment>Shown when the tool reports a simulator runtime version mismatch.
 {0} - The platform name (e.g. "iOS" or "tvOS").</comment>
     </data>
+  <data name="E7178" xml:space="preserve">
+        <value>Console.StandardOutput or Console.StandardError was accessed during a build task. This should not happen, use the MSBuild logging infrastructure instead. Stack trace: {0}</value>
+        <comment>Shown when an MSBuild task writes to the console instead of using MSBuild logging.
+{0} - The stack trace of the offending call.</comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hans.resx
@@ -1311,4 +1311,9 @@
         <comment>Shown when the tool reports a simulator runtime version mismatch.
 {0} - The platform name (e.g. "iOS" or "tvOS").</comment>
     </data>
+  <data name="E7178" xml:space="preserve">
+        <value>Console.StandardOutput or Console.StandardError was accessed during a build task. This should not happen, use the MSBuild logging infrastructure instead. Stack trace: {0}</value>
+        <comment>Shown when an MSBuild task writes to the console instead of using MSBuild logging.
+{0} - The stack trace of the offending call.</comment>
+    </data>
 </root>

--- a/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
+++ b/macios/msbuild/Xamarin.Localization.MSBuild/TranslatedAssemblies/MSBStrings.zh-Hant.resx
@@ -1311,4 +1311,9 @@
         <comment>Shown when the tool reports a simulator runtime version mismatch.
 {0} - The platform name (e.g. "iOS" or "tvOS").</comment>
     </data>
+  <data name="E7178" xml:space="preserve">
+        <value>Console.StandardOutput or Console.StandardError was accessed during a build task. This should not happen, use the MSBuild logging infrastructure instead. Stack trace: {0}</value>
+        <comment>Shown when an MSBuild task writes to the console instead of using MSBuild logging.
+{0} - The stack trace of the offending call.</comment>
+    </data>
 </root>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.cs.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.cs.resx
@@ -643,6 +643,9 @@
   <data name="MX1503" xml:space="preserve">
 		<value>One or more reference(s) to type '{0}' still exists inside '{1}' after linking</value>
 	</data>
+  <data name="MX1504" xml:space="preserve">
+		<value>Cannot find the product assembly '{0}' in the list of loaded assemblies.</value>
+	</data>
   <data name="MX1600" xml:space="preserve">
 		<value>Not a Mach-O dynamic library (unknown header '0x{0}'): {1}.</value>
 	</data>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.de.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.de.resx
@@ -643,6 +643,9 @@
   <data name="MX1503" xml:space="preserve">
 		<value>One or more reference(s) to type '{0}' still exists inside '{1}' after linking</value>
 	</data>
+  <data name="MX1504" xml:space="preserve">
+		<value>Cannot find the product assembly '{0}' in the list of loaded assemblies.</value>
+	</data>
   <data name="MX1600" xml:space="preserve">
 		<value>Not a Mach-O dynamic library (unknown header '0x{0}'): {1}.</value>
 	</data>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.es.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.es.resx
@@ -643,6 +643,9 @@
   <data name="MX1503" xml:space="preserve">
 		<value>One or more reference(s) to type '{0}' still exists inside '{1}' after linking</value>
 	</data>
+  <data name="MX1504" xml:space="preserve">
+		<value>Cannot find the product assembly '{0}' in the list of loaded assemblies.</value>
+	</data>
   <data name="MX1600" xml:space="preserve">
 		<value>Not a Mach-O dynamic library (unknown header '0x{0}'): {1}.</value>
 	</data>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.fr.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.fr.resx
@@ -643,6 +643,9 @@
   <data name="MX1503" xml:space="preserve">
 		<value>One or more reference(s) to type '{0}' still exists inside '{1}' after linking</value>
 	</data>
+  <data name="MX1504" xml:space="preserve">
+		<value>Cannot find the product assembly '{0}' in the list of loaded assemblies.</value>
+	</data>
   <data name="MX1600" xml:space="preserve">
 		<value>Not a Mach-O dynamic library (unknown header '0x{0}'): {1}.</value>
 	</data>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.it.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.it.resx
@@ -643,6 +643,9 @@
   <data name="MX1503" xml:space="preserve">
 		<value>One or more reference(s) to type '{0}' still exists inside '{1}' after linking</value>
 	</data>
+  <data name="MX1504" xml:space="preserve">
+		<value>Cannot find the product assembly '{0}' in the list of loaded assemblies.</value>
+	</data>
   <data name="MX1600" xml:space="preserve">
 		<value>Not a Mach-O dynamic library (unknown header '0x{0}'): {1}.</value>
 	</data>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.ja.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.ja.resx
@@ -643,6 +643,9 @@
   <data name="MX1503" xml:space="preserve">
 		<value>One or more reference(s) to type '{0}' still exists inside '{1}' after linking</value>
 	</data>
+  <data name="MX1504" xml:space="preserve">
+		<value>Cannot find the product assembly '{0}' in the list of loaded assemblies.</value>
+	</data>
   <data name="MX1600" xml:space="preserve">
 		<value>Not a Mach-O dynamic library (unknown header '0x{0}'): {1}.</value>
 	</data>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.ko.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.ko.resx
@@ -643,6 +643,9 @@
   <data name="MX1503" xml:space="preserve">
 		<value>One or more reference(s) to type '{0}' still exists inside '{1}' after linking</value>
 	</data>
+  <data name="MX1504" xml:space="preserve">
+		<value>Cannot find the product assembly '{0}' in the list of loaded assemblies.</value>
+	</data>
   <data name="MX1600" xml:space="preserve">
 		<value>Not a Mach-O dynamic library (unknown header '0x{0}'): {1}.</value>
 	</data>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.pl.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.pl.resx
@@ -643,6 +643,9 @@
   <data name="MX1503" xml:space="preserve">
 		<value>One or more reference(s) to type '{0}' still exists inside '{1}' after linking</value>
 	</data>
+  <data name="MX1504" xml:space="preserve">
+		<value>Cannot find the product assembly '{0}' in the list of loaded assemblies.</value>
+	</data>
   <data name="MX1600" xml:space="preserve">
 		<value>Not a Mach-O dynamic library (unknown header '0x{0}'): {1}.</value>
 	</data>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.pt-BR.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.pt-BR.resx
@@ -643,6 +643,9 @@
   <data name="MX1503" xml:space="preserve">
 		<value>One or more reference(s) to type '{0}' still exists inside '{1}' after linking</value>
 	</data>
+  <data name="MX1504" xml:space="preserve">
+		<value>Cannot find the product assembly '{0}' in the list of loaded assemblies.</value>
+	</data>
   <data name="MX1600" xml:space="preserve">
 		<value>Not a Mach-O dynamic library (unknown header '0x{0}'): {1}.</value>
 	</data>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.ru.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.ru.resx
@@ -643,6 +643,9 @@
   <data name="MX1503" xml:space="preserve">
 		<value>One or more reference(s) to type '{0}' still exists inside '{1}' after linking</value>
 	</data>
+  <data name="MX1504" xml:space="preserve">
+		<value>Cannot find the product assembly '{0}' in the list of loaded assemblies.</value>
+	</data>
   <data name="MX1600" xml:space="preserve">
 		<value>Not a Mach-O dynamic library (unknown header '0x{0}'): {1}.</value>
 	</data>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.tr.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.tr.resx
@@ -643,6 +643,9 @@
   <data name="MX1503" xml:space="preserve">
 		<value>One or more reference(s) to type '{0}' still exists inside '{1}' after linking</value>
 	</data>
+  <data name="MX1504" xml:space="preserve">
+		<value>Cannot find the product assembly '{0}' in the list of loaded assemblies.</value>
+	</data>
   <data name="MX1600" xml:space="preserve">
 		<value>Not a Mach-O dynamic library (unknown header '0x{0}'): {1}.</value>
 	</data>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.zh-Hans.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.zh-Hans.resx
@@ -643,6 +643,9 @@
   <data name="MX1503" xml:space="preserve">
 		<value>One or more reference(s) to type '{0}' still exists inside '{1}' after linking</value>
 	</data>
+  <data name="MX1504" xml:space="preserve">
+		<value>Cannot find the product assembly '{0}' in the list of loaded assemblies.</value>
+	</data>
   <data name="MX1600" xml:space="preserve">
 		<value>Not a Mach-O dynamic library (unknown header '0x{0}'): {1}.</value>
 	</data>

--- a/macios/tools/mtouch/TranslatedAssemblies/Errors.zh-Hant.resx
+++ b/macios/tools/mtouch/TranslatedAssemblies/Errors.zh-Hant.resx
@@ -643,6 +643,9 @@
   <data name="MX1503" xml:space="preserve">
 		<value>One or more reference(s) to type '{0}' still exists inside '{1}' after linking</value>
 	</data>
+  <data name="MX1504" xml:space="preserve">
+		<value>Cannot find the product assembly '{0}' in the list of loaded assemblies.</value>
+	</data>
   <data name="MX1600" xml:space="preserve">
 		<value>Not a Mach-O dynamic library (unknown header '0x{0}'): {1}.</value>
 	</data>


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.