### PR TITLE
[tests] Mark tests inconclusive on premature response termination. Fixes #25873

### DIFF
--- a/tests/common/TestRuntime.cs
+++ b/tests/common/TestRuntime.cs
@@ -1624,6 +1624,7 @@ partial class TestRuntime {
 		IgnoreInCIIfSshConnectionError (ex);
 		IgnoreInCIIfTimedOut (ex);
 		IgnoreInCIIfHttpClientTimedOut (ex);
+		IgnoreInCIIfResponseEndedPrematurely (ex);
 	}
 
 	public static void IgnoreInCIIfBadNetwork (NSError? error)
@@ -1698,6 +1699,15 @@ partial class TestRuntime {
 		if (se is not null && se.SocketErrorCode == System.Net.Sockets.SocketError.TimedOut) {
 			IgnoreInCI ($"Ignored due to socket timeout: {se.Message}");
 		}
+	}
+
+	public static void IgnoreInCIIfResponseEndedPrematurely (Exception ex)
+	{
+		var httpIoEx = FindInner<HttpIOException> (ex);
+		if (httpIoEx is null)
+			return;
+
+		IgnoreInCI ($"Ignored due to premature response termination: {httpIoEx.Message}");
 	}
 
 	public static void IgnoreInCIIfForbidden (Exception ex)


### PR DESCRIPTION
The `MessageHandlerTest.AcceptSslCertificatesServicePointManager` test intermittently fails in CI because httpbin.org drops the TCP connection mid-response, producing an `HttpIOException: The response ended prematurely`. The existing `IgnoreInCIIfBadNetwork` helper didn't handle this exception type, so the test was reported as a hard failure rather than being marked inconclusive.

This adds an `IgnoreInCIIfResponseEndedPrematurely` check that catches `HttpIOException` and marks the test `Inconclusive` when running in CI, matching the pattern used for other transient network errors (DNS failures, timeouts, connection lost).

Fixes https://github.com/dotnet/macios/issues/25873

---
🤖 Pull request created by Copilot