### PR TITLE
[net11.0] R2R-compile only System.Private.CoreLib for Debug CoreCLR arm64 builds

### DIFF
--- a/dotnet/targets/Microsoft.Sdk.R2R.targets
+++ b/dotnet/targets/Microsoft.Sdk.R2R.targets
@@ -86,6 +86,7 @@
 				Condition="'%(_ResolvedAssembliesToPublish.NuGetPackageId)' != ''" />
 			<_UserAssemblies Include="@(_ResolvedAssembliesToPublish)" Exclude="@(_NonUserAssemblies)" />
 			<PublishReadyToRunExclude Include="@(_UserAssemblies -> '%(Filename)%(Extension)')" />
+			<PublishReadyToRunCompositeRoots Condition="$(RuntimeIdentifier.EndsWith('-arm64'))" Include="System.Private.CoreLib.dll" KeepDuplicates="false" />
 		</ItemGroup>
 
 		<!-- Hash the R2R input assemblies so we can detect when the set actually changes -->
@@ -117,6 +118,14 @@
 			BeforeTargets="_CreateR2RImages">
 		<Touch Files="%(_ReadyToRunCompileList.OutputR2RImage)"
 			Condition="Exists('%(_ReadyToRunCompileList.OutputR2RImage)')" />
+	</Target>
+
+	<Target Name="_DedupUnrootedReadyToRunPublish"
+			Condition="@(PublishReadyToRunCompositeRoots->Count()) != 0"
+			AfterTargets="_PrepareForReadyToRunCompilation">
+		<ItemGroup>
+			<ResolvedFileToPublish Remove="@(_ReadyToRunCompositeUnrootedBuildInput)" />
+		</ItemGroup>
 	</Target>
 
 	<!--


### PR DESCRIPTION
Re-applies the changes from #25583 (which was reverted because it broke x64 builds), but scoped to arm64 RuntimeIdentifiers only.

The `PublishReadyToRunCompositeRoots` item is now only added when `$(RuntimeIdentifier)` ends with `-arm64`, leaving x64 builds unaffected.

🤖 Pull request created by Copilot