### PR TITLE
Migrate nuget-msi-convert to v5.yml (WiX 6)

### DIFF
--- a/tools/devops/automation/templates/release/vs-insertion-prep.yml
+++ b/tools/devops/automation/templates/release/vs-insertion-prep.yml
@@ -74,7 +74,7 @@ stages:
         name: disableCodeQLOnArm64
 
   # Check - "xamarin-macios (Prepare Release Convert NuGet to MSI)"
-  - template: nuget-msi-convert/job/v4.yml@yaml-templates
+  - template: nuget-msi-convert/job/v5.yml@yaml-templates
     parameters:
       use1ESTemplate: true
       yamlResourceName: yaml-templates
@@ -184,7 +184,7 @@ stages:
         displayName: Set variable ReleaseDropPrefix
         condition: and(succeeded(), ne(variables['DOTNET_PLATFORMS'], ''))
 
-      # Download nugets drop created by nuget-msi-convert/job/v4.yml and publish to maestro
+      # Download nugets drop created by nuget-msi-convert/job/v5.yml and publish to maestro
       - task: ms-vscs-artifact.build-tasks.artifactDropDownloadTask-1.artifactDropDownloadTask@1
         displayName: Download $(ReleaseDropPrefix)/nugets
         inputs:


### PR DESCRIPTION
Equivalent of dotnet/android#11743 for dotnet/macios.

## Changes

- Switches the nuget-msi-convert template reference from `nuget-msi-convert/job/v4.yml@yaml-templates` to `nuget-msi-convert/job/v5.yml@yaml-templates` in `tools/devops/automation/templates/release/vs-insertion-prep.yml`.
- Updates the corresponding comment from `v4.yml` to `v5.yml`.

## What changed in v5 vs v4 (for reviewer context)

- WiX packages bumped to `6.0.3-dotnet.4` (was WiX 3)
- `swixBuildPackageVersion: 1.1.922` (was 1.1.392)
- `arcadePackageVersion: 11.0.0-beta.26325.102` (was 9.0.0-beta.24509.3)
- `arcadeTasksFxVersion: net` (was `netcoreapp3.1`)
- `dotNetSdkVersion: 10.0.x` (was 9.0.x — required, arcade 11.x tasks are net10.0)
- `convert.proj` now built with `DotNetCoreCLI@2 / dotnet msbuild` (Core MSBuild) instead of `MSBuild@1` desktop msbuild, because arcade 11.x workload tasks ship only `tools/net/` (.NETCoreApp v10). SwixBuild still uses desktop msbuild via the internal `_FindMSBuild` target.

All new parameters have sensible defaults in `v5.yml`, so dotnet/macios does not need to override any of them.