### PR TITLE
[xtro] Ensure the full report zip is uploaded even when xtro finds unclassified entries.

### DIFF
--- a/tests/xtro-sharpie/Makefile
+++ b/tests/xtro-sharpie/Makefile
@@ -177,7 +177,7 @@ report-dotnet/index.html: $(XTRO_REPORT) .stamp-dotnet-classify
 	$(Q) rm -rf report-dotnet
 	$(Q_GEN) $(XTRO_REPORT_EXEC) $(DOTNET_ANNOTATIONS_DIR) report-dotnet
 
-report-dotnet/report.zip: report-dotnet/index.html
+report-dotnet/report.zip:
 	$(Q) rm -f "$@"
 	$(Q) cd report-dotnet && zip -r9 report.zip . -x report.zip
 

--- a/tests/xtro-sharpie/UnitTests/Xtro.cs
+++ b/tests/xtro-sharpie/UnitTests/Xtro.cs
@@ -15,7 +15,9 @@ namespace Xamarin.Tests {
 			// report.zip is always created even when index.html's recipe
 			// returns non-zero (which happens when there are unclassified entries).
 			var rv = ExecutionHelper.Execute ("make", new [] { "-C", dir, "report-dotnet/index.html", "-j", "8" });
-			ExecutionHelper.Execute ("make", new [] { "-C", dir, "report-dotnet/report.zip" });
+			var zipRv = ExecutionHelper.Execute ("make", new [] { "-C", dir, "report-dotnet/report.zip" });
+			if (zipRv != 0)
+				Console.WriteLine ($"Failed to create report.zip (exit code: {zipRv}).");
 
 			var reportDir = Path.Combine (dir, "report-dotnet");
 			var report = Path.Combine (reportDir, "index.html");

--- a/tests/xtro-sharpie/UnitTests/Xtro.cs
+++ b/tests/xtro-sharpie/UnitTests/Xtro.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.IO.Compression;
 using System.Xml;
 
 #nullable enable
@@ -11,12 +10,12 @@ namespace Xamarin.Tests {
 		public void RunTest ()
 		{
 			var dir = Path.Combine (Configuration.SourceRoot, "tests", "xtro-sharpie");
-			var args = new [] {
-				"-C", dir,
-				"report-dotnet/report.zip",
-				"-j", "8",
-			};
-			var rv = ExecutionHelper.Execute ("make", args);
+
+			// Run the report and zip as separate make invocations so that
+			// report.zip is always created even when index.html's recipe
+			// returns non-zero (which happens when there are unclassified entries).
+			var rv = ExecutionHelper.Execute ("make", new [] { "-C", dir, "report-dotnet/index.html", "-j", "8" });
+			ExecutionHelper.Execute ("make", new [] { "-C", dir, "report-dotnet/report.zip" });
 
 			var reportDir = Path.Combine (dir, "report-dotnet");
 			var report = Path.Combine (reportDir, "index.html");
@@ -25,16 +24,7 @@ namespace Xamarin.Tests {
 				TestContext.AddTestAttachment (report, "HTML report");
 			}
 
-			// Zip up the report directory ourselves if make didn't get to it
-			// (make stops at the index.html target when there are unclassified entries).
 			var zippedReport = Path.Combine (reportDir, "report.zip");
-			if (!File.Exists (zippedReport) && Directory.Exists (reportDir)) {
-				try {
-					ZipFile.CreateFromDirectory (reportDir, zippedReport);
-				} catch (Exception e) {
-					Console.WriteLine ($"Failed to create report zip: {e.Message}");
-				}
-			}
 			if (File.Exists (zippedReport)) {
 				Console.WriteLine ($"Added {zippedReport} as attachment.");
 				TestContext.AddTestAttachment (zippedReport, "HTML report (zipped)");

--- a/tests/xtro-sharpie/UnitTests/Xtro.cs
+++ b/tests/xtro-sharpie/UnitTests/Xtro.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.IO.Compression;
 using System.Xml;
 
 #nullable enable
@@ -17,13 +18,23 @@ namespace Xamarin.Tests {
 			};
 			var rv = ExecutionHelper.Execute ("make", args);
 
-			var report = Path.Combine (dir, "report-dotnet", "index.html");
+			var reportDir = Path.Combine (dir, "report-dotnet");
+			var report = Path.Combine (reportDir, "index.html");
 			if (File.Exists (report)) {
 				Console.WriteLine ($"Added {report} as attachment.");
 				TestContext.AddTestAttachment (report, "HTML report");
 			}
 
-			var zippedReport = Path.Combine (dir, "report-dotnet", "report.zip");
+			// Zip up the report directory ourselves if make didn't get to it
+			// (make stops at the index.html target when there are unclassified entries).
+			var zippedReport = Path.Combine (reportDir, "report.zip");
+			if (!File.Exists (zippedReport) && Directory.Exists (reportDir)) {
+				try {
+					ZipFile.CreateFromDirectory (reportDir, zippedReport);
+				} catch (Exception e) {
+					Console.WriteLine ($"Failed to create report zip: {e.Message}");
+				}
+			}
 			if (File.Exists (zippedReport)) {
 				Console.WriteLine ($"Added {zippedReport} as attachment.");
 				TestContext.AddTestAttachment (zippedReport, "HTML report (zipped)");


### PR DESCRIPTION
When xtro-report finds unclassified entries, it returns non-zero, which
causes make to stop before reaching the `report.zip` target. This means
the individual `.unclassified.html` files (linked from `index.html`) are
never zipped and uploaded, making it impossible to see the actual
failures in the CI report.

Fix by creating the zip in the test itself when make doesn't produce it.

Contributes towards https://github.com/dotnet/macios/issues/25933

🤖 Pull request created by Copilot