### PR TITLE
[msbuild] Fix building binding projects with 'dotnet build /t:Compile'

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1844,7 +1844,15 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<PropertyGroup Condition="'$(IsBindingProject)' == 'true'">
 		<!-- Add our own pre and post build steps -->
 		<!-- Override the CoreCompile Target to use bgen -->
+		<!--
+			ResolveReferences must come first: our binding-generation targets (_GenerateBindings /
+			_CompileApiDefinitions) need the resolved references (@(ReferencePath)) to compile the
+			API definitions. During a normal build ResolveReferences runs earlier as part of CoreBuild,
+			but when the Compile target is built directly (e.g. 'dotnet watch' runs 'dotnet build /t:Compile')
+			nothing else resolves references first, so we have to depend on it explicitly here.
+		-->
 		<CompileDependsOn>
+			ResolveReferences;
 			_GenerateBindings;
 			_PrepareNativeReferences;
 			_CollectGeneratedSources;

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -204,6 +204,25 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.MacOSX)]
 		[TestCase (ApplePlatform.MacCatalyst)]
 		[Category ("WindowsInclusive")]
+		public void BuildBindingsTestWithCompileTarget (ApplePlatform platform)
+		{
+			// 'dotnet watch' builds the 'Compile' target directly ('dotnet build /t:Compile'),
+			// so make sure a binding project can be built that way.
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			var assemblyName = "bindings-test";
+			var dotnet_bindings_dir = Path.Combine (Configuration.SourceRoot, "tests", assemblyName, "dotnet");
+			var project_dir = Path.Combine (dotnet_bindings_dir, platform.AsString ());
+			var project_path = Path.Combine (project_dir, $"{assemblyName}.csproj");
+
+			Clean (project_path);
+			DotNet.AssertBuild (project_path, verbosity, target: "Compile");
+		}
+
+		[TestCase (ApplePlatform.iOS)]
+		[TestCase (ApplePlatform.TVOS)]
+		[TestCase (ApplePlatform.MacOSX)]
+		[TestCase (ApplePlatform.MacCatalyst)]
+		[Category ("WindowsInclusive")]
 		public void BuildBindingsTest (ApplePlatform platform)
 		{
 			Configuration.IgnoreIfIgnoredPlatform (platform);


### PR DESCRIPTION
'dotnet watch' builds the 'Compile' target directly (it runs 'dotnet build /t:Compile'). For binding projects this failed, because the binding-project override of CompileDependsOn prepends _GenerateBindings (which in turn runs _CompileApiDefinitions) before $(CompileDependsOn) - and $(CompileDependsOn) is where the default ResolveReferences lives.

During a normal build ResolveReferences runs earlier as part of CoreBuild, so @(ReferencePath) is already populated when the binding targets run. But when the Compile target is built directly, nothing runs ResolveReferences first, so _CompileApiDefinitions compiles the API definitions with no references at all and fails with thousands of errors ("Predefined type 'System.Void' is not defined", missing System.Runtime, NSObject, ExportAttribute, etc.).

Fix this by adding ResolveReferences to the front of the binding-project CompileDependsOn override, so references are always resolved before the binding-generation targets that need them.

Also add a unit test (BuildBindingsTestWithCompileTarget) that builds a binding project with '/t:Compile'.

Contributes towards https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3024114.