### PR TITLE
[tests] Render negative TimeSpan differences with a sign in the performance report.

### DIFF
--- a/tests/dotnet/UnitTests/PerformanceTests.cs
+++ b/tests/dotnet/UnitTests/PerformanceTests.cs
@@ -138,7 +138,12 @@ namespace Xamarin.Tests {
 			}
 		}
 
-		static string FormatTimeSpan (TimeSpan value) => value.ToString (@"hh\:mm\:ss\.ff");
+		static string FormatTimeSpan (TimeSpan value)
+		{
+			// A custom TimeSpan format string doesn't include the sign, so handle negative values ourselves.
+			var sign = value < TimeSpan.Zero ? "-" : " ";
+			return sign + value.Duration ().ToString (@"hh\:mm\:ss\.ff");
+		}
 
 		static void AppendMarkdownTable (StringBuilder report, string [] headers, List<string []> rows)
 		{


### PR DESCRIPTION
A custom TimeSpan format string (hh\:mm\:ss\.ff) doesn't include the sign, so a
negative difference (when the enabled build is faster than the disabled one) was
rendered as a positive value. Emit the '-' ourselves and format the absolute value.