### PR TITLE
[tests] Capture 'log stream' output during macOS test execution

### DIFF
--- a/scripts/run-packaged-macos-tests/run-packaged-macos-tests.cs
+++ b/scripts/run-packaged-macos-tests/run-packaged-macos-tests.cs
@@ -26,6 +26,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -117,6 +118,40 @@ if (!Directory.Exists (testsDirectory)) {
 
 if (!string.IsNullOrEmpty (testOutputDir))
 	Directory.CreateDirectory (testOutputDir);
+
+// Start 'log stream' to capture system logs for the entire test run
+Process? logStreamProcess = null;
+string? logStreamFile = null;
+StreamWriter? logStreamWriter = null;
+if (!string.IsNullOrEmpty (crashReportsDir)) {
+	Directory.CreateDirectory (crashReportsDir);
+	logStreamFile = Path.Combine (crashReportsDir, "system.log");
+	logStreamWriter = new StreamWriter (logStreamFile, append: false, Encoding.UTF8);
+	logStreamProcess = new Process ();
+	logStreamProcess.StartInfo.FileName = "/usr/bin/log";
+	logStreamProcess.StartInfo.ArgumentList.Add ("stream");
+	logStreamProcess.StartInfo.ArgumentList.Add ("--style");
+	logStreamProcess.StartInfo.ArgumentList.Add ("compact");
+	logStreamProcess.StartInfo.UseShellExecute = false;
+	logStreamProcess.StartInfo.RedirectStandardOutput = true;
+	logStreamProcess.StartInfo.RedirectStandardError = true;
+	var writer = logStreamWriter;
+	logStreamProcess.OutputDataReceived += (_, e) => {
+		if (e.Data is not null)
+			lock (writer)
+				writer.WriteLine (e.Data);
+	};
+	logStreamProcess.ErrorDataReceived += (_, e) => {
+		if (e.Data is not null)
+			lock (writer)
+				writer.WriteLine (e.Data);
+	};
+	logStreamProcess.Start ();
+	logStreamProcess.BeginOutputReadLine ();
+	logStreamProcess.BeginErrorReadLine ();
+
+	Console.WriteLine ($"Started 'log stream' (pid {logStreamProcess.Id}), writing to {logStreamFile}");
+}
 
 var isAppleSilicon = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ||
 	Environment.GetEnvironmentVariable ("PROCESSOR_ARCHITECTURE")?.Contains ("ARM", StringComparison.OrdinalIgnoreCase) == true;
@@ -246,6 +281,34 @@ if (!string.IsNullOrEmpty (testSummaryPath)) {
 if (!string.IsNullOrEmpty (htmlReportPath)) {
 	GenerateHtmlReport (htmlReportPath, title, suiteOutcomes, testOutputDir, crashReportsDir, vsdropsUri);
 	Console.WriteLine ($"HTML report written to {htmlReportPath}");
+}
+
+// Stop 'log stream' and zip the output
+if (logStreamProcess is not null && logStreamFile is not null) {
+	try {
+		NativeMethods.kill (logStreamProcess.Id, 2 /* SIGINT */);
+		logStreamProcess.WaitForExit (10_000);
+	} catch {
+		// Process may have already exited
+	}
+
+	// Flush and close the log writer
+	logStreamWriter?.Dispose ();
+
+	try {
+		Console.WriteLine ($"Wrote {new FileInfo (logStreamFile).Length} bytes to {logStreamFile}");
+
+		// Zip the log file
+		var zipPath = logStreamFile + ".zip";
+		using (var zip = ZipFile.Open (zipPath, ZipArchiveMode.Create))
+			zip.CreateEntryFromFile (logStreamFile, Path.GetFileName (logStreamFile), CompressionLevel.Optimal);
+		File.Delete (logStreamFile);
+		Console.WriteLine ($"Compressed log stream to {zipPath}");
+	} catch (Exception ex) {
+		Console.Error.WriteLine ($"Warning: Failed to save log stream output: {ex.Message}");
+	}
+
+	logStreamProcess.Dispose ();
 }
 
 return failedSuites > 0 ? 1 : 0;


### PR DESCRIPTION
Start 'log stream --style compact' at the beginning of test execution and
stop it at the end. The output is written to the crash reports directory
as system.log.zip (compressed because it can be large), so it gets uploaded
together with crash reports and other test artifacts.

🤖 Pull request created by Copilot