### PR TITLE
[dotnet] Show a clear error when PublishSingleFile is set. Fixes #16754

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -106,6 +106,10 @@ Use these attributes to specify platform availability:
 
 It's typically `make run-tests` in the directory with the test project.
 
+### Adding Test Cases
+
+When adding new test cases that require a runtime identifier, prefer `-arm64` over `-x64` unless there's a specific reason to use `-x64`.
+
 ## Apple Platform Integration
 
 ### Xcode Requirements

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -2701,6 +2701,12 @@
 		<Error Text=".NET for $(_PlatformName) does not support server garbage collection. Please don't set the 'ServerGarbageCollection' property." />
 	</Target>
 
+	<Target Name="_ValidatePublishSingleFile"
+		Condition="'$(PublishSingleFile)' == 'true'"
+		BeforeTargets="Build;Publish">
+		<Error Text=".NET for $(_PlatformName) does not support publishing to a single file. Please don't set the 'PublishSingleFile' property." />
+	</Target>
+
 	<Target Name="_ValidateXcodeVersion"
 		AfterTargets="_DetectSdkLocations"
 		Condition="'$(ValidateXcodeVersion)' != 'false' And '$(_CanOutputAppBundle)' == 'true' And '$(IsMacEnabled)' == 'true'">

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -469,7 +469,7 @@ namespace Xamarin.Tests {
 			var rv = DotNet.AssertBuildFailure (project_path, properties);
 			var errors = BinLog.GetBuildLogErrors (rv.BinLogPath).ToArray ();
 			Assert.That (errors.Length, Is.GreaterThanOrEqualTo (1), "Error count");
-			Assert.That (errors [0].Message, Does.Contain ("does not support publishing to a single file"), "Error message");
+			Assert.That (errors.Select (e => e.Message), Has.Some.Contains ("does not support publishing to a single file"), "Error message");
 		}
 
 		[Test]

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -453,10 +453,10 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
-		[TestCase (ApplePlatform.iOS, "iossimulator-x64")]
-		[TestCase (ApplePlatform.TVOS, "tvossimulator-x64")]
-		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64")]
-		[TestCase (ApplePlatform.MacOSX, "osx-x64")]
+		[TestCase (ApplePlatform.iOS, "iossimulator-arm64")]
+		[TestCase (ApplePlatform.TVOS, "tvossimulator-arm64")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64")]
 		public void PublishSingleFile_IsNotSupported (ApplePlatform platform, string runtimeIdentifiers)
 		{
 			var project = "MySimpleApp";

--- a/tests/dotnet/UnitTests/ProjectTest.cs
+++ b/tests/dotnet/UnitTests/ProjectTest.cs
@@ -453,6 +453,26 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
+		[TestCase (ApplePlatform.iOS, "iossimulator-x64")]
+		[TestCase (ApplePlatform.TVOS, "tvossimulator-x64")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-x64")]
+		[TestCase (ApplePlatform.MacOSX, "osx-x64")]
+		public void PublishSingleFile_IsNotSupported (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			var project = "MySimpleApp";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+
+			var project_path = GetProjectPath (project, platform: platform);
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["PublishSingleFile"] = "true";
+			var rv = DotNet.AssertBuildFailure (project_path, properties);
+			var errors = BinLog.GetBuildLogErrors (rv.BinLogPath).ToArray ();
+			Assert.That (errors.Length, Is.GreaterThanOrEqualTo (1), "Error count");
+			Assert.That (errors [0].Message, Does.Contain ("does not support publishing to a single file"), "Error message");
+		}
+
+		[Test]
 		[TestCase (ApplePlatform.iOS, "ios-arm64;iossimulator-x64")]
 		[TestCase (ApplePlatform.iOS, "ios-arm64;iossimulator-arm64")]
 		[TestCase (ApplePlatform.TVOS, "tvos-arm64;tvossimulator-x64")]


### PR DESCRIPTION
PublishSingleFile is not supported for .NET Apple platforms. Previously,
setting this property would result in a cryptic error from the
GenerateBundle task. Now we show a clear error message explaining that
single-file publishing is not supported.

Also adds a note to copilot-instructions.md that new test cases should
prefer `-arm64` over `-x64`.

Fixes https://github.com/dotnet/macios/issues/16754

🤖 Pull request created by Copilot