### PR TITLE
[dotnet] Enable AOT generic instantiation deduplication when PrepareAssemblies=true

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1479,6 +1479,35 @@
 		</ItemGroup>
 	</Target>
 
+	<!--
+		When the assembly-preparer is used to post-process assemblies (PostProcessAssemblies=true), the set of
+		assemblies that gets AOT-compiled (and which is used to detect AOT generic instantiation deduplication)
+		is computed from ResolvedFileToPublish instead of from the linker's own assembly collection. The dedup
+		assembly (aot-instances.dll) is only added to the linker's assembly collection (via ManagedAssemblyToLink
+		and TrimmerRootAssembly in _CreateAOTDedupAssembly), so it's not part of ResolvedFileToPublish, and as a
+		result deduplication would be disabled in this case. Add the dedup assembly to ResolvedFileToPublish so
+		that it's included in the set of assemblies the assembly-preparer processes, and deduplication is enabled
+		in this case as well.
+	-->
+	<Target Name="_AddDedupAssemblyToResolvedFileToPublish"
+			Condition="'$(_IsDedupEnabled)' == 'true' And '$(PostProcessAssemblies)' == 'true'"
+			DependsOnTargets="_ComputeVariables"
+			BeforeTargets="_PrepareAssembliesForPostProcessing">
+		<ItemGroup>
+			<!-- Find out if the dedup assembly is already part of ResolvedFileToPublish (it will be when
+			     trimming is enabled, because then it goes through ILLink like any other assembly). -->
+			<_DedupAssemblyInResolvedFileToPublish Include="@(ResolvedFileToPublish)" Condition="'%(Filename)%(Extension)' == 'aot-instances.dll'" />
+		</ItemGroup>
+		<ItemGroup Condition="'@(_DedupAssemblyInResolvedFileToPublish)' == ''">
+			<ResolvedFileToPublish Include="$(_DedupAssembly)">
+				<PublishFolderType>Assembly</PublishFolderType>
+				<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+				<RelativePath>$(_AssemblyPublishDir)aot-instances.dll</RelativePath>
+				<OriginalRelativePath>aot-instances.dll</OriginalRelativePath>
+			</ResolvedFileToPublish>
+		</ItemGroup>
+	</Target>
+
 	<Target Name="_ComputeDotNetRoot">
 		<PropertyGroup>
 			<_DotNetRoot Condition="'$(IsMacEnabled)' == 'true'">$(_DotNetRootRemoteDirectory)</_DotNetRoot>

--- a/tests/dotnet/UnitTests/PerformanceTests.cs
+++ b/tests/dotnet/UnitTests/PerformanceTests.cs
@@ -1,51 +1,173 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
+
 namespace Xamarin.Tests {
 	[TestFixture]
 	public class PerformanceTests : TestBaseClass {
 		[Test]
-		[TestCase (ApplePlatform.iOS, "iossimulator-arm64")]
-		public void PrepareAssemblies (ApplePlatform platform, string runtimeIdentifiers)
+		[TestCase (ApplePlatform.iOS, false)]
+		public void PrepareAssemblies (ApplePlatform platform, bool useMonoRuntime)
 		{
 			Configuration.IgnoreIfIgnoredPlatform (platform);
+
+			string runtimeIdentifiers;
+			switch (platform) {
+			case ApplePlatform.iOS:
+				runtimeIdentifiers = "iossimulator-arm64;ios-arm64";
+				break;
+			case ApplePlatform.TVOS:
+				runtimeIdentifiers = "tvossimulator-arm64;tvos-arm64";
+				break;
+			case ApplePlatform.MacCatalyst:
+				runtimeIdentifiers = "maccatalyst-arm64";
+				break;
+			case ApplePlatform.MacOSX:
+				runtimeIdentifiers = "osx-arm64";
+				break;
+			default:
+				Assert.Inconclusive ($"Don't know which runtime identifiers to use for {platform}");
+				return;
+			}
+
 			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
 
-			if (string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("ENABLE_PERFORMANCE_TESTS")))
+			var enablePerformanceTests = Environment.GetEnvironmentVariable ("ENABLE_PERFORMANCE_TESTS");
+			if (string.IsNullOrEmpty (enablePerformanceTests))
 				Assert.Ignore ("Test ignored because ENABLE_PERFORMANCE_TESTS is not set.");
 
+			var watch = Stopwatch.StartNew ();
 			var projects = new string [] { "MySimpleApp", "monotouch-test" };
 			var results = new List<PrepareAssembliesTestResult> ();
 			var attempts = 3;
+			var report = new StringBuilder ();
 			foreach (var project in projects) {
-				var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
+				var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var _);
 
-				var result = new PrepareAssembliesTestResult {
-					Project = project,
-				};
-				foreach (var propertyValue in new bool [] { false, true }) {
-					var properties = GetDefaultProperties (runtimeIdentifiers);
-					properties ["PrepareAssemblies"] = propertyValue.ToString ();
+				foreach (var rid in runtimeIdentifiers.Split (';')) {
+					foreach (var linkMode in new string [] { "None", "SdkOnly" }) {
+						var result = new PrepareAssembliesTestResult {
+							Project = project,
+							RuntimeIdentifier = rid,
+							LinkMode = linkMode,
+						};
+						foreach (var propertyValue in new bool [] { false, true }) {
+							var properties = GetDefaultProperties (rid);
+							properties ["PrepareAssemblies"] = propertyValue.ToString ();
+							properties ["MtouchLink"] = linkMode;
+							properties ["UseMonoRuntime"] = useMonoRuntime ? "true" : "false";
 
-					for (var i = 1; i <= attempts; i++) {
-						Clean (project_path);
-						var rv = DotNet.AssertBuild (project_path, properties);
-						(propertyValue ? result.EnabledBuildTimes : result.DisabledBuildTimes).Add (rv.Duration);
+							for (var i = 1; i <= attempts; i++) {
+								Clean (project_path);
+								var rv = DotNet.AssertBuild (project_path, properties);
+								result.GetBuildTimes (propertyValue).Times.Add (rv);
+							}
+						}
+						results.Add (result);
 					}
 				}
-				results.Add (result);
 			}
-			foreach (var result in results.OrderBy (v => v.Project)) {
-				Console.WriteLine ($"Results for: {result.Project}");
-				Console.WriteLine ($" Enabled timings: {string.Join (", ", result.EnabledBuildTimes.Select (v => v.ToString ()))} average: {TimeSpan.FromTicks ((long) result.EnabledBuildTimes.Average (v => v.Ticks))}");
-				Console.WriteLine ($" Disabled timings: {string.Join (", ", result.DisabledBuildTimes.Select (v => v.ToString ()))} average: {TimeSpan.FromTicks ((long) result.DisabledBuildTimes.Average (v => v.Ticks))}");
+			var orderedResults = results.OrderBy (v => v.Project).ThenBy (v => v.RuntimeIdentifier).ThenBy (v => v.LinkMode).ToList ();
+
+			var runtime = useMonoRuntime ? "MonoVM" : "CoreCLR";
+
+			report.AppendLine ($"# PrepareAssemblies performance report ({platform.AsString ()}/{runtime})");
+			report.AppendLine ();
+			report.AppendLine ("## Summary");
+			report.AppendLine ();
+			var summaryHeaders = new [] { "Project", "Runtime identifier", "Link mode", "PrepareAssemblies=false", "PrepareAssemblies=true", "Difference" };
+			var summaryRows = new List<string []> ();
+			foreach (var result in orderedResults) {
+				summaryRows.Add (new [] {
+					result.Project,
+					result.RuntimeIdentifier,
+					result.LinkMode,
+					result.GetBuildTimes (false).Average.ToString (),
+					result.GetBuildTimes (true).Average.ToString (),
+					result.AverageDifference.ToString (),
+				});
 			}
+			AppendMarkdownTable (report, summaryHeaders, summaryRows);
+			report.AppendLine ();
+
+			foreach (var result in orderedResults) {
+				report.AppendLine ($"## {result.Project} ({result.RuntimeIdentifier} / LinkMode={result.LinkMode})");
+				report.AppendLine ();
+				var disabledTimes = result.GetBuildTimes (false).Times;
+				var enabledTimes = result.GetBuildTimes (true).Times;
+				var runCount = Math.Max (disabledTimes.Count, enabledTimes.Count);
+				var detailHeaders = new [] { "Run", "Disabled", "Enabled", "Disabled binlog", "Enabled binlog" };
+				var detailRows = new List<string []> ();
+				for (var i = 0; i < runCount; i++) {
+					var disabled = i < disabledTimes.Count ? disabledTimes [i] : null;
+					var enabled = i < enabledTimes.Count ? enabledTimes [i] : null;
+					detailRows.Add (new [] {
+						$"#{i + 1}",
+						disabled?.Duration.ToString () ?? "",
+						enabled?.Duration.ToString () ?? "",
+						disabled?.BinLogPath ?? "",
+						enabled?.BinLogPath ?? "",
+					});
+				}
+				detailRows.Add (new [] {
+					"**Average**",
+					result.GetBuildTimes (false).Average.ToString (),
+					result.GetBuildTimes (true).Average.ToString (),
+					"",
+					"",
+				});
+				AppendMarkdownTable (report, detailHeaders, detailRows);
+				report.AppendLine ();
+				report.AppendLine ($"Difference (of average): {result.AverageDifference}");
+				report.AppendLine ();
+			}
+
+			report.AppendLine ($"Total duration: {watch.Elapsed}");
+			Console.WriteLine (report);
+
+			if (enablePerformanceTests.Contains ("%SPEC%")) {
+				for (var i = 1; i < 256; i++) {
+					var path = enablePerformanceTests.Replace ("%SPEC%", $"{platform.AsString ()}-{runtime}-{i}");
+					if (File.Exists (path))
+						continue;
+					File.WriteAllText (path, report.ToString ());
+					Console.WriteLine ($"Wrote report to: {path}");
+					break;
+				}
+			}
+		}
+
+		static void AppendMarkdownTable (StringBuilder report, string [] headers, List<string []> rows)
+		{
+			var widths = new int [headers.Length];
+			for (var i = 0; i < headers.Length; i++)
+				widths [i] = headers [i].Length;
+			foreach (var row in rows) {
+				for (var i = 0; i < row.Length; i++)
+					widths [i] = Math.Max (widths [i], row [i].Length);
+			}
+
+			report.AppendLine ("| " + string.Join (" | ", headers.Select ((h, i) => h.PadRight (widths [i]))) + " |");
+			report.AppendLine ("| " + string.Join (" | ", widths.Select (w => new string ('-', w))) + " |");
+			foreach (var row in rows)
+				report.AppendLine ("| " + string.Join (" | ", row.Select ((c, i) => c.PadRight (widths [i]))) + " |");
 		}
 
 		class PrepareAssembliesTestResult {
 			public required string Project;
-			public List<TimeSpan> EnabledBuildTimes = new ();
-			public List<TimeSpan> DisabledBuildTimes = new ();
+			public required string RuntimeIdentifier;
+			public required string LinkMode;
+			BuildTimes EnabledBuildTimes = new ();
+			BuildTimes DisabledBuildTimes = new ();
+
+			public BuildTimes GetBuildTimes (bool enabled) => enabled ? EnabledBuildTimes : DisabledBuildTimes;
+			public TimeSpan AverageDifference => EnabledBuildTimes.Average - DisabledBuildTimes.Average;
+		}
+
+		class BuildTimes {
+			public List<ExecutionResult> Times = new ();
+			public TimeSpan Average => TimeSpan.FromTicks ((long) Times.Average (v => v.Duration.Ticks));
 		}
 	}
 }

--- a/tests/dotnet/UnitTests/PerformanceTests.cs
+++ b/tests/dotnet/UnitTests/PerformanceTests.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Tests {
 	[TestFixture]
 	public class PerformanceTests : TestBaseClass {
 		[Test]
-		[TestCase (ApplePlatform.iOS, false)]
+		[TestCase (ApplePlatform.iOS, true)]
 		public void PrepareAssemblies (ApplePlatform platform, bool useMonoRuntime)
 		{
 			Configuration.IgnoreIfIgnoredPlatform (platform);

--- a/tools/assembly-preparer/PopulateApplicationAssembliesStep.cs
+++ b/tools/assembly-preparer/PopulateApplicationAssembliesStep.cs
@@ -35,6 +35,7 @@ namespace MonoTouch.Tuner {
 					break;
 				default:
 					var ad = Configuration.Application.AddAssembly (assemblyDefinition);
+					ad.IsDedupAssembly = Path.GetFileName (Configuration.DedupAssembly).Equals (Path.GetFileName (assembly.OutputPath), StringComparison.OrdinalIgnoreCase);
 					ad.FullPath = assembly.OutputPath;
 					break;
 				}


### PR DESCRIPTION
When the assembly-preparer is used to post-process assemblies
(PrepareAssemblies/PostProcessAssemblies=true), the set of assemblies that gets
AOT-compiled - and which is used to detect AOT generic instantiation
deduplication - is computed from ResolvedFileToPublish (via the assembly-preparer's
ComputeAOTArguments step) instead of from the linker's own in-memory assembly
collection.

The dedup container assembly (aot-instances.dll) is only added to the linker's
assembly collection (ManagedAssemblyToLink/TrimmerRootAssembly in
_CreateAOTDedupAssembly), so it was never part of ResolvedFileToPublish. As a
result, the assembly-preparer never saw the dedup assembly, deduplication was
disabled, and every assembly was AOT-compiled with 'full' (compiling all generic
instantiations redundantly) instead of 'dedup-skip'. This roughly doubled the AOT
compiler's work (e.g. _AOTCompile for monotouch-test went from ~48s to ~76s).

Fix this with two changes:

* Add the dedup assembly to ResolvedFileToPublish when the assembly-preparer
  post-process path is used and deduplication is enabled, so it's included in the
  set of assemblies the assembly-preparer processes (and AOT-compiles). The add is
  guarded so it doesn't duplicate an entry that's already present.

* Set Assembly.IsDedupAssembly in the assembly-preparer's
  PopulateApplicationAssembliesStep, exactly like LoadNonSkippedAssembliesStep does
  in the ILLink path, so the dedup container is recognized as AOT-compiled and gets
  the 'dedup-include' flag (while the other assemblies get 'dedup-skip').

Also improved the perf test.

Before build times:

| Project        | Runtime identifier | Link mode | Disabled (average) | Enabled (average) | Difference (of average) |
| -------------- | ------------------ | --------- | ------------------ | ----------------- | ----------------------- |
| monotouch-test | ios-arm64          | None      | 00:02:07.0742190   | 00:02:48.9871886  | 00:00:41.9129696        |
| monotouch-test | ios-arm64          | SdkOnly   | 00:01:20.4693850   | 00:01:56.3924870  | 00:00:35.9231020        |
| monotouch-test | iossimulator-arm64 | None      | 00:01:37.4725223   | 00:02:16.4294141  | 00:00:38.9568918        |
| monotouch-test | iossimulator-arm64 | SdkOnly   | 00:01:11.8543345   | 00:01:27.3413050  | 00:00:15.4869705        |
| MySimpleApp    | ios-arm64          | None      | 00:01:18.7859068   | 00:01:54.7023664  | 00:00:35.9164596        |
| MySimpleApp    | ios-arm64          | SdkOnly   | 00:00:21.7704550   | 00:00:53.0059895  | 00:00:31.2355345        |
| MySimpleApp    | iossimulator-arm64 | None      | 00:00:54.6666308   | 00:01:26.3723282  | 00:00:31.7056974        |
| MySimpleApp    | iossimulator-arm64 | SdkOnly   | 00:00:19.7740878   | 00:00:34.5455132  | 00:00:14.7714254        |

After build times:

| Project        | Runtime identifier | Link mode | Disabled (average) | Enabled (average) | Difference (of average) |
| -------------- | ------------------ | --------- | ------------------ | ----------------- | ----------------------- |
| monotouch-test | ios-arm64          | None      | 00:02:05.4666859   | 00:02:09.6491832  | 00:00:04.1824973        |
| monotouch-test | ios-arm64          | SdkOnly   | 00:01:20.1368215   | 00:01:45.1826245  | 00:00:25.0458030        |
| monotouch-test | iossimulator-arm64 | None      | 00:01:34.2666644   | 00:01:38.9737062  | 00:00:04.7070418        |
| monotouch-test | iossimulator-arm64 | SdkOnly   | 00:01:06.9120929   | 00:01:18.3662064  | 00:00:11.4541135        |
| MySimpleApp    | ios-arm64          | None      | 00:01:20.3001297   | 00:01:23.2613776  | 00:00:02.9612479        |
| MySimpleApp    | ios-arm64          | SdkOnly   | 00:00:20.4954960   | 00:00:47.6480467  | 00:00:27.1525507        |
| MySimpleApp    | iossimulator-arm64 | None      | 00:00:53.6472697   | 00:00:55.3882440  | 00:00:01.7409743        |
| MySimpleApp    | iossimulator-arm64 | SdkOnly   | 00:00:19.2538091   | 00:00:31.0467173  | 00:00:11.7929082        |