### PR TITLE
[build] Fix NuGet migration race condition workaround

### DIFF
--- a/builds/Makefile
+++ b/builds/Makefile
@@ -45,10 +45,17 @@ else
 endif
 	$(Q) echo "Downloaded and installed .NET $(DOTNET_VERSION) into $@."
 	@# Workaround for https://github.com/dotnet/runtime/issues/91987
-	@# Run 'dotnet --info' once after downloading to complete the first-time NuGet
-	@# migrations logic, avoiding a race condition when multiple parallel dotnet
-	@# processes run for the first time simultaneously (only needed in CI).
-	$(Q) if test -n "$$ACES"; then "$@/dotnet" --info; fi
+	@# Create the NuGet migration marker file directly to avoid the race condition
+	@# where multiple parallel dotnet processes attempt to acquire the "NuGet-Migrations"
+	@# mutex simultaneously. If the marker file exists, NuGet skips the mutex entirely.
+	@# The migration (Migration1) only cleans up old NuGet directories, which is a no-op
+	@# on a fresh SDK install. Only needed in CI.
+	$(Q) if test -n "$$ACES"; then \
+		NUGET_MIGRATIONS_DIR="$$HOME/.local/share/NuGet/Migrations"; \
+		mkdir -p "$$NUGET_MIGRATIONS_DIR"; \
+		touch "$$NUGET_MIGRATIONS_DIR/1"; \
+		echo "Created NuGet migrations marker file to avoid race condition (dotnet/runtime#91987)"; \
+	fi
 
 # Create a symlink with a persistent (non-version-dependent) name
 # The dependency on the stamp file is to ensure the symlink is re-created


### PR DESCRIPTION
The previous workaround (from #25797) ran `dotnet --info` after downloading the SDK to trigger NuGet's first-time migration and avoid the race condition described in dotnet/runtime#91987. However, `dotnet --info` doesn't reliably trigger the migration code path -- the migration (`MigrationRunner.Run()`) is invoked from:

1. `DotnetFirstTimeUseConfigurer` in the dotnet CLI (first-use flow, which `--info` may bypass)
2. `NuGetSdkResolver` during MSBuild SDK resolution (only during build/restore)

This PR replaces the `dotnet --info` call with directly creating the NuGet migration marker file (`~/.local/share/NuGet/Migrations/1`). When this file exists, NuGet's `MigrationRunner` returns immediately without acquiring the "NuGet-Migrations" mutex -- completely eliminating the race condition.

The migration itself (`Migration1`) only cleans up old NuGet directories, which is a no-op on a fresh SDK installation, so skipping it is safe.

Ref: https://github.com/dotnet/runtime/issues/91987
Ref: https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Common/Migrations/MigrationRunner.cs

---
🤖 Pull request created by Copilot