### PR TITLE
[assembly-preparer] Log per-step timings and whether each step modified assemblies.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/PrepareAssemblies.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/PrepareAssemblies.cs
@@ -75,6 +75,13 @@ namespace Xamarin.MacDev.Tasks {
 					rv = preparer.Prepare (out exceptions);
 				}
 
+				var totalDuration = TimeSpan.Zero;
+				foreach (var step in preparer.StepExecutions) {
+					totalDuration += step.Duration;
+					Log.LogMessage (MessageImportance.Low, $"{step.Duration.ToString (@"hh\:mm\:ss\.fffffff")} {step.Name}: {(step.ModifiedAssemblies ? " ✏️ modified one or more assemblies" : " ✅ did not modify any assemblies")}");
+				}
+				Log.LogMessage (MessageImportance.Low, $"{totalDuration.ToString (@"hh\:mm\:ss\.fffffff")} Total for all steps");
+
 				foreach (var pe in exceptions) {
 					if (pe.IsError (this)) {
 						((IToolLog) this).LogError (pe);

--- a/tools/assembly-preparer/AssemblyPreparer.cs
+++ b/tools/assembly-preparer/AssemblyPreparer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.Serialization;
 using Mono.Cecil;
@@ -39,6 +40,12 @@ public class AssemblyPreparer : IDisposable {
 	public Optimizations Optimizations => configuration.Application.Optimizations;
 
 	public List<AssemblyPreparerInfo> Assemblies { get; set; } = new List<AssemblyPreparerInfo> ();
+
+	// The list of steps that were executed, along with how long each step took and whether it modified any assemblies.
+	public List<StepExecution> StepExecutions { get; } = new List<StepExecution> ();
+
+	// Set to true (via the AppBundleRewriter.AssemblySaved callback) whenever the currently executing step modifies an assembly.
+	bool currentStepModifiedAssemblies;
 
 	public IList<(string Path, AssemblyDefinition Assembly, string? OriginatingAssembly)> AddedAssemblies => configuration.AddedAssemblies;
 
@@ -203,8 +210,28 @@ public class AssemblyPreparer : IDisposable {
 
 		var linkContext = configuration.DerivedLinkContext;
 
-		foreach (var step in steps) {
-			step.Process (linkContext);
+		// We detect whether a step modified any assemblies by subscribing to the AppBundleRewriter's
+		// AssemblySaved callback, which is called whenever an assembly is modified. All the steps that
+		// modify assemblies go through the AppBundleRewriter to do so.
+		Action<AssemblyDefinition>? assemblySavedHandler = null;
+		try {
+			foreach (var step in steps) {
+				// Subscribe once the assemblies have been loaded: accessing the AppBundleRewriter before
+				// that point would create it without finding the corlib and platform assemblies.
+				if (assemblySavedHandler is null && configuration.Assemblies.Count > 0) {
+					assemblySavedHandler = (_) => currentStepModifiedAssemblies = true;
+					configuration.AppBundleRewriter.AssemblySaved += assemblySavedHandler;
+				}
+
+				currentStepModifiedAssemblies = false;
+				var watch = Stopwatch.StartNew ();
+				step.Process (linkContext);
+				watch.Stop ();
+				StepExecutions.Add (new StepExecution (step.GetType ().Name, watch.Elapsed, currentStepModifiedAssemblies));
+			}
+		} finally {
+			if (assemblySavedHandler is not null)
+				configuration.AppBundleRewriter.AssemblySaved -= assemblySavedHandler;
 		}
 
 		return exceptions.Count == 0;
@@ -218,6 +245,9 @@ public class AssemblyPreparer : IDisposable {
 		configuration.DerivedLinkContext.Assemblies.Clear ();
 	}
 }
+
+// The result of executing a single step: its name, how long it took, and whether it modified any assemblies.
+public record struct StepExecution (string Name, TimeSpan Duration, bool ModifiedAssemblies);
 
 public class AssemblyPreparerInfo {
 	internal AssemblyDefinition? Assembly { get; set; }

--- a/tools/dotnet-linker/AppBundleRewriter.cs
+++ b/tools/dotnet-linker/AppBundleRewriter.cs
@@ -29,6 +29,9 @@ namespace Xamarin.Linker {
 		AssemblyDefinition? corlib_assembly;
 		AssemblyDefinition? platform_assembly;
 
+		// Invoked whenever an assembly is modified (i.e. whenever SaveAssembly is called).
+		public Action<AssemblyDefinition>? AssemblySaved { get; set; }
+
 		public AssemblyDefinition CurrentAssembly {
 			get {
 				if (current_assembly is null)
@@ -1455,6 +1458,7 @@ namespace Xamarin.Linker {
 		{
 			if (assembly != CurrentAssembly && assembly != PlatformAssembly)
 				throw new InvalidOperationException ($"Can't save assembly {assembly.Name} because it's not the current assembly ({CurrentAssembly.Name}) or the platform assembly ({PlatformAssembly.Name}).");
+			AssemblySaved?.Invoke (assembly);
 			var annotations = configuration.Context.Annotations;
 			var action = annotations.GetAction (assembly);
 			if (action == AssemblyAction.Copy) {


### PR DESCRIPTION
Add timing information to the assembly-preparer's PrepareAssemblies task: for each step (in both the Prepare and PostProcess passes) log - at MessageImportance.Low - how long the step took, whether it modified any assemblies, and a total duration for all steps. The fixed-width duration is printed before the (variable-width) step name so the durations line up between all the log lines.

To know whether a step modified any assemblies, add an AssemblySaved callback to the AppBundleRewriter (invoked whenever SaveAssembly is called). All the steps that modify assemblies go through AppBundleRewriter.SaveAssembly (except two that's being fixed in separate PRs to either not save (RegistrarRemovalTrackingStep) or to subclass AssemblyModifierStep).