### PR TITLE
Revert "[net11.0] R2R-compile only System.Private.CoreLib for Debug CoreCLR mobile builds"

### DIFF
--- a/dotnet/targets/Microsoft.Sdk.R2R.targets
+++ b/dotnet/targets/Microsoft.Sdk.R2R.targets
@@ -128,7 +128,6 @@
 				Condition="'%(_ResolvedAssembliesToPublish.NuGetPackageId)' != ''" />
 			<_UserAssemblies Include="@(_ResolvedAssembliesToPublish)" Exclude="@(_NonUserAssemblies)" />
 			<PublishReadyToRunExclude Include="@(_UserAssemblies -> '%(Filename)%(Extension)')" />
-			<PublishReadyToRunCompositeRoots Include="System.Private.CoreLib.dll" KeepDuplicates="false" />
 		</ItemGroup>
 
 		<!-- Hash the R2R input assemblies so we can detect when the set actually changes -->
@@ -150,14 +149,6 @@
 		<ItemGroup>
 			<FileWrites Include="$(_R2RInputHashFile)" />
 			<FileWrites Include="$(_R2RInputHashFile).trigger" />
-		</ItemGroup>
-	</Target>
-
-	<Target Name="_DedupUnrootedReadyToRunPublish"
-			Condition="@(PublishReadyToRunCompositeRoots->Count()) != 0"
-			AfterTargets="_PrepareForReadyToRunCompilation">
-		<ItemGroup>
-			<ResolvedFileToPublish Remove="@(_ReadyToRunCompositeUnrootedBuildInput)" />
 		</ItemGroup>
 	</Target>
 


### PR DESCRIPTION
Reverts dotnet/macios#25583, it causes a test failure: #25734.