### PR TITLE
[msbuild] Support App Extensions on Mac Catalyst (fixes #17408)

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileAppManifest.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CompileAppManifest.cs
@@ -521,6 +521,16 @@ namespace Xamarin.MacDev.Tasks {
 
 		void SetRequiredArchitectures (PDictionary plist)
 		{
+			// UIRequiredDeviceCapabilities is neither required nor evaluated for Mac Catalyst: the
+			// macOS App Store ignores hardware capability values (such as 'arm64'). Injecting an
+			// architecture-specific value would also make the Info.plist differ between the x64 and
+			// arm64 slices of a universal ('maccatalyst-x64;maccatalyst-arm64') build, which breaks
+			// merging the per-RID app bundles (in particular nested app extensions, whose Info.plist
+			// isn't recomputed when merging). So leave any user-authored value untouched, and don't
+			// add our own, for Mac Catalyst.
+			if (Platform == ApplePlatform.MacCatalyst)
+				return;
+
 			PObject? capabilities;
 
 			if (plist.TryGetValue (ManifestKeys.UIRequiredDeviceCapabilities, out capabilities)) {

--- a/msbuild/Xamarin.Shared/Xamarin.MacCatalyst.AppExtension.CSharp.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.MacCatalyst.AppExtension.CSharp.targets
@@ -1,0 +1,45 @@
+<!--
+***********************************************************************************************
+Xamarin.MacCatalyst.AppExtension.CSharp.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+  created a backup copy.  Incorrect changes to this file will make it
+  impossible to load or build your projects from the command-line or the IDE.
+
+This file imports the version- and platform-specific targets for the project importing
+this file. This file also defines targets to produce an error if the specified targets
+file does not exist, but the project is built anyway (command-line or IDE build).
+
+***********************************************************************************************
+-->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets"
+			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
+
+	<PropertyGroup>
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<!--
+			In Xamarin.MacCatalyst.Common.targets, just before the _CompileToNative target, we modify the
+			mtouch references to ensure that we get the lib assemblies for nugets, and not the ref references:
+
+			https://github.com/dotnet/macios/blob/9e31d07ecc08a64372dd562e843c3d8950d24985/msbuild/Xamarin.MacCatalyst.Tasks.Core/Xamarin.MacCatalyst.Common.targets#L784-L791
+
+			This logic removes nuget references, and then re-adds any copy-local dll references.
+
+			This works fine in executable projects, but not in library projects (aka extensions), because nugets aren't copied for library projects:
+
+			https://github.com/NuGet/NuGet.BuildTasks/blob/cf4b0a12cf1f75e0654f28c2a9020251c41d126a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets#L86
+
+			So we need to set the CopyNuGetImplementations variable to 'true' for our library projects.
+		-->
+		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
+	</PropertyGroup>
+	<Import Project="Xamarin.MacCatalyst.AppExtension.Common.targets" />
+
+	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"
+			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets')"/>
+</Project>

--- a/msbuild/Xamarin.Shared/Xamarin.MacCatalyst.AppExtension.Common.props
+++ b/msbuild/Xamarin.Shared/Xamarin.MacCatalyst.AppExtension.Common.props
@@ -1,0 +1,22 @@
+﻿<!--
+***********************************************************************************************
+Xamarin.MacCatalyst.AppExtension.Common.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+  created a backup copy.  Incorrect changes to this file will make it
+  impossible to load or build your projects from the command-line or the IDE.
+
+This file defines default properties for iOS App Extension projects.
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.props"
+			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.props')"/>
+
+	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.props"
+			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.props')"/>
+
+</Project>

--- a/msbuild/Xamarin.Shared/Xamarin.MacCatalyst.AppExtension.Common.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.MacCatalyst.AppExtension.Common.targets
@@ -1,0 +1,32 @@
+﻿<!--
+***********************************************************************************************
+Xamarin.MacCatalyst.AppExtension.Common.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+  created a backup copy.  Incorrect changes to this file will make it
+  impossible to load or build your projects from the command-line or the IDE.
+
+This file imports the version- and platform-specific targets for the project importing
+this file. This file also defines targets to produce an error if the specified targets
+file does not exist, but the project is built anyway (command-line or IDE build).
+
+***********************************************************************************************
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<IsAppExtension>True</IsAppExtension>
+		<IsWatchExtension>False</IsWatchExtension>
+	</PropertyGroup>
+
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.MacCatalyst.Common.targets" />
+
+	<Import Project="$(MSBuildThisFileDirectory)Xamarin.MacCatalyst.AppExtension.Common.props" />
+
+	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets" 
+			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
+
+	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"
+			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets')"/>
+
+</Project>

--- a/msbuild/Xamarin.Shared/Xamarin.MacCatalyst.AppExtension.FSharp.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.MacCatalyst.AppExtension.FSharp.targets
@@ -1,0 +1,50 @@
+<!--
+***********************************************************************************************
+Xamarin.MacCatalyst.AppExtension.FSharp.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+  created a backup copy.  Incorrect changes to this file will make it
+  impossible to load or build your projects from the command-line or the IDE.
+
+This file imports the version- and platform-specific targets for the project importing
+this file. This file also defines targets to produce an error if the specified targets
+file does not exist, but the project is built anyway (command-line or IDE build).
+
+***********************************************************************************************
+-->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets"
+			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
+
+	<PropertyGroup>
+		<!-- This must be set before importing Microsoft.FSharp.targets -->
+		<!-- See Xamarin.MacCatalyst.AppExtension.CSharp.targets for a detailed explanation of this variable -->
+		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
+
+		<!-- This should be done in the F# target files, but _DebugFileExt is not an upstream
+		     msbuild feature yet, so F# doesn't have this. Once, upstream F# adds it, we can
+		     remove this -->
+		<_DebugFileExt Condition="'$(FscDebugFileExt)' != ''">$(FscDebugFileExt)</_DebugFileExt>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.CSharp.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
+	</PropertyGroup>
+
+	<!-- xbuild searches multiple MSBuildExtensionsPath32, but only in the Import element so we can't determine this with a variable -->
+	<Import
+		Condition="'$(Language)' != 'F#' And Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')"
+		Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets" />
+	<Import
+		Condition="'$(Language)' != 'F#' And Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets')"
+		Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\4.0\Framework\v4.0\Microsoft.FSharp.Targets" />
+	<Import
+		Condition="'$(Language)' != 'F#' And Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets')"
+		Project="$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets" />
+
+	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"
+			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets')"/>
+
+	<Import Project="Xamarin.MacCatalyst.AppExtension.Common.targets" />
+
+</Project>

--- a/msbuild/Xamarin.Shared/Xamarin.MacCatalyst.AppExtension.VisualBasic.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.MacCatalyst.AppExtension.VisualBasic.targets
@@ -1,0 +1,45 @@
+<!--
+***********************************************************************************************
+Xamarin.MacCatalyst.AppExtension.VisualBasic.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+  created a backup copy.  Incorrect changes to this file will make it
+  impossible to load or build your projects from the command-line or the IDE.
+
+This file imports the version- and platform-specific targets for the project importing
+this file. This file also defines targets to produce an error if the specified targets
+file does not exist, but the project is built anyway (command-line or IDE build).
+
+***********************************************************************************************
+-->
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets"
+			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).Before.targets')"/>
+
+	<PropertyGroup>
+		<!-- This must be set before importing Microsoft.VisualBasic.targets -->
+		<!--
+			In Xamarin.MacCatalyst.Common.targets, just before the _CompileToNative target, we modify the
+			mtouch references to ensure that we get the lib assemblies for nugets, and not the ref references:
+
+			https://github.com/dotnet/macios/blob/9e31d07ecc08a64372dd562e843c3d8950d24985/msbuild/Xamarin.MacCatalyst.Tasks.Core/Xamarin.MacCatalyst.Common.targets#L784-L791
+
+			This logic removes nuget references, and then re-adds any copy-local dll references.
+
+			This works fine in executable projects, but not in library projects (aka extensions), because nugets aren't copied for library projects:
+
+			https://github.com/NuGet/NuGet.BuildTasks/blob/cf4b0a12cf1f75e0654f28c2a9020251c41d126a/src/Microsoft.NuGet.Build.Tasks/Microsoft.NuGet.targets#L86
+
+			So we need to set the CopyNuGetImplementations variable to 'true' for our library projects.
+		-->
+		<CopyNuGetImplementations Condition="'$(CopyNuGetImplementations)' == ''">true</CopyNuGetImplementations>
+
+		<!-- Enable nuget package conflict resolution -->
+		<!-- This must be set before importing Microsoft.VisualBasic.targets -->
+		<ResolveAssemblyConflicts>true</ResolveAssemblyConflicts>
+	</PropertyGroup>
+	<Import Project="Xamarin.MacCatalyst.AppExtension.Common.targets" />
+
+	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"
+			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets')"/>
+</Project>

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -92,7 +92,7 @@ MONOTOUCH_ARM64_SOURCE_STEMS = $(patsubst %.s,%,$(patsubst %.m,%,$(SHARED_ARM64_
 DOTNET_iOS_LIBRARIES = libextension-dotnet.a
 DOTNET_tvOS_LIBRARIES = libextension-dotnet.a libtvextension-dotnet.a
 DOTNET_macOS_LIBRARIES = libextension-dotnet-coreclr.a
-DOTNET_MacCatalyst_LIBRARIES =
+DOTNET_MacCatalyst_LIBRARIES = libextension-dotnet.a
 
 define DotNetLibTemplate
 DOTNET_TARGETS += \

--- a/tests/dotnet/ExtensionConsumer/MacCatalyst/ExtensionConsumer.csproj
+++ b/tests/dotnet/ExtensionConsumer/MacCatalyst/ExtensionConsumer.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/ExtensionConsumer/MacCatalyst/ExtensionConsumer.slnx
+++ b/tests/dotnet/ExtensionConsumer/MacCatalyst/ExtensionConsumer.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="../../ExtensionProject/MacCatalyst/ExtensionProject.csproj" />
+  <Project Path="ExtensionConsumer.csproj" />
+</Solution>

--- a/tests/dotnet/ExtensionConsumer/MacCatalyst/Makefile
+++ b/tests/dotnet/ExtensionConsumer/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/ExtensionConsumerWithFrameworks/MacCatalyst/ExtensionConsumer.slnx
+++ b/tests/dotnet/ExtensionConsumerWithFrameworks/MacCatalyst/ExtensionConsumer.slnx
@@ -1,0 +1,4 @@
+<Solution>
+  <Project Path="../../ExtensionProject/MacCatalyst/ExtensionProject.csproj" />
+  <Project Path="MySimpleApp.csproj" />
+</Solution>

--- a/tests/dotnet/ExtensionConsumerWithFrameworks/MacCatalyst/ExtensionConsumerWithFrameworks.csproj
+++ b/tests/dotnet/ExtensionConsumerWithFrameworks/MacCatalyst/ExtensionConsumerWithFrameworks.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/ExtensionConsumerWithFrameworks/MacCatalyst/Makefile
+++ b/tests/dotnet/ExtensionConsumerWithFrameworks/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/ExtensionProject/MacCatalyst/Entitlements.plist
+++ b/tests/dotnet/ExtensionProject/MacCatalyst/Entitlements.plist
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/tests/dotnet/ExtensionProject/MacCatalyst/ExtensionProject.csproj
+++ b/tests/dotnet/ExtensionProject/MacCatalyst/ExtensionProject.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/ExtensionProject/MacCatalyst/ExtensionProject.slnx
+++ b/tests/dotnet/ExtensionProject/MacCatalyst/ExtensionProject.slnx
@@ -1,0 +1,3 @@
+<Solution>
+  <Project Path="ExtensionProject.csproj" />
+</Solution>

--- a/tests/dotnet/ExtensionProject/MacCatalyst/Info.plist
+++ b/tests/dotnet/ExtensionProject/MacCatalyst/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>MyShareExtension</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.xamarin.MyMasterDetailApp.MyShareExtension</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>com.xamarin.MyShareExtension</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<string>TRUEPREDICATE</string>
+			<key>NSExtensionPointName</key>
+			<string>com.apple.share-services</string>
+			<key>NSExtensionPointVersion</key>
+			<string>1.0</string>
+		</dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+	</dict>
+</dict>
+</plist>

--- a/tests/dotnet/ExtensionProject/MacCatalyst/MainInterface.storyboard
+++ b/tests/dotnet/ExtensionProject/MacCatalyst/MainInterface.storyboard
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6150.1" systemVersion="13D65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="j1y-V4-xli">
+	<dependencies>
+		<plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6148" />
+	</dependencies>
+	<scenes>
+		<!--Share View Controller-->
+		<scene sceneID="ceB-am-kn3">
+			<objects>
+				<viewController id="j1y-V4-xli" customClass="ShareViewController" customModuleProvider="" sceneMemberID="viewController">
+					<layoutGuides>
+						<viewControllerLayoutGuide type="top" id="8bI-gs-bmD" />
+						<viewControllerLayoutGuide type="bottom" id="d5i-Ba-RvD" />
+					</layoutGuides>
+					<view key="view" opaque="NO" contentMode="scaleToFill" id="wbc-yd-nQP">
+						<rect key="frame" x="0.0" y="0.0" width="480" height="480" />
+						<autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES" />
+						<color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite" />
+						<simulatedOrientationMetrics key="simulatedOrientationMetrics" orientation="landscapeRight" />
+					</view>
+				</viewController>
+				<placeholder placeholderIdentifier="IBFirstResponder" id="CEy-Cv-SGf" userLabel="First Responder" sceneMemberID="firstResponder" />
+			</objects>
+			<point key="canvasLocation" x="539" y="97" />
+		</scene>
+	</scenes>
+</document>

--- a/tests/dotnet/ExtensionProject/MacCatalyst/Makefile
+++ b/tests/dotnet/ExtensionProject/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/ExtensionProject/MacCatalyst/ShareViewController.cs
+++ b/tests/dotnet/ExtensionProject/MacCatalyst/ShareViewController.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Drawing;
+
+using Foundation;
+using Social;
+using UIKit;
+
+namespace MyShareExtension {
+	public partial class ShareViewController : SLComposeServiceViewController {
+		public ShareViewController (IntPtr handle) : base (handle)
+		{
+		}
+
+		public override bool IsContentValid ()
+		{
+			// Do validation of contentText and/or NSExtensionContext attachments here
+			return true;
+		}
+
+		public override void DidSelectPost ()
+		{
+			// This is called after the user selects Post. Do the upload of contentText and/or NSExtensionContext attachments.
+
+			// Inform the host that we're done, so it un-blocks its UI. Note: Alternatively you could call super's -didSelectPost, which will similarly complete the extension context.
+			ExtensionContext?.CompleteRequest ([], null);
+		}
+
+		public override SLComposeSheetConfigurationItem [] GetConfigurationItems ()
+		{
+			// To add configuration options via table cells at the bottom of the sheet, return an array of SLComposeSheetConfigurationItem here.
+			return new SLComposeSheetConfigurationItem [0];
+		}
+	}
+}

--- a/tests/dotnet/ExtensionProject/MacCatalyst/ShareViewController.cs
+++ b/tests/dotnet/ExtensionProject/MacCatalyst/ShareViewController.cs
@@ -2,12 +2,13 @@ using System;
 using System.Drawing;
 
 using Foundation;
+using ObjCRuntime;
 using Social;
 using UIKit;
 
 namespace MyShareExtension {
 	public partial class ShareViewController : SLComposeServiceViewController {
-		public ShareViewController (IntPtr handle) : base (handle)
+		public ShareViewController (NativeHandle handle) : base (handle)
 		{
 		}
 

--- a/tests/dotnet/ExtensionProject/MacCatalyst/ShareViewController.designer.cs
+++ b/tests/dotnet/ExtensionProject/MacCatalyst/ShareViewController.designer.cs
@@ -1,0 +1,18 @@
+//
+// This file has been generated automatically by MonoDevelop to store outlets and
+// actions made in the Xcode designer. If it is removed, they will be lost.
+// Manual changes to this file may not be handled correctly.
+//
+
+using Foundation;
+
+namespace MyShareExtension
+{
+	[Register ("ShareViewController")]
+	partial class ShareViewController
+	{
+		void ReleaseDesignerOutlets ()
+		{
+		}
+	}
+}

--- a/tests/dotnet/ExtensionProjectWithFrameworks/MacCatalyst/Entitlements.plist
+++ b/tests/dotnet/ExtensionProjectWithFrameworks/MacCatalyst/Entitlements.plist
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/tests/dotnet/ExtensionProjectWithFrameworks/MacCatalyst/ExtensionProject.slnx
+++ b/tests/dotnet/ExtensionProjectWithFrameworks/MacCatalyst/ExtensionProject.slnx
@@ -1,0 +1,3 @@
+<Solution>
+  <Project Path="ExtensionProject.csproj" />
+</Solution>

--- a/tests/dotnet/ExtensionProjectWithFrameworks/MacCatalyst/ExtensionProjectWithFrameworks.csproj
+++ b/tests/dotnet/ExtensionProjectWithFrameworks/MacCatalyst/ExtensionProjectWithFrameworks.csproj
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-maccatalyst</TargetFramework>
+	</PropertyGroup>
+	<Import Project="..\shared.csproj" />
+</Project>

--- a/tests/dotnet/ExtensionProjectWithFrameworks/MacCatalyst/Info.plist
+++ b/tests/dotnet/ExtensionProjectWithFrameworks/MacCatalyst/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>MyShareExtension</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.xamarin.MyMasterDetailApp.MyShareExtension</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>com.xamarin.MyShareExtension</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<string>TRUEPREDICATE</string>
+			<key>NSExtensionPointName</key>
+			<string>com.apple.share-services</string>
+			<key>NSExtensionPointVersion</key>
+			<string>1.0</string>
+		</dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+	</dict>
+</dict>
+</plist>

--- a/tests/dotnet/ExtensionProjectWithFrameworks/MacCatalyst/MainInterface.storyboard
+++ b/tests/dotnet/ExtensionProjectWithFrameworks/MacCatalyst/MainInterface.storyboard
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6150.1" systemVersion="13D65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="j1y-V4-xli">
+	<dependencies>
+		<plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6148" />
+	</dependencies>
+	<scenes>
+		<!--Share View Controller-->
+		<scene sceneID="ceB-am-kn3">
+			<objects>
+				<viewController id="j1y-V4-xli" customClass="ShareViewController" customModuleProvider="" sceneMemberID="viewController">
+					<layoutGuides>
+						<viewControllerLayoutGuide type="top" id="8bI-gs-bmD" />
+						<viewControllerLayoutGuide type="bottom" id="d5i-Ba-RvD" />
+					</layoutGuides>
+					<view key="view" opaque="NO" contentMode="scaleToFill" id="wbc-yd-nQP">
+						<rect key="frame" x="0.0" y="0.0" width="480" height="480" />
+						<autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES" />
+						<color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite" />
+						<simulatedOrientationMetrics key="simulatedOrientationMetrics" orientation="landscapeRight" />
+					</view>
+				</viewController>
+				<placeholder placeholderIdentifier="IBFirstResponder" id="CEy-Cv-SGf" userLabel="First Responder" sceneMemberID="firstResponder" />
+			</objects>
+			<point key="canvasLocation" x="539" y="97" />
+		</scene>
+	</scenes>
+</document>

--- a/tests/dotnet/ExtensionProjectWithFrameworks/MacCatalyst/Makefile
+++ b/tests/dotnet/ExtensionProjectWithFrameworks/MacCatalyst/Makefile
@@ -1,0 +1,1 @@
+include ../shared.mk

--- a/tests/dotnet/ExtensionProjectWithFrameworks/MacCatalyst/ShareViewController.cs
+++ b/tests/dotnet/ExtensionProjectWithFrameworks/MacCatalyst/ShareViewController.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Drawing;
+
+using Foundation;
+using Social;
+using UIKit;
+
+namespace MyShareExtension {
+	public partial class ShareViewController : SLComposeServiceViewController {
+		public ShareViewController (IntPtr handle) : base (handle)
+		{
+		}
+
+		public override bool IsContentValid ()
+		{
+			// Do validation of contentText and/or NSExtensionContext attachments here
+			return true;
+		}
+
+		public override void DidSelectPost ()
+		{
+			// This is called after the user selects Post. Do the upload of contentText and/or NSExtensionContext attachments.
+
+			// Inform the host that we're done, so it un-blocks its UI. Note: Alternatively you could call super's -didSelectPost, which will similarly complete the extension context.
+			ExtensionContext?.CompleteRequest ([], null);
+		}
+
+		public override SLComposeSheetConfigurationItem [] GetConfigurationItems ()
+		{
+			// To add configuration options via table cells at the bottom of the sheet, return an array of SLComposeSheetConfigurationItem here.
+			return new SLComposeSheetConfigurationItem [0];
+		}
+	}
+}

--- a/tests/dotnet/ExtensionProjectWithFrameworks/MacCatalyst/ShareViewController.cs
+++ b/tests/dotnet/ExtensionProjectWithFrameworks/MacCatalyst/ShareViewController.cs
@@ -2,12 +2,13 @@ using System;
 using System.Drawing;
 
 using Foundation;
+using ObjCRuntime;
 using Social;
 using UIKit;
 
 namespace MyShareExtension {
 	public partial class ShareViewController : SLComposeServiceViewController {
-		public ShareViewController (IntPtr handle) : base (handle)
+		public ShareViewController (NativeHandle handle) : base (handle)
 		{
 		}
 

--- a/tests/dotnet/ExtensionProjectWithFrameworks/MacCatalyst/ShareViewController.designer.cs
+++ b/tests/dotnet/ExtensionProjectWithFrameworks/MacCatalyst/ShareViewController.designer.cs
@@ -1,0 +1,18 @@
+//
+// This file has been generated automatically by MonoDevelop to store outlets and
+// actions made in the Xcode designer. If it is removed, they will be lost.
+// Manual changes to this file may not be handled correctly.
+//
+
+using Foundation;
+
+namespace MyShareExtension
+{
+	[Register ("ShareViewController")]
+	partial class ShareViewController
+	{
+		void ReleaseDesignerOutlets ()
+		{
+		}
+	}
+}

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1048,7 +1048,7 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.iOS, "ios-arm64", true)]
 		[TestCase (ApplePlatform.TVOS, "tvossimulator-arm64", false)]
 		[TestCase (ApplePlatform.TVOS, "tvossimulator-arm64", true)]
-		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64", false)]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64", false)]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64;maccatalyst-x64", true)]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64", true)]
 		[TestCase (ApplePlatform.MacOSX, "osx-arm64;osx-x64", false)]
@@ -1883,8 +1883,8 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.MacOSX, "osx-x64", true)]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64;osx-arm64", false)]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64;osx-arm64", true)]
-		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64", false)]
-		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64", true)]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64", false)]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64", true)]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64;maccatalyst-arm64", false)]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64;maccatalyst-arm64", true)]
 		public void BuildProjectsWithExtensions (ApplePlatform platform, string runtimeIdentifier, bool isNativeAot)
@@ -1934,8 +1934,8 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.MacOSX, "osx-x64", true)]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64;osx-arm64", false)]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64;osx-arm64", true)]
-		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64", false)]
-		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64", true)]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64", false)]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64", true)]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64;maccatalyst-arm64", false)]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64;maccatalyst-arm64", true)]
 		public void BuildProjectsWithExtensionsAndFrameworks (ApplePlatform platform, string runtimeIdentifier, bool isNativeAot)
@@ -2032,7 +2032,7 @@ namespace Xamarin.Tests {
 			ExecuteWithMagicWordAndAssert (platform, runtimeIdentifiers, appExecutable);
 		}
 
-		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64", false)]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64", false)]
 		[TestCase (ApplePlatform.iOS, "iossimulator-x64", true)]
 		[TestCase (ApplePlatform.TVOS, "tvossimulator-x64", true)]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64;osx-arm64", true)]
@@ -2200,8 +2200,8 @@ namespace Xamarin.Tests {
 			DotNet.AssertBuild (project_path, properties);
 		}
 
-		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64", false)]
-		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64", true)]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64", false)]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64", true)]
 		[TestCase (ApplePlatform.iOS, "ios-arm64", false)]
 		[TestCase (ApplePlatform.TVOS, "tvossimulator-arm64", true)]
 		public void AutoDetectEntitlements (ApplePlatform platform, string runtimeIdentifiers, bool exclude)

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -1883,7 +1883,10 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.MacOSX, "osx-x64", true)]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64;osx-arm64", false)]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64;osx-arm64", true)]
-		// [TestCase ("MacCatalyst", "")] - No extension support yet
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64", false)]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64", true)]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64;maccatalyst-arm64", false)]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64;maccatalyst-arm64", true)]
 		public void BuildProjectsWithExtensions (ApplePlatform platform, string runtimeIdentifier, bool isNativeAot)
 		{
 			BuildProjectsWithExtensionsImpl (platform, runtimeIdentifier, isNativeAot);
@@ -1931,7 +1934,10 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.MacOSX, "osx-x64", true)]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64;osx-arm64", false)]
 		[TestCase (ApplePlatform.MacOSX, "osx-x64;osx-arm64", true)]
-		// [TestCase ("MacCatalyst", "")] - No extension support yet
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64", false)]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64", true)]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64;maccatalyst-arm64", false)]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64;maccatalyst-arm64", true)]
 		public void BuildProjectsWithExtensionsAndFrameworks (ApplePlatform platform, string runtimeIdentifier, bool isNativeAot)
 		{
 			Configuration.IgnoreIfIgnoredPlatform (platform);
@@ -1974,7 +1980,7 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.iOS)]
 		[TestCase (ApplePlatform.TVOS)]
 		[TestCase (ApplePlatform.MacOSX)]
-		// [TestCase ("MacCatalyst", "")] - No extension support yet
+		[TestCase (ApplePlatform.MacCatalyst)]
 		public void BuildTrimmedExtensionProject (ApplePlatform platform)
 		{
 			Configuration.IgnoreIfIgnoredPlatform (platform);

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileAppManifestTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/CompileAppManifestTaskTests.cs
@@ -188,5 +188,51 @@ namespace Xamarin.MacDev.Tasks {
 			}
 			Assert.That (plist.GetString ("DTPlatformName")?.Value, Is.EqualTo (expectedDTPlatformName), "Expected DTPlatformName");
 		}
+
+		[Test]
+		[TestCase ("ARM64")]
+		[TestCase ("x86_64")]
+		[TestCase ("x86_64, ARM64")]
+		public void MacCatalystDoesNotInjectRequiredDeviceCapabilities (string targetArchitectures)
+		{
+			// UIRequiredDeviceCapabilities is neither required nor evaluated for Mac Catalyst (the
+			// macOS App Store ignores hardware capability values such as 'arm64'). Injecting an
+			// architecture-specific value would also make the Info.plist differ between the x64 and
+			// arm64 slices of a universal build, which breaks merging the per-RID app bundles. Verify
+			// we never inject it for Mac Catalyst.
+			var task = CreateTask (platform: ApplePlatform.MacCatalyst);
+			task.TargetArchitectures = targetArchitectures;
+			ExecuteTask (task);
+
+			var plist = PDictionary.OpenFile (task.CompiledAppManifest!.ItemSpec);
+			Assert.That (plist.ContainsKey (ManifestKeys.UIRequiredDeviceCapabilities), Is.False, "UIRequiredDeviceCapabilities");
+		}
+
+		[Test]
+		[TestCase ("metal")]
+		[TestCase ("arm64")]
+		public void MacCatalystPreservesUserRequiredDeviceCapabilities (string capability)
+		{
+			// A shared iOS/iPad/Mac Catalyst Info.plist may legitimately declare
+			// UIRequiredDeviceCapabilities. It's ignored on Mac Catalyst, but we must preserve it
+			// as-authored (and identically between the architecture slices of a universal build, so
+			// the app bundles can be merged).
+			var dir = Cache.CreateTemporaryDirectory ();
+			var task = CreateTask (dir, ApplePlatform.MacCatalyst);
+			task.TargetArchitectures = "ARM64";
+
+			var manifest = new PDictionary ();
+			manifest [ManifestKeys.UIRequiredDeviceCapabilities] = new PArray { new PString (capability) };
+			var manifestPath = Path.Combine (dir, "Info.plist");
+			manifest.Save (manifestPath);
+			task.AppManifest = new TaskItem (manifestPath);
+
+			ExecuteTask (task);
+
+			var plist = PDictionary.OpenFile (task.CompiledAppManifest!.ItemSpec);
+			var array = plist.Get<PArray> (ManifestKeys.UIRequiredDeviceCapabilities);
+			Assert.That (array, Is.Not.Null, "present");
+			Assert.That (array!.OfType<PString> ().Select (x => x.Value).ToArray (), Is.EqualTo (new [] { capability }), "preserved");
+		}
 	}
 }


### PR DESCRIPTION
Fixes #17408

net10.0-maccatalyst app-extension projects (`<OutputType>Library</OutputType>` +
`<IsAppExtension>true</IsAppExtension>`) currently fail to build. There are two
independent gaps; MacCatalyst is iOS-derived (Mono runtime), so both mirror iOS.

1. Missing MSBuild targets. Xamarin.Shared.Sdk.targets imports
   `Xamarin.MacCatalyst.AppExtension.$(_ProjectLanguage).targets` for the
   `MacCatalystAppExtensionProject` type, but only the iOS/tvOS/macOS variants are
   shipped:

       error MSB4019: The imported project
       "…/Xamarin.MacCatalyst.AppExtension.CSharp.targets" was not found.

   Added Xamarin.MacCatalyst.AppExtension.{Common,CSharp,FSharp,VisualBasic}.targets
   and Xamarin.MacCatalyst.AppExtension.Common.props, mirroring the iOS files (they
   chain to Xamarin.MacCatalyst.Common.targets).

2. Missing native extension entry-point library. With the targets in place the
   build then fails at native link:

       ld: library 'libextension-dotnet.a' not found

   runtime/Makefile builds the extension main lib for iOS/tvOS/macOS but
   `DOTNET_MacCatalyst_LIBRARIES` was empty, so it is never built/packaged into the
   maccatalyst runtime pack. GenerateMainStep selects `libextension-dotnet.a` for
   the (Mono) MacCatalyst runtime, so set:

       DOTNET_MacCatalyst_LIBRARIES = libextension-dotnet.a

Together these let a MacCatalyst NEPacketTunnelProvider app extension build + embed
like the iOS one. (Verified the targets-file fix locally against
Microsoft.MacCatalyst.Sdk 26.5.10284; the runtime-lib line needs a runtime build to
produce the artifact.)