### PR TITLE
[tests] Add logging around screenshot capture in run-packaged-macos-tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -346,3 +346,7 @@ try {
 
 * When creating a branch from `origin/main` (for example `git checkout -b <name> origin/main`), the new branch may be configured to track `origin/main` depending on how it is created and your Git configuration. In that case, a later `git push` or `git push origin` may try to push to `main`.
 * To avoid accidentally pushing to main, use `git push -u origin <branch>` for the first push so Git creates `origin/<branch>` and sets the branch's upstream safely. If you want to be completely explicit, use `git push origin <branch>:<branch>`.
+
+## Process stdout/stderr Capture
+
+* Never redirect both `StandardOutput` and `StandardError` and then call `ReadToEnd ()` on both streams — this can deadlock. Instead, use the asynchronous event-based approach: set `RedirectStandardOutput = true` and `RedirectStandardError = true`, subscribe to `OutputDataReceived` and `ErrorDataReceived`, then call `BeginOutputReadLine ()` and `BeginErrorReadLine ()` after `Start ()`.

--- a/scripts/run-packaged-macos-tests/run-packaged-macos-tests.cs
+++ b/scripts/run-packaged-macos-tests/run-packaged-macos-tests.cs
@@ -441,21 +441,43 @@ string TakeScreenshot (string reason, string outputDirectory)
 	var path = string.IsNullOrEmpty (outputDirectory)
 		? Path.GetFullPath (fileName)
 		: Path.Combine (outputDirectory, fileName);
+	Console.WriteLine ($"Attempting to capture the screen to {path}...");
 	try {
-		var p = Process.Start (new ProcessStartInfo {
-			FileName = "/usr/sbin/screencapture",
-			ArgumentList = { "-x", "-T", "0", path },
-			UseShellExecute = false,
-		});
-		if (p is not null) {
-			p.WaitForExit (TimeSpan.FromSeconds (10));
-			if (File.Exists (path)) {
-				Console.WriteLine ($"Screenshot saved to {path}");
-				return path;
-			}
+		var outputSb = new StringBuilder ();
+		var p = new Process ();
+		p.StartInfo.FileName = "/usr/sbin/screencapture";
+		p.StartInfo.ArgumentList.Add ("-x");
+		p.StartInfo.ArgumentList.Add ("-T");
+		p.StartInfo.ArgumentList.Add ("0");
+		p.StartInfo.ArgumentList.Add (path);
+		p.StartInfo.UseShellExecute = false;
+		p.StartInfo.RedirectStandardOutput = true;
+		p.StartInfo.RedirectStandardError = true;
+		p.OutputDataReceived += (_, e) => {
+			if (e.Data is not null)
+				lock (outputSb)
+					outputSb.AppendLine (e.Data);
+		};
+		p.ErrorDataReceived += (_, e) => {
+			if (e.Data is not null)
+				lock (outputSb)
+					outputSb.AppendLine (e.Data);
+		};
+		p.Start ();
+		p.BeginOutputReadLine ();
+		p.BeginErrorReadLine ();
+		p.WaitForExit (TimeSpan.FromSeconds (10));
+		if (File.Exists (path)) {
+			var fileSize = new FileInfo (path).Length;
+			Console.WriteLine ($"Successfully captured the screen to {path} (file size: {fileSize})");
+			return path;
 		}
+		string output;
+		lock (outputSb)
+			output = outputSb.ToString ().Trim ();
+		Console.WriteLine ($"Failed to capture the screen (exit code: {p.ExitCode}; output: '{output}').");
 	} catch (Exception e) {
-		Console.WriteLine ($"Failed to take screenshot: {e.Message}");
+		Console.WriteLine ($"Failed to capture the screen: {e.Message}");
 	}
 	return "";
 }


### PR DESCRIPTION
Log when we attempt to capture the screen, use async event-based output
capture to avoid deadlocks, and report success (with file size) or
failure (with exit code and output from screencapture).

This helps diagnose why no screenshot is created on macOS Tahoe, which
likely fails due to missing screen recording TCC permissions.

Also add a copilot instruction to avoid the ReadToEnd() deadlock pattern.

🤖 Pull request created by Copilot