### PR TITLE
[github-actions] Ignore gh-aw-managed actions in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
     ignore:
       - dependency-name: "github/gh-aw-actions/**"
       - dependency-name: "github/gh-aw-actions"  # Managed by gh aw compile. Version-locked to the gh-aw compiler; do not bump.
+      # The following actions only appear in gh-aw generated workflow files
+      # (*.lock.yml and agentics-maintenance.yml). They are managed by the
+      # gh-aw compiler and should not be bumped by dependabot.
+      - dependency-name: "actions/cache/**"
+      - dependency-name: "actions/download-artifact"
+      - dependency-name: "actions/setup-node"


### PR DESCRIPTION
Actions like actions/cache/save, actions/cache/restore, actions/download-artifact,
and actions/setup-node are only used in gh-aw generated workflow files (*.lock.yml
and agentics-maintenance.yml). Dependabot should not bump these since they are
managed by the gh-aw compiler.

Fixes https://github.com/dotnet/macios/pull/25897
Fixes https://github.com/dotnet/macios/pull/25899

🤖 Pull request created by Copilot