### PR TITLE
[tools] Fix race condition in assembly-preparer Makefile

### DIFF
--- a/tools/assembly-preparer/Makefile
+++ b/tools/assembly-preparer/Makefile
@@ -4,8 +4,14 @@ include $(TOP)/mk/rules.mk
 include ../common/Make.common
 
 # assembly-preparer.csproj.inc contains the $(assembly_preparer_dependencies) variable used to determine if assembly-preparer needs to be rebuilt or not.
+# Don't include (and thus try to rebuild) the .inc file when the target is
+# generated-files, because MSBuild may invoke 'make generated-files' in parallel
+# for multiple target frameworks, and the script that creates the .inc file
+# doesn't handle concurrent invocations (it uses shared intermediate files).
+ifneq ($(MAKECMDGOALS),generated-files)
 assembly-preparer.csproj.inc: export BUILD_VERBOSITY=$(MSBUILD_VERBOSITY)
 -include assembly-preparer.csproj.inc
+endif
 
 ASSEMBLY_PREPARER_NETCORE=bin/Debug/$(DOTNET_TFM)/assembly-preparer.dll
 ASSEMBLY_PREPARER_NETSTD=bin/Debug/netstandard2.0/assembly-preparer.dll


### PR DESCRIPTION
The `assembly-preparer.csproj` builds for two target frameworks (`netstandard2.0` and `net10.0`) in parallel. Both TFMs invoke `make generated-files` concurrently via a `BeforeTargets="CoreCompile"` target. Each `make` invocation triggers a rebuild of `assembly-preparer.csproj.inc` (via the pattern rule in `mk/rules.mk`), which runs `create-makefile-fragment.sh`. Two concurrent instances of this script share the same intermediate files (`.inputs`), causing one to corrupt or delete files the other needs. This results in a corrupt `.inc` file and a `*** missing separator` make error.

The fix wraps the `-include assembly-preparer.csproj.inc` in an `ifneq ($(MAKECMDGOALS),generated-files)` guard, so the `.inc` file is not rebuilt when the target is `generated-files` -- since it is not needed for that target anyway.

🤖 Pull request created by Copilot