### PR TITLE
[Accessibility] Update bindings up to Xcode 27 Beta 3

### DIFF
--- a/src/Accessibility/AXSettings.cs
+++ b/src/Accessibility/AXSettings.cs
@@ -144,5 +144,23 @@ namespace Accessibility {
 		{
 			return AXOpenSettingsFeatureIsSupported ((nint) (long) feature) != 0;
 		}
+
+		[SupportedOSPlatform ("ios27.0")]
+		[SupportedOSPlatform ("maccatalyst27.0")]
+		[SupportedOSPlatform ("macos27.0")]
+		[SupportedOSPlatform ("tvos27.0")]
+		[DllImport (Constants.AccessibilityLibrary)]
+		static extern byte AXApplicationAccessibilityEnabled ();
+
+		/// <summary>Returns whether application accessibility is currently enabled for this process.</summary>
+		[SupportedOSPlatform ("ios27.0")]
+		[SupportedOSPlatform ("maccatalyst27.0")]
+		[SupportedOSPlatform ("macos27.0")]
+		[SupportedOSPlatform ("tvos27.0")]
+		public static bool IsApplicationAccessibilityEnabled {
+			get {
+				return AXApplicationAccessibilityEnabled () != 0;
+			}
+		}
 	}
 }

--- a/src/accessibility.cs
+++ b/src/accessibility.cs
@@ -373,6 +373,11 @@ namespace Accessibility {
 		[Notification]
 		[Field ("AXReduceHighlightingEffectsEnabledDidChangeNotification")]
 		NSString ReduceHighlightingEffectsEnabledDidChangeNotification { get; }
+
+		[TV (27, 0), Mac (27, 0), iOS (27, 0), MacCatalyst (27, 0)]
+		[Notification]
+		[Field ("AXApplicationAccessibilityEnabledDidChangeNotification")]
+		NSString ApplicationAccessibilityEnabledDidChangeNotification { get; }
 	}
 
 	[TV (18, 0), Mac (15, 0), iOS (18, 0), MacCatalyst (18, 0)]

--- a/tests/monotouch-test/Accessibility/AXSettings.cs
+++ b/tests/monotouch-test/Accessibility/AXSettings.cs
@@ -18,6 +18,13 @@ namespace MonoTouchFixtures.Accessibility {
 			Assert.That (AXSettings.IsAssistiveAccessEnabled, Is.EqualTo (true).Or.EqualTo (false), "IsAssistiveAccessEnabled");
 		}
 
+		[Test]
+		public void IsApplicationAccessibilityEnabled ()
+		{
+			TestRuntime.AssertXcodeVersion (27, 0);
+			Assert.That (AXSettings.IsApplicationAccessibilityEnabled, Is.EqualTo (true).Or.EqualTo (false), "IsApplicationAccessibilityEnabled");
+		}
+
 		static bool testedOnce;
 		[Test]
 		public void OpenSettingsFeature ()

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-Accessibility.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-Accessibility.todo
@@ -1,2 +1,0 @@
-!missing-field! AXApplicationAccessibilityEnabledDidChangeNotification not bound
-!missing-pinvoke! AXApplicationAccessibilityEnabled is not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-Accessibility.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-Accessibility.todo
@@ -1,2 +1,0 @@
-!missing-field! AXApplicationAccessibilityEnabledDidChangeNotification not bound
-!missing-pinvoke! AXApplicationAccessibilityEnabled is not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-Accessibility.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-Accessibility.todo
@@ -1,2 +1,0 @@
-!missing-field! AXApplicationAccessibilityEnabledDidChangeNotification not bound
-!missing-pinvoke! AXApplicationAccessibilityEnabled is not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-Accessibility.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-Accessibility.todo
@@ -1,2 +1,0 @@
-!missing-field! AXApplicationAccessibilityEnabledDidChangeNotification not bound
-!missing-pinvoke! AXApplicationAccessibilityEnabled is not bound


### PR DESCRIPTION
Bind the new APIs added to the Accessibility framework's AXSettings.h in Xcode 27, available on iOS, tvOS, macOS and Mac Catalyst 27.0 (API_AVAILABLE(anyappleos(27.0))):

* AXApplicationAccessibilityEnabled () -> AXSettings.IsApplicationAccessibilityEnabled
* AXApplicationAccessibilityEnabledDidChangeNotification -> AXSettings.ApplicationAccessibilityEnabledDidChangeNotification

Also add a monotouch-test exercising the new P/Invoke and remove the now-resolved *-Accessibility.todo xtro annotation files.