### PR TITLE
[msbuild] Strip binding-embedded dynamic frameworks with 'strip -S -x'. Fixes #25952.

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/SymbolStrip.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/SymbolStrip.cs
@@ -37,6 +37,13 @@ namespace Xamarin.MacDev.Tasks {
 			if (string.Equals (value, "Framework", StringComparison.OrdinalIgnoreCase))
 				return true;
 
+			// A framework's executable lives inside a '*.framework' directory. Detect that even when
+			// the 'Kind' metadata is missing, so we never do a full strip on a framework (which fails
+			// for dynamic libraries). Ref: https://github.com/dotnet/macios/issues/25952
+			var directory = Path.GetDirectoryName (item.ItemSpec);
+			if (!string.IsNullOrEmpty (directory) && directory.EndsWith (".framework", StringComparison.OrdinalIgnoreCase))
+				return true;
+
 			if (string.Equals (value, "Dynamic", StringComparison.OrdinalIgnoreCase) || item.ItemSpec.EndsWith (".dylib", StringComparison.OrdinalIgnoreCase))
 				return true;
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -3015,6 +3015,11 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			     that will actually be present in the app bundle. Ref: https://github.com/dotnet/macios/issues/24840 -->
 			<!-- The condition is necessary due to https://github.com/dotnet/msbuild/issues/4056 -->
 			<_PostProcessingItem Condition="@(_FilteredFrameworkToPublish->Count()) &gt; 0" Include="@(_FilteredFrameworkToPublish->'$(_AppBundleName)$(AppBundleExtension)/$(_AppFrameworksRelativePath)%(Filename)%(Extension).framework/%(Filename)%(Extension)')">
+				<!-- These are frameworks, so make sure they're stripped as such (only debug symbols are stripped from frameworks).
+				     Some frameworks (in particular ones embedded in a binding project) don't carry the 'Kind' metadata, so set it
+				     here to make sure symbol stripping doesn't do a full strip on them (which fails for dynamic libraries).
+				     Ref: https://github.com/dotnet/macios/issues/25952 -->
+				<Kind>Framework</Kind>
 				<!-- Store where this item came from -->
 				<ItemSourcePath>%(Identity)</ItemSourcePath>
 				<!-- If the item in question came with a .dSYM directory, this would be the path to it: -->

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -2837,6 +2837,36 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
+		[TestCase (ApplePlatform.iOS, "iossimulator-arm64")]
+		[TestCase (ApplePlatform.TVOS, "tvossimulator-arm64")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64")]
+		public void StripEmbeddedDynamicFramework (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			// A binding project with 'NoBindingEmbedding=false' embeds its native framework inside the
+			// binding assembly. The managed linker extracts the framework without any 'Kind' metadata, so
+			// make sure such an embedded dynamic framework is stripped correctly (with 'strip -S -x', and
+			// not a full strip, which fails for a dynamic library that references undefined symbols).
+			// The framework embedded by this project (XTest.framework) references the Objective-C runtime,
+			// so a full strip of it would fail. We build in Release (so the linker runs and extracts the
+			// framework) and set NoSymbolStrip=false (so the framework is stripped even for the simulator).
+			// Ref: https://github.com/dotnet/macios/issues/25952
+			var project = "EmbeddedFrameworkInBindingProjectApp";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath, configuration: "Release");
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["Configuration"] = "Release";
+			properties ["NoSymbolStrip"] = "false";
+			DotNet.AssertBuild (project_path, properties);
+
+			var appExecutable = GetNativeExecutable (platform, appPath);
+			ExecuteWithMagicWordAndAssert (platform, runtimeIdentifiers, appExecutable);
+		}
+
+		[Test]
 		[TestCase (ApplePlatform.MacOSX, "osx-arm64;osx-x64")]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64;")]
 		public void StrippedWithExportSymbolsExplicitlyFalse (ApplePlatform platform, string runtimeIdentifiers)

--- a/tests/test-libraries/libframework.m
+++ b/tests/test-libraries/libframework.m
@@ -11,6 +11,14 @@ theUltimateAnswer ()
 }
 -(int) func
 {
+	// Send an Objective-C message so this dynamic library imports an Objective-C runtime
+	// function (objc_msgSend/objc_opt_self/...) referenced via the indirect symbol table.
+	// This means the framework binary can't be fully stripped ('strip <binary>' fails with
+	// "symbols referenced by indirect symbol table entries that can't be stripped"), it has
+	// to be stripped with 'strip -S -x' instead. This lets tests that embed this framework as
+	// a dynamic library exercise the symbol stripping code path.
+	// Ref: https://github.com/dotnet/macios/issues/25952
+	(void) [self self];
 	return 42;
 }
 @end


### PR DESCRIPTION
A Release build of an app that references a binding project with an embedded dynamic framework failed with:

    strip: error: symbols referenced by indirect symbol table entries that
    can't be stripped in: .../CameraFramework.framework/CameraFramework

The SymbolStrip task only passes '-S -x' to strip (to strip just debug/local symbols) when an item's 'Kind' metadata is 'Framework'/'Dynamic' (or the path ends in '.dylib'); otherwise it does a full strip, which fails for a dynamic library that references undefined symbols (objc_msgSend, ...) via the indirect symbol table.

This regressed in commit 6b9cfc9a25 ("[msbuild] Filter static frameworks from post-processing items. Fixes #24840.", #24845), which changed the framework post-processing item in Xamarin.Shared.targets from:

    <_PostProcessingItem Include="@(_ResolvedNativeReference->'...')" Condition="'%(Kind)' == 'Framework'">

to:

    <_PostProcessingItem Include="@(_FilteredFrameworkToPublish->'...')">

`@(_ResolvedNativeReference)` carried the `Kind=Framework` metadata (as the removed condition shows), but `@(_FilteredFrameworkToPublish)` does not, so the metadata was silently lost. Frameworks embedded in a binding project are extracted by the linker without 'Kind' metadata, so they reached the SymbolStrip task with an empty 'Kind' and got a full strip. Apps that use a direct `<NativeReference Kind="Framework">` are not affected (the Kind flows through); only binding-embedded frameworks are.

Fix this in two places:

* Set `Kind=Framework` on the framework _PostProcessingItem (the block only ever contains frameworks), restoring the metadata the SymbolStrip task relies on.

* Also detect frameworks by path in the SymbolStrip task (an item inside a '.framework' directory), mirroring the existing '.dylib' fallback, so a full strip is never done on a framework even if the 'Kind' metadata is missing.

Also add a test (StripEmbeddedDynamicFramework) that builds an app which references a binding project that embeds a dynamic framework (NoBindingEmbedding=false) with symbol stripping enabled, and asserts the build succeeds. Without the fix this fails at the strip step. The test builds in Release (so the linker extracts the framework into the post-processing path), with a single RuntimeIdentifier (frameworks aren't post-processed in multi-RID builds) and NoSymbolStrip=false (so the framework is stripped even for the simulator).

The existing binding projects that embed a framework only embed static libraries (as frameworks), which are filtered out and never copied to the app (so never stripped). The one project that embeds a dynamic framework (EmbeddedFrameworkInBindingProjectApp, which embeds XTest.framework) didn't hit the problem, because XTest.framework (built from libframework.m) doesn't call any external functions and so can be fully stripped. Make libframework.m send an Objective-C message so the framework binary imports an Objective-C runtime function referenced via the indirect symbol table; such a binary can't be fully stripped, so the test now exercises the strip code path.

Fixes https://github.com/dotnet/macios/issues/25952

🤖 Pull request created by Copilot
