### PR TITLE
[msbuild] Fix simulator OS version comparison in GetAvailableDevices

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetAvailableDevices.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetAvailableDevices.cs
@@ -390,7 +390,7 @@ public class GetAvailableDevices : XamarinTask, ICancelableTask {
 						break;
 					}
 					if (Version.TryParse (runtimeVersion, out var parsedMinimumOSVersion))
-						minimumOSVersion = parsedMinimumOSVersion;
+						minimumOSVersion = parsedMinimumOSVersion; // TODO: Refactor minimumOSVersion and maximumOSVersion to use only runtimeVersion in DeviceInfo
 					maximumOSVersion = new Version (65535, 255, 255);
 				} else {
 					discardedReason = $"Unknown device type identifier '{device.DeviceTypeIdentifier}'";

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetAvailableDevices.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetAvailableDevices.cs
@@ -389,10 +389,9 @@ public class GetAvailableDevices : XamarinTask, ICancelableTask {
 						discardedReason = $"Unknown product family '{deviceTypeInfo.ProductFamily}'";
 						break;
 					}
-					if (Version.TryParse (deviceTypeInfo.MinRuntimeVersionString, out var parsedMinimumOSVersion))
+					if (Version.TryParse (runtimeVersion, out var parsedMinimumOSVersion))
 						minimumOSVersion = parsedMinimumOSVersion;
-					if (Version.TryParse (deviceTypeInfo.MaxRuntimeVersionString, out var parsedMaximumOSVersion))
-						maximumOSVersion = parsedMaximumOSVersion;
+					maximumOSVersion = new Version (65535, 255, 255);
 				} else {
 					discardedReason = $"Unknown device type identifier '{device.DeviceTypeIdentifier}'";
 				}


### PR DESCRIPTION
## Description

`GetAvailableDevices.RunSimCtlAsync()` uses the **device type's** `MinRuntimeVersionString` (e.g. `"26.0.0"`) as the device's OS version when filtering against the app's `MinimumOSVersion`. This is wrong -- it should use the **actual runtime version** from `simctl` (e.g. `"26.5"`).

The device type's `minRuntimeVersionString` represents the minimum OS version the physical device hardware supports, not the actual OS version running on the simulator. For example, an iPhone 17 Pro device type has `minRuntimeVersionString: "26.0.0"`, but when created with the iOS 26.5 simulator runtime, its actual OS version is **26.5**.

This causes `dotnet run --device` to reject every simulator device when the SDK version exceeds all device type `minRuntimeVersionString` values -- for example in Xcode 26.5 (iOS 26.5 SDK) where every device type has `minRuntimeVersionString <= 26.3`.

## The fix

```diff
-                   if (Version.TryParse (deviceTypeInfo.MinRuntimeVersionString, out var parsedMinimumOSVersion))
+                   if (Version.TryParse (runtimeVersion, out var parsedMinimumOSVersion))
                        minimumOSVersion = parsedMinimumOSVersion;
-                   if (Version.TryParse (deviceTypeInfo.MaxRuntimeVersionString, out var parsedMaximumOSVersion))
-                       maximumOSVersion = parsedMaximumOSVersion;
+                   maximumOSVersion = new Version (65535, 255, 255);
```

This matches how `RunDeviceCtlAsync()` already handles physical devices:
```cs
Version.TryParse (device.OSVersion, out var minimumOSVersion);
var maximumOSVersion = new Version (65535, 255, 255);
```

Note: `MaxRuntimeVersionString` was always `"65535.255.255"` for every device type, so hardcoding the sentinel has no behavioral change but makes the code consistent with the physical device path.
