### PR TITLE
[UserNotifications] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/usernotifications.cs
+++ b/src/usernotifications.cs
@@ -41,6 +41,8 @@ namespace UserNotifications {
 		AttachmentMoveIntoDataStoreFailed,
 		/// <summary>The attached file is corrupt.</summary>
 		AttachmentCorrupt,
+		/// <summary>The type of the attached file is not supported.</summary>
+		AttachmentUnsupportedType,
 		/// <summary>To be added.</summary>
 		NotificationInvalidNoDate = 1400,
 		/// <summary>To be added.</summary>

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-UserNotifications.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-UserNotifications.todo
@@ -1,1 +1,0 @@
-!missing-enum-value! UNErrorCode native value UNErrorCodeAttachmentUnsupportedType = 106 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-UserNotifications.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-UserNotifications.todo
@@ -1,1 +1,0 @@
-!missing-enum-value! UNErrorCode native value UNErrorCodeAttachmentUnsupportedType = 106 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-UserNotifications.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-UserNotifications.todo
@@ -1,1 +1,0 @@
-!missing-enum-value! UNErrorCode native value UNErrorCodeAttachmentUnsupportedType = 106 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-UserNotifications.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-UserNotifications.todo
@@ -1,1 +1,0 @@
-!missing-enum-value! UNErrorCode native value UNErrorCodeAttachmentUnsupportedType = 106 not bound


### PR DESCRIPTION
Add the UNErrorCodeAttachmentUnsupportedType (= 106) value to the UNErrorCode enum, new in the Xcode 27 SDK. The native header declares no per-member availability, so the value inherits the enum's existing availability (matching its sibling members).

Removes the now-resolved xtro .todo entries for iOS, tvOS, macOS and MacCatalyst.