### PR TITLE
[release/10.0.1xx] Sign new mlaunch.app dependencies

### DIFF
--- a/dotnet/Workloads/SignList.xml
+++ b/dotnet/Workloads/SignList.xml
@@ -83,12 +83,15 @@
     <FirstParty Include="Xamarin.*.dll" />
     <!-- mlaunch.app MonoBundle content-->
     <FirstParty Include="Microsoft.macOS.dll" />
+    <FirstParty Include="Microsoft.Testing.Platform.dll" />
+    <FirstParty Include="Microsoft.Testing.Platform.resources.dll" />
     <FirstParty Include="mlaunch.dll" />
     <FirstParty Include="System.Collections.Concurrent.dll" />
     <FirstParty Include="System.Collections.dll" />
     <FirstParty Include="System.Collections.Immutable.dll" />
     <FirstParty Include="System.Collections.NonGeneric.dll" />
     <FirstParty Include="System.Collections.Specialized.dll" />
+    <FirstParty Include="System.ComponentModel.dll" />
     <FirstParty Include="System.ComponentModel.Primitives.dll" />
     <FirstParty Include="System.ComponentModel.TypeConverter.dll" />
     <FirstParty Include="System.Console.dll" />
@@ -118,13 +121,17 @@
     <FirstParty Include="System.Private.CoreLib.dll" />
     <FirstParty Include="System.Private.Uri.dll" />
     <FirstParty Include="System.Private.Xml.dll" />
+    <FirstParty Include="System.Private.Xml.Linq.dll" />
     <FirstParty Include="System.Reflection.Metadata.dll" />
     <FirstParty Include="System.Runtime.Numerics.dll" />
     <FirstParty Include="System.Security.Claims.dll" />
     <FirstParty Include="System.Security.Cryptography.dll" />
+    <FirstParty Include="System.Text.Encodings.Web.dll" />
     <FirstParty Include="System.Text.Json.dll" />
     <FirstParty Include="System.Text.RegularExpressions.dll" />
     <FirstParty Include="System.Threading.Channels.dll" />
+    <FirstParty Include="System.Threading.dll" />
+    <FirstParty Include="System.Xml.Linq.dll" />
     <FirstParty Include="Xamarin.Hosting.dll" />
     <FirstParty Include="Xamarin.Localization.Mlaunch.dll" />
     <FirstParty Include="Xamarin.Localization.Mlaunch.resources.dll" />


### PR DESCRIPTION
Bumping mlaunch and xharness (#25767) bundled new dependencies into mlaunch.app/Contents/MonoBundle/.xamarin/{osx-arm64,osx-x64}, which made the "Sign Package Contents" CI step fail because the files were not classified in the sign list:

    Please update your SignList.xml to include the following unknown files
    which should be signed:
        ...mlaunch.app/.../Microsoft.Testing.Platform.dll
        ...

Classify the new files as FirstParty in dotnet/Workloads/SignList.xml, matching the equivalent fix already on the xcode27.0 branch:

    Microsoft.Testing.Platform.dll
    Microsoft.Testing.Platform.resources.dll
    System.ComponentModel.dll
    System.Private.Xml.Linq.dll
    System.Text.Encodings.Web.dll
    System.Threading.dll
    System.Xml.Linq.dll