### PR TITLE
[assembly-preparer] Use a trimmer feature switch for DynamicRegistrationSupported.

### DIFF
--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -466,6 +466,23 @@ The full path to the `ditto` executable.
 
 The default behavior is to use `/usr/bin/ditto`.
 
+## DynamicRegistrationSupported
+
+Controls whether the dynamic registrar is available at runtime (as reported by
+`ObjCRuntime.Runtime.DynamicRegistrationSupported`).
+
+If this value is not specified, the build will compute a default value based
+on whether the app needs the dynamic registrar, and enables the
+`ObjCRuntime.Runtime.DynamicRegistrationSupported` trimmer feature switch
+accordingly (so the trimmer can remove the dynamic registrar when it's not
+needed, making the app smaller).
+
+Set this property to `true` or `false` to override the computed default.
+
+Removing the dynamic registrar requires a static registrar (`Registrar=static` or
+`Registrar=managed-static`) and trimming, so setting this property has no effect (and the
+build warns) when those conditions aren't met.
+
 ## EmbedOnDemandResources
 
 If on-demand resources should be embedded in the app bundle.

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -272,6 +272,7 @@
 			_ExtendAppExtensionReferences;
 			_ComputeLinkerArguments;
 			_PrepareAssemblies;
+			_SetDynamicRegistrationSupportedFeature;
 			_ComputeFrameworkFilesToPublish;
 			_ComputeDynamicLibrariesToPublish;
 			ComputeFilesToPublish;
@@ -560,6 +561,37 @@
 		</ItemGroup>
 	</Target>
 
+	<!--
+		Enables the 'ObjCRuntime.Runtime.DynamicRegistrationSupported' trimmer feature switch so that ILLink
+		hardcodes Runtime.DynamicRegistrationSupported. When PrepareAssemblies is enabled, the assembly-preparer's
+		RegistrarRemovalTrackingStep computes whether the dynamic registrar is needed (instead of rewriting the
+		platform assembly) and writes the value - as the 'DynamicRegistrationSupported' MSBuild output property -
+		to $(_AssemblyPreparerMSBuildOutputFile). This target runs after _PrepareAssemblies and before the trimmer.
+		It's not incremental-gated, so even if _PrepareAssemblies was skipped (because its outputs were up-to-date),
+		the value is still read from the (persisted) file and the feature switch is set. A user-specified
+		$(DynamicRegistrationSupported) always wins.
+	-->
+	<Target Name="_SetDynamicRegistrationSupportedFeature" Condition="'$(PrepareAssemblies)' == 'true'">
+		<ReadLinesFromFile
+			File="$(_AssemblyPreparerMSBuildOutputFile)"
+			Condition="'$(DynamicRegistrationSupported)' == '' And Exists('$(_AssemblyPreparerMSBuildOutputFile)')">
+			<Output TaskParameter="Lines" ItemName="_AssemblyPreparerMSBuildOutputProperty" />
+		</ReadLinesFromFile>
+		<ItemGroup>
+			<_DynamicRegistrationSupportedLine Include="@(_AssemblyPreparerMSBuildOutputProperty)" Condition="$([System.String]::Copy('%(Identity)').StartsWith('DynamicRegistrationSupported='))" />
+		</ItemGroup>
+		<PropertyGroup>
+			<!-- The user-specified $(DynamicRegistrationSupported) always wins; otherwise use the value the
+			     assembly-preparer wrote (the 'DynamicRegistrationSupported=<value>' line in the output file). -->
+			<_DynamicRegistrationSupportedLineText>@(_DynamicRegistrationSupportedLine)</_DynamicRegistrationSupportedLineText>
+			<_DynamicRegistrationSupported>$(DynamicRegistrationSupported)</_DynamicRegistrationSupported>
+			<_DynamicRegistrationSupported Condition="'$(_DynamicRegistrationSupported)' == '' And '$(_DynamicRegistrationSupportedLineText)' != ''">$(_DynamicRegistrationSupportedLineText.Replace('DynamicRegistrationSupported=', ''))</_DynamicRegistrationSupported>
+		</PropertyGroup>
+		<ItemGroup Condition="'$(_DynamicRegistrationSupported)' != ''">
+			<RuntimeHostConfigurationOption Include="ObjCRuntime.Runtime.DynamicRegistrationSupported" Value="$(_DynamicRegistrationSupported)" Trim="true" />
+		</ItemGroup>
+	</Target>
+
 	<Target Name="_ComputeLinkerArguments" DependsOnTargets="$(_ComputeLinkerArgumentsDependsOn)" />
 
 	<Target Name="_ComputeLinkerInputs">
@@ -607,6 +639,10 @@
 			<_CustomLinkerOptionsFile>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)custom-linker-options.txt'))</_CustomLinkerOptionsFile>
 			<_CustomLinkerOptionsFile Condition="'$(BuildSessionId)' != ''">$(IntermediateOutputPath)custom-linker-options.txt</_CustomLinkerOptionsFile>
 
+			<!-- The files the assembly-preparer writes its MSBuild output properties to (one per pass; read back in _SetDynamicRegistrationSupportedFeature and added to FileWrites). -->
+			<_AssemblyPreparerMSBuildOutputFile Condition="'$(PrepareAssemblies)' == 'true'">$(DeviceSpecificIntermediateOutputPath)assembly-preparer-msbuild-output.txt</_AssemblyPreparerMSBuildOutputFile>
+			<_AssemblyPostProcessorMSBuildOutputFile Condition="'$(PrepareAssemblies)' == 'true'">$(DeviceSpecificIntermediateOutputPath)assembly-postprocessor-msbuild-output.txt</_AssemblyPostProcessorMSBuildOutputFile>
+
 			<!-- The directory where the linker puts *.items files that will be loaded in the _LoadLinkerOutput target -->
 			<_LinkerItemsDirectory>$([System.IO.Path]::GetFullPath('$(IntermediateOutputPath)linker-items'))</_LinkerItemsDirectory>
 			<_LinkerItemsDirectory Condition="'$(BuildSessionId)' != ''">$(IntermediateOutputPath)linker-items</_LinkerItemsDirectory>
@@ -649,6 +685,7 @@
 				@(_BundlerDlsym -> 'Dlsym=%(Identity)')
 				Debug=$(_BundlerDebug)
 				DeploymentTarget=$(_MinimumOSVersion)
+				DynamicRegistrationSupported=$(DynamicRegistrationSupported)
 				@(_CustomLinkFlags -> 'CustomLinkFlags=%(Identity)')
 				EnableSGenConc=$(EnableSGenConc)
 				@(_BundlerEnvironmentVariables -> 'EnvironmentVariable=Overwrite=%(Overwrite)|%(Identity)=%(Value)')
@@ -668,6 +705,8 @@
 				MarshalManagedExceptionMode=$(MarshalManagedExceptionMode)
 				MarshalObjectiveCExceptionMode=$(MarshalObjectiveCExceptionMode)
 				@(_MonoLibrary -> 'MonoLibrary=%(Identity)')
+				MSBuildOutputFile=$(_AssemblyPreparerMSBuildOutputFile)
+				MSBuildPostProcessOutputFile=$(_AssemblyPostProcessorMSBuildOutputFile)
 				MtouchFloat32=$(MtouchFloat32)
 				NoWarn=$(_BundlerNoWarn)
 				Optimize=$(_BundlerOptimize)

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -3502,7 +3502,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		Name="_PrepareAssemblies"
 		Condition="'$(PrepareAssemblies)' == 'true'"
 		Inputs="@(_AssembliesToPrepare)"
-		Outputs="@(_AssembliesToPrepare->'$(PreparedAssembliesDirectory)%(Filename)%(Extension)')"
+		Outputs="@(_AssembliesToPrepare->'$(PreparedAssembliesDirectory)%(Filename)%(Extension)');$(_AssemblyPreparerMSBuildOutputFile)"
 		DependsOnTargets="_PrepareAssembliesForPreparation;_ComputeAssembliesToPostprocessOnPublish;SelectRegistrar"
 		>
 		<PrepareAssemblies
@@ -3520,6 +3520,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<ResolvedFileToPublish Include="@(_PreparedAssemblies)" />
 			<FileWrites Include="@(_PreparedAssemblies)" />
 			<FileWrites Include="$(_UnmanagedCallersOnlyMapPath)" />
+			<FileWrites Include="$(_AssemblyPreparerMSBuildOutputFile)" Condition="Exists('$(_AssemblyPreparerMSBuildOutputFile)')" />
 		</ItemGroup>
 	</Target>
 
@@ -3565,6 +3566,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			<ResolvedFileToPublish Remove="@(_AssembliesToPostProcess)" />
 			<ResolvedFileToPublish Include="@(_PostProcessedAssemblies)" />
 			<FileWrites Include="@(_PostProcessedAssemblies)" />
+			<FileWrites Include="$(_AssemblyPostProcessorMSBuildOutputFile)" Condition="Exists('$(_AssemblyPostProcessorMSBuildOutputFile)')" />
 		</ItemGroup>
 	</Target>
 

--- a/src/ILLink.Substitutions.MacCatalyst.xml
+++ b/src/ILLink.Substitutions.MacCatalyst.xml
@@ -10,6 +10,8 @@
       <method signature="System.Boolean get_IsNativeAOT()" body="stub" feature="ObjCRuntime.Runtime.IsNativeAOT" featurevalue="true" value="true" />
       <method signature="System.Boolean get_IsManagedStaticRegistrar()" body="stub" feature="ObjCRuntime.Runtime.IsManagedStaticRegistrar" featurevalue="false" value="false" />
       <method signature="System.Boolean get_IsManagedStaticRegistrar()" body="stub" feature="ObjCRuntime.Runtime.IsManagedStaticRegistrar" featurevalue="true" value="true" />
+      <method signature="System.Boolean get_DynamicRegistrationSupported()" body="stub" feature="ObjCRuntime.Runtime.DynamicRegistrationSupported" featurevalue="false" value="false" />
+      <method signature="System.Boolean get_DynamicRegistrationSupported()" body="stub" feature="ObjCRuntime.Runtime.DynamicRegistrationSupported" featurevalue="true" value="true" />
       <method signature="System.Boolean get_IsTrimmableStaticRegistrar()" body="stub" feature="ObjCRuntime.Runtime.IsTrimmableStaticRegistrar" featurevalue="false" value="false" />
       <method signature="System.Boolean get_IsTrimmableStaticRegistrar()" body="stub" feature="ObjCRuntime.Runtime.IsTrimmableStaticRegistrar" featurevalue="true" value="true" />
       <method signature="System.Boolean get_UseCFNetworkHandler()" body="stub" feature="System.Net.Http.NativeHandler.UseCFNetworkHandler" featurevalue="false" value="false" />

--- a/src/ILLink.Substitutions.iOS.xml
+++ b/src/ILLink.Substitutions.iOS.xml
@@ -12,6 +12,8 @@
       <method signature="System.Int32 GetRuntimeArch()" body="stub" feature="ObjCRuntime.Runtime.Arch.IsSimulator" featurevalue="true" value="1" />
       <method signature="System.Boolean get_IsManagedStaticRegistrar()" body="stub" feature="ObjCRuntime.Runtime.IsManagedStaticRegistrar" featurevalue="false" value="false" />
       <method signature="System.Boolean get_IsManagedStaticRegistrar()" body="stub" feature="ObjCRuntime.Runtime.IsManagedStaticRegistrar" featurevalue="true" value="true" />
+      <method signature="System.Boolean get_DynamicRegistrationSupported()" body="stub" feature="ObjCRuntime.Runtime.DynamicRegistrationSupported" featurevalue="false" value="false" />
+      <method signature="System.Boolean get_DynamicRegistrationSupported()" body="stub" feature="ObjCRuntime.Runtime.DynamicRegistrationSupported" featurevalue="true" value="true" />
       <method signature="System.Boolean get_IsTrimmableStaticRegistrar()" body="stub" feature="ObjCRuntime.Runtime.IsTrimmableStaticRegistrar" featurevalue="false" value="false" />
       <method signature="System.Boolean get_IsTrimmableStaticRegistrar()" body="stub" feature="ObjCRuntime.Runtime.IsTrimmableStaticRegistrar" featurevalue="true" value="true" />
       <method signature="System.Boolean get_UseCFNetworkHandler()" body="stub" feature="System.Net.Http.NativeHandler.UseCFNetworkHandler" featurevalue="false" value="false" />

--- a/src/ILLink.Substitutions.macOS.xml
+++ b/src/ILLink.Substitutions.macOS.xml
@@ -9,6 +9,8 @@
       <method signature="System.Boolean get_IsNativeAOT()" body="stub" feature="ObjCRuntime.Runtime.IsNativeAOT" featurevalue="true" value="true" />
       <method signature="System.Boolean get_IsManagedStaticRegistrar()" body="stub" feature="ObjCRuntime.Runtime.IsManagedStaticRegistrar" featurevalue="false" value="false" />
       <method signature="System.Boolean get_IsManagedStaticRegistrar()" body="stub" feature="ObjCRuntime.Runtime.IsManagedStaticRegistrar" featurevalue="true" value="true" />
+      <method signature="System.Boolean get_DynamicRegistrationSupported()" body="stub" feature="ObjCRuntime.Runtime.DynamicRegistrationSupported" featurevalue="false" value="false" />
+      <method signature="System.Boolean get_DynamicRegistrationSupported()" body="stub" feature="ObjCRuntime.Runtime.DynamicRegistrationSupported" featurevalue="true" value="true" />
       <method signature="System.Boolean get_IsTrimmableStaticRegistrar()" body="stub" feature="ObjCRuntime.Runtime.IsTrimmableStaticRegistrar" featurevalue="false" value="false" />
       <method signature="System.Boolean get_IsTrimmableStaticRegistrar()" body="stub" feature="ObjCRuntime.Runtime.IsTrimmableStaticRegistrar" featurevalue="true" value="true" />
       <method signature="System.Boolean get_UseCFNetworkHandler()" body="stub" feature="System.Net.Http.NativeHandler.UseCFNetworkHandler" featurevalue="false" value="false" />

--- a/src/ILLink.Substitutions.tvOS.xml
+++ b/src/ILLink.Substitutions.tvOS.xml
@@ -12,6 +12,8 @@
       <method signature="System.Int32 GetRuntimeArch()" body="stub" feature="ObjCRuntime.Runtime.Arch.IsSimulator" featurevalue="true" value="1" />
       <method signature="System.Boolean get_IsManagedStaticRegistrar()" body="stub" feature="ObjCRuntime.Runtime.IsManagedStaticRegistrar" featurevalue="false" value="false" />
       <method signature="System.Boolean get_IsManagedStaticRegistrar()" body="stub" feature="ObjCRuntime.Runtime.IsManagedStaticRegistrar" featurevalue="true" value="true" />
+      <method signature="System.Boolean get_DynamicRegistrationSupported()" body="stub" feature="ObjCRuntime.Runtime.DynamicRegistrationSupported" featurevalue="false" value="false" />
+      <method signature="System.Boolean get_DynamicRegistrationSupported()" body="stub" feature="ObjCRuntime.Runtime.DynamicRegistrationSupported" featurevalue="true" value="true" />
       <method signature="System.Boolean get_IsTrimmableStaticRegistrar()" body="stub" feature="ObjCRuntime.Runtime.IsTrimmableStaticRegistrar" featurevalue="false" value="false" />
       <method signature="System.Boolean get_IsTrimmableStaticRegistrar()" body="stub" feature="ObjCRuntime.Runtime.IsTrimmableStaticRegistrar" featurevalue="true" value="true" />
       <method signature="System.Boolean get_UseCFNetworkHandler()" body="stub" feature="System.Net.Http.NativeHandler.UseCFNetworkHandler" featurevalue="false" value="false" />

--- a/tests/dotnet/UnitTests/DynamicRegistrationSupportedTest.cs
+++ b/tests/dotnet/UnitTests/DynamicRegistrationSupportedTest.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Logging.StructuredLogger;
+
+#nullable enable
+
+namespace Xamarin.Tests {
+	[TestFixture]
+	public class DynamicRegistrationSupportedTest : TestBaseClass {
+		[Test]
+		[TestCase (ApplePlatform.iOS, "iossimulator-arm64", "true")]
+		[TestCase (ApplePlatform.iOS, "iossimulator-arm64", "false")]
+		public void UserSpecifiedValue (ApplePlatform platform, string runtimeIdentifiers, string dynamicRegistrationSupported)
+		{
+			// When the user sets $(DynamicRegistrationSupported), the value must be passed straight through to
+			// the 'ObjCRuntime.Runtime.DynamicRegistrationSupported' trimmer feature switch (the assembly-preparer
+			// doesn't need to compute it, so RegistrarRemovalTrackingStep is skipped).
+			var project = "MySimpleApp";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var project_path = GetProjectPath (project, platform: platform);
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			// DynamicRegistrationSupported maps to the 'remove-dynamic-registrar' optimization, which is only
+			// valid with a static registrar, so use one (managed-static) and enable trimming.
+			properties ["MtouchLink"] = "SdkOnly";
+			properties ["Registrar"] = "managed-static";
+			properties ["PrepareAssemblies"] = "true";
+			properties ["PostProcessAssemblies"] = "true";
+			properties ["DynamicRegistrationSupported"] = dynamicRegistrationSupported;
+
+			var rv = DotNet.AssertBuild (project_path, properties);
+
+			var featureSwitch = GetRuntimeHostConfigurationOption (rv.BinLogPath, "ObjCRuntime.Runtime.DynamicRegistrationSupported");
+			Assert.That (featureSwitch, Is.Not.Null, "The DynamicRegistrationSupported feature switch must be set.");
+			Assert.That (featureSwitch?.GetMetadata ("Value"), Is.EqualTo (dynamicRegistrationSupported), "The feature switch value must match the user-specified value.");
+		}
+
+		// Returns the last RuntimeHostConfigurationOption item with the given name (ItemSpec) added during the build.
+		static ITaskItem? GetRuntimeHostConfigurationOption (string binLogPath, string name)
+		{
+			ITaskItem? rv = null;
+			foreach (var args in BinLog.ReadBuildEvents (binLogPath)) {
+				if (args is not TaskParameterEventArgs tpea)
+					continue;
+				if (tpea.Kind != TaskParameterMessageKind.AddItem)
+					continue;
+				if (tpea.ItemType != "RuntimeHostConfigurationOption")
+					continue;
+				foreach (var item in tpea.Items) {
+					if (item is ITaskItem taskItem && taskItem.ItemSpec == name)
+						rv = taskItem;
+				}
+			}
+			return rv;
+		}
+	}
+}

--- a/tools/assembly-preparer/AssemblyPreparer.cs
+++ b/tools/assembly-preparer/AssemblyPreparer.cs
@@ -116,8 +116,8 @@ public class AssemblyPreparer : IDisposable {
 
 	public bool Prepare (out List<ProductException> exceptions)
 	{
-		var steps = new ConfigurationAwareStep [] {
-			// All the same steps as the custom trimmer steps that are run before MarkStep in Xamarin.Shared.Sdk.targets (and in the same order).
+		// All the same steps as the custom trimmer steps that are run before MarkStep in Xamarin.Shared.Sdk.targets (and in the same order).
+		var steps = new List<ConfigurationAwareStep> {
 			// CollectAssembliesStep
 			new LoadAssembliesStep (),
 			new ComputeMethodOverridesStep (),
@@ -131,14 +131,20 @@ public class AssemblyPreparer : IDisposable {
 			new MarkForStaticRegistrarStep (),
 			new MarkNSObjectsStep (),
 			new InlineDlfcnMethodsStep (),
-			new RegistrarRemovalTrackingStep (),
-			// PreMarkDispatcher: I don't think we need this one
-			new ManagedRegistrarStep (),
-			new TrimmableRegistrarStep (),
-			new ManagedRegistrarLookupTablesStep (),
-			new InlineClassGetHandleStep (),
-			new SaveAssembliesStep (),
 		};
+
+		// If the user explicitly set $(DynamicRegistrationSupported), we don't need to compute the value, so
+		// skip RegistrarRemovalTrackingStep entirely (the value is passed straight through to the trimmer feature switch).
+		if (!configuration.DynamicRegistrationSupported.HasValue)
+			steps.Add (new RegistrarRemovalTrackingStep ());
+
+		// PreMarkDispatcher: I don't think we need this one
+		steps.Add (new ManagedRegistrarStep ());
+		steps.Add (new TrimmableRegistrarStep ());
+		steps.Add (new ManagedRegistrarLookupTablesStep ());
+		steps.Add (new InlineClassGetHandleStep ());
+		steps.Add (new SaveAssembliesStep ());
+
 		return RunSteps (steps, out exceptions);
 	}
 
@@ -206,6 +212,11 @@ public class AssemblyPreparer : IDisposable {
 		foreach (var step in steps) {
 			step.Process (linkContext);
 		}
+
+		// The post-processing pass flushes its MSBuild output as its last step (DoneStep). The preparation
+		// pass has no DoneStep, so flush here so that its MSBuild output properties are written.
+		if (!configuration.Application.IsPostProcessingAssemblies)
+			configuration.FlushOutputForMSBuild ();
 
 		return exceptions.Count == 0;
 	}

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -30,6 +30,9 @@ namespace Xamarin.Linker {
 		public string DedupAssembly = string.Empty;
 		public string CacheDirectory { get; private set; } = string.Empty;
 		public Version? DeploymentTarget { get; private set; }
+		// The user-provided value of the $(DynamicRegistrationSupported) MSBuild property (null if not set).
+		// When set, RegistrarRemovalTrackingStep doesn't need to run in the assembly-preparer.
+		public bool? DynamicRegistrationSupported { get; private set; }
 		public HashSet<string> FrameworkAssemblies { get; private set; } = new HashSet<string> ();
 		public string IntermediateLinkDir { get; private set; } = string.Empty;
 		public bool InvariantGlobalization { get; private set; }
@@ -43,6 +46,9 @@ namespace Xamarin.Linker {
 		public HashSet<string> FieldSymbols { get; } = new HashSet<string> ();
 		public string IntermediateOutputPath { get; private set; } = string.Empty;
 		public string ItemsDirectory { get; private set; } = string.Empty;
+		// The files the assembly-preparer writes its MSBuild output properties to (one per pass).
+		public string MSBuildOutputFile { get; private set; } = string.Empty;
+		public string MSBuildPostProcessOutputFile { get; private set; } = string.Empty;
 		public bool IsSimulatorBuild { get; private set; }
 		public string PartialStaticRegistrarLibrary { get; set; } = string.Empty;
 		public ApplePlatform Platform { get; private set; }
@@ -99,6 +105,10 @@ namespace Xamarin.Linker {
 		string? user_optimize_flags;
 
 		Dictionary<string, List<MSBuildItem>> msbuild_items = new Dictionary<string, List<MSBuildItem>> ();
+
+		// MSBuild output properties (property name -> value), written (alphabetically sorted) to the
+		// MSBuild output file by FlushOutputForMSBuild.
+		SortedDictionary<string, string> msbuild_properties = new SortedDictionary<string, string> (StringComparer.Ordinal);
 
 		AppBundleRewriter? abr;
 		internal AppBundleRewriter AppBundleRewriter {
@@ -286,6 +296,24 @@ namespace Xamarin.Linker {
 						}
 					})
 				)},
+				{ "DynamicRegistrationSupported", (
+					// This is the user-overridable $(DynamicRegistrationSupported) MSBuild property. It maps to
+					// the RemoveDynamicRegistrar optimization (inverted): if dynamic registration is supported,
+					// then we're not removing the dynamic registrar. When set, RegistrarRemovalTrackingStep doesn't
+					// need to run in the assembly-preparer (the value is passed straight through to the trimmer
+					// feature switch), and it won't recompute the value in the real linker either.
+					new LoadValue ((key, value) => {
+						if (string.IsNullOrEmpty (value))
+							return; // Not set: RegistrarRemovalTrackingStep will compute a default value.
+						if (!TryParseOptionalBoolean (value, out var dynamicRegistrationSupported))
+							throw new InvalidOperationException ($"Unable to parse the {key} value: {value} in {linker_file}");
+						if (dynamicRegistrationSupported.HasValue) {
+							DynamicRegistrationSupported = dynamicRegistrationSupported.Value;
+							Application.Optimizations.RemoveDynamicRegistrar = !dynamicRegistrationSupported.Value;
+						}
+					}),
+					new SaveValue ((key, storage) => saveNullableBool (key, DynamicRegistrationSupported, storage))
+				)},
 				{ "EnableSGenConc", (
 					new LoadValue ((key, value) => Application.EnableSGenConc = string.Equals ("true", value, StringComparison.OrdinalIgnoreCase)),
 					new SaveValue ((key, storage) => storage.Add ($"{key}={(Application.EnableSGenConc ? "true" : "false")}"))
@@ -403,6 +431,16 @@ namespace Xamarin.Linker {
 				{ "MonoLibrary", (
 					new LoadValue ((key, value) => Application.MonoLibraries.Add (value)),
 					new SaveValue ((key, storage) => storage.AddRange (Application.MonoLibraries.OrderBy (v => v).Select (v => $"{key}={v}")))
+				)},
+				{ "MSBuildOutputFile", (
+					// The file the assembly-preparer's preparation pass writes its MSBuild output properties to.
+					new LoadValue ((key, value) => MSBuildOutputFile = value),
+					new SaveValue ((key, storage) => saveNonEmpty (key, MSBuildOutputFile, storage))
+				)},
+				{ "MSBuildPostProcessOutputFile", (
+					// The file the assembly-preparer's post-processing pass writes its MSBuild output properties to.
+					new LoadValue ((key, value) => MSBuildPostProcessOutputFile = value),
+					new SaveValue ((key, storage) => saveNonEmpty (key, MSBuildPostProcessOutputFile, storage))
 				)},
 				{ "MtouchFloat32", (
 					new LoadValue ((key, value) => loadNullableBool (key, value, out Application.AotFloat32)),
@@ -866,6 +904,13 @@ namespace Xamarin.Linker {
 			}
 		}
 
+		// Register an MSBuild output property. The collected properties are written to the MSBuild
+		// output file (see FlushOutputForMSBuild) so that MSBuild can read them back.
+		public void SetOutputForMSBuild (string propertyName, string value)
+		{
+			msbuild_properties [propertyName] = value;
+		}
+
 		public void FlushOutputForMSBuild ()
 		{
 			Directory.CreateDirectory (ItemsDirectory);
@@ -885,6 +930,18 @@ namespace Xamarin.Linker {
 							elements)));
 
 				document.Save (Path.Combine (ItemsDirectory, itemName + ".items"));
+			}
+
+			// Write the collected MSBuild output properties (alphabetically sorted, one 'Name=Value' per line)
+			// to the output file for the current pass, so that MSBuild can read them back. We always write the
+			// file (even when there are no properties), so it's a consistent, persistent artifact of the pass
+			// (it's added to FileWrites by the _PrepareAssemblies/_PostprocessAssemblies targets).
+			var outputFile = Application.IsPostProcessingAssemblies ? MSBuildPostProcessOutputFile : MSBuildOutputFile;
+			if (!string.IsNullOrEmpty (outputFile)) {
+				var directory = Path.GetDirectoryName (outputFile);
+				if (!string.IsNullOrEmpty (directory))
+					Directory.CreateDirectory (directory);
+				File.WriteAllLines (outputFile, msbuild_properties.Select (kvp => $"{kvp.Key}={kvp.Value}"));
 			}
 		}
 

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -913,23 +913,27 @@ namespace Xamarin.Linker {
 
 		public void FlushOutputForMSBuild ()
 		{
-			Directory.CreateDirectory (ItemsDirectory);
-			foreach (var kvp in msbuild_items) {
-				var itemName = kvp.Key;
-				var items = kvp.Value;
+			// ItemsDirectory isn't set when running in the assembly-preparer, so only write
+			// the item files when we have a directory to write them to.
+			if (!string.IsNullOrEmpty (ItemsDirectory)) {
+				Directory.CreateDirectory (ItemsDirectory);
+				foreach (var kvp in msbuild_items) {
+					var itemName = kvp.Key;
+					var items = kvp.Value;
 
-				var xmlNs = XNamespace.Get ("http://schemas.microsoft.com/developer/msbuild/2003");
-				var elements = items.Select (item =>
-					new XElement (xmlNs + itemName,
-						new XAttribute ("Include", item.Include),
-							item.Metadata.Select (metadata => new XElement (xmlNs + metadata.Key, metadata.Value))));
+					var xmlNs = XNamespace.Get ("http://schemas.microsoft.com/developer/msbuild/2003");
+					var elements = items.Select (item =>
+						new XElement (xmlNs + itemName,
+							new XAttribute ("Include", item.Include),
+								item.Metadata.Select (metadata => new XElement (xmlNs + metadata.Key, metadata.Value))));
 
-				var document = new XDocument (
-					new XElement (xmlNs + "Project",
-						new XElement (xmlNs + "ItemGroup",
-							elements)));
+					var document = new XDocument (
+						new XElement (xmlNs + "Project",
+							new XElement (xmlNs + "ItemGroup",
+								elements)));
 
-				document.Save (Path.Combine (ItemsDirectory, itemName + ".items"));
+					document.Save (Path.Combine (ItemsDirectory, itemName + ".items"));
+				}
 			}
 
 			// Write the collected MSBuild output properties (alphabetically sorted, one 'Name=Value' per line)

--- a/tools/linker/RegistrarRemovalTrackingStep.cs
+++ b/tools/linker/RegistrarRemovalTrackingStep.cs
@@ -28,7 +28,9 @@ namespace MonoTouch.Tuner {
 			Process (assembly);
 		}
 
+#if !ASSEMBLY_PREPARER
 		AssemblyDefinition? PlatformAssembly;
+#endif
 
 		bool dynamic_registration_support_required;
 
@@ -49,7 +51,9 @@ namespace MonoTouch.Tuner {
 			if (Profile.IsProductAssembly (assembly)) {
 				if (Annotations.GetAction (assembly) != AssemblyAction.Link)
 					return false;
+#if !ASSEMBLY_PREPARER
 				PlatformAssembly = assembly;
+#endif
 			}
 
 			// Can't touch the forbidden fruit in the product assembly unless there's a reference to it
@@ -166,20 +170,27 @@ namespace MonoTouch.Tuner {
 
 			App.Log (4, "Optimization dynamic registrar removal: {0}", Optimizations.RemoveDynamicRegistrar.Value ? "enabled" : "disabled");
 
-			if (Optimizations.RemoveDynamicRegistrar.Value) {
+#if ASSEMBLY_PREPARER
+			// In the assembly-preparer we don't rewrite the platform assembly. Instead we surface the computed
+			// value to MSBuild (as the DynamicRegistrationSupported output property), which enables the
+			// 'ObjCRuntime.Runtime.DynamicRegistrationSupported' trimmer feature switch so that ILLink hardcodes
+			// Runtime.DynamicRegistrationSupported. This way the assembly-preparer doesn't have to modify (and
+			// thus re-save) any assembly.
+			Configuration.SetOutputForMSBuild ("DynamicRegistrationSupported", App.DynamicRegistrationSupported ? "true" : "false");
+#else
+			if (Optimizations.RemoveDynamicRegistrar.Value && PlatformAssembly is not null) {
 				// ILLink will optimize `Runtime.Initialize` based on `DynamicRegistrationSupported` returning a constant (`true`)
 				// and this will runs before we have the chance to set it to `false` in `CoreOptimizedGeneratedCode` so we instead
 				// do the change here so the linker can do this without further ado
 				// note: it does not matter for _legacy_ so we apply the change (to earlier) to minimize the difference between them
-				if (PlatformAssembly is not null) {
-					var method = PlatformAssembly.MainModule.GetType ("ObjCRuntime.Runtime").Methods.First ((n) => n.Name == "get_DynamicRegistrationSupported");
-					// Rewrite to return 'false'
-					var instr = method.Body.Instructions;
-					instr.Clear ();
-					instr.Add (Instruction.Create (OpCodes.Ldc_I4_0));
-					instr.Add (Instruction.Create (OpCodes.Ret));
-				}
+				var method = PlatformAssembly.MainModule.GetType ("ObjCRuntime.Runtime").Methods.First ((n) => n.Name == "get_DynamicRegistrationSupported");
+				// Rewrite to return 'false'
+				var instr = method.Body.Instructions;
+				instr.Clear ();
+				instr.Add (Instruction.Create (OpCodes.Ldc_I4_0));
+				instr.Add (Instruction.Create (OpCodes.Ret));
 			}
+#endif
 		}
 	}
 }


### PR DESCRIPTION
When running as a step in the assembly-preparer, `RegistrarRemovalTrackingStep` used to
rewrite `Runtime.get_DynamicRegistrationSupported` in the platform assembly (to return
`false`) when it determined the dynamic registrar could be removed. That required the
assembly-preparer to modify - and thus re-save - the platform assembly.

Instead, compute the value and surface it to MSBuild, which enables the
`ObjCRuntime.Runtime.DynamicRegistrationSupported` trimmer feature switch so that ILLink
hardcodes the property (the same way it already does for e.g.
`ObjCRuntime.Runtime.IsManagedStaticRegistrar`). This way the assembly-preparer doesn't
have to touch any assembly for this optimization.

## How it works

* Added `get_DynamicRegistrationSupported` substitution entries (feature
  `ObjCRuntime.Runtime.DynamicRegistrationSupported`) to the `ILLink.Substitutions.*.xml`
  for all four platforms.
* `RegistrarRemovalTrackingStep` still computes `Optimizations.RemoveDynamicRegistrar`, but
  under `ASSEMBLY_PREPARER` it no longer rewrites the assembly - it reports the value via a
  new generic "MSBuild output property" mechanism instead. The real ILLink path (when
  `PrepareAssemblies` isn't enabled) is unchanged and still rewrites the assembly.

## Generic MSBuild output mechanism

* `LinkerConfiguration.SetOutputForMSBuild (name, value)` collects output properties, and
  `FlushOutputForMSBuild` writes them - alphabetically sorted, one `Name=Value` per line -
  to a file. There's a separate file for the preparation and post-processing passes so the
  two passes don't clobber each other.
* The files are added to `FileWrites` (when they exist after the assembly-preparer has run).
* The `_SetDynamicRegistrationSupportedFeature` target (which runs after `_PrepareAssemblies`
  and before the trimmer) parses the `DynamicRegistrationSupported` property out of the
  preparation pass's output file and adds the `RuntimeHostConfigurationOption`. It's not
  incremental-gated and the file is persisted, so the feature switch is still set correctly
  when `_PrepareAssemblies` is skipped because its outputs are up-to-date.

## User override

* Added a user-overridable `$(DynamicRegistrationSupported)` MSBuild property (documented in
  `build-properties.md`); the user value always wins.
* When the user sets `$(DynamicRegistrationSupported)`, the value doesn't need to be computed,
  so `RegistrarRemovalTrackingStep` is skipped entirely in the preparation pass.

## Testing

Added a `DynamicRegistrationSupportedTest` build test asserting the user value flows through
to the feature switch. Also verified manually (default + explicit true/false) and with
monotouch-test (`release|linksdk`, `PrepareAssemblies=true PostProcessAssemblies=true`).

## Note

While working on this I ran into a pre-existing incremental-build failure with
`PrepareAssemblies=true` (unrelated to this change); filed as #25938.

🤖 Pull request created by Copilot
