### PR TITLE
[dependabot] Fix formatting of dependabot.yml.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
-updates:
-- cooldown:
-    default-days: 7
-  directory: /
-  ignore:
-  - dependency-name: "github/gh-aw-actions/**"
-  - dependency-name: "github/gh-aw-actions" # Managed by gh aw compile. Version-locked to the gh-aw compiler; do not bump.
-  package-ecosystem: github-actions
-  schedule:
-    interval: weekly
 version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    ignore:
+    - dependency-name: "github/gh-aw-actions/**"
+    - dependency-name: "github/gh-aw-actions" # Managed by gh aw compile. Version-locked to the gh-aw compiler; do not bump.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,5 @@ updates:
     cooldown:
       default-days: 7
     ignore:
-    - dependency-name: "github/gh-aw-actions/**"
-    - dependency-name: "github/gh-aw-actions" # Managed by gh aw compile. Version-locked to the gh-aw compiler; do not bump.
+      - dependency-name: "github/gh-aw-actions/**"
+      - dependency-name: "github/gh-aw-actions"  # Managed by gh aw compile. Version-locked to the gh-aw compiler; do not bump.


### PR DESCRIPTION
Below the top-level 'updates' entry, there should be only the 'package-ecosystem' entry, all other entries should be under that 'package-ecosystem' entry.

This hopefully fixes a problem with dependabot where dependabot shouldn't update compiled  agentic workflow *.lock.yml files.