### PR TITLE
[templates] Use DOTNET_TFM placeholder and add TFM update script

### DIFF
--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/csharp/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/csharp/.template.config/template.json
@@ -55,7 +55,7 @@
           "description": "Target net10.0-maccatalyst"
         }
       ],
-      "replaces": "net10.0-maccatalyst",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-maccatalyst"
     }
   },

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/csharp/MacCatalystApp1.csproj
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/csharp/MacCatalystApp1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-maccatalyst</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <!-- The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.
          When specifying both architectures, use the plural <RuntimeIdentifiers> instead of the singular <RuntimeIdentifer>.
          The App Store will NOT accept apps with ONLY maccatalyst-arm64 indicated;

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/visualbasic/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/visualbasic/.template.config/template.json
@@ -55,7 +55,7 @@
           "description": "Target net10.0-maccatalyst"
         }
       ],
-      "replaces": "net10.0-maccatalyst",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-maccatalyst"
     }
   },

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/visualbasic/MacCatalystApp1.vbproj
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalyst/visualbasic/MacCatalystApp1.vbproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-maccatalyst</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <!-- The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.
          When specifying both architectures, use the plural <RuntimeIdentifiers> instead of the singular <RuntimeIdentifer>.
          The App Store will NOT accept apps with ONLY maccatalyst-arm64 indicated;

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/csharp/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/csharp/.template.config/template.json
@@ -28,7 +28,7 @@
           "description": "Target net10.0-maccatalyst"
         }
       ],
-      "replaces": "net10.0-maccatalyst",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-maccatalyst"
     }
   }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/csharp/MacCatalystBinding1.csproj
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystbinding/csharp/MacCatalystBinding1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-maccatalyst</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">MacCatalystBinding1</RootNamespace>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/csharp/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/csharp/.template.config/template.json
@@ -28,7 +28,7 @@
           "description": "Target net10.0-maccatalyst"
         }
       ],
-      "replaces": "net10.0-maccatalyst",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-maccatalyst"
     }
   }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/csharp/MacCatalystLib1.csproj
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/csharp/MacCatalystLib1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-maccatalyst</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">MacCatalystLib1</RootNamespace>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/visualbasic/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/visualbasic/.template.config/template.json
@@ -28,7 +28,7 @@
           "description": "Target net10.0-maccatalyst"
         }
       ],
-      "replaces": "net10.0-maccatalyst",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-maccatalyst"
     }
   }

--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/visualbasic/MacCatalystLib1.vbproj
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalystlib/visualbasic/MacCatalystLib1.vbproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-maccatalyst</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">MacCatalystLib1</RootNamespace>
   </PropertyGroup>
 </Project>

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-notification-content-extension/csharp/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-notification-content-extension/csharp/.template.config/template.json
@@ -67,7 +67,7 @@
           "description": "Target net10.0-ios"
         }
       ],
-      "replaces": "net10.0-ios",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-ios"
     }
   },

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-notification-content-extension/csharp/iOSNotificationContentExtension1.csproj
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-notification-content-extension/csharp/iOSNotificationContentExtension1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-ios</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">iOSNotificationContentExtension1</RootNamespace>
     <Nullable>enable</Nullable>

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-notification-service-extension/csharp/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-notification-service-extension/csharp/.template.config/template.json
@@ -75,7 +75,7 @@
           "description": "Target net10.0-ios"
         }
       ],
-      "replaces": "net10.0-ios",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-ios"
     }
   },

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-notification-service-extension/csharp/iOSNotificationServiceExtension1.csproj
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-notification-service-extension/csharp/iOSNotificationServiceExtension1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-ios</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <OutputType>Library</OutputType>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">iOSNotificationServiceExtension1</RootNamespace>
     <Nullable>enable</Nullable>

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-tabbed/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-tabbed/.template.config/template.json
@@ -79,7 +79,7 @@
           "description": "Target net10.0-ios"
         }
       ],
-      "replaces": "net10.0-ios",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-ios"
     }
   },

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios-tabbed/iOSTabbedApp1.csproj
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios-tabbed/iOSTabbedApp1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-ios</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">iOSTabbedApp1</RootNamespace>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/csharp/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/csharp/.template.config/template.json
@@ -77,7 +77,7 @@
           "description": "Target net10.0-ios"
         }
       ],
-      "replaces": "net10.0-ios",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-ios"
     }
   },

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/csharp/iOSApp1.csproj
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/csharp/iOSApp1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-ios</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">iOSApp1</RootNamespace>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/fsharp/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/fsharp/.template.config/template.json
@@ -77,7 +77,7 @@
           "description": "Target net10.0-ios"
         }
       ],
-      "replaces": "net10.0-ios",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-ios"
     }
   },

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/fsharp/iOSApp1.fsproj
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/fsharp/iOSApp1.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-ios</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">iOSApp1</RootNamespace>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>minOSVersion</SupportedOSPlatformVersion>

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/visualbasic/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/visualbasic/.template.config/template.json
@@ -77,7 +77,7 @@
           "description": "Target net10.0-ios"
         }
       ],
-      "replaces": "net10.0-ios",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-ios"
     }
   },

--- a/dotnet/Templates/Microsoft.iOS.Templates/ios/visualbasic/iOSApp1.vbproj
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ios/visualbasic/iOSApp1.vbproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-ios</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">iOSApp1</RootNamespace>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>minOSVersion</SupportedOSPlatformVersion>

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/csharp/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/csharp/.template.config/template.json
@@ -28,7 +28,7 @@
           "description": "Target net10.0-ios"
         }
       ],
-      "replaces": "net10.0-ios",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-ios"
     }
   }

--- a/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/csharp/iOSBinding1.csproj
+++ b/dotnet/Templates/Microsoft.iOS.Templates/iosbinding/csharp/iOSBinding1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-ios</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">iOSBinding1</RootNamespace>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/csharp/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/csharp/.template.config/template.json
@@ -28,7 +28,7 @@
           "description": "Target net10.0-ios"
         }
       ],
-      "replaces": "net10.0-ios",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-ios"
     }
   }

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/csharp/iOSLib1.csproj
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/csharp/iOSLib1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-ios</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">iOSLib1</RootNamespace>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/visualbasic/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/visualbasic/.template.config/template.json
@@ -28,7 +28,7 @@
           "description": "Target net10.0-ios"
         }
       ],
-      "replaces": "net10.0-ios",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-ios"
     }
   }

--- a/dotnet/Templates/Microsoft.iOS.Templates/ioslib/visualbasic/iOSLib1.vbproj
+++ b/dotnet/Templates/Microsoft.iOS.Templates/ioslib/visualbasic/iOSLib1.vbproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-ios</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">iOSLib1</RootNamespace>
   </PropertyGroup>
 </Project>

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/csharp/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/csharp/.template.config/template.json
@@ -54,7 +54,7 @@
           "description": "Target net10.0-macos"
         }
       ],
-      "replaces": "net10.0-macos",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-macos"
     }
   },

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/csharp/macOSApp1.csproj
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/csharp/macOSApp1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-macos</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">macOSApp1</RootNamespace>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/visualbasic/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/visualbasic/.template.config/template.json
@@ -54,7 +54,7 @@
           "description": "Target net10.0-macos"
         }
       ],
-      "replaces": "net10.0-macos",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-macos"
     }
   },

--- a/dotnet/Templates/Microsoft.macOS.Templates/macos/visualbasic/macOSApp1.vbproj
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macos/visualbasic/macOSApp1.vbproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-macos</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">macOSApp1</RootNamespace>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>minOSVersion</SupportedOSPlatformVersion>

--- a/dotnet/Templates/Microsoft.macOS.Templates/macosbinding/csharp/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macosbinding/csharp/.template.config/template.json
@@ -28,7 +28,7 @@
           "description": "Target net10.0-macos"
         }
       ],
-      "replaces": "net10.0-macos",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-macos"
     }
   }

--- a/dotnet/Templates/Microsoft.macOS.Templates/macosbinding/csharp/macOSBinding1.csproj
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macosbinding/csharp/macOSBinding1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-macos</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">macOSBinding1</RootNamespace>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/csharp/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/csharp/.template.config/template.json
@@ -28,7 +28,7 @@
           "description": "Target net10.0-macos"
         }
       ],
-      "replaces": "net10.0-macos",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-macos"
     }
   }

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/csharp/macOSLib1.csproj
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/csharp/macOSLib1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-macos</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">macOSLib1</RootNamespace>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/visualbasic/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/visualbasic/.template.config/template.json
@@ -28,7 +28,7 @@
           "description": "Target net10.0-macos"
         }
       ],
-      "replaces": "net10.0-macos",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-macos"
     }
   }

--- a/dotnet/Templates/Microsoft.macOS.Templates/macoslib/visualbasic/macOSLib1.vbproj
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macoslib/visualbasic/macOSLib1.vbproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-macos</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">macOSLib1</RootNamespace>
   </PropertyGroup>
 </Project>

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/csharp/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/csharp/.template.config/template.json
@@ -54,7 +54,7 @@
           "description": "Target net10.0-tvos"
         }
       ],
-      "replaces": "net10.0-tvos",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-tvos"
     }
   },

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/csharp/tvOSApp1.csproj
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/csharp/tvOSApp1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-tvos</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">tvOSApp1</RootNamespace>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/visualbasic/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/visualbasic/.template.config/template.json
@@ -54,7 +54,7 @@
           "description": "Target net10.0-tvos"
         }
       ],
-      "replaces": "net10.0-tvos",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-tvos"
     }
   },

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvos/visualbasic/tvOSApp1.vbproj
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvos/visualbasic/tvOSApp1.vbproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-tvos</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">tvOSApp1</RootNamespace>
     <OutputType>Exe</OutputType>
     <SupportedOSPlatformVersion>minOSVersion</SupportedOSPlatformVersion>

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvosbinding/csharp/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvosbinding/csharp/.template.config/template.json
@@ -28,7 +28,7 @@
           "description": "Target net10.0-tvos"
         }
       ],
-      "replaces": "net10.0-tvos",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-tvos"
     }
   }

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvosbinding/csharp/tvOSBinding1.csproj
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvosbinding/csharp/tvOSBinding1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-tvos</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">tvOSBinding1</RootNamespace>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/csharp/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/csharp/.template.config/template.json
@@ -28,7 +28,7 @@
           "description": "Target net10.0-tvos"
         }
       ],
-      "replaces": "net10.0-tvos",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-tvos"
     }
   }

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/csharp/tvOSLib1.csproj
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/csharp/tvOSLib1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-tvos</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">tvOSLib1</RootNamespace>
     <Nullable>enable</Nullable>
     <ImplicitUsings>true</ImplicitUsings>

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/visualbasic/.template.config/template.json
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/visualbasic/.template.config/template.json
@@ -28,7 +28,7 @@
           "description": "Target net10.0-tvos"
         }
       ],
-      "replaces": "net10.0-tvos",
+      "replaces": "DOTNET_TFM",
       "defaultValue": "net10.0-tvos"
     }
   }

--- a/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/visualbasic/tvOSLib1.vbproj
+++ b/dotnet/Templates/Microsoft.tvOS.Templates/tvoslib/visualbasic/tvOSLib1.vbproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-tvos</TargetFramework>
+    <TargetFramework>DOTNET_TFM</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">tvOSLib1</RootNamespace>
   </PropertyGroup>
 </Project>

--- a/dotnet/update-tfm-in-templates.sh
+++ b/dotnet/update-tfm-in-templates.sh
@@ -1,0 +1,293 @@
+#!/bin/bash -eu
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# This script updates the target framework values in the project templates
+# for a new .NET version.
+#
+# It updates:
+#   - template.json: choices, defaultValue, and description fields
+#   - localize/*.json: Framework choice keys and descriptions
+#
+# The 'replaces' field in template.json and the <TargetFramework> in .csproj/.vbproj/.fsproj
+# files use the fixed placeholder 'DOTNET_TFM' and do not need updating.
+#
+# Usage: ./dotnet/update-tfm-in-templates.sh
+#
+# The script reads DOTNET_TFM from Make.config to determine the current .NET version,
+# then computes which TFMs to offer based on the support policy:
+#   - The previous TFM is supported until May 15th of the year after the current
+#     major .NET version was released.
+#   - At most two TFMs are offered (current + previous, if still supported).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Read DOTNET_TFM from Make.config
+DOTNET_TFM=$(grep '^DOTNET_TFM=' "$REPO_ROOT/Make.config" | head -1 | cut -d= -f2)
+if [ -z "$DOTNET_TFM" ]; then
+    echo "Error: Could not read DOTNET_TFM from Make.config"
+    exit 1
+fi
+
+# Extract major version number (e.g., "net10.0" -> 10)
+CURRENT_MAJOR=$(echo "$DOTNET_TFM" | sed -E 's/net([0-9]+)\.0/\1/')
+PREVIOUS_MAJOR=$((CURRENT_MAJOR - 1))
+
+# Determine if the previous TFM should still be offered.
+# Policy: previous TFM is supported until May 15th of the year after the
+# current major .NET version was released.
+# .NET versions are released in November of their version year (e.g., .NET 10
+# was released in November 2025), so the previous TFM is supported until
+# May 15th of the following year (e.g., May 15th, 2026 for .NET 10).
+SUPPORT_CUTOFF_YEAR=$((CURRENT_MAJOR + 2016))
+SUPPORT_CUTOFF_DATE="${SUPPORT_CUTOFF_YEAR}-05-15"
+TODAY=$(date +%Y-%m-%d)
+
+INCLUDE_PREVIOUS=false
+if [[ "$TODAY" < "$SUPPORT_CUTOFF_DATE" ]]; then
+    INCLUDE_PREVIOUS=true
+fi
+
+PREVIOUS_TFM="net${PREVIOUS_MAJOR}.0"
+
+echo "Current DOTNET_TFM: $DOTNET_TFM (major: $CURRENT_MAJOR)"
+echo "Previous TFM: $PREVIOUS_TFM (major: $PREVIOUS_MAJOR)"
+echo "Support cutoff for previous TFM: $SUPPORT_CUTOFF_DATE"
+echo "Today: $TODAY"
+echo "Include previous TFM: $INCLUDE_PREVIOUS"
+echo ""
+
+TEMPLATES_DIR="$REPO_ROOT/dotnet/Templates"
+
+# Map template directories to their platform suffix
+get_platform () {
+    case "$1" in
+        Microsoft.iOS.Templates) echo "ios" ;;
+        Microsoft.tvOS.Templates) echo "tvos" ;;
+        Microsoft.macOS.Templates) echo "macos" ;;
+        Microsoft.MacCatalyst.Templates) echo "maccatalyst" ;;
+    esac
+}
+
+TEMPLATE_DIRS="Microsoft.iOS.Templates Microsoft.tvOS.Templates Microsoft.macOS.Templates Microsoft.MacCatalyst.Templates"
+
+update_template_json () {
+    local file="$1"
+    local platform="$2"
+    local current_tfm="${DOTNET_TFM}-${platform}"
+    local previous_tfm="${PREVIOUS_TFM}-${platform}"
+    local include_previous="$INCLUDE_PREVIOUS"
+
+    python3 - "$file" "$current_tfm" "$previous_tfm" "$include_previous" << 'PYTHON_EOF'
+import re
+import sys
+import codecs
+import json
+
+file_path = sys.argv[1]
+current_tfm = sys.argv[2]
+previous_tfm = sys.argv[3]
+include_previous = sys.argv[4] == "true"
+
+with open(file_path, 'rb') as f:
+    raw = f.read()
+
+# Detect and preserve BOM
+has_bom = raw.startswith(codecs.BOM_UTF8)
+if has_bom:
+    text = raw.decode('utf-8-sig')
+else:
+    text = raw.decode('utf-8')
+
+if '"Framework"' not in text:
+    sys.exit(0)
+
+# Find the Framework block and replace choices/defaultValue within it only.
+# Locate "Framework": { ... } by finding its start and matching braces.
+fw_match = re.search(r'"Framework"\s*:\s*\{', text)
+if not fw_match:
+    sys.exit(0)
+
+# Find the matching closing brace for the Framework object
+start = fw_match.end() - 1  # position of the opening {
+depth = 0
+end = start
+for i in range(start, len(text)):
+    if text[i] == '{':
+        depth += 1
+    elif text[i] == '}':
+        depth -= 1
+        if depth == 0:
+            end = i + 1
+            break
+
+fw_text = text[start:end]
+
+# Build the new choices block
+if include_previous:
+    new_choices = (
+        '[\n'
+        '        {\n'
+        f'          "choice": "{current_tfm}",\n'
+        f'          "description": "Target {current_tfm}"\n'
+        '        },\n'
+        '        {\n'
+        f'          "choice": "{previous_tfm}",\n'
+        f'          "description": "Target {previous_tfm}"\n'
+        '        }\n'
+        '      ]'
+    )
+else:
+    new_choices = (
+        '[\n'
+        '        {\n'
+        f'          "choice": "{current_tfm}",\n'
+        f'          "description": "Target {current_tfm}"\n'
+        '        }\n'
+        '      ]'
+    )
+
+# Replace choices and defaultValue within the Framework block only
+fw_text = re.sub(
+    r'("choices"\s*:\s*)\[.*?\]',
+    r'\g<1>' + new_choices,
+    fw_text,
+    count=1,
+    flags=re.DOTALL
+)
+fw_text = re.sub(
+    r'("defaultValue"\s*:\s*)"[^"]*"',
+    rf'\g<1>"{current_tfm}"',
+    fw_text,
+    count=1
+)
+
+text = text[:start] + fw_text + text[end:]
+
+with open(file_path, 'wb') as f:
+    if has_bom:
+        f.write(codecs.BOM_UTF8)
+    f.write(text.encode('utf-8'))
+PYTHON_EOF
+}
+
+update_localize_json () {
+    local file="$1"
+    local platform="$2"
+    local current_tfm="${DOTNET_TFM}-${platform}"
+    local previous_tfm="${PREVIOUS_TFM}-${platform}"
+    local include_previous="$INCLUDE_PREVIOUS"
+
+    python3 - "$file" "$current_tfm" "$previous_tfm" "$include_previous" << 'PYTHON_EOF'
+import re
+import sys
+import codecs
+
+file_path = sys.argv[1]
+current_tfm = sys.argv[2]
+previous_tfm = sys.argv[3]
+include_previous = sys.argv[4] == "true"
+
+with open(file_path, 'rb') as f:
+    raw = f.read()
+
+# Detect and preserve BOM
+has_bom = raw.startswith(codecs.BOM_UTF8)
+if has_bom:
+    text = raw.decode('utf-8-sig')
+else:
+    text = raw.decode('utf-8')
+
+had_trailing_newline = text.endswith('\n')
+
+# Remove all existing Framework choice lines
+lines = text.split('\n')
+result = []
+for line in lines:
+    if '"symbols/Framework/choices/' in line:
+        continue
+    result.append(line)
+text = '\n'.join(result)
+
+# Build replacement lines
+new_lines = f'  "symbols/Framework/choices/{current_tfm}/description": "Target {current_tfm}"'
+if include_previous:
+    new_lines += f',\n  "symbols/Framework/choices/{previous_tfm}/description": "Target {previous_tfm}"'
+
+# Insert before the closing }
+# Find the last closing brace and insert before it
+lines = text.split('\n')
+# Find the index of the last line that is just '}'
+close_idx = None
+for i in range(len(lines) - 1, -1, -1):
+    if lines[i].strip() == '}':
+        close_idx = i
+        break
+
+if close_idx is not None:
+    # Ensure the previous content line has a trailing comma
+    for j in range(close_idx - 1, -1, -1):
+        stripped = lines[j].strip()
+        if stripped and stripped != '{':
+            if not stripped.endswith(','):
+                lines[j] = lines[j].rstrip() + ','
+            break
+    lines.insert(close_idx, new_lines)
+
+text = '\n'.join(lines)
+
+# Preserve original trailing newline behavior
+if had_trailing_newline and not text.endswith('\n'):
+    text += '\n'
+elif not had_trailing_newline and text.endswith('\n'):
+    text = text.rstrip('\n')
+
+with open(file_path, 'wb') as f:
+    if has_bom:
+        f.write(codecs.BOM_UTF8)
+    f.write(text.encode('utf-8'))
+PYTHON_EOF
+}
+
+for template_dir_name in $TEMPLATE_DIRS; do
+    platform=$(get_platform "$template_dir_name")
+    template_base="$TEMPLATES_DIR/$template_dir_name"
+
+    if [ ! -d "$template_base" ]; then
+        echo "Warning: $template_base not found, skipping."
+        continue
+    fi
+
+    echo "Processing $template_dir_name (platform: $platform)..."
+
+    # Find and update all template.json files
+    while IFS= read -r -d '' template_json; do
+        # Only process templates that have a Framework parameter
+        if ! grep -q '"Framework"' "$template_json"; then
+            continue
+        fi
+
+        echo "  Updating: $template_json"
+        update_template_json "$template_json" "$platform"
+
+        # Update localize files in the same .template.config directory
+        localize_dir="$(dirname "$template_json")/localize"
+        if [ -d "$localize_dir" ]; then
+            for localize_file in "$localize_dir"/templatestrings.*.json; do
+                if [ -f "$localize_file" ]; then
+                    update_localize_json "$localize_file" "$platform"
+                fi
+            done
+        fi
+    done < <(find "$template_base" -path '*/.template.config/template.json' -print0)
+done
+
+echo ""
+echo "Done. Templates updated for $DOTNET_TFM."
+if [ "$INCLUDE_PREVIOUS" = true ]; then
+    echo "Previous TFM ($PREVIOUS_TFM) is included as an option (cutoff: $SUPPORT_CUTOFF_DATE)."
+else
+    echo "Previous TFM ($PREVIOUS_TFM) is NOT included (past cutoff: $SUPPORT_CUTOFF_DATE)."
+fi


### PR DESCRIPTION
The template engine's `replaces` field and the `<TargetFramework>` in project files now use the
fixed placeholder `DOTNET_TFM` instead of a literal TFM like `net10.0-ios`. This means those
values no longer need manual updates when bumping to a new .NET version.

A new script (`dotnet/update-tfm-in-templates.sh`) handles the remaining version-specific values
(choices, defaultValue, descriptions in template.json and localize files). It reads `DOTNET_TFM`
from `Make.config` and computes whether to include the previous TFM as an option based on the
support policy: the previous TFM is offered until May 15th of the year after the current major
.NET version was released.

The script:
- Preserves file formatting (BOM, indentation, trailing newlines)
- Is idempotent (safe to run repeatedly)
- Requires only bash 3.2+ and python3

🤖 Pull request created by Copilot