### PR TITLE
[AudioToolbox] Bind new Xcode 27 AudioToolbox APIs.

### DIFF
--- a/src/AudioUnit/AUEnums.cs
+++ b/src/AudioUnit/AUEnums.cs
@@ -1339,6 +1339,9 @@ namespace AudioUnit {
 		MediumHall3 = 11,
 		/// <summary>To be added.</summary>
 		LargeHall2 = 12,
+		/// <summary>A general-purpose outdoor reverberation environment.</summary>
+		[iOS (27, 0), TV (27, 0), Mac (27, 0), MacCatalyst (27, 0)]
+		OutdoorGeneral = 24,
 	}
 
 	public enum AUScheduledAudioSliceFlags : uint {

--- a/src/AudioUnit/AUHeadTrackingBinauralRenderer.cs
+++ b/src/AudioUnit/AUHeadTrackingBinauralRenderer.cs
@@ -1,0 +1,23 @@
+#nullable enable
+
+namespace AudioUnit {
+#if __IOS__ && !__MACCATALYST__
+	public partial class AUHeadTrackingBinauralRenderer {
+		/// <summary>Create a new <see cref="AUHeadTrackingBinauralRenderer" /> instance.</summary>
+		/// <param name="componentDescription">A description of the component to create.</param>
+		/// <param name="options">Any options for the returned audio unit.</param>
+		/// <param name="error">The error if an error occurred, null otherwise.</param>
+		/// <returns>A new <see cref="AUHeadTrackingBinauralRenderer" /> instance if successful, null otherwise.</returns>
+		public static AUHeadTrackingBinauralRenderer? Create (AudioComponentDescription componentDescription, AudioComponentInstantiationOptions options, out NSError? error)
+		{
+			var rv = new AUHeadTrackingBinauralRenderer (NSObjectFlag.Empty);
+			rv.InitializeHandle (rv._InitWithComponentDescription (componentDescription, options, out error), "initWithComponentDescription:options:error:", false);
+			if (rv.Handle == NativeHandle.Zero) {
+				rv.Dispose ();
+				return null;
+			}
+			return rv;
+		}
+	}
+#endif // __IOS__ && !__MACCATALYST__
+}

--- a/src/audiounit.cs
+++ b/src/audiounit.cs
@@ -1347,6 +1347,6 @@ namespace AudioUnit {
 		/// <summary>Gets the unique identifier (UID) of the Bluetooth headphone device that provides IMU sensor data for head tracking.</summary>
 		/// <value>The UID of the matched Bluetooth headphone device, or <see langword="null" /> if no device is matched.</value>
 		[NullAllowed, Export ("deviceUID")]
-		string DeviceUID { get; }
+		string DeviceUId { get; }
 	}
 }

--- a/src/audiounit.cs
+++ b/src/audiounit.cs
@@ -1321,4 +1321,32 @@ namespace AudioUnit {
 		[return: NullAllowed]
 		AUAudioUnit CreateAudioUnit (AudioComponentDescription desc, [NullAllowed] out NSError error);
 	}
+
+	/// <summary>A subclass of <see cref="AUAudioUnit" /> for third-party spatial audio units that provides head-tracking properties for Bluetooth head tracking support.</summary>
+	[iOS (27, 0)]
+	[NoMac, NoTV, NoMacCatalyst]
+	[BaseType (typeof (AUAudioUnit))]
+	[DisableDefaultCtor]
+	interface AUHeadTrackingBinauralRenderer {
+		// re-exposed from base class
+		[Export ("initWithComponentDescription:options:error:")]
+		[DesignatedInitializer]
+		[Internal]
+		NativeHandle _InitWithComponentDescription (AudioComponentDescription componentDescription, AudioComponentInstantiationOptions options, [NullAllowed] out NSError outError);
+
+		/// <summary>Gets a Boolean value that tells whether the host has enabled head tracking for this spatial audio unit.</summary>
+		/// <value><see langword="true" /> if the host has enabled head tracking; otherwise, <see langword="false" />.</value>
+		[Export ("headTracking")]
+		bool HeadTracking { [Bind ("isHeadTracking")] get; }
+
+		/// <summary>Gets a Boolean value that tells whether the host is bypassing the renderer due to poor performance.</summary>
+		/// <value><see langword="true" /> if the host is bypassing the audio unit; otherwise, <see langword="false" />.</value>
+		[Export ("disabled")]
+		bool Disabled { [Bind ("isDisabled")] get; }
+
+		/// <summary>Gets the unique identifier (UID) of the Bluetooth headphone device that provides IMU sensor data for head tracking.</summary>
+		/// <value>The UID of the matched Bluetooth headphone device, or <see langword="null" /> if no device is matched.</value>
+		[NullAllowed, Export ("deviceUID")]
+		string DeviceUID { get; }
+	}
 }

--- a/src/frameworks.sources
+++ b/src/frameworks.sources
@@ -226,6 +226,7 @@ AUDIOUNIT_SOURCES = \
 	AudioUnit/ExtAudioFile.cs \
 	AudioUnit/AUScheduledAudioFileRegion.cs \
 	AudioUnit/AUParameter.cs \
+	AudioUnit/AUHeadTrackingBinauralRenderer.cs \
 
 # AuthenticationServices
 

--- a/tests/introspection/ApiCtorInitTest.cs
+++ b/tests/introspection/ApiCtorInitTest.cs
@@ -561,6 +561,12 @@ namespace Introspection {
 					return true;
 				}
 				break;
+			case "AUHeadTrackingBinauralRenderer":
+				if (cstr == "Void .ctor(AudioUnit.AudioComponentDescription, AudioUnit.AudioComponentInstantiationOptions, Foundation.NSError ByRef)") {
+					// This constructor is exposed using a factory method.
+					return true;
+				}
+				break;
 			}
 
 			var ep = ctor.GetParameters ();

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-AudioToolbox.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-AudioToolbox.todo
@@ -1,1 +1,0 @@
-!missing-enum-value! AUReverbRoomType native value kReverbRoomType_OutdoorGeneral = 24 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-AudioToolbox.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-AudioToolbox.todo
@@ -1,5 +1,0 @@
-!missing-enum-value! AUReverbRoomType native value kReverbRoomType_OutdoorGeneral = 24 not bound
-!missing-selector! AUHeadTrackingBinauralRenderer::deviceUID not bound
-!missing-selector! AUHeadTrackingBinauralRenderer::isDisabled not bound
-!missing-selector! AUHeadTrackingBinauralRenderer::isHeadTracking not bound
-!missing-type! AUHeadTrackingBinauralRenderer not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-AudioToolbox.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-AudioToolbox.todo
@@ -1,1 +1,0 @@
-!missing-enum-value! AUReverbRoomType native value kReverbRoomType_OutdoorGeneral = 24 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-AudioToolbox.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-AudioToolbox.todo
@@ -1,1 +1,0 @@
-!missing-enum-value! AUReverbRoomType native value kReverbRoomType_OutdoorGeneral = 24 not bound


### PR DESCRIPTION
Bind the missing AudioToolbox APIs reported by xtro-sharpie:

* AUReverbRoomType.OutdoorGeneral (kReverbRoomType_OutdoorGeneral = 24) on iOS, tvOS, macOS and Mac Catalyst.
* AUHeadTrackingBinauralRenderer (an AUAudioUnit subclass) and its three readonly properties (HeadTracking, Disabled, DeviceUID) on iOS.

AUHeadTrackingBinauralRenderer re-exposes the base AUAudioUnit designated initializer as an [Internal] init plus a manual Create factory (guarded for iOS-only), mirroring AVCaptureEventSound, so it satisfies both the introspection DesignatedInitializer test and the cecil NoConstructorsWithOutErrorArguments test.