### PR TITLE
[Vision] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/vision.cs
+++ b/src/vision.cs
@@ -75,6 +75,8 @@ namespace Vision {
 		Timeout,
 		UnsupportedComputeStage,
 		UnsupportedComputeDevice,
+		ResourceUnavailable,
+		ResourceCorrupted,
 	}
 
 	/// <summary>Enumerates the emphasis of the tracking algorithm.</summary>

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -8007,6 +8007,8 @@ F:Vision.VNElementType.Double
 F:Vision.VNElementType.Float
 F:Vision.VNElementType.Unknown
 F:Vision.VNErrorCode.DataUnavailable
+F:Vision.VNErrorCode.ResourceCorrupted
+F:Vision.VNErrorCode.ResourceUnavailable
 F:Vision.VNErrorCode.Timeout
 F:Vision.VNErrorCode.TimeStampNotFound
 F:Vision.VNErrorCode.TuriCore

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-Vision.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-Vision.todo
@@ -1,2 +1,0 @@
-!missing-enum-value! VNErrorCode native value VNErrorResourceCorrupted = 24 not bound
-!missing-enum-value! VNErrorCode native value VNErrorResourceUnavailable = 23 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-Vision.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-Vision.todo
@@ -1,2 +1,0 @@
-!missing-enum-value! VNErrorCode native value VNErrorResourceCorrupted = 24 not bound
-!missing-enum-value! VNErrorCode native value VNErrorResourceUnavailable = 23 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-Vision.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-Vision.todo
@@ -1,2 +1,0 @@
-!missing-enum-value! VNErrorCode native value VNErrorResourceCorrupted = 24 not bound
-!missing-enum-value! VNErrorCode native value VNErrorResourceUnavailable = 23 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-Vision.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-Vision.todo
@@ -1,2 +1,0 @@
-!missing-enum-value! VNErrorCode native value VNErrorResourceCorrupted = 24 not bound
-!missing-enum-value! VNErrorCode native value VNErrorResourceUnavailable = 23 not bound


### PR DESCRIPTION
Add the two new VNErrorCode values introduced in Xcode 27 (macos/ios/tvos 27.0) on all four platforms. As error-enum members they carry no availability attributes (per EnumTest.NoAvailabilityOnError), matching the existing sibling members.

Resolves the missing-enum-value entries in the *-Vision.todo files.