### PR TITLE
[release/10.0.1xx] [msbuild] Always build referenced extension projects by default

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -2722,9 +2722,10 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 	<Target Name="_ResolveAppExtensionReferences" DependsOnTargets="_SplitAppExtensionReferencesByExistent">
 		<PropertyGroup>
-			<!-- When building a .sln with msbuild, the dependent projects may not be built. So, always build
-			     the referenced projects unless building from IDE. -->
-			<_BuildReferencedExtensionProjects Condition="'$(BuildingInsideVisualStudio)' != 'true'">true</_BuildReferencedExtensionProjects>
+			<!-- Always build the referenced extension projects unless the IDE has explicitly set this property.
+			     This used to only be done when not building from the IDE, but some versions of the IDE don't
+			     build extension projects correctly, so default to always building them. Ref: https://github.com/dotnet/macios/issues/25461 -->
+			<_BuildReferencedExtensionProjects Condition="'$(_BuildReferencedExtensionProjects)' == ''">true</_BuildReferencedExtensionProjects>
 		</PropertyGroup>
 
 		<!-- If the referenced projects have already been built, then just get the app extensions' bundle paths -->

--- a/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
@@ -227,9 +227,10 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<Target Name="_ResolveWatchAppReferences" DependsOnTargets="_SplitWatchAppReferencesByExistent">
 		<PropertyGroup>
-			<!-- When building a .sln with msbuild, the dependent projects may not be built. So, always build
-			     the referenced projects unless building from IDE. -->
-			<_BuildReferencedExtensionProjects Condition="'$(BuildingInsideVisualStudio)' != 'true'">true</_BuildReferencedExtensionProjects>
+			<!-- Always build the referenced extension projects unless the IDE has explicitly set this property.
+			     This used to only be done when not building from the IDE, but some versions of the IDE don't
+			     build extension projects correctly, so default to always building them. Ref: https://github.com/dotnet/macios/issues/25461 -->
+			<_BuildReferencedExtensionProjects Condition="'$(_BuildReferencedExtensionProjects)' == ''">true</_BuildReferencedExtensionProjects>
 		</PropertyGroup>
 
 		<!-- If the referenced projects have already been built, then just get the target paths -->


### PR DESCRIPTION
Change the condition for _BuildReferencedExtensionProjects from `BuildingInsideVisualStudio != true` to 'not already set'. This way the property defaults to true (always build extensions), but the IDE can still override it by setting it explicitly.

This fixes VS 2026 builds where the IDE doesn't build the extension project before the main project, leaving the .appex missing.

Fixes https://github.com/dotnet/macios/issues/25461

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Backport of #25805.