### PR TITLE
[AutomaticAssessmentConfiguration] Update bindings up to Xcode 27 Beta 3

### DIFF
--- a/src/automaticassessmentconfiguration.cs
+++ b/src/automaticassessmentconfiguration.cs
@@ -257,6 +257,8 @@ namespace AutomaticAssessmentConfiguration {
 
 		[NoMac, iOS (14, 0)]
 		[MacCatalyst (14, 0)]
+		[Deprecated (PlatformName.iOS, 27, 0, message: "Use 'AllowsAccessibilitySpokenContent' instead.")]
+		[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use 'AllowsAccessibilitySpokenContent' instead.")]
 		[Export ("allowsAccessibilitySpeech")]
 		bool AllowsAccessibilitySpeech { get; set; }
 

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-AutomaticAssessmentConfiguration.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-AutomaticAssessmentConfiguration.todo
@@ -1,2 +1,0 @@
-!deprecated-attribute-missing! AEAssessmentConfiguration::allowsAccessibilitySpeech missing a [Deprecated] attribute
-!deprecated-attribute-missing! AEAssessmentConfiguration::setAllowsAccessibilitySpeech: missing a [Deprecated] attribute


### PR DESCRIPTION
Xcode 27 deprecates AEAssessmentConfiguration.allowsAccessibilitySpeech in favor of allowsAccessibilitySpokenContent
(API_DEPRECATED_WITH_REPLACEMENT ("allowsAccessibilitySpokenContent", ios(14.0, 27.0)) API_UNAVAILABLE(macos, macCatalyst)). Add the corresponding [Deprecated] attribute so the managed binding matches the native header and resolve the two entries in iOS-AutomaticAssessmentConfiguration.todo.

The property is bound on both iOS and Mac Catalyst ([MacCatalyst (14, 0)]), so the deprecation is applied to both platforms with an identical message. The paired Mac Catalyst [Deprecated] is required (not just iOS): the cross-assembly cecil test FindMissingObsoleteAttributes flags any API that is obsoleted on some platforms but still supported on another, so an iOS-only deprecation would leave AllowsAccessibilitySpeech supported-but-not-obsoleted on Mac Catalyst and fail that test.

Remove the now-empty iOS-AutomaticAssessmentConfiguration.todo file.