### PR TITLE
[msbuild] Fix simulator OS version comparison in GetAvailableDevices

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetAvailableDevices.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetAvailableDevices.cs
@@ -390,7 +390,7 @@ public class GetAvailableDevices : XamarinTask, ICancelableTask {
 						break;
 					}
 					if (Version.TryParse (runtimeVersion, out var parsedMinimumOSVersion))
-						minimumOSVersion = parsedMinimumOSVersion;
+						minimumOSVersion = parsedMinimumOSVersion; // TODO: Refactor minimumOSVersion and maximumOSVersion to use only runtimeVersion in DeviceInfo
 					maximumOSVersion = new Version (65535, 255, 255);
 				} else {
 					discardedReason = $"Unknown device type identifier '{device.DeviceTypeIdentifier}'";

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetAvailableDevices.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetAvailableDevices.cs
@@ -389,10 +389,9 @@ public class GetAvailableDevices : XamarinTask, ICancelableTask {
 						discardedReason = $"Unknown product family '{deviceTypeInfo.ProductFamily}'";
 						break;
 					}
-					if (Version.TryParse (deviceTypeInfo.MinRuntimeVersionString, out var parsedMinimumOSVersion))
+					if (Version.TryParse (runtimeVersion, out var parsedMinimumOSVersion))
 						minimumOSVersion = parsedMinimumOSVersion;
-					if (Version.TryParse (deviceTypeInfo.MaxRuntimeVersionString, out var parsedMaximumOSVersion))
-						maximumOSVersion = parsedMaximumOSVersion;
+					maximumOSVersion = new Version (65535, 255, 255);
 				} else {
 					discardedReason = $"Unknown device type identifier '{device.DeviceTypeIdentifier}'";
 				}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetAvailableDevices.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetAvailableDevices.cs
@@ -86,8 +86,6 @@ public class GetAvailableDevices : XamarinTask, ICancelableTask {
 			if (Version.TryParse (minimumOSVersionString, out var minimumOSVersion)) {
 				foreach (var d in devices.Where (d => !d.Discarded && d.MinimumOSVersion < minimumOSVersion))
 					d.DiscardedReason = $"Device OS version '{d.MinimumOSVersion}' is lower than the app's minimum OS version '{minimumOSVersion}'";
-				foreach (var d in devices.Where (d => !d.Discarded && d.MaximumOSVersion < minimumOSVersion))
-					d.DiscardedReason = $"Device maximum OS version '{d.MaximumOSVersion}' is lower than the app's minimum OS version '{minimumOSVersion}'";
 			}
 		}
 
@@ -139,17 +137,15 @@ public class GetAvailableDevices : XamarinTask, ICancelableTask {
 		public ApplePlatform Platform { get; set; }
 		public IPhoneDeviceType DeviceType { get; set; }
 		public Version MinimumOSVersion { get; set; }
-		public Version MaximumOSVersion { get; set; }
 		public string DiscardedReason { get; set; }
 		public bool Discarded { get => !string.IsNullOrEmpty (DiscardedReason); }
-		public DeviceInfo (ITaskItem item, IEnumerable<string> runtimeIdentifiers, ApplePlatform platform, IPhoneDeviceType deviceType, Version minimumOSVersion, Version maximumOSVersion, string discardedReason)
+		public DeviceInfo (ITaskItem item, IEnumerable<string> runtimeIdentifiers, ApplePlatform platform, IPhoneDeviceType deviceType, Version minimumOSVersion, string discardedReason)
 		{
 			Item = item;
 			RuntimeIdentifiers = runtimeIdentifiers;
 			Platform = platform;
 			DeviceType = deviceType;
 			MinimumOSVersion = minimumOSVersion;
-			MaximumOSVersion = maximumOSVersion;
 			DiscardedReason = discardedReason;
 		}
 	}
@@ -255,9 +251,8 @@ public class GetAvailableDevices : XamarinTask, ICancelableTask {
 			}
 
 			Version.TryParse (device.OSVersion, out var minimumOSVersion);
-			var maximumOSVersion = new Version (65535, 255, 255);
 
-			rv.Add (new DeviceInfo (item, [runtimeIdentifier], platform, deviceType, minimumOSVersion ?? new Version (0, 0), maximumOSVersion, discardedReason));
+			rv.Add (new DeviceInfo (item, [runtimeIdentifier], platform, deviceType, minimumOSVersion ?? new Version (0, 0), discardedReason));
 		}
 		return rv;
 	}
@@ -370,7 +365,6 @@ public class GetAvailableDevices : XamarinTask, ICancelableTask {
 			}
 			var deviceType = IPhoneDeviceType.NotSet;
 			var minimumOSVersion = new Version (0, 0);
-			var maximumOSVersion = new Version (65535, 255, 255);
 			if (string.IsNullOrEmpty (discardedReason)) {
 				if (deviceTypes.TryGetValue (device.DeviceTypeIdentifier, out var deviceTypeInfo)) {
 					switch (deviceTypeInfo.ProductFamily.ToLowerInvariant ()) {
@@ -390,14 +384,13 @@ public class GetAvailableDevices : XamarinTask, ICancelableTask {
 						break;
 					}
 					if (Version.TryParse (runtimeVersion, out var parsedMinimumOSVersion))
-						minimumOSVersion = parsedMinimumOSVersion; // TODO: Refactor minimumOSVersion and maximumOSVersion to use only runtimeVersion in DeviceInfo
-					maximumOSVersion = new Version (65535, 255, 255);
+						minimumOSVersion = parsedMinimumOSVersion;
 				} else {
 					discardedReason = $"Unknown device type identifier '{device.DeviceTypeIdentifier}'";
 				}
 			}
 
-			rv.Add (new DeviceInfo (item, runtimeIdentifiers, platform, deviceType, minimumOSVersion, maximumOSVersion, discardedReason));
+			rv.Add (new DeviceInfo (item, runtimeIdentifiers, platform, deviceType, minimumOSVersion, discardedReason));
 		}
 		return rv;
 	}

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetAvailableDevicesTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/GetAvailableDevicesTest.cs
@@ -168,39 +168,39 @@ namespace Xamarin.MacDev.Tasks {
 				Assert.That (task.Devices.Count, Is.EqualTo (5), "Devices count mismatch.");
 				Assert.That (task.DiscardedDevices.Count, Is.EqualTo (4), "Discarded device count mismatch.");
 
-				Assert.That (task.Devices [0].ItemSpec, Is.EqualTo ("00008003-012301230123ABCD"), "Device 1 UDID mismatch.");
-				Assert.That (task.Devices [0].GetMetadata ("Description"), Is.EqualTo ("Rolf's iPhone 15 - iOS 26.1"), "Device 1 Name mismatch.");
+				Assert.That (task.Devices [0].ItemSpec, Is.EqualTo ("3F1C114D-FC3D-481A-9CA1-499EE1339390"), "Device 1 UDID mismatch.");
+				Assert.That (task.Devices [0].GetMetadata ("Description"), Is.EqualTo ("iPad Pro 13-inch (M5) - iOS 26.1 (Shutdown)"), "Device 1 Name mismatch.");
 				Assert.That (task.Devices [0].GetMetadata ("OSVersion"), Is.EqualTo ("26.1"), "Device 1 OSVersion mismatch.");
-				Assert.That (task.Devices [0].GetMetadata ("UDID"), Is.EqualTo ("00008003-012301230123ABCD"), "Device 1 UDID mismatch.");
-				Assert.That (task.Devices [0].GetMetadata ("RuntimeIdentifier"), Is.EqualTo ("ios-arm64"), "Device 1 RuntimeIdentifier mismatch.");
+				Assert.That (task.Devices [0].GetMetadata ("UDID"), Is.EqualTo ("3F1C114D-FC3D-481A-9CA1-499EE1339390"), "Device 1 UDID mismatch.");
+				Assert.That (task.Devices [0].GetMetadata ("RuntimeIdentifier"), Is.EqualTo ("iossimulator-arm64"), "Device 1 RuntimeIdentifier mismatch.");
 				Assert.That (task.Devices [0].GetMetadata ("DiscardedReason"), Is.Empty, "Device 1 discarded reason mismatch.");
 
-				Assert.That (task.Devices [1].ItemSpec, Is.EqualTo ("3F1C114D-FC3D-481A-9CA1-499EE1339390"), "Device 2 UDID mismatch.");
-				Assert.That (task.Devices [1].GetMetadata ("Description"), Is.EqualTo ("iPad Pro 13-inch (M5) - iOS 26.1 (Shutdown)"), "Device 2 Name mismatch.");
+				Assert.That (task.Devices [1].ItemSpec, Is.EqualTo ("D40CE982-3E65-4756-8162-90EFE50AF7FA"), "Device 2 UDID mismatch.");
+				Assert.That (task.Devices [1].GetMetadata ("Description"), Is.EqualTo ("iPhone 11 - iOS 26.1 (Shutdown)"), "Device 2 Name mismatch.");
 				Assert.That (task.Devices [1].GetMetadata ("OSVersion"), Is.EqualTo ("26.1"), "Device 2 OSVersion mismatch.");
-				Assert.That (task.Devices [1].GetMetadata ("UDID"), Is.EqualTo ("3F1C114D-FC3D-481A-9CA1-499EE1339390"), "Device 2 UDID mismatch.");
+				Assert.That (task.Devices [1].GetMetadata ("UDID"), Is.EqualTo ("D40CE982-3E65-4756-8162-90EFE50AF7FA"), "Device 2 UDID mismatch.");
 				Assert.That (task.Devices [1].GetMetadata ("RuntimeIdentifier"), Is.EqualTo ("iossimulator-arm64"), "Device 2 RuntimeIdentifier mismatch.");
 				Assert.That (task.Devices [1].GetMetadata ("DiscardedReason"), Is.Empty, "Device 2 discarded reason mismatch.");
 
-				Assert.That (task.Devices [2].ItemSpec, Is.EqualTo ("00008001-012301230123ABCD"), "Device 3 UDID mismatch.");
-				Assert.That (task.Devices [2].GetMetadata ("Description"), Is.EqualTo ("Rolf's iPad Pro 3rd Gen - iOS 26.0"), "Device 3 Name mismatch.");
-				Assert.That (task.Devices [2].GetMetadata ("OSVersion"), Is.EqualTo ("26.0"), "Device 3 OSVersion mismatch.");
-				Assert.That (task.Devices [2].GetMetadata ("UDID"), Is.EqualTo ("00008001-012301230123ABCD"), "Device 3 UDID mismatch.");
+				Assert.That (task.Devices [2].ItemSpec, Is.EqualTo ("00008003-012301230123ABCD"), "Device 3 UDID mismatch.");
+				Assert.That (task.Devices [2].GetMetadata ("Description"), Is.EqualTo ("Rolf's iPhone 15 - iOS 26.1"), "Device 3 Name mismatch.");
+				Assert.That (task.Devices [2].GetMetadata ("OSVersion"), Is.EqualTo ("26.1"), "Device 3 OSVersion mismatch.");
+				Assert.That (task.Devices [2].GetMetadata ("UDID"), Is.EqualTo ("00008003-012301230123ABCD"), "Device 3 UDID mismatch.");
 				Assert.That (task.Devices [2].GetMetadata ("RuntimeIdentifier"), Is.EqualTo ("ios-arm64"), "Device 3 RuntimeIdentifier mismatch.");
 				Assert.That (task.Devices [2].GetMetadata ("DiscardedReason"), Is.Empty, "Device 3 discarded reason mismatch.");
 
-				Assert.That (task.Devices [3].ItemSpec, Is.EqualTo ("00008002-012301230123ABCD"), "Device 4 UDID mismatch.");
-				Assert.That (task.Devices [3].GetMetadata ("Description"), Is.EqualTo ("Rolf's iPhone 13 - iOS 18.7.1"), "Device 4 Name mismatch.");
-				Assert.That (task.Devices [3].GetMetadata ("OSVersion"), Is.EqualTo ("18.7.1"), "Device 4 OSVersion mismatch.");
-				Assert.That (task.Devices [3].GetMetadata ("UDID"), Is.EqualTo ("00008002-012301230123ABCD"), "Device 4 UDID mismatch.");
+				Assert.That (task.Devices [3].ItemSpec, Is.EqualTo ("00008001-012301230123ABCD"), "Device 4 UDID mismatch.");
+				Assert.That (task.Devices [3].GetMetadata ("Description"), Is.EqualTo ("Rolf's iPad Pro 3rd Gen - iOS 26.0"), "Device 4 Name mismatch.");
+				Assert.That (task.Devices [3].GetMetadata ("OSVersion"), Is.EqualTo ("26.0"), "Device 4 OSVersion mismatch.");
+				Assert.That (task.Devices [3].GetMetadata ("UDID"), Is.EqualTo ("00008001-012301230123ABCD"), "Device 4 UDID mismatch.");
 				Assert.That (task.Devices [3].GetMetadata ("RuntimeIdentifier"), Is.EqualTo ("ios-arm64"), "Device 4 RuntimeIdentifier mismatch.");
 				Assert.That (task.Devices [3].GetMetadata ("DiscardedReason"), Is.Empty, "Device 4 discarded reason mismatch.");
 
-				Assert.That (task.Devices [4].ItemSpec, Is.EqualTo ("D40CE982-3E65-4756-8162-90EFE50AF7FA"), "Device 5 UDID mismatch.");
-				Assert.That (task.Devices [4].GetMetadata ("Description"), Is.EqualTo ("iPhone 11 - iOS 26.1 (Shutdown)"), "Device 5 Name mismatch.");
-				Assert.That (task.Devices [4].GetMetadata ("OSVersion"), Is.EqualTo ("26.1"), "Device 5 OSVersion mismatch.");
-				Assert.That (task.Devices [4].GetMetadata ("UDID"), Is.EqualTo ("D40CE982-3E65-4756-8162-90EFE50AF7FA"), "Device 5 UDID mismatch.");
-				Assert.That (task.Devices [4].GetMetadata ("RuntimeIdentifier"), Is.EqualTo ("iossimulator-arm64"), "Device 5 RuntimeIdentifier mismatch.");
+				Assert.That (task.Devices [4].ItemSpec, Is.EqualTo ("00008002-012301230123ABCD"), "Device 5 UDID mismatch.");
+				Assert.That (task.Devices [4].GetMetadata ("Description"), Is.EqualTo ("Rolf's iPhone 13 - iOS 18.7.1"), "Device 5 Name mismatch.");
+				Assert.That (task.Devices [4].GetMetadata ("OSVersion"), Is.EqualTo ("18.7.1"), "Device 5 OSVersion mismatch.");
+				Assert.That (task.Devices [4].GetMetadata ("UDID"), Is.EqualTo ("00008002-012301230123ABCD"), "Device 5 UDID mismatch.");
+				Assert.That (task.Devices [4].GetMetadata ("RuntimeIdentifier"), Is.EqualTo ("ios-arm64"), "Device 5 RuntimeIdentifier mismatch.");
 				Assert.That (task.Devices [4].GetMetadata ("DiscardedReason"), Is.Empty, "Device 5 discarded reason mismatch.");
 
 				Assert.That (task.DiscardedDevices [0].ItemSpec, Is.EqualTo ("00008004-012301230123ABCD"), "Discarded Device 1 ItemSpec mismatch.");
@@ -258,39 +258,39 @@ namespace Xamarin.MacDev.Tasks {
 				Assert.That (task.Devices.Count, Is.EqualTo (5), "Devices count mismatch.");
 				Assert.That (task.DiscardedDevices.Count, Is.EqualTo (4), "Discarded device count mismatch.");
 
-				Assert.That (task.Devices [0].ItemSpec, Is.EqualTo ("00008003-012301230123ABCD"), "Device 1 UDID mismatch.");
-				Assert.That (task.Devices [0].GetMetadata ("Description"), Is.EqualTo ("Rolf's iPhone 15 - iOS 26.1"), "Device 1 Name mismatch.");
+				Assert.That (task.Devices [0].ItemSpec, Is.EqualTo ("3F1C114D-FC3D-481A-9CA1-499EE1339390"), "Device 1 UDID mismatch.");
+				Assert.That (task.Devices [0].GetMetadata ("Description"), Is.EqualTo ("iPad Pro 13-inch (M5) - iOS 26.1 (Shutdown)"), "Device 1 Name mismatch.");
 				Assert.That (task.Devices [0].GetMetadata ("OSVersion"), Is.EqualTo ("26.1"), "Device 1 OSVersion mismatch.");
-				Assert.That (task.Devices [0].GetMetadata ("UDID"), Is.EqualTo ("00008003-012301230123ABCD"), "Device 1 UDID mismatch.");
-				Assert.That (task.Devices [0].GetMetadata ("RuntimeIdentifier"), Is.EqualTo ("ios-arm64"), "Device 1 RuntimeIdentifier mismatch.");
+				Assert.That (task.Devices [0].GetMetadata ("UDID"), Is.EqualTo ("3F1C114D-FC3D-481A-9CA1-499EE1339390"), "Device 1 UDID mismatch.");
+				Assert.That (task.Devices [0].GetMetadata ("RuntimeIdentifier"), Is.EqualTo ("iossimulator-arm64"), "Device 1 RuntimeIdentifier mismatch.");
 				Assert.That (task.Devices [0].GetMetadata ("DiscardedReason"), Is.Empty, "Device 1 discarded reason mismatch.");
 
-				Assert.That (task.Devices [1].ItemSpec, Is.EqualTo ("3F1C114D-FC3D-481A-9CA1-499EE1339390"), "Device 2 UDID mismatch.");
-				Assert.That (task.Devices [1].GetMetadata ("Description"), Is.EqualTo ("iPad Pro 13-inch (M5) - iOS 26.1 (Shutdown)"), "Device 2 Name mismatch.");
+				Assert.That (task.Devices [1].ItemSpec, Is.EqualTo ("D40CE982-3E65-4756-8162-90EFE50AF7FA"), "Device 2 UDID mismatch.");
+				Assert.That (task.Devices [1].GetMetadata ("Description"), Is.EqualTo ("iPhone 11 - iOS 26.1 (Shutdown)"), "Device 2 Name mismatch.");
 				Assert.That (task.Devices [1].GetMetadata ("OSVersion"), Is.EqualTo ("26.1"), "Device 2 OSVersion mismatch.");
-				Assert.That (task.Devices [1].GetMetadata ("UDID"), Is.EqualTo ("3F1C114D-FC3D-481A-9CA1-499EE1339390"), "Device 2 UDID mismatch.");
+				Assert.That (task.Devices [1].GetMetadata ("UDID"), Is.EqualTo ("D40CE982-3E65-4756-8162-90EFE50AF7FA"), "Device 2 UDID mismatch.");
 				Assert.That (task.Devices [1].GetMetadata ("RuntimeIdentifier"), Is.EqualTo ("iossimulator-arm64"), "Device 2 RuntimeIdentifier mismatch.");
 				Assert.That (task.Devices [1].GetMetadata ("DiscardedReason"), Is.Empty, "Device 2 discarded reason mismatch.");
 
-				Assert.That (task.Devices [2].ItemSpec, Is.EqualTo ("00008001-012301230123ABCD"), "Device 3 UDID mismatch.");
-				Assert.That (task.Devices [2].GetMetadata ("Description"), Is.EqualTo ("Rolf's iPad Pro 3rd Gen - iOS 26.0"), "Device 3 Name mismatch.");
-				Assert.That (task.Devices [2].GetMetadata ("OSVersion"), Is.EqualTo ("26.0"), "Device 3 OSVersion mismatch.");
-				Assert.That (task.Devices [2].GetMetadata ("UDID"), Is.EqualTo ("00008001-012301230123ABCD"), "Device 3 UDID mismatch.");
+				Assert.That (task.Devices [2].ItemSpec, Is.EqualTo ("00008003-012301230123ABCD"), "Device 3 UDID mismatch.");
+				Assert.That (task.Devices [2].GetMetadata ("Description"), Is.EqualTo ("Rolf's iPhone 15 - iOS 26.1"), "Device 3 Name mismatch.");
+				Assert.That (task.Devices [2].GetMetadata ("OSVersion"), Is.EqualTo ("26.1"), "Device 3 OSVersion mismatch.");
+				Assert.That (task.Devices [2].GetMetadata ("UDID"), Is.EqualTo ("00008003-012301230123ABCD"), "Device 3 UDID mismatch.");
 				Assert.That (task.Devices [2].GetMetadata ("RuntimeIdentifier"), Is.EqualTo ("ios-arm64"), "Device 3 RuntimeIdentifier mismatch.");
 				Assert.That (task.Devices [2].GetMetadata ("DiscardedReason"), Is.Empty, "Device 3 discarded reason mismatch.");
 
-				Assert.That (task.Devices [3].ItemSpec, Is.EqualTo ("00008002-012301230123ABCD"), "Device 4 UDID mismatch.");
-				Assert.That (task.Devices [3].GetMetadata ("Description"), Is.EqualTo ("Rolf's iPhone 13 - iOS 18.7.1"), "Device 4 Name mismatch.");
-				Assert.That (task.Devices [3].GetMetadata ("OSVersion"), Is.EqualTo ("18.7.1"), "Device 4 OSVersion mismatch.");
-				Assert.That (task.Devices [3].GetMetadata ("UDID"), Is.EqualTo ("00008002-012301230123ABCD"), "Device 4 UDID mismatch.");
+				Assert.That (task.Devices [3].ItemSpec, Is.EqualTo ("00008001-012301230123ABCD"), "Device 4 UDID mismatch.");
+				Assert.That (task.Devices [3].GetMetadata ("Description"), Is.EqualTo ("Rolf's iPad Pro 3rd Gen - iOS 26.0"), "Device 4 Name mismatch.");
+				Assert.That (task.Devices [3].GetMetadata ("OSVersion"), Is.EqualTo ("26.0"), "Device 4 OSVersion mismatch.");
+				Assert.That (task.Devices [3].GetMetadata ("UDID"), Is.EqualTo ("00008001-012301230123ABCD"), "Device 4 UDID mismatch.");
 				Assert.That (task.Devices [3].GetMetadata ("RuntimeIdentifier"), Is.EqualTo ("ios-arm64"), "Device 4 RuntimeIdentifier mismatch.");
 				Assert.That (task.Devices [3].GetMetadata ("DiscardedReason"), Is.Empty, "Device 4 discarded reason mismatch.");
 
-				Assert.That (task.Devices [4].ItemSpec, Is.EqualTo ("D40CE982-3E65-4756-8162-90EFE50AF7FA"), "Device 5 UDID mismatch.");
-				Assert.That (task.Devices [4].GetMetadata ("Description"), Is.EqualTo ("iPhone 11 - iOS 26.1 (Shutdown)"), "Device 5 Name mismatch.");
-				Assert.That (task.Devices [4].GetMetadata ("OSVersion"), Is.EqualTo ("26.1"), "Device 5 OSVersion mismatch.");
-				Assert.That (task.Devices [4].GetMetadata ("UDID"), Is.EqualTo ("D40CE982-3E65-4756-8162-90EFE50AF7FA"), "Device 5 UDID mismatch.");
-				Assert.That (task.Devices [4].GetMetadata ("RuntimeIdentifier"), Is.EqualTo ("iossimulator-arm64"), "Device 5 RuntimeIdentifier mismatch.");
+				Assert.That (task.Devices [4].ItemSpec, Is.EqualTo ("00008002-012301230123ABCD"), "Device 5 UDID mismatch.");
+				Assert.That (task.Devices [4].GetMetadata ("Description"), Is.EqualTo ("Rolf's iPhone 13 - iOS 18.7.1"), "Device 5 Name mismatch.");
+				Assert.That (task.Devices [4].GetMetadata ("OSVersion"), Is.EqualTo ("18.7.1"), "Device 5 OSVersion mismatch.");
+				Assert.That (task.Devices [4].GetMetadata ("UDID"), Is.EqualTo ("00008002-012301230123ABCD"), "Device 5 UDID mismatch.");
+				Assert.That (task.Devices [4].GetMetadata ("RuntimeIdentifier"), Is.EqualTo ("ios-arm64"), "Device 5 RuntimeIdentifier mismatch.");
 				Assert.That (task.Devices [4].GetMetadata ("DiscardedReason"), Is.Empty, "Device 5 discarded reason mismatch.");
 
 				Assert.That (task.DiscardedDevices [0].ItemSpec, Is.EqualTo ("00008004-012301230123ABCD"), "Discarded Device 1 ItemSpec mismatch.");
@@ -443,29 +443,36 @@ namespace Xamarin.MacDev.Tasks {
 
 			Assert.That (task.Execute (), Is.True, "Task should have succeeded.");
 			Assert.Multiple (() => {
-				Assert.That (task.Devices.Count, Is.EqualTo (3), "Devices count mismatch.");
-				Assert.That (task.DiscardedDevices.Count, Is.EqualTo (6), "Discarded device count mismatch.");
+				Assert.That (task.Devices.Count, Is.EqualTo (4), "Devices count mismatch.");
+				Assert.That (task.DiscardedDevices.Count, Is.EqualTo (5), "Discarded device count mismatch.");
 
-				Assert.That (task.Devices [0].ItemSpec, Is.EqualTo ("00008003-012301230123ABCD"), "Device 1 UDID mismatch.");
-				Assert.That (task.Devices [0].GetMetadata ("Description"), Is.EqualTo ("Rolf's iPhone 15 - iOS 26.1"), "Device 1 Name mismatch.");
+				Assert.That (task.Devices [0].ItemSpec, Is.EqualTo ("3F1C114D-FC3D-481A-9CA1-499EE1339390"), "Device 1 UDID mismatch.");
+				Assert.That (task.Devices [0].GetMetadata ("Description"), Is.EqualTo ("iPad Pro 13-inch (M5) - iOS 26.1 (Shutdown)"), "Device 1 Name mismatch.");
 				Assert.That (task.Devices [0].GetMetadata ("OSVersion"), Is.EqualTo ("26.1"), "Device 1 OSVersion mismatch.");
-				Assert.That (task.Devices [0].GetMetadata ("UDID"), Is.EqualTo ("00008003-012301230123ABCD"), "Device 1 UDID mismatch.");
-				Assert.That (task.Devices [0].GetMetadata ("RuntimeIdentifier"), Is.EqualTo ("ios-arm64"), "Device 1 RuntimeIdentifier mismatch.");
+				Assert.That (task.Devices [0].GetMetadata ("UDID"), Is.EqualTo ("3F1C114D-FC3D-481A-9CA1-499EE1339390"), "Device 1 UDID mismatch.");
+				Assert.That (task.Devices [0].GetMetadata ("RuntimeIdentifier"), Is.EqualTo ("iossimulator-arm64"), "Device 1 RuntimeIdentifier mismatch.");
 				Assert.That (task.Devices [0].GetMetadata ("DiscardedReason"), Is.Empty, "Device 1 discarded reason mismatch.");
 
-				Assert.That (task.Devices [1].ItemSpec, Is.EqualTo ("3F1C114D-FC3D-481A-9CA1-499EE1339390"), "Device 2 UDID mismatch.");
-				Assert.That (task.Devices [1].GetMetadata ("Description"), Is.EqualTo ("iPad Pro 13-inch (M5) - iOS 26.1 (Shutdown)"), "Device 2 Name mismatch.");
+				Assert.That (task.Devices [1].ItemSpec, Is.EqualTo ("D40CE982-3E65-4756-8162-90EFE50AF7FA"), "Device 2 UDID mismatch.");
+				Assert.That (task.Devices [1].GetMetadata ("Description"), Is.EqualTo ("iPhone 11 - iOS 26.1 (Shutdown)"), "Device 2 Name mismatch.");
 				Assert.That (task.Devices [1].GetMetadata ("OSVersion"), Is.EqualTo ("26.1"), "Device 2 OSVersion mismatch.");
-				Assert.That (task.Devices [1].GetMetadata ("UDID"), Is.EqualTo ("3F1C114D-FC3D-481A-9CA1-499EE1339390"), "Device 2 UDID mismatch.");
+				Assert.That (task.Devices [1].GetMetadata ("UDID"), Is.EqualTo ("D40CE982-3E65-4756-8162-90EFE50AF7FA"), "Device 2 UDID mismatch.");
 				Assert.That (task.Devices [1].GetMetadata ("RuntimeIdentifier"), Is.EqualTo ("iossimulator-arm64"), "Device 2 RuntimeIdentifier mismatch.");
 				Assert.That (task.Devices [1].GetMetadata ("DiscardedReason"), Is.Empty, "Device 2 discarded reason mismatch.");
 
-				Assert.That (task.Devices [2].ItemSpec, Is.EqualTo ("00008001-012301230123ABCD"), "Device 3 UDID mismatch.");
-				Assert.That (task.Devices [2].GetMetadata ("Description"), Is.EqualTo ("Rolf's iPad Pro 3rd Gen - iOS 26.0"), "Device 3 Name mismatch.");
-				Assert.That (task.Devices [2].GetMetadata ("OSVersion"), Is.EqualTo ("26.0"), "Device 3 OSVersion mismatch.");
-				Assert.That (task.Devices [2].GetMetadata ("UDID"), Is.EqualTo ("00008001-012301230123ABCD"), "Device 3 UDID mismatch.");
+				Assert.That (task.Devices [2].ItemSpec, Is.EqualTo ("00008003-012301230123ABCD"), "Device 3 UDID mismatch.");
+				Assert.That (task.Devices [2].GetMetadata ("Description"), Is.EqualTo ("Rolf's iPhone 15 - iOS 26.1"), "Device 3 Name mismatch.");
+				Assert.That (task.Devices [2].GetMetadata ("OSVersion"), Is.EqualTo ("26.1"), "Device 3 OSVersion mismatch.");
+				Assert.That (task.Devices [2].GetMetadata ("UDID"), Is.EqualTo ("00008003-012301230123ABCD"), "Device 3 UDID mismatch.");
 				Assert.That (task.Devices [2].GetMetadata ("RuntimeIdentifier"), Is.EqualTo ("ios-arm64"), "Device 3 RuntimeIdentifier mismatch.");
 				Assert.That (task.Devices [2].GetMetadata ("DiscardedReason"), Is.Empty, "Device 3 discarded reason mismatch.");
+
+				Assert.That (task.Devices [3].ItemSpec, Is.EqualTo ("00008001-012301230123ABCD"), "Device 4 UDID mismatch.");
+				Assert.That (task.Devices [3].GetMetadata ("Description"), Is.EqualTo ("Rolf's iPad Pro 3rd Gen - iOS 26.0"), "Device 4 Name mismatch.");
+				Assert.That (task.Devices [3].GetMetadata ("OSVersion"), Is.EqualTo ("26.0"), "Device 4 OSVersion mismatch.");
+				Assert.That (task.Devices [3].GetMetadata ("UDID"), Is.EqualTo ("00008001-012301230123ABCD"), "Device 4 UDID mismatch.");
+				Assert.That (task.Devices [3].GetMetadata ("RuntimeIdentifier"), Is.EqualTo ("ios-arm64"), "Device 4 RuntimeIdentifier mismatch.");
+				Assert.That (task.Devices [3].GetMetadata ("DiscardedReason"), Is.Empty, "Device 4 discarded reason mismatch.");
 
 				Assert.That (task.DiscardedDevices [0].ItemSpec, Is.EqualTo ("00008002-012301230123ABCD"), "Discarded Device 1 UDID mismatch.");
 				Assert.That (task.DiscardedDevices [0].GetMetadata ("Description"), Is.EqualTo ("Rolf's iPhone 13 - iOS 18.7.1"), "Discarded Device 1 Name mismatch.");
@@ -495,19 +502,12 @@ namespace Xamarin.MacDev.Tasks {
 				Assert.That (task.DiscardedDevices [3].GetMetadata ("RuntimeIdentifier"), Is.EqualTo (""), "Discarded Device 4 RuntimeIdentifier mismatch.");
 				Assert.That (task.DiscardedDevices [3].GetMetadata ("DiscardedReason"), Is.EqualTo ("Device is not available: runtime profile not found using \"System\" match policy"), "Discarded Device 4 reason mismatch.");
 
-				Assert.That (task.DiscardedDevices [4].ItemSpec, Is.EqualTo ("D40CE982-3E65-4756-8162-90EFE50AF7FA"), "Discarded Device 5 UDID mismatch.");
-				Assert.That (task.DiscardedDevices [4].GetMetadata ("Description"), Is.EqualTo ("iPhone 11 - iOS 26.1 (Shutdown)"), "Discarded Device 5 Name mismatch.");
+				Assert.That (task.DiscardedDevices [4].ItemSpec, Is.EqualTo ("F8BEDB0B-441A-4D05-AED6-E9724DEA6BF4"), "Discarded Device 5 UDID mismatch.");
+				Assert.That (task.DiscardedDevices [4].GetMetadata ("Description"), Is.EqualTo ("iPad Pro 11-inch (M5) - iOS 26.1 (Shutdown)"), "Discarded Device 5 Name mismatch.");
 				Assert.That (task.DiscardedDevices [4].GetMetadata ("OSVersion"), Is.EqualTo ("26.1"), "Discarded Device 5 OSVersion mismatch.");
-				Assert.That (task.DiscardedDevices [4].GetMetadata ("UDID"), Is.EqualTo ("D40CE982-3E65-4756-8162-90EFE50AF7FA"), "Discarded Device 5 UDID mismatch.");
+				Assert.That (task.DiscardedDevices [4].GetMetadata ("UDID"), Is.EqualTo ("F8BEDB0B-441A-4D05-AED6-E9724DEA6BF4"), "Discarded Device 5 UDID mismatch.");
 				Assert.That (task.DiscardedDevices [4].GetMetadata ("RuntimeIdentifier"), Is.EqualTo ("iossimulator-arm64"), "Discarded Device 5 RuntimeIdentifier mismatch.");
-				Assert.That (task.DiscardedDevices [4].GetMetadata ("DiscardedReason"), Is.EqualTo ("Device OS version '13.0.0' is lower than the app's minimum OS version '26.0'"), "Discarded Device 5 reason mismatch.");
-
-				Assert.That (task.DiscardedDevices [5].ItemSpec, Is.EqualTo ("F8BEDB0B-441A-4D05-AED6-E9724DEA6BF4"), "Discarded Device 6 UDID mismatch.");
-				Assert.That (task.DiscardedDevices [5].GetMetadata ("Description"), Is.EqualTo ("iPad Pro 11-inch (M5) - iOS 26.1 (Shutdown)"), "Discarded Device 6 Name mismatch.");
-				Assert.That (task.DiscardedDevices [5].GetMetadata ("OSVersion"), Is.EqualTo ("26.1"), "Discarded Device 6 OSVersion mismatch.");
-				Assert.That (task.DiscardedDevices [5].GetMetadata ("UDID"), Is.EqualTo ("F8BEDB0B-441A-4D05-AED6-E9724DEA6BF4"), "Discarded Device 6 UDID mismatch.");
-				Assert.That (task.DiscardedDevices [5].GetMetadata ("RuntimeIdentifier"), Is.EqualTo ("iossimulator-arm64"), "Discarded Device 6 RuntimeIdentifier mismatch.");
-				Assert.That (task.DiscardedDevices [5].GetMetadata ("DiscardedReason"), Is.EqualTo ("Unknown device type identifier 'com.apple.CoreSimulator.SimDeviceType.iPad-Pro-11-inch-M5-12GB'"), "Discarded Device 6 reason mismatch.");
+				Assert.That (task.DiscardedDevices [4].GetMetadata ("DiscardedReason"), Is.EqualTo ("Unknown device type identifier 'com.apple.CoreSimulator.SimDeviceType.iPad-Pro-11-inch-M5-12GB'"), "Discarded Device 5 reason mismatch.");
 			});
 		}
 


### PR DESCRIPTION
`GetAvailableDevices.RunSimCtlAsync()` used the **device type's** `MinRuntimeVersionString` (e.g. `"26.0.0"`) as the simulator's OS version when filtering against the app's `MinimumOSVersion`. This is wrong — it should use the **actual runtime version** from `simctl` (e.g. `"26.5"`).

The device type's `minRuntimeVersionString` represents the minimum OS version the physical device hardware supports, not the actual OS version running on the simulator. For example, an iPhone 17 Pro device type has `minRuntimeVersionString: "26.0.0"`, but when created with the iOS 26.5 simulator runtime, its actual OS version is **26.5**.

This causes `dotnet run --device` to reject every simulator device when the SDK version exceeds all device type `minRuntimeVersionString` values — for example in Xcode 26.5 (iOS 26.5 SDK) where every device type has `minRuntimeVersionString <= 26.3`.

## The fix

Use the actual `simctl` runtime version, matching how `RunDeviceCtlAsync()` already handles physical devices:

```cs
Version.TryParse (device.OSVersion, out var minimumOSVersion);
```

## Removing `maximumOSVersion`

`maximumOSVersion` was always set to the sentinel maximum value (`65535.255.255`) in both the simulator and physical-device code paths — `simctl` itself reports `maxRuntimeVersionString` as `65535.255.255` for every device type. As a result the max-version comparison in the filtering logic could never discard a device. This PR removes the now-redundant `DeviceInfo.MaximumOSVersion` property, the constructor parameter, the local variables, and the dead filter loop.

## Note

This is partially a re-creation of #25931 (from @Happypig375). We have to re-create it because #25931 is from a fork, and our CI can't build from forks.

🤖 Pull request created by Copilot
