### PR TITLE
[net11.0] Pass excluded user assemblies to crossgen2 as references for Debug R2R

### DIFF
--- a/dotnet/targets/Microsoft.Sdk.R2R.targets
+++ b/dotnet/targets/Microsoft.Sdk.R2R.targets
@@ -89,8 +89,10 @@
 			<PublishReadyToRunCompositeRoots Condition="$(RuntimeIdentifier.EndsWith('-arm64'))" Include="System.Private.CoreLib.dll" KeepDuplicates="false" />
 		</ItemGroup>
 
-		<!-- Hash the R2R input assemblies so we can detect when the set actually changes -->
-		<GetFileHash Files="@(_NonUserAssemblies)" Algorithm="SHA256">
+		<!-- Hash the R2R input assemblies so we can detect when the set actually changes.
+		     User assemblies are excluded from the composite but passed to crossgen2 as
+		     references, so include them to invalidate cached R2R images when they change. -->
+		<GetFileHash Files="@(_NonUserAssemblies);@(_UserAssemblies)" Algorithm="SHA256">
 			<Output TaskParameter="Items" ItemName="_NonUserAssembliesWithHash" />
 		</GetFileHash>
 		<Hash ItemsToHash="@(_NonUserAssembliesWithHash->'%(FileHash)')" IgnoreCase="false">
@@ -111,7 +113,17 @@
 		</ItemGroup>
 	</Target>
 
-	<!-- Touch R2R outputs when only user assemblies changed. If hash file is older than trigger, hash didn't change, so touch outputs to skip R2R -->
+	<Target Name="_AddExcludedAssembliesAsR2RCompositeReferences"
+			AfterTargets="_PrepareForReadyToRunCompilation"
+			BeforeTargets="_CreateR2RImages">
+		<ItemGroup>
+			<_ReadyToRunCompositeBuildReferences
+				Include="@(_ReadyToRunAssembliesToReference)"
+				Exclude="@(_ReadyToRunCompositeBuildInput);@(_ReadyToRunCompositeUnrootedBuildInput)" />
+		</ItemGroup>
+	</Target>
+
+	<!-- Touch R2R outputs when the R2R input set is unchanged. If hash file is older than trigger, hash didn't change, so touch outputs to skip R2R -->
 	<Target Name="_TouchR2ROutputs"
 			Condition="'$(FilterReadyToRunAssemblies)' == 'true' And Exists('$(_R2RInputHashFile)') And Exists('$(_R2RInputHashFile).trigger') And $([System.IO.File]::GetLastWriteTime('$(_R2RInputHashFile)').Ticks) &lt; $([System.IO.File]::GetLastWriteTime('$(_R2RInputHashFile).trigger').Ticks)"
 			AfterTargets="_PrepareForReadyToRunCompilation"


### PR DESCRIPTION
## Description

The Debug CoreCLR ReadyToRun composite build excludes user assemblies from compilation so they run interpreted, but it never hands them to crossgen2 as references, so when a rooted composite assembly explicitly implements an interface declared in one of those excluded assemblies, crossgen2 `ReadyToRunVisibilityRootProvider` resolves the declaring interface of every MethodImpl and fails to load the excluded assembly even though the file is published right next to the app.

Contributes #25830