### PR TITLE
[dotnet] Don't quote the 'RunCommand' property.

### DIFF
--- a/dotnet/targets/Microsoft.Sdk.Mobile.targets
+++ b/dotnet/targets/Microsoft.Sdk.Mobile.targets
@@ -139,7 +139,7 @@
 			 />
 
 		<PropertyGroup>
-			<RunCommand>'$(MlaunchPath)'</RunCommand>
+			<RunCommand>$(MlaunchPath)</RunCommand>
 			<RunArguments>$(MlaunchRunArguments) -- </RunArguments>
 		</PropertyGroup>
 	</Target>


### PR DESCRIPTION
The 'RunCommand' property is supposed to be the path to a single executable, and as such should not be quoted.

See: https://github.com/dotnet/sdk/issues/54917#issuecomment-4769827686