### PR TITLE
[assembly-preparer] Skip re-serializing assemblies that weren't modified.

### DIFF
--- a/tools/assembly-preparer/AssemblyPreparer.cs
+++ b/tools/assembly-preparer/AssemblyPreparer.cs
@@ -225,7 +225,10 @@ public class AssemblyPreparer : IDisposable {
 				// Subscribe once the assemblies have been loaded: accessing the AppBundleRewriter before
 				// that point would create it without finding the corlib and platform assemblies.
 				if (assemblySavedHandler is null && configuration.Assemblies.Count > 0) {
-					assemblySavedHandler = (_) => currentStepModifiedAssemblies = true;
+					assemblySavedHandler = (asm) => {
+						currentStepModifiedAssemblies = true;
+						configuration.ModifiedAssemblies.Add (asm);
+					};
 					configuration.AppBundleRewriter.AssemblySaved += assemblySavedHandler;
 				}
 

--- a/tools/assembly-preparer/SaveAssembliesStep.cs
+++ b/tools/assembly-preparer/SaveAssembliesStep.cs
@@ -37,16 +37,17 @@ namespace MonoTouch.Tuner {
 				switch (action) {
 				case AssemblyAction.Copy:
 				case AssemblyAction.CopyUsed:
-					if (configuration.Application.IsPostProcessingAssemblies && assembly.InputPath != assembly.OutputPath) {
-						// During post-processing, copy unchanged assemblies to the output directory
-						// so all assemblies are in the same directory (required for AOT compilation).
-						CopyAssemblyToOutput (assembly.InputPath, assembly.OutputPath);
-					} else {
-						assembly.OutputPath = assembly.InputPath;
-					}
+					OutputWithoutRewriting (assembly);
 					continue;
 				case AssemblyAction.Link:
 				case AssemblyAction.Save:
+					if (!configuration.ModifiedAssemblies.Contains (assemblyDefinition)) {
+						// The assembly is marked to be saved (e.g. it's part of the set of assemblies to
+						// trim), but the assembly-preparer didn't actually modify it, so there's no need to
+						// re-serialize it - just output the original assembly.
+						OutputWithoutRewriting (assembly);
+						continue;
+					}
 					log.Log ($"Saving {assembly.InputPath} to {assembly.OutputPath}");
 					break;
 				default:
@@ -77,6 +78,17 @@ namespace MonoTouch.Tuner {
 					log.Log ($"Failed to write {assembly.OutputPath}: {e}");
 					return;
 				}
+			}
+		}
+
+		void OutputWithoutRewriting (Xamarin.Build.AssemblyPreparerInfo assembly)
+		{
+			if (Configuration.Application.IsPostProcessingAssemblies && assembly.InputPath != assembly.OutputPath) {
+				// During post-processing, copy unchanged assemblies to the output directory
+				// so all assemblies are in the same directory (required for AOT compilation).
+				CopyAssemblyToOutput (assembly.InputPath, assembly.OutputPath);
+			} else {
+				assembly.OutputPath = assembly.InputPath;
 			}
 		}
 

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -97,6 +97,9 @@ namespace Xamarin.Linker {
 		public List<AssemblyDefinition> Assemblies => Application.LinkContext.Assemblies;
 		public required List<AssemblyPreparerInfo> AssemblyInfos;
 		public List<(string Path, AssemblyDefinition Assembly, string? OriginatingAssembly)> AddedAssemblies = new ();
+		// The set of assemblies that were modified (i.e. that AppBundleRewriter.SaveAssembly was called for).
+		// Assemblies that aren't modified don't need to be re-serialized when saved.
+		public HashSet<AssemblyDefinition> ModifiedAssemblies = new ();
 #else
 		// The list of assemblies is populated in CollectAssembliesStep.
 		public List<AssemblyDefinition> Assemblies = new List<AssemblyDefinition> ();


### PR DESCRIPTION
SaveAssembliesStep used to Cecil-Write every assembly whose action is Link or Save,
which in a trimming build re-serializes every assembly in the trim set even though
the assembly-preparer didn't modify them (the trimming is done later by ILLink). Now
assemblies that weren't modified are output as-is - the original file is referenced
during preparation, or copied during post-processing so all assemblies end up in the
same directory for AOT compilation - instead of being re-serialized.

The modified assemblies are collected in a set on the LinkerConfiguration from the
AppBundleRewriter.AssemblySaved callback. Note we can't just encode "modified" in the
assembly action (i.e. switch Link to Save when an assembly is modified and then only
re-serialize Save assemblies), because AssemblyAction.Link is used as a gating
condition by many steps (their IsActiveFor checks 'GetAction (assembly) == Link');
changing a modified assembly's action from Link to Save mid-pipeline would make later
Link-gated steps skip it.

For monotouch-test (ios-arm64, SdkOnly) this cut the number of Cecil writes from ~170
to 14 and roughly halved the time spent in SaveAssembliesStep. Verified with the
monotouch-test suite (both 'release|linksdk' and link None, with PrepareAssemblies=true):
all tests pass.

Before build times:

| Project        | Runtime identifier | Link mode | PrepareAssemblies=false | PrepareAssemblies=true | Difference  |
| -------------- | ------------------ | --------- | ----------------------- | ---------------------- | ----------- |
| monotouch-test | ios-arm64          | None      | 00:02:04.03             | 00:02:05.67            | 00:00:01.64 |
| monotouch-test | ios-arm64          | SdkOnly   | 00:01:17.47             | 00:01:43.61            | 00:00:26.14 |
| monotouch-test | iossimulator-arm64 | None      | 00:01:37.04             | 00:01:38.26            | 00:00:01.21 |
| monotouch-test | iossimulator-arm64 | SdkOnly   | 00:01:09.96             | 00:01:19.42            | 00:00:09.46 |
| MySimpleApp    | ios-arm64          | None      | 00:01:12.77             | 00:01:15.47            | 00:00:02.70 |
| MySimpleApp    | ios-arm64          | SdkOnly   | 00:00:20.12             | 00:00:47.29            | 00:00:27.17 |
| MySimpleApp    | iossimulator-arm64 | None      | 00:00:56.20             | 00:00:55.54            | 00:00:00.66 |
| MySimpleApp    | iossimulator-arm64 | SdkOnly   | 00:00:19.68             | 00:00:31.96            | 00:00:12.27 |

After build times:

| Project        | Runtime identifier | Link mode | PrepareAssemblies=false | PrepareAssemblies=true | Difference  |
| -------------- | ------------------ | --------- | ----------------------- | ---------------------- | ----------- |
| monotouch-test | ios-arm64          | None      | 00:02:05.92             | 00:02:07.87            | 00:00:01.94 |
| monotouch-test | ios-arm64          | SdkOnly   | 00:01:22.09             | 00:01:45.01            | 00:00:22.92 |
| monotouch-test | iossimulator-arm64 | None      | 00:01:36.61             | 00:01:37.47            | 00:00:00.85 |
| monotouch-test | iossimulator-arm64 | SdkOnly   | 00:01:10.02             | 00:01:14.54            | 00:00:04.51 |
| MySimpleApp    | ios-arm64          | None      | 00:01:14.37             | 00:01:16.49            | 00:00:02.11 |
| MySimpleApp    | ios-arm64          | SdkOnly   | 00:00:20.63             | 00:00:42.59            | 00:00:21.96 |
| MySimpleApp    | iossimulator-arm64 | None      | 00:00:53.89             | 00:00:54.73            | 00:00:00.83 |
| MySimpleApp    | iossimulator-arm64 | SdkOnly   | 00:00:19.67             | 00:00:27.25            | 00:00:07.58 |