### PR TITLE
[docs] Improve XML docs for WKWindowFeatures

### DIFF
--- a/src/WebKit/WKWindowFeatures.cs
+++ b/src/WebKit/WKWindowFeatures.cs
@@ -11,30 +11,26 @@
 
 namespace WebKit {
 	public partial class WKWindowFeatures {
-		/// <summary>Whether the menu bar should be visible. null if menu bar visibility was not specified.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets whether the menu bar should be visible.</summary>
+		/// <value><see langword="true" /> if the menu bar should be visible; <see langword="false" /> if not; <see langword="null" /> if not specified.</value>
 		public bool? MenuBarVisibility {
 			get => menuBarVisibility?.BoolValue;
 		}
 
-		/// <summary>Whether the status bar should be visible. null if status bar visibility was not specified.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets whether the status bar should be visible.</summary>
+		/// <value><see langword="true" /> if the status bar should be visible; <see langword="false" /> if not; <see langword="null" /> if not specified.</value>
 		public bool? StatusBarVisibility {
 			get => statusBarVisibility?.BoolValue;
 		}
 
-		/// <summary>Whether toolbars should be visible. null if toolbar visibility was not specified.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets whether toolbars should be visible.</summary>
+		/// <value><see langword="true" /> if toolbars should be visible; <see langword="false" /> if not; <see langword="null" /> if not specified.</value>
 		public bool? ToolbarsVisibility {
 			get => toolbarsVisibility?.BoolValue;
 		}
 
-		/// <summary>Whether the containing window should be resizable. null if resizability was not specified.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets whether the containing window should be resizable.</summary>
+		/// <value><see langword="true" /> if the window is resizable; <see langword="false" /> if not; <see langword="null" /> if not specified.</value>
 		public bool? AllowsResizing {
 			get => allowsResizing?.BoolValue;
 		}
@@ -47,30 +43,26 @@ namespace WebKit {
 				return (nfloat) number.DoubleValue;
 		}
 
-		/// <summary>The x coordinate of the containing window. null if the x coordinate was not specified.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets the x coordinate of the containing window.</summary>
+		/// <value>The x coordinate, or <see langword="null" /> if not specified.</value>
 		public nfloat? X {
 			get { return NFloatValue (x); }
 		}
 
-		/// <summary>The y coordinate of the containing window. null if the y coordinate was not specified.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets the y coordinate of the containing window.</summary>
+		/// <value>The y coordinate, or <see langword="null" /> if not specified.</value>
 		public nfloat? Y {
 			get { return NFloatValue (y); }
 		}
 
-		/// <summary>The width coordinate of the containing window. null if the width was not specified.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets the width of the containing window.</summary>
+		/// <value>The width, or <see langword="null" /> if not specified.</value>
 		public nfloat? Width {
 			get { return NFloatValue (width); }
 		}
 
-		/// <summary>The height coordinate of the containing window. nil if the height was not specified</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets the height of the containing window.</summary>
+		/// <value>The height, or <see langword="null" /> if not specified.</value>
 		public nfloat? Height {
 			get { return NFloatValue (height); }
 		}


### PR DESCRIPTION
Improve XML documentation for the `WKWindowFeatures` type:

- Replace 'To be added.' placeholders with meaningful descriptions
- Remove empty `<remarks>` nodes
- Add proper documentation for all properties (MenuBarVisibility, StatusBarVisibility, ToolbarsVisibility, etc.)

🤖 Pull request created by Copilot