### PR TITLE
[msbuild] Deprecate NoBindingEmbedding=false in .NET 11, remove in .NET 12

### DIFF
--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -1065,6 +1065,9 @@ Default:
 
 ## NoBindingEmbedding
 
+> [!WARNING]
+> Setting this property to `false` is deprecated in .NET 11 and will produce a build error in .NET 12+.
+
 A boolean property that specifies whether native libraries in binding projects should be embedded
 in the managed assembly, or put into a `.resources` directory next to the managed assembly.
 

--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -1066,7 +1066,7 @@ Default:
 ## NoBindingEmbedding
 
 > [!WARNING]
-> Setting this property to `false` is deprecated in .NET 11 and will produce a build error in .NET 12+.
+> Setting this property to `false` is currently deprecated and will produce a build error in .NET 12+.
 
 A boolean property that specifies whether native libraries in binding projects should be embedded
 in the managed assembly, or put into a `.resources` directory next to the managed assembly.

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.ObjCBinding.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.ObjCBinding.targets
@@ -110,6 +110,8 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 	</Target>
 
 	<Target Name="_PrepareNativeReferences" Condition="'$(_DisableBindingProjectBuild)' != 'true'" DependsOnTargets="_SanitizeNativeReferences">
+		<Warning Condition="'$(_NoBindingEmbeddingDeprecated)' == 'true'" Text="Setting 'NoBindingEmbedding' to 'false' is deprecated and will not be supported in .NET 12+. Please remove this property from your project file." />
+		<Error Condition="'$(_NoBindingEmbeddingRemoved)' == 'true'" Text="Setting 'NoBindingEmbedding' to 'false' is not supported in .NET 12+. Please remove this property from your project file." />
 		<PrepareNativeReferences
 			IntermediateOutputPath="$(IntermediateOutputPath)"
 			NativeReferences="@(NativeReference)"

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -244,8 +244,8 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		<!-- Default NoBindingEmbedding to 'true' for .NET projects, it's the new way -->
 		<NoBindingEmbedding Condition="'$(NoBindingEmbedding)' == ''">true</NoBindingEmbedding>
 
-		<!-- NoBindingEmbedding=false is deprecated in .NET 11, and removed in .NET 12+ -->
-		<_NoBindingEmbeddingDeprecated Condition="'$(NoBindingEmbedding)' != 'true' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 11.0)) And !$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 12.0))">true</_NoBindingEmbeddingDeprecated>
+		<!-- NoBindingEmbedding=false is deprecated in .NET 10, and removed in .NET 12+ -->
+		<_NoBindingEmbeddingDeprecated Condition="'$(NoBindingEmbedding)' != 'true' And !$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 12.0))">true</_NoBindingEmbeddingDeprecated>
 		<_NoBindingEmbeddingRemoved Condition="'$(NoBindingEmbedding)' != 'true' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 12.0))">true</_NoBindingEmbeddingRemoved>
 
 		<!-- We don't want to build a binding project when in design time mode, and not bundling original resources, because we might end up requiring a connection to a remote mac, which is not a good idea for a supposedly quick design-time build. -->

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -244,6 +244,10 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		<!-- Default NoBindingEmbedding to 'true' for .NET projects, it's the new way -->
 		<NoBindingEmbedding Condition="'$(NoBindingEmbedding)' == ''">true</NoBindingEmbedding>
 
+		<!-- NoBindingEmbedding=false is deprecated in .NET 11, and removed in .NET 12+ -->
+		<_NoBindingEmbeddingDeprecated Condition="'$(NoBindingEmbedding)' != 'true' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 11.0)) And !$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 12.0))">true</_NoBindingEmbeddingDeprecated>
+		<_NoBindingEmbeddingRemoved Condition="'$(NoBindingEmbedding)' != 'true' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 12.0))">true</_NoBindingEmbeddingRemoved>
+
 		<!-- We don't want to build a binding project when in design time mode, and not bundling original resources, because we might end up requiring a connection to a remote mac, which is not a good idea for a supposedly quick design-time build. -->
 		<_DisableBindingProjectBuild Condition="'$(_DisableBindingProjectBuild)' == '' And '$(BundleOriginalResources)' != 'true' And '$(DesignTimeBuild)' == 'true'">true</_DisableBindingProjectBuild>
 	</PropertyGroup>


### PR DESCRIPTION
Setting `NoBindingEmbedding=false` (embedding native libraries in the managed assembly) should no longer be necessary (and doesn't even work with `.xcframework`s, only `.framework`s, `.a` and `.dylib` files).

However, supporting it duplicates the testing matrix for binding projects, and it's also a source of bugs, so start the process of removing support for it.

Setting `NoBindingEmbedding=false` will now be deprecated in .NET 10+ with a build warning, and produces a build error in .NET 12+. And then at some point after .NET 12+ we can remove any supporting code/tests.