### PR TITLE
[dotnet] Fix `dotnet test` on macOS and Mac Catalyst templates

### DIFF
--- a/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalysttest/csharp/Main.cs
+++ b/dotnet/Templates/Microsoft.MacCatalyst.Templates/maccatalysttest/csharp/Main.cs
@@ -63,7 +63,13 @@ class SceneDelegate : UIResponder, IUIWindowSceneDelegate {
 				var documentsPath = Environment.GetFolderPath (Environment.SpecialFolder.MyDocuments);
 				var resultsPath = Path.Combine (documentsPath, "TestResults");
 
+				// Forward args from 'dotnet test', which sends the MTP protocol config
+				// (--server / --dotnet-test-pipe) via the command line.
+				// Environment.GetCommandLineArgs()[0] is the executable path, not an argument.
+				string [] cliArgs = Environment.GetCommandLineArgs ();
+				string [] mtpArgs = cliArgs.Length > 1 ? cliArgs [1..] : [];
 				var builder = await TestApplication.CreateBuilderAsync ([
+					.. mtpArgs,
 					"--results-directory", resultsPath,
 					"--report-trx"
 				]);

--- a/dotnet/Templates/Microsoft.macOS.Templates/macostest/csharp/Main.cs
+++ b/dotnet/Templates/Microsoft.macOS.Templates/macostest/csharp/Main.cs
@@ -52,7 +52,13 @@ class AppDelegate : NSApplicationDelegate {
 				var documentsPath = Environment.GetFolderPath (Environment.SpecialFolder.MyDocuments);
 				var resultsPath = Path.Combine (documentsPath, "TestResults");
 
+				// Forward args from 'dotnet test', which sends the MTP protocol config
+				// (--server / --dotnet-test-pipe) via the command line.
+				// Environment.GetCommandLineArgs()[0] is the executable path, not an argument.
+				string [] cliArgs = Environment.GetCommandLineArgs ();
+				string [] mtpArgs = cliArgs.Length > 1 ? cliArgs [1..] : [];
 				var builder = await TestApplication.CreateBuilderAsync ([
+					.. mtpArgs,
 					"--results-directory", resultsPath,
 					"--report-trx"
 				]);

--- a/dotnet/targets/Xamarin.Shared.Sdk.MSTest.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.MSTest.props
@@ -11,6 +11,14 @@
 		<GenerateTestingPlatformEntryPoint Condition="'$(GenerateTestingPlatformEntryPoint)' == ''">false</GenerateTestingPlatformEntryPoint>
 		<!-- Suppress trimmer warnings from test framework dependencies (e.g. Microsoft.ApplicationInsights) -->
 		<SuppressTrimAnalysisWarnings Condition="'$(SuppressTrimAnalysisWarnings)' == ''">true</SuppressTrimAnalysisWarnings>
+		<!--
+			On macOS and Mac Catalyst 'dotnet run/test' launches the app via 'open' by default,
+			which goes through LaunchServices and does not propagate the parent process's
+			environment variables or reliably forward CLI arguments to the app. That breaks
+			the Microsoft.Testing.Platform (MTP) handshake that 'dotnet test' relies on.
+			Launching the app binary directly avoids the problem.
+		-->
+		<RunWithOpen Condition="'$(RunWithOpen)' == ''">false</RunWithOpen>
 	</PropertyGroup>
 	<ItemGroup>
 		<!-- Disable ANSI escape codes in MSTest output, as they appear as garbled text in simulator/device logs -->

--- a/tests/dotnet/UnitTests/DotNetTestTest.cs
+++ b/tests/dotnet/UnitTests/DotNetTestTest.cs
@@ -13,10 +13,8 @@ namespace Xamarin.Tests {
 		[Test]
 		[TestCase (ApplePlatform.iOS, "iostest")]
 		[TestCase (ApplePlatform.TVOS, "tvostest")]
-		// macOS and Mac Catalyst don't use mlaunch (they use 'open' via Desktop.targets),
-		// so MTP support requires a different approach for these platforms.
-		// [TestCase (ApplePlatform.MacCatalyst, "maccatalysttest")]
-		// [TestCase (ApplePlatform.MacOSX, "macostest")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalysttest")]
+		[TestCase (ApplePlatform.MacOSX, "macostest")]
 		public void DotNetTest (ApplePlatform platform, string template)
 		{
 			Configuration.IgnoreIfIgnoredPlatform (platform);
@@ -26,24 +24,21 @@ namespace Xamarin.Tests {
 			DotNet.AssertNew (outputDir, template);
 			var proj = Path.Combine (outputDir, $"{template}.csproj");
 
-			// Boot a simulator so that ComputeRunArguments can find a device
+			var isDesktop = platform == ApplePlatform.MacOSX || platform == ApplePlatform.MacCatalyst;
 			var log = ConsoleLogger.Instance;
 			var simService = new SimulatorService (log);
-			var runtimeService = new RuntimeService (log);
-			var device = GetOrCreateDevice (platform, simService, runtimeService);
+			SimulatorDeviceInfo? device = null;
 
-			if (!device.IsBooted)
-				Assert.That (simService.Boot (device.Udid), Is.True, $"Failed to boot simulator {device.Udid}.");
+			if (!isDesktop) {
+				// Boot a simulator so that ComputeRunArguments can find a device
+				var runtimeService = new RuntimeService (log);
+				device = GetOrCreateDevice (platform, simService, runtimeService);
+
+				if (!device.IsBooted)
+					Assert.That (simService.Boot (device.Udid), Is.True, $"Failed to boot simulator {device.Udid}.");
+			}
 
 			try {
-				// dotnet test internally calls ComputeRunArguments via MSBuild API without
-				// forwarding /p: properties, so we must set them in the project file directly.
-				var csproj = File.ReadAllText (proj);
-				csproj = csproj.Replace (
-					"</PropertyGroup>",
-					$"  <UseFloatingTargetPlatformVersion>true</UseFloatingTargetPlatformVersion>\n    <Device>{device.Udid}</Device>\n  </PropertyGroup>");
-				File.WriteAllText (proj, csproj);
-
 				// Replace generated tests with a single passing test
 				var testFile = Path.Combine (outputDir, "Test1.cs");
 				File.WriteAllText (testFile, $@"namespace {template};
@@ -59,21 +54,26 @@ public sealed class Test1 {{
 
 				// Run 'dotnet test' directly using Execution.RunAsync.
 				// dotnet test's MTP flow doesn't forward /p: properties to its internal
-				// ComputeRunArguments MSBuild API call, so properties must be in the csproj.
+				// ComputeRunArguments MSBuild API call, so pass properties as environment
+				// variables instead — MSBuild picks those up as global properties in the
+				// child process.
 				var env = new Dictionary<string, string?> ();
 				env ["MSBuildSDKsPath"] = null;
 				env ["MSBUILD_EXE_PATH"] = null;
+				env ["UseFloatingTargetPlatformVersion"] = "true";
 				var binlog = Path.Combine (outputDir, "log-test.binlog");
 				var testArgs = new List<string> {
 					"test",
 					proj,
-					$"--device:{device.Udid}",
 					$"/bl:{binlog}"
 				};
+				if (device is not null)
+					testArgs.Add ($"--device:{device.Udid}");
 				var testResult = Execution.RunAsync (DotNet.Executable, testArgs, env, Console.Out, workingDirectory: outputDir, timeout: TimeSpan.FromMinutes (10)).Result;
 				Assert.That (testResult.ExitCode, Is.EqualTo (0), $"'dotnet test' failed with exit code {testResult.ExitCode}.\nBinlog: {binlog}\nOutput:\n{testResult.Output.MergedOutput}");
 			} finally {
-				simService.Shutdown (device.Udid);
+				if (device is not null)
+					simService.Shutdown (device.Udid);
 			}
 		}
 


### PR DESCRIPTION
`dotnet test` on the `macostest` and `maccatalysttest` templates was failing with "Zero tests ran" and Microsoft.Testing.Platform (MTP) handshake failures.

Two bugs, both needed for the desktop platforms to work:

1. **The desktop test templates' `Main.cs` was dropping the incoming `args`** when calling `TestApplication.CreateBuilderAsync`. `dotnet test` invokes the app with MTP protocol arguments appended to the command line (the server type and the named-pipe path for the test host), so discarding `args` disables the MTP handshake. Forward the current process' command-line arguments into `CreateBuilderAsync` alongside the existing `--results-directory` / `--report-trx` args. iOS and tvOS aren't affected because `mlaunch` forwards MTP env vars into the simulator and MTP picks up the protocol config from those env vars.

2. **On macOS and Mac Catalyst the default `dotnet run/test` launch path goes through `open`** (LaunchServices), which does not propagate the parent process' environment variables and does not reliably forward trailing CLI arguments to the app. Default `RunWithOpen` to `false` in `Xamarin.Shared.Sdk.MSTest.props` so MSTest projects launch the app binary directly. This is a no-op for iOS/tvOS (`RunWithOpen` is only consulted by the desktop targets).

Re-enable the previously-commented-out `[TestCase]` entries for `maccatalysttest` and `macostest` in `DotNetTestTest`, and skip the simulator boot/shutdown steps for desktop platforms.

### Verified locally

`dotnet new macostest` / `dotnet new maccatalysttest` + `dotnet test`, using the default template's built-in tests (1 passing, 1 skipped, 1 expected-to-fail):

```
Test run summary: Failed!
  total: 3
  failed: 1
  succeeded: 1
  skipped: 1
```

No handshake failures, per-test results reported via MTP protocol, exit code matches the expected failure.

Fixes https://github.com/dotnet/macios/issues/13319.