### PR TITLE
[dotnet] Default PublishTrimmed=false when there's nothing for the trimmer to do.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -319,13 +319,24 @@
 	<Target Name="_ComputePublishTrimmed">
 		<PropertyGroup>
 			<_MustTrim Condition="'$(_MustTrim)' == '' And '$(RuntimeIdentifier)' != '' And ($(_ProjectType.EndsWith('ExecutableProject')) Or $(_ProjectType.EndsWith('AppExtensionProject'))) And '$(IsMacEnabled)' == 'true'">true</_MustTrim>
+
+			<!--
+				If we're not trimming anything (the link mode is 'None', which means no assemblies are trimmed) and
+				we're not running any custom trimmer steps (which is the case when both PrepareAssemblies and
+				PostProcessAssemblies are 'true', because then all the custom trimmer steps are moved to the
+				assembly-preparer's post-processing step instead), then there's nothing for the trimmer to do, so
+				default PublishTrimmed to false to skip running the trimmer entirely.
+			-->
+			<_CanSkipTrimmer Condition="'$(_CanSkipTrimmer)' == '' And '$(_LinkMode)' == 'None' And '$(TrimMode)' == 'copy' And '$(PrepareAssemblies)' == 'true' And '$(PostProcessAssemblies)' == 'true'">true</_CanSkipTrimmer>
+			<PublishTrimmed Condition="'$(PublishTrimmed)' == '' And '$(_CanSkipTrimmer)' == 'true'">false</PublishTrimmed>
+
 			<PublishTrimmed Condition="'$(PublishTrimmed)' == '' And '$(_MustTrim)' == 'true'">true</PublishTrimmed>
 
 			<_LinkModeProperty Condition="'$(_PlatformName)' == 'macOS'">LinkMode</_LinkModeProperty>
 			<_LinkModeProperty Condition="'$(_PlatformName)' != 'macOS'">MtouchLink</_LinkModeProperty>
 		</PropertyGroup>
-		<Error Condition="'$(_MustTrim)' == 'true' And '$(PublishTrimmed)' != 'true'" Text="$(_PlatformName) projects must build with PublishTrimmed=true. Current value: $(PublishTrimmed). Set '$(_LinkModeProperty)=None' instead to disable trimming for all assemblies." />
-		<PropertyGroup Condition="'$(PublishTrimmed)' != '' And '$(IsMacEnabled)' != 'true'">
+		<Error Condition="'$(_MustTrim)' == 'true' And '$(PublishTrimmed)' != 'true' And '$(_CanSkipTrimmer)' != 'true'" Text="$(_PlatformName) projects must build with PublishTrimmed=true. Current value: $(PublishTrimmed). Set '$(_LinkModeProperty)=None' instead to disable trimming for all assemblies." />
+		<PropertyGroup Condition="'$(PublishTrimmed)' != '' And '$(IsMacEnabled)' != 'true' And '$(_CanSkipTrimmer)' != 'true'">
 			<_PreviousPublishTrimmedValue>$(PublishTrimmed)</_PreviousPublishTrimmedValue>
 			<PublishTrimmed />
 		</PropertyGroup>
@@ -1491,7 +1502,7 @@
 	-->
 	<Target Name="_AddDedupAssemblyToResolvedFileToPublish"
 			Condition="'$(_IsDedupEnabled)' == 'true' And '$(PostProcessAssemblies)' == 'true'"
-			DependsOnTargets="_ComputeVariables"
+			DependsOnTargets="_ComputeVariables;_CreateAOTDedupAssembly"
 			BeforeTargets="_PrepareAssembliesForPostProcessing">
 		<ItemGroup>
 			<!-- Find out if the dedup assembly is already part of ResolvedFileToPublish (it will be when

--- a/tests/dotnet/UnitTests/PerformanceTests.cs
+++ b/tests/dotnet/UnitTests/PerformanceTests.cs
@@ -83,9 +83,9 @@ namespace Xamarin.Tests {
 					result.Project,
 					result.RuntimeIdentifier,
 					result.LinkMode,
-					result.GetBuildTimes (false).Average.ToString (),
-					result.GetBuildTimes (true).Average.ToString (),
-					result.AverageDifference.ToString (),
+					FormatTimeSpan (result.GetBuildTimes (false).Average),
+					FormatTimeSpan (result.GetBuildTimes (true).Average),
+					FormatTimeSpan (result.AverageDifference),
 				});
 			}
 			AppendMarkdownTable (report, summaryHeaders, summaryRows);
@@ -104,26 +104,26 @@ namespace Xamarin.Tests {
 					var enabled = i < enabledTimes.Count ? enabledTimes [i] : null;
 					detailRows.Add (new [] {
 						$"#{i + 1}",
-						disabled?.Duration.ToString () ?? "",
-						enabled?.Duration.ToString () ?? "",
+						disabled is not null ? FormatTimeSpan (disabled.Duration) : "",
+						enabled is not null ? FormatTimeSpan (enabled.Duration) : "",
 						disabled?.BinLogPath ?? "",
 						enabled?.BinLogPath ?? "",
 					});
 				}
 				detailRows.Add (new [] {
 					"**Average**",
-					result.GetBuildTimes (false).Average.ToString (),
-					result.GetBuildTimes (true).Average.ToString (),
+					FormatTimeSpan (result.GetBuildTimes (false).Average),
+					FormatTimeSpan (result.GetBuildTimes (true).Average),
 					"",
 					"",
 				});
 				AppendMarkdownTable (report, detailHeaders, detailRows);
 				report.AppendLine ();
-				report.AppendLine ($"Difference (of average): {result.AverageDifference}");
+				report.AppendLine ($"Difference (of average): {FormatTimeSpan (result.AverageDifference)}");
 				report.AppendLine ();
 			}
 
-			report.AppendLine ($"Total duration: {watch.Elapsed}");
+			report.AppendLine ($"Total duration: {FormatTimeSpan (watch.Elapsed)}");
 			Console.WriteLine (report);
 
 			if (enablePerformanceTests.Contains ("%SPEC%")) {
@@ -137,6 +137,8 @@ namespace Xamarin.Tests {
 				}
 			}
 		}
+
+		static string FormatTimeSpan (TimeSpan value) => value.ToString (@"hh\:mm\:ss\.ff");
 
 		static void AppendMarkdownTable (StringBuilder report, string [] headers, List<string []> rows)
 		{

--- a/tests/dotnet/UnitTests/PublishTrimmedTest.cs
+++ b/tests/dotnet/UnitTests/PublishTrimmedTest.cs
@@ -25,5 +25,28 @@ namespace Xamarin.Tests {
 			var linkModeName = platform == ApplePlatform.MacOSX ? "LinkMode" : "MtouchLink";
 			Assert.That (errors [0].Message, Is.EqualTo ($"{platform.AsString ()} projects must build with PublishTrimmed=true. Current value: false. Set '{linkModeName}=None' instead to disable trimming for all assemblies."), "Error message");
 		}
+
+		[Test]
+		[TestCase (ApplePlatform.iOS, "iossimulator-arm64")]
+		public void SkipTrimmerWhenNotTrimming (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			// When we're not trimming anything (the link mode is 'None') and we're not running any custom
+			// trimmer steps (which is the case when both PrepareAssemblies and PostProcessAssemblies are
+			// 'true'), then there's nothing for the trimmer to do, so PublishTrimmed defaults to false.
+			var project = "MySimpleApp";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var project_path = GetProjectPath (project, platform: platform);
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["MtouchLink"] = "None";
+			properties ["PrepareAssemblies"] = "true";
+			properties ["PostProcessAssemblies"] = "true";
+
+			var rv = DotNet.AssertBuild (project_path, properties);
+			Assert.That (BinLog.TryFindPropertyValue (rv.BinLogPath, "PublishTrimmed", out var publishTrimmed), Is.True, "PublishTrimmed found");
+			Assert.That (publishTrimmed, Is.EqualTo ("false"), "PublishTrimmed");
+		}
 	}
 }

--- a/tests/dotnet/UnitTests/PublishTrimmedTest.cs
+++ b/tests/dotnet/UnitTests/PublishTrimmedTest.cs
@@ -45,8 +45,15 @@ namespace Xamarin.Tests {
 			properties ["PostProcessAssemblies"] = "true";
 
 			var rv = DotNet.AssertBuild (project_path, properties);
-			Assert.That (BinLog.TryFindPropertyValue (rv.BinLogPath, "PublishTrimmed", out var publishTrimmed), Is.True, "PublishTrimmed found");
-			Assert.That (publishTrimmed, Is.EqualTo ("false"), "PublishTrimmed");
+
+			// Verify that the trimmer didn't run: when there's nothing for the trimmer to do, the
+			// 'ILLink' target isn't executed. We check the executed targets instead of the
+			// 'PublishTrimmed' property value, because 'PublishTrimmed' is computed inside a target,
+			// and target-assigned property values are only logged in the binlog when property tracking
+			// is enabled (the 'MsBuildLogPropertyTracking' environment variable), which isn't the case
+			// on CI.
+			var targets = BinLog.GetAllTargets (rv.BinLogPath);
+			AssertTargetNotExecuted (targets, "ILLink", "The trimmer should not have executed.");
 		}
 	}
 }


### PR DESCRIPTION
Previously we always defaulted PublishTrimmed to true (except when building from Windows without a connection to a Mac), and disallowed setting it to false.

Now default PublishTrimmed to false when all of the following are true:

* No assemblies are being trimmed (TrimMode is 'copy').
* The link mode is 'None'.
* Both PrepareAssemblies and PostProcessAssemblies are 'true'.

When both PrepareAssemblies and PostProcessAssemblies are true, all the custom trimmer steps are moved to the assembly-preparer's post-processing step instead of running inside the trimmer. Combined with a link mode of 'None' (nothing is trimmed), there's nothing left for the trimmer (ILLink) to do, so we can skip it entirely.

Skipping the trimmer meant the AOT dedup assembly (aot-instances.dll) was no longer created, because _CreateAOTDedupAssembly runs BeforeTargets=PrepareForILLink, and PrepareForILLink doesn't run when the trimmer is skipped. Fix this by making _AddDedupAssemblyToResolvedFileToPublish depend on _CreateAOTDedupAssembly, so the dedup assembly is created before the assemblies are post-processed regardless of whether the trimmer runs.

Perf numbers are kind of all over the place, probably due to randomness on my machine, but this should eventually speed up the build once the PrepareAssembly task is optimized.

Before:

| Project        | Runtime identifier | Link mode | PrepareAssemblies=false | PrepareAssemblies=true | Difference  |
| -------------- | ------------------ | --------- | ----------------------- | ---------------------- | ----------- |
| monotouch-test | ios-arm64          | None      | 00:02:05.46             | 00:02:09.64            | 00:00:04.18 |
| monotouch-test | iossimulator-arm64 | None      | 00:01:34.26             | 00:01:38.97            | 00:00:04.70 |
| MySimpleApp    | ios-arm64          | None      | 00:01:20.30             | 00:01:23.26            | 00:00:02.96 |
| MySimpleApp    | iossimulator-arm64 | None      | 00:00:53.64             | 00:00:55.38            | 00:00:01.74 |

After:

| Project        | Runtime identifier | Link mode | PrepareAssemblies=false | PrepareAssemblies=true | Difference  |
| -------------- | ------------------ | --------- | ----------------------- | ---------------------- | ----------- |
| monotouch-test | ios-arm64          | None      | 00:02:06.53             | 00:02:12.52            | 00:00:05.99 |
| monotouch-test | iossimulator-arm64 | None      | 00:01:36.81             | 00:01:36.34            | 00:00:00.46 |
| MySimpleApp    | ios-arm64          | None      | 00:01:14.63             | 00:01:19.11            | 00:00:04.48 |
| MySimpleApp    | iossimulator-arm64 | None      | 00:00:54.26             | 00:00:53.07            | 00:00:01.19 |

Also change the TimeSpan formatting in the performance report to print 2 fractional-second digits instead of 7. Even 2 is way too much precision, but it looks nicely symmetrical with the other double-digit numerical values.