### PR TITLE
[dotnet] Fix inlined-dlfcn native symbol generation when the trimmer is skipped

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1802,7 +1802,13 @@
 		DependsOnTargets="_LoadLinkerOutput"
 		>
 		<ItemGroup>
-			<_TrimmedAssembly Include="$(IntermediateLinkDir)*.dll" />
+			<!-- Collect the assemblies to scan from the assemblies to publish. This works whether or not the
+			     trimmer ran: when the trimmer is skipped (PrepareAssemblies + PostProcessAssemblies, see
+			     _CanSkipTrimmer) its output directory (IntermediateLinkDir) is empty, and when it did run the
+			     published assemblies are derived from the trimmed output. Either way these are the final
+			     assemblies, and they contain the inlined dlfcn P/Invokes (injected by the assembly-preparer)
+			     that this step needs to collect. -->
+			<_TrimmedAssembly Condition="'%(ResolvedFileToPublish.Extension)' == '.dll' And '%(ResolvedFileToPublish.Culture)' == '' And !$([System.String]::Copy ('%(ResolvedFileToPublish.Filename)').EndsWith ('.resources'))" Include="@(ResolvedFileToPublish)" />
 		</ItemGroup>
 	</Target>
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CollectPostILTrimInformation.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CollectPostILTrimInformation.cs
@@ -119,23 +119,35 @@ namespace Xamarin.MacDev.Tasks {
 				.Select (symbol => symbol.Substring (prefix.Length, symbol.Length - prefix.Length - suffix.Length));
 		}
 
-		static void CollectInternalSymbolsFromAssembly (string assemblyPath, HashSet<string> survivingSymbols)
+		void CollectInternalSymbolsFromAssembly (string assemblyPath, HashSet<string> survivingSymbols)
 		{
-			using var assembly = AssemblyDefinition.ReadAssembly (assemblyPath, new ReaderParameters { ReadSymbols = false });
-			foreach (var module in assembly.Modules) {
-				if (!module.HasModuleReferences)
-					continue;
-				if (!module.ModuleReferences.Any (mr => mr.Name == "__Internal"))
-					continue;
-				foreach (var type in module.Types) {
-					if (!type.HasMethods)
+			AssemblyDefinition assembly;
+			try {
+				assembly = AssemblyDefinition.ReadAssembly (assemblyPath, new ReaderParameters { ReadSymbols = false });
+			} catch (BadImageFormatException) {
+				// The input list of assemblies can contain native libraries with a managed extension
+				// (for example a native 'NativeLibrary.dll'), which aren't managed assemblies. Just skip
+				// those, they can't contain any managed P/Invokes.
+				Log.LogMessage (MessageImportance.Low, "Skipping '{0}' because it's not a managed assembly.", assemblyPath);
+				return;
+			}
+
+			using (assembly) {
+				foreach (var module in assembly.Modules) {
+					if (!module.HasModuleReferences)
 						continue;
-					foreach (var method in type.Methods) {
-						if (!method.IsPInvokeImpl)
+					if (!module.ModuleReferences.Any (mr => mr.Name == "__Internal"))
+						continue;
+					foreach (var type in module.Types) {
+						if (!type.HasMethods)
 							continue;
-						if (method.PInvokeInfo?.Module?.Name != "__Internal")
-							continue;
-						survivingSymbols.Add (Symbol.Prefix + (method.PInvokeInfo.EntryPoint ?? method.Name));
+						foreach (var method in type.Methods) {
+							if (!method.IsPInvokeImpl)
+								continue;
+							if (method.PInvokeInfo?.Module?.Name != "__Internal")
+								continue;
+							survivingSymbols.Add (Symbol.Prefix + (method.PInvokeInfo.EntryPoint ?? method.Name));
+						}
 					}
 				}
 			}

--- a/tests/common/test-variations.csproj
+++ b/tests/common/test-variations.csproj
@@ -29,6 +29,7 @@
 		<TestVariations Include="inline-class-gethandle-compat" Description="Enables 'InlineClassGetHandle' in compatibility mode." />
 		<TestVariations Include="inline-class-gethandle-strict" Description="Enables 'InlineClassGetHandle' in strict mode." />
 		<TestVariations Include="prepare-assemblies" Description="Enables 'PrepareAssemblies'." />
+		<TestVariations Include="dontlink" Description="Disables the trimmer (MtouchLink/LinkMode set to 'None')." />
 	</ItemGroup>
 
 	<PropertyGroup>
@@ -193,6 +194,12 @@
 
 	<PropertyGroup Condition="$(_TestVariationForComparison.Contains('|prepare-assemblies|'))">
 		<PrepareAssemblies>true</PrepareAssemblies>
+		<_TestVariationApplied>true</_TestVariationApplied>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="$(_TestVariationForComparison.Contains('|dontlink|'))">
+		<MtouchLink>None</MtouchLink>
+		<LinkMode>None</LinkMode>
 		<_TestVariationApplied>true</_TestVariationApplied>
 	</PropertyGroup>
 

--- a/tests/xharness/Jenkins/TestVariationsFactory.cs
+++ b/tests/xharness/Jenkins/TestVariationsFactory.cs
@@ -96,6 +96,12 @@ namespace Xharness.Jenkins {
 				yield return new TestData { Variation = "Release (link sdk)", TestVariation = "release|linksdk", Ignored = ignore };
 				yield return new TestData { Variation = "Release (link all)", TestVariation = "release|linkall", Ignored = ignore };
 				yield return new TestData { Variation = $"{test.ProjectConfiguration} (PrepareAssemblies)", TestVariation = "prepare-assemblies", Ignored = ignore };
+				// Explicitly disable the trimmer (dontlink) and enable InlineDlfcnMethods together with
+				// PrepareAssemblies to exercise the inlined-dlfcn native symbol generation when the trimmer
+				// is skipped. On .NET 11+ this is already covered by the plain 'prepare-assemblies' variation
+				// above (iOS defaults to CoreCLR, which doesn't link, and InlineDlfcnMethods is enabled by
+				// default there), so only run this explicit combination on .NET 10.
+				yield return new TestData { Variation = $"{test.ProjectConfiguration} (PrepareAssemblies, inline dlfcn, dont link)", TestVariation = "dontlink|prepare-assemblies|inline-dlfcn-methods-compat", Ignored = jenkins.Harness.DotNetVersion.Major >= 11 ? true : ignore };
 				break;
 			}
 


### PR DESCRIPTION
When `PrepareAssemblies` + `PostProcessAssemblies` are enabled and the trimmer is skipped (`_CanSkipTrimmer`), its output directory (`IntermediateLinkDir`) is empty, so `_ComputeTrimmedAssemblies` found no assemblies to scan. As a result `_CollectPostILTrimInformation` collected no inlined-dlfcn native symbols and no native code was generated for them, causing undefined native symbols (`_xamarin_Dlfcn_*_Native`) at link time.

## Fix

- Collect the assemblies to scan from `@(ResolvedFileToPublish)` (the same source every other target uses) instead of the trimmer's output directory. This works whether or not the trimmer ran: when it's skipped the published assemblies are the final ones, and when it did run they're derived from the trimmed output, so the surviving symbol set is identical (verified against a normal trimmed build).
- Harden `CollectPostILTrimInformation` to skip files that aren't managed assemblies, since `@(ResolvedFileToPublish)` can contain native libraries with a managed extension (e.g. a native `NativeLibrary.dll`), which make Cecil throw `BadImageFormatException`.

## Test

Add a `dontlink|prepare-assemblies|inline-dlfcn-methods-compat` variation for monotouch-test that reproduces the issue. This only needs explicit coverage on .NET 10: there iOS defaults to MonoVM, which links the SDK by default, so the trimmer isn't skipped unless linking is explicitly disabled and `InlineDlfcnMethods` is enabled. On .NET 11+ iOS defaults to CoreCLR (which doesn't link) and `InlineDlfcnMethods` is enabled by default, so the plain `prepare-assemblies` variation already covers it — the new variation is therefore ignored on .NET 11+. A reusable `dontlink` test variation is also added.

🤖 Pull request created by Copilot
