### PR TITLE
Set DOTNET_MODIFIABLE_ASSEMBLIES environment variable for CoreCLR

### DIFF
--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -65,6 +65,7 @@ namespace Xamarin.Bundler {
 		// The list of assemblies that we do generate debugging info for.
 		public bool DebugAll;
 		public bool UseInterpreter; // Only applicable to mobile platforms.
+		public bool UseInterpreterCoreCLR;
 		public List<string> DebugAssemblies = new List<string> ();
 		public Optimizations Optimizations = new Optimizations ();
 #if LEGACY_TOOLS

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -739,6 +739,8 @@ namespace Xamarin.Linker {
 			if (Application.XamarinRuntime != XamarinRuntime.MonoVM && Application.UseInterpreter) {
 				Application.Log (4, "The interpreter is enabled, but the current runtime isn't MonoVM. The interpreter settings will be ignored.");
 				Application.UnsetInterpreter ();
+				if (Application.XamarinRuntime == XamarinRuntime.CoreCLR)
+					Application.UseInterpreterCoreCLR = true;
 			}
 
 			Driver.ValidateXcode (Application, false, false);

--- a/tools/dotnet-linker/Steps/GenerateMainStep.cs
+++ b/tools/dotnet-linker/Steps/GenerateMainStep.cs
@@ -32,7 +32,7 @@ namespace Xamarin {
 			contents.AppendLine ();
 			contents.AppendLine ("static void xamarin_initialize_dotnet ()");
 			contents.AppendLine ("{");
-			if (Configuration.Application.PackageManagedDebugSymbols && Configuration.Application.UseInterpreter)
+			if (Configuration.Application.PackageManagedDebugSymbols && (Configuration.Application.UseInterpreter || Configuration.Application.UseInterpreterCoreCLR))
 				contents.AppendLine ($"\tsetenv (\"DOTNET_MODIFIABLE_ASSEMBLIES\", \"debug\", 1);");
 			contents.AppendLine ("}");
 			contents.AppendLine ();


### PR DESCRIPTION
When using the interpreter with CoreCLR runtime, set `DOTNET_MODIFIABLE_ASSEMBLIES=debug` environment variable in the generated `main.m`. This enables hot reload and modifiable assemblies support for CoreCLR on iOS.

Cherry-picked from thaystg/xamarin-macios@38db4b5899 (dev/thays/set_modifiable_assemblies_env_var).