### PR TITLE
[docs] Improve XML docs for SKCloudServiceSetupOptions

### DIFF
--- a/src/StoreKit/SKCloudServiceSetupOptions.cs
+++ b/src/StoreKit/SKCloudServiceSetupOptions.cs
@@ -7,8 +7,7 @@ namespace StoreKit {
 	partial class SKCloudServiceSetupOptions {
 
 		/// <summary>Gets or sets the setup action.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <value>The cloud service setup action, or <see langword="null" /> if not set.</value>
 		public virtual SKCloudServiceSetupAction? Action {
 			get {
 				if (_Action is null)


### PR DESCRIPTION
Improve XML documentation for the `SKCloudServiceSetupOptions` type:

- Remove "To be added." placeholder entries for `<value>` and `<remarks>`
- Add meaningful `<value>` description for the `Action` property

🤖 Pull request created by Copilot