### PR TITLE
[devops] Switch CI builds to use ACES pool

### DIFF
--- a/tools/devops/automation/build-pipeline.yml
+++ b/tools/devops/automation/build-pipeline.yml
@@ -132,7 +132,7 @@ extends:
           forceInsertion: ${{ parameters.forceInsertion }}
           pushNugets: ${{ parameters.pushNugets }}
           pushNugetsToMaestro: ${{ parameters.pushNugetsToMaestro }}
-          useACES: false  # flip to true to opt CI into ACES; see templates/variables/common.yml
+          useACES: true  # see templates/variables/common.yml
 
       - template: localization/v1.yml@yaml-templates
         parameters:

--- a/tools/devops/automation/run-ci-api-diff.yml
+++ b/tools/devops/automation/run-ci-api-diff.yml
@@ -17,4 +17,4 @@ extends:
   parameters:
     isPR: false
     pool: $(CIBuildPool)
-    useACES: false  # flip to true to opt CI api-diff into ACES; see templates/variables/common.yml
+    useACES: true  # see templates/variables/common.yml

--- a/tools/devops/automation/run-post-ci-build-tests.yml
+++ b/tools/devops/automation/run-post-ci-build-tests.yml
@@ -17,4 +17,4 @@ extends:
   template: templates/pipelines/run-tests-pipeline.yml
   parameters:
     isPR: false
-    useACES: false  # flip to true to opt CI simulator tests into ACES; see templates/variables/common.yml
+    useACES: true  # see templates/variables/common.yml

--- a/tools/devops/automation/templates/variables/common.yml
+++ b/tools/devops/automation/templates/variables/common.yml
@@ -66,14 +66,14 @@ variables:
 # point — they are runtime-only. So there is no working "single global
 # variable" we can read here; the literal lives in each entry pipeline:
 #
-#   CI (uses CIBuildPool / ACES):
+#   CI:
 #     - build-pipeline.yml            -> useACES: true
 #     - run-ci-api-diff.yml           -> useACES: true
 #     - run-post-ci-build-tests.yml   -> useACES: true
-#   PR (uses PRBuildPool):
-#     - build-pull-request.yml        -> useACES: false
-#     - run-pr-api-diff.yml           -> useACES: false
-#     - run-post-pr-build-tests.yml   -> useACES: false
+#   PR:
+#     - build-pull-request.yml        -> useACES: true
+#     - run-pr-api-diff.yml           -> useACES: true
+#     - run-post-pr-build-tests.yml   -> useACES: true
 #
 # Flip the literal in the three files on the side you want to move (e.g. when
 # the ACES pool is unavailable, or when you need an Xcode/macOS beta that is


### PR DESCRIPTION
PR builds have been running on the ACES shared pool successfully. This switches
the three CI entry pipelines to use ACES as well, so all builds run on the same
pool infrastructure.

Pipelines changed:
- `build-pipeline.yml`
- `run-ci-api-diff.yml`
- `run-post-ci-build-tests.yml`

Also updates the documentation comment in `templates/variables/common.yml` to
reflect the current state (all pipelines now use ACES).

🤖 Pull request created by Copilot