### PR TITLE
[docs] Improve XML docs for QLPreviewPanel

### DIFF
--- a/src/QuickLookUI/QLPreviewPanel.cs
+++ b/src/QuickLookUI/QLPreviewPanel.cs
@@ -7,16 +7,14 @@ using System.ComponentModel;
 
 namespace QuickLookUI {
 	public partial class QLPreviewPanel {
-		/// <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Enters full-screen mode with default options.</summary>
+		/// <returns><see langword="true" /> if the panel entered full-screen mode successfully; otherwise, <see langword="false" />.</returns>
 		public bool EnterFullScreenMode ()
 		{
 			return EnterFullScreenMode (null, null);
 		}
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Exits full-screen mode with default options.</summary>
 		public void ExitFullScreenModeWithOptions ()
 		{
 			ExitFullScreenModeWithOptions (null);


### PR DESCRIPTION
Improve XML documentation for the `QLPreviewPanel` type:

- Replace 'To be added.' placeholders with meaningful descriptions
- Remove empty `<remarks>` nodes
- Add proper documentation for `EnterFullScreenMode` and `ExitFullScreenModeWithOptions` methods

🤖 Pull request created by Copilot