### PR TITLE
[release/11.0.1xx-preview6] [net11.0] Don't run GenerateR2RModuleRegistration remotely.

### DIFF
--- a/dotnet/targets/Microsoft.Sdk.R2R.targets
+++ b/dotnet/targets/Microsoft.Sdk.R2R.targets
@@ -333,7 +333,6 @@
 			>
 
 		<GenerateR2RModuleRegistration
-			SessionId="$(BuildSessionId)"
 			R2RModules="@(_R2RModule)"
 			OutputFile="$(_R2RModuleRegistrationFile)"
 		/>


### PR DESCRIPTION
This fixes a problem when building remotely:

* The GenerateR2RModuleRegistration task runs remotely and generates the r2r_modules.mm file (remotely).
* For some reason this file isn't copied back to Windows.
* The '_AddR2RModuleRegistrationToMainFile' target checks for the existence of the r2r_modules.mm file, can't find it, and thus the r2r module registration code isn't built and linked into the app.
* This causes the app to crash at launch.

Admittedly, the fix could also be to make sure the r2r_modules.mm is copied back to Windows, but a much easier (and faster!) solution is to just run this task locally on Windows instead, because this task doesn't need to run remotely.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3027326.

Backport of #25950.