### PR TITLE
[assembly-preparer] Only run RegistrarRemovalTrackingStep if the platform assembly is trimmed.

### DIFF
--- a/tests/dotnet/UnitTests/DynamicRegistrationSupportedTest.cs
+++ b/tests/dotnet/UnitTests/DynamicRegistrationSupportedTest.cs
@@ -39,6 +39,30 @@ namespace Xamarin.Tests {
 			Assert.That (featureSwitch?.GetMetadata ("Value"), Is.EqualTo (dynamicRegistrationSupported), "The feature switch value must match the user-specified value.");
 		}
 
+		[Test]
+		[TestCase (ApplePlatform.iOS, "iossimulator-arm64")]
+		public void SkippedWhenPlatformAssemblyNotTrimmed (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			// When the platform assembly isn't being trimmed (link mode None), the dynamic registrar can't be
+			// removed, so RegistrarRemovalTrackingStep is skipped and no DynamicRegistrationSupported feature
+			// switch is emitted (the dynamic registrar is kept, which is the default).
+			var project = "MySimpleApp";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var project_path = GetProjectPath (project, platform: platform);
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["MtouchLink"] = "None";
+			properties ["PrepareAssemblies"] = "true";
+			properties ["PostProcessAssemblies"] = "true";
+
+			var rv = DotNet.AssertBuild (project_path, properties);
+
+			var featureSwitch = GetRuntimeHostConfigurationOption (rv.BinLogPath, "ObjCRuntime.Runtime.DynamicRegistrationSupported");
+			Assert.That (featureSwitch, Is.Null, "No DynamicRegistrationSupported feature switch should be set when the platform assembly isn't trimmed.");
+		}
+
 		// Returns the last RuntimeHostConfigurationOption item with the given name (ItemSpec) added during the build.
 		static ITaskItem? GetRuntimeHostConfigurationOption (string binLogPath, string name)
 		{

--- a/tools/assembly-preparer/AssemblyPreparer.cs
+++ b/tools/assembly-preparer/AssemblyPreparer.cs
@@ -140,9 +140,12 @@ public class AssemblyPreparer : IDisposable {
 			new InlineDlfcnMethodsStep (),
 		};
 
-		// If the user explicitly set $(DynamicRegistrationSupported), we don't need to compute the value, so
-		// skip RegistrarRemovalTrackingStep entirely (the value is passed straight through to the trimmer feature switch).
-		if (!configuration.DynamicRegistrationSupported.HasValue)
+		// Only add RegistrarRemovalTrackingStep if it's needed:
+		// * If the user explicitly set $(DynamicRegistrationSupported), we don't need to compute the value (it's
+		//   passed straight through to the trimmer feature switch).
+		// * If nothing is being trimmed, the dynamic registrar (which lives in the platform assembly, an SDK
+		//   assembly that's only trimmed when trimming is enabled) can't be removed, so there's nothing to compute.
+		if (!configuration.DynamicRegistrationSupported.HasValue && configuration.Application.AreAnyAssembliesTrimmed)
 			steps.Add (new RegistrarRemovalTrackingStep ());
 
 		// PreMarkDispatcher: I don't think we need this one


### PR DESCRIPTION
RegistrarRemovalTrackingStep computes whether the dynamic registrar can be
removed and reports the result to MSBuild as the DynamicRegistrationSupported
feature switch. The dynamic registrar lives in the platform assembly, which is
an SDK assembly that's only trimmed when trimming is enabled; so when nothing is
being trimmed the dynamic registrar can't be removed and there's nothing for the
step to compute.

Don't add the step to the assembly-preparer's step list in that case (in
addition to the existing skip when the user explicitly set
$(DynamicRegistrationSupported)). This avoids unnecessary work when building
without trimming.

🤖 Pull request created by Copilot
