### PR TITLE
[dotnet] Add new mlaunch 1.1.127 assemblies to SignList.xml

### DIFF
--- a/dotnet/Workloads/SignList.xml
+++ b/dotnet/Workloads/SignList.xml
@@ -86,12 +86,15 @@
     <FirstParty Include="Xamarin.*.dll" />
     <!-- mlaunch.app MonoBundle content-->
     <FirstParty Include="Microsoft.macOS.dll" />
+    <FirstParty Include="Microsoft.Testing.Platform.dll" />
+    <FirstParty Include="Microsoft.Testing.Platform.resources.dll" />
     <FirstParty Include="mlaunch.dll" />
     <FirstParty Include="System.Collections.Concurrent.dll" />
     <FirstParty Include="System.Collections.dll" />
     <FirstParty Include="System.Collections.Immutable.dll" />
     <FirstParty Include="System.Collections.NonGeneric.dll" />
     <FirstParty Include="System.Collections.Specialized.dll" />
+    <FirstParty Include="System.ComponentModel.dll" />
     <FirstParty Include="System.ComponentModel.Primitives.dll" />
     <FirstParty Include="System.ComponentModel.TypeConverter.dll" />
     <FirstParty Include="System.Console.dll" />
@@ -121,13 +124,17 @@
     <FirstParty Include="System.Private.CoreLib.dll" />
     <FirstParty Include="System.Private.Uri.dll" />
     <FirstParty Include="System.Private.Xml.dll" />
+    <FirstParty Include="System.Private.Xml.Linq.dll" />
     <FirstParty Include="System.Reflection.Metadata.dll" />
     <FirstParty Include="System.Runtime.Numerics.dll" />
     <FirstParty Include="System.Security.Claims.dll" />
     <FirstParty Include="System.Security.Cryptography.dll" />
+    <FirstParty Include="System.Text.Encodings.Web.dll" />
     <FirstParty Include="System.Text.Json.dll" />
     <FirstParty Include="System.Text.RegularExpressions.dll" />
     <FirstParty Include="System.Threading.Channels.dll" />
+    <FirstParty Include="System.Threading.dll" />
+    <FirstParty Include="System.Xml.Linq.dll" />
     <FirstParty Include="Xamarin.Hosting.dll" />
     <FirstParty Include="Xamarin.Localization.Mlaunch.dll" />
     <FirstParty Include="Xamarin.Localization.Mlaunch.resources.dll" />


### PR DESCRIPTION
The mlaunch bump from 1.1.113 to 1.1.127 (Xcode 27.0 Beta 1 baseline, #25729) added new assemblies to mlaunch.app/Contents/MonoBundle: the Microsoft.Testing.Platform managed assembly + localized satellites, and a few architecture-specific (R2R) runtime assemblies under .xamarin/<rid>/ (System.ComponentModel, System.Private.Xml.Linq, System.Text.Encodings.Web, System.Threading and System.Xml.Linq).

These new files are not classified in SignList.xml, so the MicroBuild signing step in the "Prepare .NET Release" stage fails with "unknown files which should be signed" (HandleUnmappedFiles=fail).

Add the 7 new assemblies as FirstParty so they are signed, consistent with the rest of the mlaunch.app MonoBundle content.