### PR TITLE
[msbuild] Disable device-specific builds by default.

### DIFF
--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -1292,8 +1292,9 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			Xamarin.iOS and Xamarin.Mac converges, more and more of this logic
 			will apply to Xamarin.Mac as well.
 		-->
+		<!-- The device-specific build support can be entirely removed in .NET 12 (see https://github.com/dotnet/macios/issues/23846) -->
 		<ParseDeviceSpecificBuildInformation
-			Condition="'$(DeviceSpecificBuild)' == 'true' And '$(TargetiOSDevice)' != '' And '$(_CanDeployToDeviceOrSimulator)' == 'true' And '$(SdkIsDesktop)' != 'true'"
+			Condition="'$(DeviceSpecificBuild)' == 'true' And '$(TargetiOSDevice)' != '' And '$(_CanDeployToDeviceOrSimulator)' == 'true' And '$(SdkIsDesktop)' != 'true' And (!$([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 11.0)) Or '$(_DeviceSpecificBuildOverride)' == 'true')"
 			Architectures="$(TargetArchitectures)"
 			IntermediateOutputPath="$(IntermediateOutputPath)"
 			OutputPath="$(OutputPath)"

--- a/msbuild/Xamarin.Shared/Xamarin.iOS.Common.props
+++ b/msbuild/Xamarin.Shared/Xamarin.iOS.Common.props
@@ -37,8 +37,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<EmbedOnDemandResources Condition="'$(EmbedOnDemandResources)' == ''">true</EmbedOnDemandResources>
 
 		<!-- Device-Specific Builds -->
-		<DeviceSpecificBuild Condition="'$(DeviceSpecificBuild)' == ''">$(_BundlerDebug)</DeviceSpecificBuild>
-		<DeviceSpecificBuild Condition="'$(_BundlerDebug)' != 'true'">False</DeviceSpecificBuild>
+		<DeviceSpecificBuild Condition="'$(DeviceSpecificBuild)' == ''">false</DeviceSpecificBuild>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/dotnet/UnitTests/MauiTest.cs
+++ b/tests/dotnet/UnitTests/MauiTest.cs
@@ -27,6 +27,7 @@ namespace Xamarin.Tests {
 
 			var properties = GetDefaultProperties (runtimeIdentifiers);
 			if (deviceSpecificBuild) {
+				properties ["DeviceSpecificBuild"] = "true";
 				properties ["file:TargetiOSDevice"] =
 					"""
 					<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Device-specific builds were originally implemented to:

1. Build for a single architecture when we knew which device the app was going to be installed on.
2. Speed up resource compilation a bit by filtering resource compilation to the target device.

However, the first reason is no longer applicable (arm64 is the only architecture), and the feature adds complexity and increases path lengths in the bin directory (which causes MAX_PATH issues on Windows).

Changes:

- Default `DeviceSpecificBuild` to `false` (was tied to `_BundlerDebug`).
- Don't run ParseDeviceSpecificBuildInformation on .NET 11+, unless the private `_DeviceSpecificBuildOverride` property is set to true. This completely disables device-specific builds (unless the override is specified, which will hopefully never be necessary, and then we can remove the code in .NET 12).

Contributes towards https://github.com/dotnet/macios/issues/23846

🤖 Pull request created by Copilot