### PR TITLE
[AppKit] Update bindings up to Xcode 27 Beta 3

### DIFF
--- a/src/appkit.cs
+++ b/src/appkit.cs
@@ -17635,6 +17635,10 @@ namespace AppKit {
 		[Export ("setIgnoredWords:inSpellDocumentWithTag:")]
 		void SetIgnoredWords (string [] words, nint documentTag);
 
+		[Mac (27, 0)]
+		[Export ("ignoreGrammarRange:inSentence:inSpellDocumentWithTag:")]
+		void IgnoreGrammarRange (NSRange grammarRange, string sentence, nint documentTag);
+
 		[Export ("guessesForWordRange:inString:language:inSpellDocumentWithTag:")]
 		string [] GuessesForWordRange (NSRange range, string theString, string language, nint documentTag);
 
@@ -28972,6 +28976,10 @@ namespace AppKit {
 		[Mac (26, 0)]
 		[Field ("NSTextCheckingAutomaticCapitalizationEnabledKey")]
 		NSString TextCheckingAutomaticCapitalizationEnabledKey { get; }
+
+		[Mac (27, 0)]
+		[Field ("NSTextCheckingWaitForAllGrammarCheckingResultsKey")]
+		NSString TextCheckingWaitForAllGrammarCheckingResultsKey { get; }
 	}
 
 	partial interface NSTextViewDidChangeSelectionEventArgs {

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -11047,6 +11047,7 @@ M:AppKit.NSSpellChecker.GetLanguage(Foundation.NSRange,System.String,Foundation.
 M:AppKit.NSSpellChecker.GuessesForWordRange(Foundation.NSRange,System.String,System.String,System.IntPtr)
 M:AppKit.NSSpellChecker.HasLearnedWord(System.String)
 M:AppKit.NSSpellChecker.IgnoredWords(System.IntPtr)
+M:AppKit.NSSpellChecker.IgnoreGrammarRange(Foundation.NSRange,System.String,System.IntPtr)
 M:AppKit.NSSpellChecker.IgnoreWord(System.String,System.IntPtr)
 M:AppKit.NSSpellChecker.LearnWord(System.String)
 M:AppKit.NSSpellChecker.MenuForResults(Foundation.NSTextCheckingResult,System.String,Foundation.NSDictionary,CoreGraphics.CGPoint,AppKit.NSView)

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.todo
@@ -1,2 +1,0 @@
-!missing-field! NSTextCheckingWaitForAllGrammarCheckingResultsKey not bound
-!missing-selector! NSSpellChecker::ignoreGrammarRange:inSentence:inSpellDocumentWithTag: not bound


### PR DESCRIPTION
Bind the two macOS-only AppKit APIs introduced in the Xcode 27 SDK:

* NSSpellChecker.ignoreGrammarRange:inSentence:inSpellDocumentWithTag:
* NSTextCheckingWaitForAllGrammarCheckingResultsKey (an NSTextCheckingOptionKey)

Both are available on macOS 27.0 only (NSSpellChecker is [NoMacCatalyst]), so they carry [Mac (27, 0)] and inherit the type's Mac Catalyst exclusion.

This resolves the two entries in
tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.todo (deleting the now-empty file) and adds the cecil documentation known-failure entry for the new IgnoreGrammarRange method.