### PR TITLE
[tests] Delete saved application state before executing test apps. Fixes #25922

### DIFF
--- a/tests/common/shared-dotnet.mk
+++ b/tests/common/shared-dotnet.mk
@@ -151,7 +151,7 @@ EXECUTABLE="$(abspath .)/bin/$(CONFIG)/$(TEST_TFM)-tvos/$(PATH_RID)$(TESTNAME).a
 else ifeq ($(PLATFORM),MacCatalyst)
 EXECUTABLE="$(abspath .)/bin/$(CONFIG)/$(TEST_TFM)-maccatalyst/$(PATH_RID)$(TESTNAME).app/Contents/MacOS/$(TESTNAME)"
 APPMANIFEST:=$(abspath .)/bin/$(CONFIG)/$(TEST_TFM)-maccatalyst/$(PATH_RID)$(TESTNAME).app/Contents/Info.plist
-BUNDLE_ID:=$(shell defaults read "$(basename $(APPMANIFEST))" CFBundleIdentifier 2>/dev/null)
+BUNDLE_ID=$(shell defaults read "$(APPMANIFEST)" CFBundleIdentifier 2>/dev/null)
 else ifeq ($(PLATFORM),macOS)
 EXECUTABLE="$(abspath .)/bin/$(CONFIG)/$(TEST_TFM)-macos/$(PATH_RID)$(TESTNAME).app/Contents/MacOS/$(TESTNAME)"
 APPMANIFEST:=$(abspath .)/bin/$(CONFIG)/$(TEST_TFM)-macos/$(PATH_RID)$(TESTNAME).app/Contents/Info.plist

--- a/tests/common/shared-dotnet.mk
+++ b/tests/common/shared-dotnet.mk
@@ -155,7 +155,7 @@ BUNDLE_ID=$(shell defaults read "$(APPMANIFEST)" CFBundleIdentifier 2>/dev/null)
 else ifeq ($(PLATFORM),macOS)
 EXECUTABLE="$(abspath .)/bin/$(CONFIG)/$(TEST_TFM)-macos/$(PATH_RID)$(TESTNAME).app/Contents/MacOS/$(TESTNAME)"
 APPMANIFEST:=$(abspath .)/bin/$(CONFIG)/$(TEST_TFM)-macos/$(PATH_RID)$(TESTNAME).app/Contents/Info.plist
-BUNDLE_ID:=$(shell defaults read "$(basename $(APPMANIFEST))" CFBundleIdentifier 2>/dev/null)
+BUNDLE_ID=$(shell defaults read "$(APPMANIFEST)" CFBundleIdentifier 2>/dev/null)
 else
 EXECUTABLE="unknown-executable-platform-$(PLATFORM)"
 endif

--- a/tests/common/shared-dotnet.mk
+++ b/tests/common/shared-dotnet.mk
@@ -150,8 +150,12 @@ else ifeq ($(PLATFORM),tvOS)
 EXECUTABLE="$(abspath .)/bin/$(CONFIG)/$(TEST_TFM)-tvos/$(PATH_RID)$(TESTNAME).app/$(TESTNAME)"
 else ifeq ($(PLATFORM),MacCatalyst)
 EXECUTABLE="$(abspath .)/bin/$(CONFIG)/$(TEST_TFM)-maccatalyst/$(PATH_RID)$(TESTNAME).app/Contents/MacOS/$(TESTNAME)"
+APPMANIFEST:=$(abspath .)/bin/$(CONFIG)/$(TEST_TFM)-maccatalyst/$(PATH_RID)$(TESTNAME).app/Contents/Info.plist
+BUNDLE_ID:=$(shell defaults read "$(basename $(APPMANIFEST))" CFBundleIdentifier 2>/dev/null)
 else ifeq ($(PLATFORM),macOS)
 EXECUTABLE="$(abspath .)/bin/$(CONFIG)/$(TEST_TFM)-macos/$(PATH_RID)$(TESTNAME).app/Contents/MacOS/$(TESTNAME)"
+APPMANIFEST:=$(abspath .)/bin/$(CONFIG)/$(TEST_TFM)-macos/$(PATH_RID)$(TESTNAME).app/Contents/Info.plist
+BUNDLE_ID:=$(shell defaults read "$(basename $(APPMANIFEST))" CFBundleIdentifier 2>/dev/null)
 else
 EXECUTABLE="unknown-executable-platform-$(PLATFORM)"
 endif
@@ -187,8 +191,15 @@ run: prepare
 	@echo "Running $(wildcard *.?sproj)..."
 	$(Q) $(DOTNET) build "/bl:$(abspath $@-$(BINLOG_TIMESTAMP).binlog)" *.?sproj $(DOTNET_BUILD_VERBOSITY) $(BUILD_ARGUMENTS) $(CONFIG_ARGUMENT) $(UNIVERSAL_ARGUMENT) $(NATIVEAOT_ARGUMENTS) $(TEST_VARIATION_ARGUMENT) -t:Run $(RUN_ARGUMENTS) -tl:off
 
-run-bare:
+# Delete the saved application state for the app, to prevent the
+# "Do you want to try to reopen its windows again?" dialog from
+# blocking automated runs after a crash. See https://github.com/dotnet/macios/issues/25922
+delete-saved-state:
+	$(Q) if test -n "$(BUNDLE_ID)"; then rm -rf "$(HOME)/Library/Saved Application State/$(BUNDLE_ID).savedState" && echo "Deleted saved state for $(BUNDLE_ID)"; fi
+
+run-bare: delete-saved-state
 	$(Q) $(EXECUTABLE) --autostart --autoexit $(RUN_ARGUMENTS)
+	$(Q) $(MAKE) delete-saved-state
 
 # Get the list of applicable simulators, and pick the first in the list.
 # Make sure to have a matching simulator runtime installed, otherwise this won't work.

--- a/tests/dotnet/UnitTests/TestBaseClass.cs
+++ b/tests/dotnet/UnitTests/TestBaseClass.cs
@@ -480,6 +480,8 @@ namespace Xamarin.Tests {
 			if (!File.Exists (executable))
 				throw new FileNotFoundException ($"The executable '{executable}' does not exists.");
 
+			DeleteSavedState (executable);
+
 			magicWord = Guid.NewGuid ().ToString ();
 			var env = new Dictionary<string, string?> {
 				{ "MAGIC_WORD", magicWord },
@@ -492,7 +494,53 @@ namespace Xamarin.Tests {
 
 			var rv = Execution.RunAsync (executable, Array.Empty<string> (), environment: env, timeout: TimeSpan.FromSeconds (30)).Result;
 			output = rv.Output.MergedOutput;
+
+			DeleteSavedState (executable);
+
 			return rv;
+		}
+
+		// Delete the saved application state for the app being launched, to prevent
+		// the "Do you want to try to reopen its windows again?" dialog from showing
+		// if the app crashed during a previous test run. See https://github.com/dotnet/macios/issues/25922
+		static void DeleteSavedState (string executable)
+		{
+			// Find the .app bundle directory from the executable path
+			var dir = Path.GetDirectoryName (executable);
+			while (!string.IsNullOrEmpty (dir) && !dir.EndsWith (".app", StringComparison.OrdinalIgnoreCase))
+				dir = Path.GetDirectoryName (dir);
+
+			if (string.IsNullOrEmpty (dir))
+				return;
+
+			// Read the bundle identifier from Info.plist
+			string? bundleIdentifier = null;
+			var infoPlistPath = Path.Combine (dir, "Contents", "Info.plist");
+			if (!File.Exists (infoPlistPath))
+				infoPlistPath = Path.Combine (dir, "Info.plist");
+			if (!File.Exists (infoPlistPath))
+				return;
+
+			try {
+				var infoPlist = PDictionary.OpenFile (infoPlistPath);
+				bundleIdentifier = infoPlist.GetString ("CFBundleIdentifier")?.Value;
+			} catch (Exception e) {
+				Console.WriteLine ($"Could not read bundle identifier from '{infoPlistPath}': {e.Message}");
+				return;
+			}
+
+			if (string.IsNullOrEmpty (bundleIdentifier))
+				return;
+
+			var savedStateDir = Path.Combine (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile), "Library", "Saved Application State", $"{bundleIdentifier}.savedState");
+			try {
+				if (Directory.Exists (savedStateDir)) {
+					Directory.Delete (savedStateDir, true);
+					Console.WriteLine ($"Deleted saved application state: {savedStateDir}");
+				}
+			} catch (Exception e) {
+				Console.WriteLine ($"Could not delete saved application state '{savedStateDir}': {e.Message}");
+			}
 		}
 
 		public static StringBuilder AssertExecute (string executable, params string [] arguments)


### PR DESCRIPTION
Before and after launching a macOS/Mac Catalyst app in tests, delete its saved
application state directory (`~/Library/Saved Application State/<bundle-id>.savedState`).
This prevents the "Do you want to try to reopen its windows again?" dialog
from blocking automated test runs after a previous crash.

Two implementations:
- **C# (`TestBaseClass.cs`)**: The `Execute` method calls `DeleteSavedState` before and after running the app. It walks up the executable path to find the `.app` bundle, reads the bundle identifier from `Info.plist`, and deletes the saved state directory.
- **Makefile (`shared-dotnet.mk`)**: A `delete-saved-state` target reads the bundle identifier via `defaults read` and removes the saved state directory. The `run-bare` target invokes it before and after execution.

Fixes https://github.com/dotnet/macios/issues/25922

🤖 Pull request created by Copilot