### PR TITLE
[msbuild] Fix using .NET Core assemblies for MSBuild tasks within VS

### DIFF
--- a/dotnet/Microsoft.iOS.Sdk/targets/Microsoft.iOS.Sdk.props
+++ b/dotnet/Microsoft.iOS.Sdk/targets/Microsoft.iOS.Sdk.props
@@ -4,7 +4,6 @@
     <_PlatformName>iOS</_PlatformName>
     <_PlatformRidNoArch>ios</_PlatformRidNoArch>
     <!-- Used by Microsoft.iOS.Windows.Sdk -->
-    <_UseDesktopTaskAssemblies Condition="'$(_UseDesktopTaskAssemblies)' == '' And '$(BuildingInsideVisualStudio)' == 'true'">true</_UseDesktopTaskAssemblies>
     <CoreiOSSdkDirectory Condition="'$(_UseDesktopTaskAssemblies)' != 'true'">$(MSBuildThisFileDirectory)..\tools\msbuild\net$(BundledNETCoreAppTargetFrameworkVersion)\</CoreiOSSdkDirectory>
     <CoreiOSSdkDirectory Condition="'$(_UseDesktopTaskAssemblies)' == 'true'">$(MSBuildThisFileDirectory)..\tools\msbuild\netstandard2.0\</CoreiOSSdkDirectory>
   </PropertyGroup>

--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -19,9 +19,6 @@
 	<Import Project="$(_MobilePropsPath)" Condition="Exists('$(_MobilePropsPath)') And ('$(BuildingInsideVisualStudio)' == 'true' Or '$(DesignTimeBuild)' == 'true')" />
 	
 	<PropertyGroup>
-		<!-- Keep using the desktop (netstandard2.0) MSBuild task assemblies when building from within Visual Studio (on Windows), instead of the net assemblies that require a .NET task host (which doesn't work reliably, in particular on Windows ARM64). The iOS Sdk.props sets this earlier because it also drives CoreiOSSdkDirectory; the condition below makes it apply to the other platforms (MacCatalyst, macOS, tvOS) too. -->
-		<_UseDesktopTaskAssemblies Condition="'$(_UseDesktopTaskAssemblies)' == '' And '$(BuildingInsideVisualStudio)' == 'true'">true</_UseDesktopTaskAssemblies>
-
 		<!-- Set to true when using the Microsoft.<platform>.Sdk NuGet. This is used by pre-existing/shared targets to tweak behavior depending on build system -->
 		<UsingAppleNETSdk>true</UsingAppleNETSdk>
 		<!-- This is the location of the Microsoft.<platform>.Sdk NuGet (/usr/local/share/dotnet/sdk/<version>/Sdks/Microsoft.[iOS/tvOS/MacCatalyst/macOS].Sdk) on the platform the build is running from (Mac or Win) -->

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -15,6 +15,17 @@
 		<_TaskAssemblyName Condition="'$(_UseDesktopTaskAssemblies)' == 'true'">$(_TaskAssemblyRootDirectory)netstandard2.0\$(_TaskAssemblyFileName)</_TaskAssemblyName>
 		<_TaskRuntime Condition="'$(_UseDesktopTaskAssemblies)' != 'true'">NET</_TaskRuntime>
 		<_TaskRuntime Condition="'$(_UseDesktopTaskAssemblies)' == 'true'">CurrentRuntime</_TaskRuntime>
+		<!--
+			The standard MSBuild task overrides (MakeDir, Copy, Delete, etc.) exist to support remoting
+			from VS/Windows to a Mac. These tasks inherit from the built-in MSBuild tasks and add remoting
+			logic, so they work fine with the netstandard2.0 assembly running in-process.
+			They do NOT need to use the .NET task host, and forcing them through it (Runtime="NET") causes
+			failures in Visual Studio, because VS can't reliably create the .NET task host process
+			(especially on Windows ARM64). By always using netstandard2.0 for these overrides (and not
+			setting the Runtime metadata), we avoid the task host issue while still allowing our custom
+			tasks to use the .NET Core assemblies via the task host.
+		-->
+		<_DesktopTaskAssemblyName>$(_TaskAssemblyRootDirectory)netstandard2.0\$(_TaskAssemblyFileName)</_DesktopTaskAssemblyName>
 	</PropertyGroup>
 
 	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Xamarin.MacDev.Tasks.CompileNativeCode" AssemblyFile="$(_TaskAssemblyName)" />

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -18,15 +18,19 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-	<!-- Tasks that override built-in tasks to support remoting from VS/Windows -->
-	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Microsoft.Build.Tasks.Copy" AssemblyFile="$(_TaskAssemblyName)" />
-	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Microsoft.Build.Tasks.Delete" AssemblyFile="$(_TaskAssemblyName)" />
-	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Microsoft.Build.Tasks.Exec" AssemblyFile="$(_TaskAssemblyName)" />
-	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Microsoft.Build.Tasks.MakeDir" AssemblyFile="$(_TaskAssemblyName)" />
-	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Microsoft.Build.Tasks.Move" AssemblyFile="$(_TaskAssemblyName)" />
-	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Microsoft.Build.Tasks.RemoveDir" AssemblyFile="$(_TaskAssemblyName)" />
-	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Microsoft.Build.Tasks.Touch" AssemblyFile="$(_TaskAssemblyName)" />
-	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Microsoft.Build.Tasks.WriteLinesToFile" AssemblyFile="$(_TaskAssemblyName)" />
+	<!-- Tasks that override built-in tasks to support remoting from VS/Windows.
+		 These always use the netstandard2.0 assembly (via _DesktopTaskAssemblyName) and don't set a
+		 Runtime, so they run in-process and don't require the .NET task host. Setting Runtime="NET"
+		 on these overrides causes failures in VS because the task host can't be created reliably
+		 (especially on ARM64). -->
+	<UsingTask TaskName="Microsoft.Build.Tasks.Copy" AssemblyFile="$(_DesktopTaskAssemblyName)" />
+	<UsingTask TaskName="Microsoft.Build.Tasks.Delete" AssemblyFile="$(_DesktopTaskAssemblyName)" />
+	<UsingTask TaskName="Microsoft.Build.Tasks.Exec" AssemblyFile="$(_DesktopTaskAssemblyName)" />
+	<UsingTask TaskName="Microsoft.Build.Tasks.MakeDir" AssemblyFile="$(_DesktopTaskAssemblyName)" />
+	<UsingTask TaskName="Microsoft.Build.Tasks.Move" AssemblyFile="$(_DesktopTaskAssemblyName)" />
+	<UsingTask TaskName="Microsoft.Build.Tasks.RemoveDir" AssemblyFile="$(_DesktopTaskAssemblyName)" />
+	<UsingTask TaskName="Microsoft.Build.Tasks.Touch" AssemblyFile="$(_DesktopTaskAssemblyName)" />
+	<UsingTask TaskName="Microsoft.Build.Tasks.WriteLinesToFile" AssemblyFile="$(_DesktopTaskAssemblyName)" />
 
 	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Xamarin.MacDev.Tasks.ACTool" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Xamarin.MacDev.Tasks.ALToolUpload" AssemblyFile="$(_TaskAssemblyName)" />


### PR DESCRIPTION
The standard MSBuild task overrides (MakeDir, Copy, Delete, etc.) in Xamarin.Shared.targets exist to support remoting from VS/Windows to a Mac. Previously, they shared the same Runtime and AssemblyFile as our custom tasks (via _TaskRuntime/_TaskAssemblyName), which meant when _TaskRuntime='NET', these standard task overrides would also try to use the .NET task host. This caused MSB4216 errors in Visual Studio because VS couldn't reliably create the .NET task host process (especially on Windows ARM64).

The fix introduces separate properties (_RemotingTaskRuntime and _RemotingTaskAssemblyName) for these standard task overrides, which always use the netstandard2.0 assembly with CurrentRuntime. This lets them run in-process without requiring the task host, while our custom tasks (Xamarin.MacDev.Tasks.*) continue to use the .NET Core assemblies via the task host as intended.

With this fix, the _UseDesktopTaskAssemblies workaround that forced ALL tasks to use netstandard2.0 when building inside Visual Studio is no longer needed and has been removed. The property is still honored as an escape hatch if explicitly set.

Fixes https://github.com/dotnet/macios/issues/25418