### PR TITLE
[msbuild] Only run _CreateInstaller target for desktop platforms

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -3382,7 +3382,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		</_CreateInstallerDependsOn>
 	</PropertyGroup>
 
-	<Target Name="_CreateInstaller" Condition="'$(CreatePackage)' == 'true' And '$(_CanOutputAppBundle)' == 'true'" DependsOnTargets="$(_CreateInstallerDependsOn)">
+	<Target Name="_CreateInstaller" Condition="'$(CreatePackage)' == 'true' And '$(_CanOutputAppBundle)' == 'true' And '$(SdkIsDesktop)' == 'true'" DependsOnTargets="$(_CreateInstallerDependsOn)">
 		<PropertyGroup>
 			<PkgPackageDir Condition="'$(PkgPackageDir)' == ''">$(TargetDir)</PkgPackageDir>
 		</PropertyGroup>


### PR DESCRIPTION
The _CreateInstaller target creates a .pkg installer, which is only useful for desktop platforms (macOS and Mac Catalyst). Previously, setting CreatePackage=true for an iOS or tvOS project would attempt to create a .pkg, which is useless and would fail if /usr/bin/productbuild is not available.

Add a 'SdkIsDesktop' == 'true' condition to the target so it only runs for macOS and Mac Catalyst projects.

Fixes https://github.com/dotnet/macios/issues/19790