### PR TITLE
[tests] Use Regex instead of string interpolation for Xcode location warning filter

### DIFF
--- a/tests/dotnet/UnitTests/Extensions.cs
+++ b/tests/dotnet/UnitTests/Extensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text.RegularExpressions;
 
 #nullable enable
 
@@ -132,9 +133,9 @@ namespace Xamarin.Tests {
 			if (filterXcodeLocation) {
 				if (v.Contains ("The environment variable 'MD_APPLE_SDK_ROOT' is deprecated, and will be ignored. Please use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to choose which Xcode to use."))
 					return true;
-				if (v.Contains ($"The settings file '{Environment.GetEnvironmentVariable ("HOME")}/Library/Preferences/maui/Settings.plist' is deprecated, and will be ignored. Please use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to choose which Xcode to use."))
+				if (Regex.IsMatch (v, @"The settings file '/.*/Library/Preferences/maui/Settings\.plist' is deprecated, and will be ignored\. Please use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to choose which Xcode to use\."))
 					return true;
-				if (v.Contains ($"The settings file '{Environment.GetEnvironmentVariable ("HOME")}/Library/Preferences/Xamarin/Settings.plist' is deprecated, and will be ignored. Please use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to choose which Xcode to use."))
+				if (Regex.IsMatch (v, @"The settings file '/.*/Library/Preferences/Xamarin/Settings\.plist' is deprecated, and will be ignored\. Please use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to choose which Xcode to use\."))
 					return true;
 			}
 


### PR DESCRIPTION
Replace Environment.GetEnvironmentVariable("HOME") with a '/.*' regex
pattern so the filter matches regardless of the actual home directory path.