### PR TITLE
[dotnet] Remove DOTNET_STARTUP_HOOKS 'env' workaround. Fixes #25799.

### DIFF
--- a/dotnet/targets/Microsoft.Sdk.Desktop.targets
+++ b/dotnet/targets/Microsoft.Sdk.Desktop.targets
@@ -97,12 +97,5 @@
 			<RunCommand>$(TargetDir)/$(_AppBundleName).app/Contents/MacOS/$(_NativeExecutableName)</RunCommand>
 			<RunArguments />
 		</PropertyGroup>
-
-		<!-- Override the RunCommand to use 'env' to set DOTNET_STARTUP_HOOKS to the container path -->
-		<!-- This is a workaround for https://github.com/dotnet/sdk/pull/54922 -->
-		<PropertyGroup Condition="'$(RunWithOpen)' == 'false' And '$(_StartupHooksContainerDir)' != ''">
-			<RunArguments>"DOTNET_STARTUP_HOOKS=$(_StartupHooksContainerDir)$(_StartupHooksFilename)" "$(RunCommand)"</RunArguments>
-			<RunCommand>env</RunCommand>
-		</PropertyGroup>
 	</Target>
 </Project>


### PR DESCRIPTION
PR #25738 added a temporary workaround in `Microsoft.Sdk.Desktop.targets` for
sandboxed Mac Catalyst apps: when `dotnet watch` set `DOTNET_STARTUP_HOOKS` to a
path outside the app sandbox, we overrode `RunCommand` to `env` to force the
container-relative `DOTNET_STARTUP_HOOKS` value onto the launched process,
because the SDK didn't honor changes made to the `@(RuntimeEnvironmentVariable)`
item group after `ComputeRunArguments`.

[dotnet/sdk#54922](https://github.com/dotnet/sdk/pull/54922) now honors those
item-group changes for projects with the `RuntimeEnvironmentVariableSupport`
capability (which .NET for iOS / Mac Catalyst projects set), so the `env`
override is redundant. The targets still copy the startup hook into the sandbox
container and re-point the `DOTNET_STARTUP_HOOKS` `@(RuntimeEnvironmentVariable)`
item at it; the SDK applies that when launching.

Verified the SDK pinned in `global.json` (`11.0.100-preview.7.26358.120`)
contains the fix (`HasRuntimeEnvironmentVariableSupport` / `ReadFromItems`).

Fixes https://github.com/dotnet/macios/issues/25799

🤖 Pull request created by Copilot