### PR TITLE
[dotnet] Add 'Desktop' classification to Mac Catalyst and macOS templates. Fixes #15136.

### DIFF
--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-controller/.template.config/template.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "macOS", "Mac Catalyst" ],
+  "classifications": [ "Desktop", "macOS", "Mac Catalyst" ],
   "name": "Mac Catalyst Controller",
   "description": "A MacCatalyst Controller class",
   "tags": {

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-storyboard/.template.config/template.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "macOS", "Mac Catalyst" ],
+  "classifications": [ "Desktop", "macOS", "Mac Catalyst" ],
   "name": "Mac Catalyst Storyboard",
   "description": "A MacCatalyst Storyboard",
   "tags": {

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-view/.template.config/template.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "macOS", "Mac Catalyst" ],
+  "classifications": [ "Desktop", "macOS", "Mac Catalyst" ],
   "name": "Mac Catalyst View",
   "description": "A MacCatalyst View",
   "tags": {

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst-viewcontroller/.template.config/template.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "macOS", "Mac Catalyst" ],
+  "classifications": [ "Desktop", "macOS", "Mac Catalyst" ],
   "name": "Mac Catalyst View Controller",
   "description": "A MacCatalyst View Controller class and xib",
   "tags": {

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/csharp/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/csharp/.template.config/template.json
@@ -2,6 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": [
+    "Desktop",
     "macOS",
     "Mac Catalyst"
   ],

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/visualbasic/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/visualbasic/.template.config/template.json
@@ -2,6 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": [
+    "Desktop",
     "macOS",
     "Mac Catalyst"
   ],

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/csharp/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/csharp/.template.config/template.json
@@ -1,7 +1,7 @@
 ﻿{
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "macOS", "Mac Catalyst" ],
+  "classifications": [ "Desktop", "macOS", "Mac Catalyst" ],
   "groupIdentity": "Microsoft.MacCatalyst.MacCatalystBinding",
   "identity": "Microsoft.MacCatalyst.MacCatalystBinding.CSharp",
   "name": "Mac Catalyst Binding Library",

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/csharp/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/csharp/.template.config/template.json
@@ -1,7 +1,7 @@
 ﻿{
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "macOS", "Mac Catalyst" ],
+  "classifications": [ "Desktop", "macOS", "Mac Catalyst" ],
   "groupIdentity": "Microsoft.MacCatalyst.MacCatalystLib",
   "identity": "Microsoft.MacCatalyst.MacCatalystLib.CSharp",
   "name": "Mac Catalyst Class Library",

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/visualbasic/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/visualbasic/.template.config/template.json
@@ -1,7 +1,7 @@
 ﻿{
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "macOS", "Mac Catalyst" ],
+  "classifications": [ "Desktop", "macOS", "Mac Catalyst" ],
   "groupIdentity": "Microsoft.MacCatalyst.MacCatalystLib",
   "identity": "Microsoft.MacCatalyst.MacCatalystLib.VisualBasic",
   "name": "Mac Catalyst Class Library",

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-controller/.template.config/template.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "macOS" ],
+  "classifications": [ "Desktop", "macOS" ],
   "name": "macOS Controller",
   "description": "A macOS View Controller with UI implemented in code",
   "tags": {

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-storyboard/.template.config/template.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "macOS" ],
+  "classifications": [ "Desktop", "macOS" ],
   "name": "macOS Storyboard",
   "description": "A macOS Storyboard",
   "tags": {

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-view/.template.config/template.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "macOS" ],
+  "classifications": [ "Desktop", "macOS" ],
   "name": "macOS View",
   "description": "A macOS View with UI implemented in Xcode's Interface Builder (XIB file)",
   "tags": {

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos-viewcontroller/.template.config/template.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "macOS" ],
+  "classifications": [ "Desktop", "macOS" ],
   "name": "macOS View Controller",
   "description": "A macOS View Controller with UI implemented in Xcode's Interface Builder (XIB file)",
   "tags": {

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/csharp/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/csharp/.template.config/template.json
@@ -2,6 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": [
+    "Desktop",
     "macOS"
   ],
   "groupIdentity": "Microsoft.macOS.macOSApp",

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/visualbasic/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/visualbasic/.template.config/template.json
@@ -2,6 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": [
+    "Desktop",
     "macOS"
   ],
   "groupIdentity": "Microsoft.macOS.macOSApp",

--- a/dotnet/Templates/Microsoft.macOS.Templates/macosbinding/csharp/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macosbinding/csharp/.template.config/template.json
@@ -1,7 +1,7 @@
 ﻿{
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "macOS" ],
+  "classifications": [ "Desktop", "macOS" ],
   "groupIdentity": "Microsoft.macOS.macOSBinding",
   "identity": "Microsoft.macOS.macOSBinding.CSharp",
   "name": "macOS Binding Library",

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/csharp/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/csharp/.template.config/template.json
@@ -1,7 +1,7 @@
 ﻿{
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "macOS" ],
+  "classifications": [ "Desktop", "macOS" ],
   "groupIdentity": "Microsoft.macOS.macOSLib",
   "identity": "Microsoft.macOS.macOSLib.CSharp",
   "name": "macOS Class Library",

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/visualbasic/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/visualbasic/.template.config/template.json
@@ -1,7 +1,7 @@
 ﻿{
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": [ "macOS" ],
+  "classifications": [ "Desktop", "macOS" ],
   "groupIdentity": "Microsoft.macOS.macOSLib",
   "identity": "Microsoft.macOS.macOSLib.VisualBasic",
   "name": "macOS Class Library",


### PR DESCRIPTION
Add "Desktop" to the `classifications` array in all Mac Catalyst and macOS template.json files so they appear in the appropriate Desktop template category in Visual Studio and `dotnet new` filtering.

Fixes https://github.com/dotnet/macios/issues/15136

🤖 Pull request created by Copilot