### PR TITLE
[net11.0] Exclude user assemblies from the Debug R2R input hash

### DIFF
--- a/dotnet/targets/Microsoft.Sdk.R2R.targets
+++ b/dotnet/targets/Microsoft.Sdk.R2R.targets
@@ -89,10 +89,8 @@
 			<PublishReadyToRunCompositeRoots Condition="$(RuntimeIdentifier.EndsWith('-arm64'))" Include="System.Private.CoreLib.dll" KeepDuplicates="false" />
 		</ItemGroup>
 
-		<!-- Hash the R2R input assemblies so we can detect when the set actually changes.
-		     User assemblies are excluded from the composite but passed to crossgen2 as
-		     references, so include them to invalidate cached R2R images when they change. -->
-		<GetFileHash Files="@(_NonUserAssemblies);@(_UserAssemblies)" Algorithm="SHA256">
+		<!-- Hash the R2R input assemblies so we can detect when the set actually changes -->
+		<GetFileHash Files="@(_NonUserAssemblies)" Algorithm="SHA256">
 			<Output TaskParameter="Items" ItemName="_NonUserAssembliesWithHash" />
 		</GetFileHash>
 		<Hash ItemsToHash="@(_NonUserAssembliesWithHash->'%(FileHash)')" IgnoreCase="false">
@@ -123,7 +121,7 @@
 		</ItemGroup>
 	</Target>
 
-	<!-- Touch R2R outputs when the R2R input set is unchanged. If hash file is older than trigger, hash didn't change, so touch outputs to skip R2R -->
+	<!-- Touch R2R outputs when only user assemblies changed. If hash file is older than trigger, hash didn't change, so touch outputs to skip R2R -->
 	<Target Name="_TouchR2ROutputs"
 			Condition="'$(FilterReadyToRunAssemblies)' == 'true' And Exists('$(_R2RInputHashFile)') And Exists('$(_R2RInputHashFile).trigger') And $([System.IO.File]::GetLastWriteTime('$(_R2RInputHashFile)').Ticks) &lt; $([System.IO.File]::GetLastWriteTime('$(_R2RInputHashFile).trigger').Ticks)"
 			AfterTargets="_PrepareForReadyToRunCompilation"

--- a/tests/dotnet/UnitTests/IncrementalBuildTest.cs
+++ b/tests/dotnet/UnitTests/IncrementalBuildTest.cs
@@ -324,15 +324,15 @@ kernel void myKernel (texture2d<half, access::read> inTexture [[texture(0)]],
 
 			var rv = DotNet.AssertBuild (project_path, properties);
 			var allTargets = BinLog.GetAllTargets (rv.BinLogPath);
-			AssertTargetExecuted (allTargets, "_SelectR2RAssemblies", "A");
-			AssertTargetExecuted (allTargets, "_CreateR2RImages", "A");
+			AssertTargetExecuted (allTargets, "_SelectR2RAssemblies", "First build");
+			AssertTargetExecuted (allTargets, "_CreateR2RImages", "First build");
 
 			properties ["AdditionalDefineConstants"] = "INCLUDED_ADDITIONAL_CODE";
 
 			rv = DotNet.AssertBuild (project_path, properties);
 			allTargets = BinLog.GetAllTargets (rv.BinLogPath);
-			AssertTargetExecuted (allTargets, "_TouchR2ROutputs", "B");
-			AssertTargetNotExecuted (allTargets, "_CreateR2RImages", "B");
+			AssertTargetExecuted (allTargets, "_TouchR2ROutputs", "Second build");
+			AssertTargetNotExecuted (allTargets, "_CreateR2RImages", "Second build");
 		}
 
 		void CodeChangeSkipsTargetsImpl (ApplePlatform platform, string runtimeIdentifiers, bool useMonoRuntime, bool interpreterEnabled)

--- a/tests/dotnet/UnitTests/IncrementalBuildTest.cs
+++ b/tests/dotnet/UnitTests/IncrementalBuildTest.cs
@@ -321,7 +321,6 @@ kernel void myKernel (texture2d<half, access::read> inTexture [[texture(0)]],
 			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
 			Clean (project_path);
 			var properties = GetDefaultProperties (runtimeIdentifiers);
-			properties ["UseMonoRuntime"] = "false";
 
 			var rv = DotNet.AssertBuild (project_path, properties);
 			var allTargets = BinLog.GetAllTargets (rv.BinLogPath);

--- a/tests/dotnet/UnitTests/IncrementalBuildTest.cs
+++ b/tests/dotnet/UnitTests/IncrementalBuildTest.cs
@@ -309,6 +309,33 @@ kernel void myKernel (texture2d<half, access::read> inTexture [[texture(0)]],
 			AssertTargetNotExecuted (allTargets, "_TemperMetal", "Second build");
 		}
 
+		[Test]
+		[TestCase (ApplePlatform.iOS, "iossimulator-arm64")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
+		public void UserCodeChangeSkipsR2RCompilation_CoreCLR (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			var project = "IncrementalTestApp";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["UseMonoRuntime"] = "false";
+
+			var rv = DotNet.AssertBuild (project_path, properties);
+			var allTargets = BinLog.GetAllTargets (rv.BinLogPath);
+			AssertTargetExecuted (allTargets, "_SelectR2RAssemblies", "A");
+			AssertTargetExecuted (allTargets, "_CreateR2RImages", "A");
+
+			properties ["AdditionalDefineConstants"] = "INCLUDED_ADDITIONAL_CODE";
+
+			rv = DotNet.AssertBuild (project_path, properties);
+			allTargets = BinLog.GetAllTargets (rv.BinLogPath);
+			AssertTargetExecuted (allTargets, "_TouchR2ROutputs", "B");
+			AssertTargetNotExecuted (allTargets, "_CreateR2RImages", "B");
+		}
+
 		void CodeChangeSkipsTargetsImpl (ApplePlatform platform, string runtimeIdentifiers, bool useMonoRuntime, bool interpreterEnabled)
 		{
 			var project = "IncrementalTestApp";


### PR DESCRIPTION
## Description

User assemblies are passed to crossgen2 only as `-r:` references, which places them outside the composite version bubble, so crossgen2 reaches their types through runtime fixups rather than inlining or hardcoded layout. A change to a user assembly is resolved at load time and does not require recompiling the composite, so including them in the R2R input hash only forces crossgen2 to rerun on every user-code edit and defeats the Debug caching. This reverts the hash back to `@(_NonUserAssemblies)` only, matching how the .NET SDK's `_CreateR2RImages` incremental inputs already treat references.

Follow-up to #25879.