### PR TITLE
[msbuild/tools] Move post-trimming custom trimmer steps to a post-ILLink MSBuild task.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -781,7 +781,9 @@
 			>
 				<TrimMode>copy</TrimMode> <!-- Don't use 'copyused', because that might still end up saving some assemblies, and if that's the platform assembly, it may break the partial static registrar -->
 			</ResolvedFileToPublish>
+		</ItemGroup>
 
+		<ItemGroup Condition="!('$(PrepareAssemblies)' == 'true' And '$(PostProcessAssemblies)' == 'true')">
 			<!--
 				pre-mark custom steps
 			-->
@@ -832,28 +834,30 @@
 			<!--
 				pre-output custom steps
 			-->
-			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" BeforeStep="OutputStep" Type="Xamarin.Linker.LoadNonSkippedAssembliesStep" />
-			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" BeforeStep="OutputStep" Type="Xamarin.Linker.ExtractBindingLibrariesStep" />
+			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" BeforeStep="OutputStep" Condition="'$(PostProcessAssemblies)' != 'true'" Type="Xamarin.Linker.LoadNonSkippedAssembliesStep" />
+			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" BeforeStep="OutputStep" Condition="'$(PostProcessAssemblies)' != 'true'" Type="Xamarin.Linker.ExtractBindingLibrariesStep" />
 			<!-- The ListExportedSymbols must run after ExtractBindingLibrariesStep, otherwise we won't properly list exported Objective-C classes from binding libraries -->
-			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" BeforeStep="OutputStep" Type="Xamarin.Linker.Steps.ListExportedSymbols" />
-			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" BeforeStep="OutputStep" Type="Xamarin.Linker.Steps.PreOutputDispatcher" />
-			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" BeforeStep="OutputStep" Type="Xamarin.Linker.ClassHandleRewriterStep" Condition="'$(InlineClassGetHandle)' == '' Or '$(InlineClassGetHandle)' == 'disabled'" />
+			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" BeforeStep="OutputStep" Condition="'$(PostProcessAssemblies)' != 'true'" Type="Xamarin.Linker.Steps.ListExportedSymbols" />
+			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" BeforeStep="OutputStep" Condition="'$(PostProcessAssemblies)' != 'true'" Type="Xamarin.Linker.Steps.PreOutputDispatcher" />
+			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" BeforeStep="OutputStep" Condition="'$(PostProcessAssemblies)' != 'true' And ('$(InlineClassGetHandle)' == '' Or '$(InlineClassGetHandle)' == 'disabled')" Type="Xamarin.Linker.ClassHandleRewriterStep" />
 
 			<!--
 				post-output steps
 			-->
-			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Type="Xamarin.Linker.ManagedRegistrarStep" Condition="'$(PrepareAssemblies)' == 'true' And ('$(Registrar)' == 'managed-static' Or '$(Registrar)' == 'trimmable-static')" />
-			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Type="Xamarin.Linker.TrimmableRegistrarStep" Condition="'$(PrepareAssemblies)' == 'true' And '$(Registrar)' == 'trimmable-static'" />
-			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Type="Xamarin.Linker.ManagedRegistrarLookupTablesStep" Condition="'$(PrepareAssemblies)' == 'true' And '$(Registrar)' == 'managed-static'" />
-			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Type="Xamarin.Linker.RegistrarStep" />
-			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Type="Xamarin.GenerateMainStep" />
-			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Type="Xamarin.GenerateReferencesStep" />
-			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Type="Xamarin.GatherFrameworksStep" />
-			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Type="Xamarin.Linker.ComputeNativeBuildFlagsStep" />
-			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Type="Xamarin.Linker.ComputeAOTArguments" />
+			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Type="Xamarin.Linker.ManagedRegistrarStep" Condition="'$(PrepareAssemblies)' == 'true' And '$(PostProcessAssemblies)' != 'true' And ('$(Registrar)' == 'managed-static' Or '$(Registrar)' == 'trimmable-static')" />
+			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Type="Xamarin.Linker.TrimmableRegistrarStep" Condition="'$(PrepareAssemblies)' == 'true' And '$(PostProcessAssemblies)' != 'true' And '$(Registrar)' == 'trimmable-static'" />
+			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Type="Xamarin.Linker.ManagedRegistrarLookupTablesStep" Condition="'$(PrepareAssemblies)' == 'true' And '$(PostProcessAssemblies)' != 'true' And '$(Registrar)' == 'managed-static'" />
+			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Type="Xamarin.Linker.RegistrarStep" Condition="'$(PostProcessAssemblies)' != 'true'" />
+			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Type="Xamarin.GenerateMainStep" Condition="'$(PostProcessAssemblies)' != 'true'" />
+			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Type="Xamarin.GenerateReferencesStep" Condition="'$(PostProcessAssemblies)' != 'true'" />
+			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Type="Xamarin.GatherFrameworksStep" Condition="'$(PostProcessAssemblies)' != 'true'" />
+			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Type="Xamarin.Linker.ComputeNativeBuildFlagsStep" Condition="'$(PostProcessAssemblies)' != 'true'" />
+			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Type="Xamarin.Linker.ComputeAOTArguments" Condition="'$(PostProcessAssemblies)' != 'true'" />
 			<!-- Must be the last step. -->
-			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Type="Xamarin.Linker.DoneStep" />
+			<_TrimmerCustomSteps Include="$(_AdditionalTaskAssembly)" Type="Xamarin.Linker.DoneStep" Condition="'$(PostProcessAssemblies)' != 'true'" />
+		</ItemGroup>
 
+		<ItemGroup>
 			<!-- _BundlerXmlDefinitions comes from any -xml arguments to mtouch/mmp -->
 			<TrimmerRootDescriptor Include="@(_BundlerXmlDefinitions)" />
 			<!-- LinkDescription can be defined in the user's csproj -->

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1690,4 +1690,7 @@
         <comment>Shown when a binding resource package's manifest contains a native reference whose 'Name' attribute is missing or empty.
 {0} - The path to the binding resource package.</comment>
     </data>
+    <data name="E0192" xml:space="preserve">
+        <value>The PrepareAssemblies task failed without reporting a specific error. Please rebuild with increased verbosity for more details.</value>
+    </data>
 </root>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/PrepareAssemblies.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/PrepareAssemblies.cs
@@ -14,6 +14,7 @@ using Microsoft.Build.Utilities;
 
 using Xamarin.Build;
 using Xamarin.Bundler;
+using Xamarin.Localization.MSBuild;
 using Xamarin.Utils;
 
 #nullable enable
@@ -34,6 +35,8 @@ namespace Xamarin.MacDev.Tasks {
 		[Required]
 		public ITaskItem? OptionsFile { get; set; }
 		#endregion
+
+		public bool PostProcessing { get; set; }
 
 		#region Outputs
 		[Output]
@@ -63,7 +66,14 @@ namespace Xamarin.MacDev.Tasks {
 				var infos = InputAssemblies.Select (GetAssemblyInfo).ToArray ();
 				using var preparer = new AssemblyPreparer (this, infos, OptionsFile?.ItemSpec ?? "");
 				preparer.MakeReproPath = MakeReproPath;
-				var rv = preparer.Prepare (out var exceptions);
+				bool rv;
+				List<ProductException> exceptions;
+
+				if (PostProcessing) {
+					rv = preparer.PostProcess (out exceptions);
+				} else {
+					rv = preparer.Prepare (out exceptions);
+				}
 
 				foreach (var pe in exceptions) {
 					if (pe.IsError (this)) {
@@ -100,6 +110,8 @@ namespace Xamarin.MacDev.Tasks {
 				}));
 
 				OutputAssemblies = outputAssemblies.ToArray ();
+				if (!rv && !Log.HasLoggedErrors)
+					Log.LogError (MSBStrings.E0192);
 				return rv && !Log.HasLoggedErrors;
 			} catch (Exception e) {
 				((IToolLog) this).LogException (e);

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -3460,6 +3460,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 	<PropertyGroup>
 		<PrepareAssemblies Condition="'$(PrepareAssemblies)' == ''">false</PrepareAssemblies>
+		<PostProcessAssemblies Condition="'$(PostProcessAssemblies)' == ''">$(PrepareAssemblies)</PostProcessAssemblies>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -3506,6 +3507,51 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<ResolvedFileToPublish Include="@(_PreparedAssemblies)" />
 			<FileWrites Include="@(_PreparedAssemblies)" />
 			<FileWrites Include="$(_UnmanagedCallersOnlyMapPath)" />
+		</ItemGroup>
+	</Target>
+
+	<Target
+		Name="_PrepareAssembliesForPostProcessing"
+		DependsOnTargets="$(_PrepareAssembliesForPostProcessingDependsOn)"
+		>
+		<ItemGroup>
+			<!-- Include all managed assemblies (not just those with PostprocessAssembly=true), because the assembly-preparer
+			     needs to know about all assemblies (including the platform assembly) to do its work. This matches what the
+			     linker does internally (via CollectAssembliesStep which resolves all referenced assemblies). -->
+			<_AssembliesToPostProcess Include="@(ResolvedFileToPublish)" Condition="'%(ResolvedFileToPublish.Extension)' == '.dll' And '%(ResolvedFileToPublish.Culture)' == '' And !$([System.String]::Copy ('%(Filename)').EndsWith ('.resources'))" />
+		</ItemGroup>
+		<PropertyGroup>
+			<_PostprocessedAssembliesDirectory>$([MSBuild]::EnsureTrailingSlash('$(DeviceSpecificIntermediateOutputPath)postprocessed-assemblies'))</_PostprocessedAssembliesDirectory>
+		</PropertyGroup>
+	</Target>
+
+	<!--
+		_PostprocessAssemblies must run after the trimmer (ILLink) and before the assemblies are (Native)AOT/R2R-compiled.
+	-->
+	<Target
+		Name="_PostprocessAssemblies"
+		Condition="'$(PostProcessAssemblies)' == 'true' And '$(RuntimeIdentifiers)' == ''"
+		Inputs="@(_AssembliesToPostProcess)"
+		Outputs="@(_AssembliesToPostProcess->'$(_PostprocessedAssembliesDirectory)%(Filename)%(Extension)')"
+		AfterTargets="ILLink"
+		BeforeTargets="NativeCompile;CreateReadyToRunImages"
+		DependsOnTargets="_PrepareAssembliesForPostProcessing;_ComputeLinkerInputs"
+		>
+		<PrepareAssemblies
+			InputAssemblies="@(_AssembliesToPostProcess)"
+			MakeReproPath="$(_PostprocessAssembliesMakeReproPath)"
+			OptionsFile="$(_CustomLinkerOptionsFile)"
+			OutputDirectory="$(_PostprocessedAssembliesDirectory)"
+			Postprocessing="true"
+			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
+		>
+			<Output TaskParameter="OutputAssemblies" ItemName="_PostProcessedAssemblies" />
+		</PrepareAssemblies>
+
+		<ItemGroup>
+			<ResolvedFileToPublish Remove="@(_AssembliesToPostProcess)" />
+			<ResolvedFileToPublish Include="@(_PostProcessedAssemblies)" />
+			<FileWrites Include="@(_PostProcessedAssemblies)" />
 		</ItemGroup>
 	</Target>
 

--- a/tests/dotnet/UnitTests/WindowsTest.cs
+++ b/tests/dotnet/UnitTests/WindowsTest.cs
@@ -341,6 +341,101 @@ namespace Xamarin.Tests {
 			DotNet.AssertBuild (project_path, properties, timeout: TimeSpan.FromMinutes (15));
 		}
 
+#if !NET11_0_OR_GREATER // in .NET the assembly preparer mode is the default, so no need for a separate test.
+		[Category ("RemoteWindows")]
+		[TestCase (ApplePlatform.iOS, "ios-arm64")]
+		public void AssemblyPreparerRemoteTest (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			var project = "MySimpleApp";
+			var configuration = "Debug";
+
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+			Configuration.IgnoreIfNotOnWindows ();
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
+			var project_dir = Path.GetDirectoryName (project_path)!;
+			Clean (project_path);
+
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+
+			// Copy the app bundle to Windows so that we can inspect the results.
+			properties ["CopyAppBundleToWindows"] = "true";
+			// Check for updated files on the remote output and update them locally so the app is ready for debug
+			properties ["KeepLocalOutputUpToDate"] = "true";
+			// Don't clean the zip file with the updated files from the remote side so they can be asserted
+			properties ["CleanChangedOutputFilesZipFile"] = "false";
+			// Enable the assembly preparer
+			properties ["AssemblyPreparer"] = "true";
+
+			var result = DotNet.AssertBuild (project_path, properties, timeout: TimeSpan.FromMinutes (15));
+			AssertThatLinkerExecuted (result);
+
+			var objDir = GetObjDir (project_path, platform, runtimeIdentifiers, configuration);
+
+			var zippedAppBundlePath = Path.Combine (objDir, "AppBundle.zip");
+			Assert.That (zippedAppBundlePath, Does.Exist, "AppBundle.zip");
+
+			// Open the zipped app bundle and get the Info.plist
+			using var zip = ZipFile.OpenRead (zippedAppBundlePath);
+			ZipHelpers.DumpZipFile (zip, zippedAppBundlePath);
+			var infoPlistEntry = zip.Entries.SingleOrDefault (v => v.Name == "Info.plist");
+			Assert.That (infoPlistEntry, Is.Not.Null, "Info.plist");
+
+			// Parse the Info.plist
+			// PDictionary.FromStream requires a seekable stream, but the zip stream isn't seekable, so copy to a
+			// MemoryStream and use that. Info.plist files aren't big, so this shouldn't become a memory consumption problem.
+			using var memoryStream = new MemoryStream ((int) infoPlistEntry!.Length);
+			using var plistStream = infoPlistEntry.Open ();
+			plistStream.CopyTo (memoryStream);
+
+			var infoPlist = (PDictionary) PDictionary.FromStream (memoryStream)!;
+			Assert.That (infoPlist.GetString ("CFBundleIdentifier").Value, Is.EqualTo ("com.xamarin.mysimpleapp"), "CFBundleIdentifier");
+			Assert.That (infoPlist.GetString ("CFBundleDisplayName").Value, Is.EqualTo ("MySimpleApp"), "CFBundleDisplayName");
+			Assert.That (infoPlist.GetString ("CFBundleVersion").Value, Is.EqualTo ("3.14"), "CFBundleVersion");
+			Assert.That (infoPlist.GetString ("CFBundleShortVersionString").Value, Is.EqualTo ("3.14"), "CFBundleShortVersionString");
+
+			//Validate that the output assemblies report file with the list of local assemblies, lengths and MVIDs has been created
+			var outputAssembliesReportFileName = "OutputAssembliesReport.txt";
+			var outputAssembliesReportFile = Path.Combine (objDir, outputAssembliesReportFileName);
+			Assert.That (outputAssembliesReportFile, Does.Exist, outputAssembliesReportFileName);
+
+			//Validate that the file with the updated assemblies to replace locally has been created
+			var zippedChangedOutputFilesFileName = "ChangedOutputFiles.zip";
+			var zippedChangedOutputFiles = Path.Combine (objDir, zippedChangedOutputFilesFileName);
+			Assert.That (zippedChangedOutputFiles, Does.Exist, zippedChangedOutputFilesFileName);
+
+			//Create a directory in the obj to extract the updated assemblies
+			var changedOutputFilesDirectory = Path.Combine (objDir, "ChangedOutputFiles");
+			Directory.CreateDirectory (changedOutputFilesDirectory);
+
+			//Extract the updated assemblies from the zip file
+			using var changedOutputFilesZip = ZipFile.OpenRead (zippedChangedOutputFiles);
+			ZipHelpers.DumpZipFile (changedOutputFilesZip, zippedChangedOutputFiles);
+			changedOutputFilesZip.ExtractToDirectory (changedOutputFilesDirectory, overwriteFiles: true);
+
+			//Reads the output assemblies report file
+			var outputAssembliesReportFileList = GetOutputAssembliesReportFileList (outputAssembliesReportFile);
+			var changedOutputAssemblies = Directory.GetFiles (changedOutputFilesDirectory, "*.dll", SearchOption.TopDirectoryOnly);
+
+			foreach (var file in changedOutputAssemblies) {
+				var fileName = Path.GetFileName (file);
+				var fileInReport = outputAssembliesReportFileList.TryGetValue (fileName, out (long length, Guid mvid) localInfo);
+
+				if (fileInReport) {
+					var fileInfo = new FileInfo (file);
+					using Stream stream = fileInfo.OpenRead ();
+					using var peReader = new PEReader (stream);
+					MetadataReader metadataReader = peReader.GetMetadataReader ();
+					Guid mvid = metadataReader.GetGuid (metadataReader.GetModuleDefinition ().Mvid);
+					var fileWasUpdated = fileInfo.Length != localInfo.length || mvid != localInfo.mvid;
+
+					Assert.That (fileWasUpdated, Is.True, $"The file '{fileName}' is identical to the one present in the output assemblies report file '{outputAssembliesReportFile}'");
+				}
+			}
+		}
+#endif // NET11_0_OR_GREATER
+
 		[Category ("RemoteWindows")]
 		[TestCase (ApplePlatform.iOS, "ios-arm64")]
 		public void RemoteTest (ApplePlatform platform, string runtimeIdentifiers)

--- a/tools/assembly-preparer/AssemblyPreparer.cs
+++ b/tools/assembly-preparer/AssemblyPreparer.cs
@@ -136,8 +136,56 @@ public class AssemblyPreparer : IDisposable {
 			new ManagedRegistrarStep (),
 			new TrimmableRegistrarStep (),
 			new ManagedRegistrarLookupTablesStep (),
+			new InlineClassGetHandleStep (),
 			new SaveAssembliesStep (),
 		};
+		return RunSteps (steps, out exceptions);
+	}
+
+	public bool PostProcess (out List<ProductException> exceptions)
+	{
+		configuration.Application.IsPostProcessingAssemblies = true;
+
+		var steps = new ConfigurationAwareStep [] {
+			// All the same steps as the custom trimmer steps that are run after sweeping in Xamarin.Shared.Sdk.targets (and in the same order).
+			new LoadAssembliesStep (), // LoadNonSkippedAssembliesStep
+
+			// post-sweep
+			new CollectFieldsStep (), // Must run before ListExportedSymbols to populate ExportedFields annotation
+			new ExtractBindingLibrariesStep (),
+			// The ListExportedSymbols must run after ExtractBindingLibrariesStep, otherwise we won't properly list exported Objective-C classes from binding libraries
+			new ListExportedSymbols (),
+			new RemoveUserResourcesSubStep (), // from PreOutputDispatcher.
+			// We're not doing ClassHandleRewriterStep, that's replaced by InlineClassGetHandleStep, which is run in Prepare().
+
+			// ManagedRegistrarStep/TrimmableRegistrarStep/ManagedRegistrarLookupTablesStep
+			// must run before SaveAssembliesStep because they modify assemblies (adding
+			// lookup tables and ldtoken instructions). SaveAssembliesStep writes the final
+			// versions to disk with correct metadata tokens.
+			new ManagedRegistrarStep (),
+			new TrimmableRegistrarStep (),
+			new ManagedRegistrarLookupTablesStep (),
+
+			new SaveAssembliesStep (),
+
+			// PopulateApplicationAssembliesStep must run after SaveAssembliesStep so that
+			// OutputPath is set correctly (used by ComputeAOTArguments and GatherFrameworksStep).
+			new PopulateApplicationAssembliesStep (),
+
+			// post-output
+
+			new RegistrarStep (),
+
+			new GenerateMainStep (),
+			new GenerateReferencesStep (),
+			new GatherFrameworksStep (),
+			new ComputeNativeBuildFlagsStep (),
+			new ComputeAOTArguments (),
+
+			// Must be the last step.
+			new DoneStep (),
+		};
+
 		return RunSteps (steps, out exceptions);
 	}
 

--- a/tools/assembly-preparer/CollectFieldsStep.cs
+++ b/tools/assembly-preparer/CollectFieldsStep.cs
@@ -2,21 +2,22 @@
 // Licensed under the MIT License.
 
 using Mono.Cecil;
+using Mono.Linker;
 using Mono.Tuner;
+
+using Xamarin.Linker;
 
 namespace MonoTouch.Tuner {
 
-	// Populate FieldSymbols for InlineDlfcnMethodsStep's compatibility mode.
-	// This is equivalent to what ProcessExportedFields does in the ILLink pipeline.
+	// Populate FieldSymbols and ExportedFields annotation for InlineDlfcnMethodsStep
+	// and ListExportedSymbols. This is equivalent to what ProcessExportedFields does
+	// in the ILLink pipeline.
 	public class CollectFieldsStep : ConfigurationAwareStep {
 		protected override string Name { get; } = "CollectFields";
 		protected override int ErrorCode { get; } = 2480;
 
 		protected override bool IsActiveFor (AssemblyDefinition assembly)
 		{
-			if (!Configuration.InlineDlfcnMethodsEnabled)
-				return false;
-
 			if (!assembly.MainModule.HasTypeReference (Namespaces.Foundation + ".FieldAttribute"))
 				return false;
 
@@ -49,7 +50,21 @@ namespace MonoTouch.Tuner {
 						continue;
 					if (attrib.ConstructorArguments.Count < 1)
 						continue;
-					Configuration.FieldSymbols.Add ((string) attrib.ConstructorArguments [0].Value);
+
+					var symbolName = (string) attrib.ConstructorArguments [0].Value;
+
+					// Populate FieldSymbols for InlineDlfcnMethodsStep's compatibility mode.
+					if (Configuration.InlineDlfcnMethodsEnabled)
+						Configuration.FieldSymbols.Add (symbolName);
+
+					// Populate ExportedFields annotation for ListExportedSymbols
+					// (so native linker keeps __Internal field symbols for dlsym).
+					if (attrib.ConstructorArguments.Count == 2) {
+						var libraryName = (string) attrib.ConstructorArguments [1].Value;
+						if (libraryName == "__Internal")
+							Annotations.GetCustomAnnotations ("ExportedFields") [property] = symbolName;
+					}
+
 					break;
 				}
 			}

--- a/tools/assembly-preparer/PopulateApplicationAssembliesStep.cs
+++ b/tools/assembly-preparer/PopulateApplicationAssembliesStep.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.IO;
+
+using Mono.Cecil;
+using Mono.Linker;
+
+using Xamarin.Build;
+using Xamarin.Bundler;
+using Xamarin.Linker;
+
+namespace MonoTouch.Tuner {
+	// Populate Application.Assemblies with the loaded assemblies.
+	// This is needed so that steps like ComputeAOTArguments and GatherFrameworksStep
+	// can find the assemblies they need to process.
+	// This is equivalent to LoadNonSkippedAssembliesStep in the ILLink path.
+	// This step must run after SaveAssembliesStep, so that OutputPath is set correctly.
+	public class PopulateApplicationAssembliesStep : ConfigurationAwareStep {
+		protected override string Name { get; } = "PopulateApplicationAssemblies";
+		protected override int ErrorCode { get; } = 2520;
+
+		protected override void TryProcess ()
+		{
+			foreach (var assembly in Configuration.AssemblyInfos) {
+				if (!assembly.IsCILAssembly)
+					continue;
+				var assemblyDefinition = assembly.Assembly;
+				if (assemblyDefinition is null)
+					continue;
+				var action = Context.Annotations.GetAction (assemblyDefinition);
+				switch (action) {
+				case AssemblyAction.Delete:
+				case AssemblyAction.Skip:
+					break;
+				default:
+					var ad = Configuration.Application.AddAssembly (assemblyDefinition);
+					ad.FullPath = assembly.OutputPath;
+					break;
+				}
+			}
+		}
+	}
+}

--- a/tools/assembly-preparer/SaveAssembliesStep.cs
+++ b/tools/assembly-preparer/SaveAssembliesStep.cs
@@ -22,8 +22,10 @@ namespace MonoTouch.Tuner {
 			var log = Configuration;
 
 			foreach (var assembly in configuration.AssemblyInfos) {
-				if (!assembly.IsCILAssembly)
+				if (!assembly.IsCILAssembly) {
+					// Non-managed assembly, already handled by LoadAssembliesStep (OutputPath = InputPath).
 					continue;
+				}
 
 				var assemblyDefinition = assembly.Assembly;
 				if (assemblyDefinition is null) {
@@ -35,7 +37,13 @@ namespace MonoTouch.Tuner {
 				switch (action) {
 				case AssemblyAction.Copy:
 				case AssemblyAction.CopyUsed:
-					assembly.OutputPath = assembly.InputPath;
+					if (configuration.Application.IsPostProcessingAssemblies && assembly.InputPath != assembly.OutputPath) {
+						// During post-processing, copy unchanged assemblies to the output directory
+						// so all assemblies are in the same directory (required for AOT compilation).
+						CopyAssemblyToOutput (assembly.InputPath, assembly.OutputPath);
+					} else {
+						assembly.OutputPath = assembly.InputPath;
+					}
 					continue;
 				case AssemblyAction.Link:
 				case AssemblyAction.Save:
@@ -87,6 +95,30 @@ namespace MonoTouch.Tuner {
 					module.Characteristics |= ModuleCharacteristics.NoSEH;
 				}
 			}
+		}
+
+		void CopyAssemblyToOutput (string source, string target)
+		{
+			PathUtils.CreateDirectoryForFile (target);
+
+			CopyIfNeeded (source, target);
+			CopyIfNeeded (Path.ChangeExtension (source, ".pdb"), Path.ChangeExtension (target, ".pdb"));
+			CopyIfNeeded (source + ".config", target + ".config");
+		}
+
+		void CopyIfNeeded (string source, string target)
+		{
+			if (!File.Exists (source))
+				return;
+
+			// Skip if target is already up-to-date.
+			if (File.Exists (target) && File.GetLastWriteTimeUtc (source) <= File.GetLastWriteTimeUtc (target)) {
+				Configuration.Log ($"Not copying '{source}' to '{target}' because it's already up-to-date.");
+				return;
+			}
+
+			Configuration.Log ($"Copying '{source}' to '{target}'.");
+			File.Copy (source, target, true);
 		}
 	}
 }

--- a/tools/assembly-preparer/assembly-preparer.csproj
+++ b/tools/assembly-preparer/assembly-preparer.csproj
@@ -165,8 +165,32 @@
 		<Compile Include="../dotnet-linker/Steps/AssemblyModifierStep.cs">
 			<Link>external/tools/dotnet-linker/Steps/AssemblyModifierStep.cs</Link>
 		</Compile>
+		<Compile Include="../dotnet-linker/Steps/ComputeAOTArguments.cs">
+			<Link>external/tools/dotnet-linker/Steps/ComputeAOTArguments.cs</Link>
+		</Compile>
+		<Compile Include="../dotnet-linker/Steps/ComputeNativeBuildFlagsStep.cs">
+			<Link>external/tools/dotnet-linker/Steps/ComputeNativeBuildFlagsStep.cs</Link>
+		</Compile>
 		<Compile Include="../dotnet-linker/Steps/ConfigurationAwareStep.cs">
 			<Link>external/tools/dotnet-linker/Steps/ConfigurationAwareStep.cs</Link>
+		</Compile>
+		<Compile Include="../dotnet-linker/Steps/DoneStep.cs">
+			<Link>external/tools/dotnet-linker/Steps/DoneStep.cs</Link>
+		</Compile>
+		<Compile Include="../dotnet-linker/Steps/ExtractBindingLibrariesStep.cs">
+			<Link>external/tools/dotnet-linker/Steps/ExtractBindingLibrariesStep.cs</Link>
+		</Compile>
+		<Compile Include="../dotnet-linker/Steps/GatherFrameworksStep.cs">
+			<Link>external/tools/dotnet-linker/Steps/GatherFrameworksStep.cs</Link>
+		</Compile>
+		<Compile Include="../dotnet-linker/Steps/GenerateMainStep.cs">
+			<Link>external/tools/dotnet-linker/Steps/GenerateMainStep.cs</Link>
+		</Compile>
+		<Compile Include="../dotnet-linker/Steps/GenerateReferencesStep.cs">
+			<Link>external/tools/dotnet-linker/Steps/GenerateReferencesStep.cs</Link>
+		</Compile>
+		<Compile Include="../dotnet-linker/Steps/InlineClassGetHandleStep.cs">
+			<Link>external/tools/dotnet-linker/Steps/InlineClassGetHandleStep.cs</Link>
 		</Compile>
 		<Compile Include="../dotnet-linker/Steps/InlineDlfcnMethodsStep.cs">
 			<Link>external/tools/dotnet-linker/Steps/InlineDlfcnMethodsStep.cs</Link>
@@ -179,6 +203,9 @@
 		</Compile>
 		<Compile Include="../dotnet-linker/Steps/PreserveBlockCodeStep.cs">
 			<Link>external/tools/dotnet-linker/Steps/PreserveBlockCodeStep.cs</Link>
+		</Compile>
+		<Compile Include="../dotnet-linker/Steps/RegistrarStep.cs">
+			<Link>external/tools/dotnet-linker/Steps/RegistrarStep.cs</Link>
 		</Compile>
 		<Compile Include="../dotnet-linker/Steps/SetBeforeFieldInitStep.cs">
 			<Link>external/tools/dotnet-linker/Steps/SetBeforeFieldInitStep.cs</Link>
@@ -201,6 +228,9 @@
 		<Compile Include="../linker/MonoTouch.Tuner/Extensions.cs">
 		  <Link>external/tools/linker/MonoTouch.Tuner/Extensions.cs</Link>
 		</Compile>
+		<Compile Include="../linker/MonoTouch.Tuner/ListExportedSymbols.cs">
+		  <Link>external/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs</Link>
+		</Compile>
 		<Compile Include="../linker/ObjCExtensions.cs">
 			<Link>external/tools/linker/ObjCExtensions.cs</Link>
 		</Compile>
@@ -209,6 +239,9 @@
 		</Compile>
 		<Compile Include="../linker/RegistrarRemovalTrackingStep.cs">
 			<Link>external/tools/linker/RegistrarRemovalTrackingStep.cs</Link>
+		</Compile>
+		<Compile Include="../linker/RemoveUserResourcesSubStep.cs">
+			<Link>external/tools/linker/RemoveUserResourcesSubStep.cs</Link>
 		</Compile>
 		<Compile Include="../../src/Foundation/ExportAttribute.cs">
 			<Link>external/src/Foundation/ExportAttribute.cs</Link>
@@ -260,6 +293,9 @@
 		</Compile>
 		<Compile Include="../dotnet-linker/DocumentionComments.cs">
 			<Link>external/tools/dotnet-linker/DocumentionComments.cs</Link>
+		</Compile>
+		<Compile Include="../common/CompilerFlags.cs">
+			<Link>external/tools/common/CompilerFlags.cs</Link>
 		</Compile>
 		<Compile Include="../common/SdkVersions.cs">
 			<Link>external/tools/common/SdkVersions.cs</Link>

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -83,10 +83,11 @@ namespace Xamarin.Bundler {
 		public bool PrepareAssemblies; // True if '$(PrepareAssemblies)' == 'true'
 #if ASSEMBLY_PREPARER
 		public bool InCustomTrimmerStep = false;
+		public bool IsPostProcessingAssemblies;
 #else
 		public bool InCustomTrimmerStep = true;
-#endif
 		public bool IsPostProcessingAssemblies => PrepareAssemblies && InCustomTrimmerStep;
+#endif
 
 #if !LEGACY_TOOLS
 		public DlsymOptions DlsymOptions;

--- a/tools/common/Assembly.cs
+++ b/tools/common/Assembly.cs
@@ -66,10 +66,7 @@ namespace Xamarin.Bundler {
 			set {
 				full_path = value;
 				if (!is_framework_assembly.HasValue && !string.IsNullOrEmpty (full_path)) {
-#if ASSEMBLY_PREPARER
-					is_framework_assembly = false; // silence compiler warning
-					throw new InvalidOperationException ();
-#elif !LEGACY_TOOLS
+#if !LEGACY_TOOLS
 					is_framework_assembly = App.Configuration.FrameworkAssemblies.Contains (GetIdentity (full_path));
 #else
 					var real_full_path = Application.GetRealPath (App, full_path);

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -3964,7 +3964,7 @@ namespace Registrar {
 				nslog_start.AppendLine (");");
 			}
 
-#if !LEGACY_TOOLS && !ASSEMBLY_PREPARER
+#if !LEGACY_TOOLS
 			// Generate the native trampoline to call the generated UnmanagedCallersOnly method if we're using the managed static registrar.
 			if (LinkContext.App.Registrar == RegistrarMode.ManagedStatic || LinkContext.App.Registrar == RegistrarMode.TrimmableStatic) {
 				GenerateCallToUnmanagedCallersOnlyMethod (sb, method, isCtor, isVoid, num_arg, descriptiveMethodName, exceptions);
@@ -4194,7 +4194,7 @@ namespace Registrar {
 			}
 		}
 
-#if !LEGACY_TOOLS && !ASSEMBLY_PREPARER
+#if !LEGACY_TOOLS
 		void GenerateCallToUnmanagedCallersOnlyMethod (AutoIndentStringBuilder sb, ObjCMethod method, bool isCtor, bool isVoid, int num_arg, string descriptiveMethodName, List<Exception> exceptions)
 		{
 			// Generate the native trampoline to call the generated UnmanagedCallersOnly method.
@@ -5170,7 +5170,7 @@ namespace Registrar {
 		{
 			var token = member.MetadataToken;
 
-#if !LEGACY_TOOLS && !ASSEMBLY_PREPARER
+#if !LEGACY_TOOLS
 			if (App.Registrar == RegistrarMode.TrimmableStatic)
 				throw ErrorHelper.CreateError (99, $"Can't create a token reference when using the trimmable static registrar (for: {member.FullName})");
 

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -65,9 +65,7 @@ namespace Xamarin.Linker {
 
 		public IList<string> RegistrationMethods { get; set; } = new List<string> ();
 		public List<string> NativeCodeToCompileAndLink { get; private set; } = new List<string> ();
-#if !ASSEMBLY_PREPARER
 		public CompilerFlags CompilerFlags;
-#endif
 
 #if ASSEMBLY_PREPARER
 		List<ProductException> exceptions = new List<ProductException> ();
@@ -653,9 +651,7 @@ namespace Xamarin.Linker {
 			configurations.Add (this.Context, this);
 #endif
 
-#if !ASSEMBLY_PREPARER
 			CompilerFlags = new CompilerFlags (Application);
-#endif
 
 			var configurator = GetConfigurator (linker_file);
 
@@ -872,6 +868,7 @@ namespace Xamarin.Linker {
 
 		public void FlushOutputForMSBuild ()
 		{
+			Directory.CreateDirectory (ItemsDirectory);
 			foreach (var kvp in msbuild_items) {
 				var itemName = kvp.Key;
 				var items = kvp.Value;

--- a/tools/dotnet-linker/Steps/ComputeAOTArguments.cs
+++ b/tools/dotnet-linker/Steps/ComputeAOTArguments.cs
@@ -28,7 +28,11 @@ namespace Xamarin.Linker {
 				if (!isAOTCompiled)
 					continue;
 
+#if ASSEMBLY_PREPARER
+				var item = new MSBuildItem (asm.FullPath);
+#else
 				var item = new MSBuildItem (Path.Combine (Configuration.IntermediateLinkDir, asm.FileName));
+#endif
 
 				var input = asm.FullPath;
 				bool? isDedupAssembly = null;

--- a/tools/dotnet-linker/Steps/ExtractBindingLibrariesStep.cs
+++ b/tools/dotnet-linker/Steps/ExtractBindingLibrariesStep.cs
@@ -77,8 +77,9 @@ namespace Xamarin.Linker {
 
 					// Store a relative path if possible, it makes things easier with XVS.
 					var fwkDirectory = fwk;
-					if (Path.IsPathRooted (fwkDirectory))
-						fwkDirectory = Path.GetRelativePath (Environment.CurrentDirectory, PathUtils.ResolveSymbolicLinks (fwkDirectory));
+					if (Path.IsPathRooted (fwkDirectory)) {
+						fwkDirectory = PathUtils.AbsoluteToRelative (Environment.CurrentDirectory, PathUtils.ResolveSymbolicLinks (fwkDirectory));
+					}
 
 					var executable = Path.Combine (fwkDirectory, Path.GetFileNameWithoutExtension (fwkDirectory));
 

--- a/tools/dotnet-linker/Steps/GenerateReferencesStep.cs
+++ b/tools/dotnet-linker/Steps/GenerateReferencesStep.cs
@@ -7,6 +7,7 @@ using Mono.Cecil;
 
 using Xamarin.Bundler;
 using Xamarin.Linker;
+using Xamarin.Utils;
 
 #nullable enable
 
@@ -30,7 +31,7 @@ namespace Xamarin {
 			case SymbolMode.Code:
 				var reference_m = Path.Combine (Configuration.CacheDirectory, "reference.m");
 				reference_m = Configuration.Application.GenerateReferencingSource (reference_m, required_symbols);
-				if (!string.IsNullOrEmpty (reference_m)) {
+				if (!StringUtils.IsNullOrEmpty (reference_m)) {
 					var item = new MSBuildItem (reference_m);
 					items.Add (item);
 				}

--- a/tools/dotnet-linker/Steps/InlineClassGetHandleStep.cs
+++ b/tools/dotnet-linker/Steps/InlineClassGetHandleStep.cs
@@ -41,6 +41,11 @@ public class InlineClassGetHandleStep : AssemblyModifierStep {
 	public const string PInvokePrefix = "xamarin_Class_GetHandle_";
 	public const string PInvokeSuffix = "_Native";
 
+	protected override bool ConditionToProcess ()
+	{
+		return Configuration.InlineClassGetHandle != InlineClassGetHandleMode.Disabled;
+	}
+
 	protected override void TryProcess ()
 	{
 		strictMode = Configuration.InlineClassGetHandle == InlineClassGetHandleMode.Strict;

--- a/tools/dotnet-linker/Steps/RegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/RegistrarStep.cs
@@ -35,12 +35,14 @@ namespace Xamarin.Linker {
 				var dir = Configuration.CacheDirectory;
 				var header = Path.Combine (dir, "registrar.h");
 				var code = Path.Combine (dir, "registrar.mm");
+#if !ASSEMBLY_PREPARER
 				if (app.Registrar == RegistrarMode.ManagedStatic || app.Registrar == RegistrarMode.TrimmableStatic) {
 					// Every api has been registered if we're using the managed registrar
 					// (since we registered types before the trimmer did anything),
 					// so we need to remove those that were later trimmed away by the trimmer.
 					Configuration.Application.StaticRegistrar.FilterTrimmedApi (Annotations);
 				}
+#endif
 				Configuration.Application.StaticRegistrar.Generate (header, code, out var initialization_method);
 
 				var items = new List<MSBuildItem> ();

--- a/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
+++ b/tools/linker/MonoTouch.Tuner/ListExportedSymbols.cs
@@ -16,7 +16,13 @@ using Xamarin.Utils;
 #nullable enable
 
 namespace Xamarin.Linker.Steps {
+#if ASSEMBLY_PREPARER
+	public class ListExportedSymbols : ConfigurationAwareStep {
+		protected override string Name { get; } = "List Exported Symbols";
+		protected override int ErrorCode { get; } = 2510;
+#else
 	public class ListExportedSymbols : BaseStep {
+#endif
 		PInvokeWrapperGenerator? state;
 
 		PInvokeWrapperGenerator? State {
@@ -34,16 +40,23 @@ namespace Xamarin.Linker.Steps {
 			}
 		}
 
+#if ASSEMBLY_PREPARER
+		protected override void TryEndProcess ()
+#else
 		protected override void EndProcess ()
+#endif
 		{
 			if (state?.Started == true) {
 				// The generator is 'started' by the linker, which means it may not
 				// be started if the linker was not executed due to re-using cached results.
 				state.End ();
 			}
+#if !ASSEMBLY_PREPARER
 			base.EndProcess ();
+#endif
 		}
 
+#if !ASSEMBLY_PREPARER
 		public LinkerConfiguration Configuration {
 			get {
 				return LinkerConfiguration.GetInstance (Context);
@@ -55,15 +68,20 @@ namespace Xamarin.Linker.Steps {
 				return Configuration.DerivedLinkContext;
 			}
 		}
+#endif
 
 		public ListExportedSymbols ()
 		{
 		}
 
+#if ASSEMBLY_PREPARER
+		protected override void TryProcessAssembly (AssemblyDefinition assembly)
+		{
+#else
 		protected override void ProcessAssembly (AssemblyDefinition assembly)
 		{
 			base.ProcessAssembly (assembly);
-
+#endif
 			if (Annotations.GetAction (assembly) == AssemblyAction.Delete)
 				return;
 
@@ -176,10 +194,11 @@ namespace Xamarin.Linker.Steps {
 				// * with and without a "lib" prefix
 				// * with and without the ".dylib" extension
 				var app = LinkerConfiguration.GetInstance (Context).Application;
-				var monoLibraryVariations = app.MonoLibraries.
+				var monoLibraryVariationsEnumerable = app.MonoLibraries.
 					Where (v => v.EndsWith (".dylib", StringComparison.OrdinalIgnoreCase) || v.EndsWith (".a", StringComparison.OrdinalIgnoreCase)).
 					Select (v => Path.GetFileNameWithoutExtension (v)).
-					Select (v => v.StartsWith ("lib", StringComparison.OrdinalIgnoreCase) ? v.Substring (3) : v).ToHashSet ();
+					Select (v => v.StartsWith ("lib", StringComparison.OrdinalIgnoreCase) ? v.Substring (3) : v);
+				var monoLibraryVariations = new HashSet<string> (monoLibraryVariationsEnumerable);
 				monoLibraryVariations.Add ("System.Globalization.Native"); // System.Private.CoreLib has P/Invokes pointing to libSystem.Globalization.Native, but they're actually in libmonosgen-2.0
 				monoLibraryVariations.UnionWith (monoLibraryVariations.Select (v => "lib" + v).ToArray ());
 				monoLibraryVariations.UnionWith (monoLibraryVariations.Select (v => v + ".dylib").ToArray ());

--- a/tools/linker/RemoveUserResourcesSubStep.cs
+++ b/tools/linker/RemoveUserResourcesSubStep.cs
@@ -9,59 +9,87 @@ using Mono.Linker.Steps;
 using Mono.Tuner;
 
 using Xamarin.Bundler;
+using Xamarin.Linker.Steps;
 using Xamarin.Utils;
 
 #nullable enable
 
 namespace Xamarin.Linker {
 
+#if ASSEMBLY_PREPARER
+	public class RemoveUserResourcesSubStep : AssemblyModifierStep {
+#else
 	public class RemoveUserResourcesSubStep : ExceptionalSubStep {
-		string [] prefixes = Array.Empty<string> ();
+#endif
+		static string [] monotouch_prefixes = new string [] {
+			"__monotouch_content_",
+			"__monotouch_page_",
+			"__monotouch_item_",
+		};
 
+		static string [] xammac_prefixes = new string [] {
+			"__xammac_content_",
+			"__xammac_page_",
+			"__xammac_item_",
+		};
+
+#if !ASSEMBLY_PREPARER
 		public override SubStepTargets Targets {
 			get { return SubStepTargets.Assembly; }
 		}
+#endif
 
+		ApplePlatform Platform {
+			get { return Configuration.Platform; }
+		}
+
+#if ASSEMBLY_PREPARER
+		public bool Simulator { get { return Configuration.IsSimulatorBuild; } }
+#else
 		public bool Simulator { get { return LinkContext.App.IsSimulatorBuild; } }
+		public Application App { get { return LinkContext.App; } }
+#endif
 
 		protected override string Name { get; } = "Removing User Resources";
 		protected override int ErrorCode { get; } = 2030;
 
-		public override void Initialize (LinkContext context)
+		public string [] GetPrefixes (ApplePlatform platform)
 		{
-			base.Initialize (context);
-
-			switch (LinkContext.App.Platform) {
+			switch (platform) {
 			case ApplePlatform.iOS:
 			case ApplePlatform.TVOS:
 			case ApplePlatform.MacCatalyst:
-				prefixes = new string [] {
-					"__monotouch_content_",
-					"__monotouch_page_",
-					"__monotouch_item_",
-				};
-				break;
+				return monotouch_prefixes;
 			case ApplePlatform.MacOSX:
-				prefixes = new string [] {
-					"__xammac_content_",
-					"__xammac_page_",
-					"__xammac_item_",
-				};
-				break;
+				return xammac_prefixes;
 			default:
-				Report (ErrorHelper.CreateError (71, Errors.MX0071, LinkContext.App.Platform, LinkContext.App.ProductName));
+				Report (ErrorHelper.CreateError (71, Errors.MX0071, platform, App.ProductName));
 				break;
 			}
+			return Array.Empty<string> ();
 		}
 
+#if ASSEMBLY_PREPARER
+		protected override bool ModifyAssembly (AssemblyDefinition assembly)
+#else
 		protected override void Process (AssemblyDefinition assembly)
 		{
-			if (Profile.IsProductAssembly (assembly) || Profile.IsSdkAssembly (assembly))
-				return;
+			var modified = ModifyAssembly (assembly);
+
+			// we'll need to save (if we're not linking) this assembly
+			if (modified && Annotations.GetAction (assembly) != AssemblyAction.Link)
+				Annotations.SetAction (assembly, AssemblyAction.Save);
+		}
+
+		bool ModifyAssembly (AssemblyDefinition assembly)
+#endif
+		{
+			if (App.Profile.IsProductAssembly (assembly) || App.Profile.IsSdkAssembly (assembly))
+				return false;
 
 			var module = assembly.MainModule;
 			if (!module.HasResources)
-				return;
+				return false;
 
 			HashSet<string>? libraries = null;
 			if (assembly.HasCustomAttributes) {
@@ -93,9 +121,7 @@ namespace Xamarin.Linker {
 				found = true;
 			}
 
-			// we'll need to save (if we're not linking) this assembly
-			if (found && Annotations.GetAction (assembly) != AssemblyAction.Link)
-				Annotations.SetAction (assembly, AssemblyAction.Save);
+			return found;
 		}
 
 		bool IsMonoTouchResource (string resourceName)
@@ -104,7 +130,7 @@ namespace Xamarin.Linker {
 			if (Simulator)
 				return false;
 
-			foreach (var prefix in prefixes) {
+			foreach (var prefix in GetPrefixes (Platform)) {
 				if (resourceName.StartsWith (prefix, StringComparison.OrdinalIgnoreCase))
 					return true;
 			}


### PR DESCRIPTION
## Summary

This continues the work to replace our custom ILLink trimmer steps with standalone solutions, so that we no longer depend on the linker's custom-step support (which the ILLink and NativeAOT teams want to remove, and which prevents us from running the trimmer on Windows).

Several of our custom trimmer steps currently run *after* the trimmer has finished sweeping (the "post-sweep" / "pre-output" / "post-output" steps). This PR moves those steps out of the trimmer pipeline and into a new MSBuild task that runs as a separate post-ILLink step (the "assembly preparer" / post-processor), driven by the `PostProcessAssemblies` property.

When `PrepareAssemblies` (and therefore `PostProcessAssemblies`) is enabled, these steps are no longer registered as `_TrimmerCustomSteps` in `Xamarin.Shared.Sdk.targets`; instead they're executed by the new `_PostprocessAssemblies` target, which runs after `ILLink` and before native/AOT/R2R compilation.

## Changes

### MSBuild

- **`Xamarin.Shared.targets`**: Added the `PostProcessAssemblies` property (defaults to the value of `PrepareAssemblies`), and two new targets:
  - `_PrepareAssembliesForPostProcessing` — collects all managed assemblies (including the platform assembly, matching what the trimmer resolves internally) and computes the output directory.
  - `_PostprocessAssemblies` — runs after `ILLink` and before `NativeCompile`/`CreateReadyToRunImages`, invokes the `PrepareAssemblies` task in post-processing mode, and swaps the post-processed assemblies into `ResolvedFileToPublish` (and `FileWrites`).
- **`Xamarin.Shared.Sdk.targets`**: The post-sweep / pre-output / post-output custom trimmer steps are now conditioned on `'$(PostProcessAssemblies)' != 'true'`, so they no longer run inside the trimmer when post-processing is enabled.
- **`PrepareAssemblies.cs`**: Added a `PostProcessing` parameter that selects between `Prepare()` and the new `PostProcess()` path, plus a generic fallback error (`E0192`) when the task fails without logging a specific error.

### Tools / assembly-preparer

- **`AssemblyPreparer.cs`**: Added the `PostProcess()` method, which runs the same set of steps (in the same order) that previously ran as post-sweep/pre-output/post-output custom trimmer steps, including registrar, exported-symbol listing, framework gathering, AOT argument computation, etc. Also added `InlineClassGetHandleStep` to the existing `Prepare()` path.
- **`PopulateApplicationAssembliesStep.cs`** (new): Populates `Application.Assemblies` from the loaded assemblies (equivalent to `LoadNonSkippedAssembliesStep`), so later steps like `ComputeAOTArguments` and `GatherFrameworksStep` can find the assemblies. Runs after `SaveAssembliesStep` so `OutputPath` is set.
- **`SaveAssembliesStep.cs`**: When post-processing, copy unchanged (`Copy`/`CopyUsed`) assemblies (plus `.pdb`/`.config`) into the output directory so all assemblies live together for AOT compilation, instead of just pointing `OutputPath` at the input.
- **`CollectFieldsStep.cs`**: Now also populates the `ExportedFields` annotation (used by `ListExportedSymbols`), not just `FieldSymbols`, and runs regardless of `InlineDlfcnMethodsEnabled`.
- **`assembly-preparer.csproj`**: Linked in the additional shared source files needed by the new post-processing steps (`ComputeAOTArguments`, `ComputeNativeBuildFlagsStep`, `DoneStep`, `ExtractBindingLibrariesStep`, `GatherFrameworksStep`, `GenerateMainStep`, `GenerateReferencesStep`, `InlineClassGetHandleStep`, `RegistrarStep`, `ListExportedSymbols`, `RemoveUserResourcesSubStep`, `CompilerFlags`).

### Shared steps made `ASSEMBLY_PREPARER`-aware

- **`ListExportedSymbols.cs`** and **`RemoveUserResourcesSubStep.cs`**: Refactored to derive from `ConfigurationAwareStep` / `AssemblyModifierStep` when built for the assembly preparer, while keeping the existing trimmer-based behavior otherwise.
- **`InlineClassGetHandleStep.cs`**: Added a `ConditionToProcess()` guard so it only runs when inline class-get-handle is not disabled.
- **`RegistrarStep.cs`**, **`ComputeAOTArguments.cs`**, **`StaticRegistrar.cs`**, **`Application.cs`**, **`Assembly.cs`**, **`LinkerConfiguration.cs`**, **`GenerateReferencesStep.cs`**, **`ExtractBindingLibrariesStep.cs`**: Various `#if ASSEMBLY_PREPARER` adjustments so the shared code compiles and behaves correctly in the post-processor (e.g. `IsPostProcessingAssemblies` becomes a settable field, `CompilerFlags` is always available, the output items directory is created on demand).

### Tests

- **`WindowsTest.cs`**: Added `AssemblyPreparerRemoteTest`, a `RemoteWindows` test that builds with `AssemblyPreparer=true`, copies the app bundle back to Windows, and validates the `Info.plist` and the changed-output-files reporting (only built when not `NET11_0_OR_GREATER`, since the assembly-preparer mode is the default there).

## Notes

This is an incremental step; the post-processing path is gated behind `PostProcessAssemblies`/`PrepareAssemblies` and does not change the default build for shipping configurations.

Contributes towards #17693.
