### PR TITLE
[release/11.0.1xx-preview6] Update dependencies from dotnet/macios

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -12,7 +12,7 @@
     <!--  Begin: Package sources from dotnet-dotnet -->
     <!--  End: Package sources from dotnet-dotnet -->
     <!--  Begin: Package sources from dotnet-macios -->
-    <add key="darc-pub-dotnet-macios-ce56202" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-ce562026/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-macios-e6aeff4" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-e6aeff4e/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-macios -->
     <!--  Begin: Package sources from dotnet-emsdk -->
     <!--  End: Package sources from dotnet-emsdk -->

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -18,13 +18,13 @@ This file should be imported by eng/Versions.props
     <MicrosoftTemplateEngineAuthoringTasksPackageVersion>11.0.100-preview.6.26322.110</MicrosoftTemplateEngineAuthoringTasksPackageVersion>
     <!-- dotnet-macios dependencies -->
     <MicrosoftiOSSdknet100_260PackageVersion>26.0.11017</MicrosoftiOSSdknet100_260PackageVersion>
-    <MicrosoftiOSSdknet100_265PackageVersion>26.5.10299</MicrosoftiOSSdknet100_265PackageVersion>
+    <MicrosoftiOSSdknet100_265PackageVersion>26.5.10301</MicrosoftiOSSdknet100_265PackageVersion>
     <MicrosoftMacCatalystSdknet100_260PackageVersion>26.0.11017</MicrosoftMacCatalystSdknet100_260PackageVersion>
-    <MicrosoftMacCatalystSdknet100_265PackageVersion>26.5.10299</MicrosoftMacCatalystSdknet100_265PackageVersion>
+    <MicrosoftMacCatalystSdknet100_265PackageVersion>26.5.10301</MicrosoftMacCatalystSdknet100_265PackageVersion>
     <MicrosoftmacOSSdknet100_260PackageVersion>26.0.11017</MicrosoftmacOSSdknet100_260PackageVersion>
-    <MicrosoftmacOSSdknet100_265PackageVersion>26.5.10299</MicrosoftmacOSSdknet100_265PackageVersion>
+    <MicrosoftmacOSSdknet100_265PackageVersion>26.5.10301</MicrosoftmacOSSdknet100_265PackageVersion>
     <MicrosofttvOSSdknet100_260PackageVersion>26.0.11017</MicrosofttvOSSdknet100_260PackageVersion>
-    <MicrosofttvOSSdknet100_265PackageVersion>26.5.10299</MicrosofttvOSSdknet100_265PackageVersion>
+    <MicrosofttvOSSdknet100_265PackageVersion>26.5.10301</MicrosofttvOSSdknet100_265PackageVersion>
     <!-- dotnet-xharness dependencies -->
     <MicrosoftDotNetXHarnessiOSSharedPackageVersion>11.0.0-prerelease.26217.1</MicrosoftDotNetXHarnessiOSSharedPackageVersion>
   </PropertyGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,21 +43,21 @@
       <Sha>23eb1c2c9465fe76c810c8a69982c1254161f4b0</Sha>
     </Dependency>
     <!-- This is a subscription of the .NET 10/Xcode 26.5 versions of our packages -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.5" Version="26.5.10299">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.5" Version="26.5.10301">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>ce562026607fbe214874862de1f333064a0d2ff9</Sha>
+      <Sha>e6aeff4eaafa3918d4a27db2dcf5aba43cc3443c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.5" Version="26.5.10299">
+    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.5" Version="26.5.10301">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>ce562026607fbe214874862de1f333064a0d2ff9</Sha>
+      <Sha>e6aeff4eaafa3918d4a27db2dcf5aba43cc3443c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.5" Version="26.5.10299">
+    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.5" Version="26.5.10301">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>ce562026607fbe214874862de1f333064a0d2ff9</Sha>
+      <Sha>e6aeff4eaafa3918d4a27db2dcf5aba43cc3443c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.5" Version="26.5.10299">
+    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.5" Version="26.5.10301">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>ce562026607fbe214874862de1f333064a0d2ff9</Sha>
+      <Sha>e6aeff4eaafa3918d4a27db2dcf5aba43cc3443c</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>


### PR DESCRIPTION
This pull request updates the following dependencies

[marker]: <> (Begin:54e62af8-87ae-460e-96f0-34e0f6ffe51e)
## From https://github.com/dotnet/macios
- **Subscription**: [54e62af8-87ae-460e-96f0-34e0f6ffe51e](https://maestro.dot.net/subscriptions?search=54e62af8-87ae-460e-96f0-34e0f6ffe51e)
- **Build**: [20260629.13](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=14519240) ([320787](https://maestro.dot.net/channel/5173/github:dotnet:macios/build/320787))
- **Date Produced**: June 29, 2026 10:34:29 PM UTC
- **Commit**: [e6aeff4eaafa3918d4a27db2dcf5aba43cc3443c](https://github.com/dotnet/macios/commit/e6aeff4eaafa3918d4a27db2dcf5aba43cc3443c)
- **Branch**: [release/10.0.1xx](https://github.com/dotnet/macios/tree/release/10.0.1xx)

[DependencyUpdate]: <> (Begin)

- **Dependency Updates**:
  - From [26.5.10299 to 26.5.10301][1]
     - Microsoft.iOS.Sdk.net10.0_26.5
     - Microsoft.MacCatalyst.Sdk.net10.0_26.5
     - Microsoft.macOS.Sdk.net10.0_26.5
     - Microsoft.tvOS.Sdk.net10.0_26.5

[1]: https://github.com/dotnet/macios/compare/ce56202660...e6aeff4eaa

[DependencyUpdate]: <> (End)


[marker]: <> (End:54e62af8-87ae-460e-96f0-34e0f6ffe51e)