### PR TITLE
[CI] Handle missing Xcode gracefully in provision script. Fixes #25934

### DIFF
--- a/tools/devops/provision-shared.in.csx
+++ b/tools/devops/provision-shared.in.csx
@@ -31,9 +31,13 @@ void RemoveXcodeSymlinks (string xcodePath)
 void ListXcodes ()
 {
 	Console.WriteLine ($"Xcodes:");
-	var lines = Exec ("bash", "-c", "ls -lad /Applications/Xcode*");
-	foreach (var line in lines)
-		Console.WriteLine ($"\t{line}");
+	try {
+		var lines = Exec ("bash", "-c", "ls -lad /Applications/Xcode*");
+		foreach (var line in lines)
+			Console.WriteLine ($"\t{line}");
+	} catch {
+		Console.WriteLine ("\tNo Xcode installations found in /Applications.");
+	}
 }
 
 // Provision Xcode using the xip name declared in Make.config

--- a/tools/devops/provision-shared.in.csx
+++ b/tools/devops/provision-shared.in.csx
@@ -35,8 +35,8 @@ void ListXcodes ()
 		var lines = Exec ("bash", "-c", "ls -lad /Applications/Xcode*");
 		foreach (var line in lines)
 			Console.WriteLine ($"\t{line}");
-	} catch {
-		Console.WriteLine ("\tNo Xcode installations found in /Applications.");
+	} catch (Exception e) {
+		Console.WriteLine ($"\tNo Xcode installations found in /Applications (ls failed: {e.Message}).");
 	}
 }
 


### PR DESCRIPTION

The `ListXcodes()` function in the provisioning script calls `ls -lad /Applications/Xcode*` which throws an unhandled `ExitException` when no Xcode is installed (exit code 1 from ls when the glob matches nothing). This causes the entire provisioning step to abort before any actual provisioning can happen.

Wrap the ls call in a try-catch so that a missing Xcode installation is reported as informational output instead of crashing. The actual provisioning step (`Xcode(...).XcodeSelect()`) still runs afterwards and installs the required Xcode.

Fixes https://github.com/dotnet/macios/issues/25934

🤖 Pull request created by Copilot