### PR TITLE
[runtime] Use SYSTEM_CORELIB_DIRECTORY to locate System.Private.CoreLib.dll

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1437,6 +1437,7 @@
 			<_RuntimeConfigReservedProperties Include="NATIVE_DLL_SEARCH_DIRECTORIES" />
 			<_RuntimeConfigReservedProperties Include="RUNTIME_IDENTIFIER" />
 			<_RuntimeConfigReservedProperties Include="APP_CONTEXT_BASE_DIRECTORY" />
+			<_RuntimeConfigReservedProperties Include="SYSTEM_CORELIB_DIRECTORY" />
 			<_RuntimeConfigReservedProperties Include="STARTUP_HOOKS" />
 		</ItemGroup>
 		<RuntimeConfigParserTask

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -2362,6 +2362,31 @@ xamarin_compute_trusted_platform_assemblies ()
 	return rv;
 }
 
+// Find the directory that contains System.Private.CoreLib.dll, looking in:
+// - The bundle directory
+// - The runtimeidentifier-specific subdirectory
+// Returns an empty string if the file can't be found in any of those directories
+// (an empty value is treated by the runtime as if the property wasn't set).
+// Caller must free the return value using xamarin_free.
+char *
+xamarin_compute_system_corelib_directory ()
+{
+	const char *bundle_path = xamarin_get_bundle_path ();
+
+	NSMutableArray<NSString *> *directories = [NSMutableArray array];
+	[directories addObject: [NSString stringWithUTF8String: bundle_path]];
+	[directories addObject: [NSString stringWithFormat: @"%s/.xamarin/%s", bundle_path, RUNTIMEIDENTIFIER]];
+
+	NSFileManager *manager = [NSFileManager defaultManager];
+	for (NSString *dir in directories) {
+		NSString *corelib = [dir stringByAppendingPathComponent: @"System.Private.CoreLib.dll"];
+		if ([manager fileExistsAtPath: corelib])
+			return xamarin_strdup_printf ("%s", [dir UTF8String]);
+	}
+
+	return xamarin_strdup_printf ("%s", "");
+}
+
 char *
 xamarin_compute_native_dll_search_directories ()
 {
@@ -2404,6 +2429,7 @@ xamarin_vm_initialize ()
 	char *pinvokeOverride = xamarin_strdup_printf ("%p", &xamarin_pinvoke_override);
 	char *trusted_platform_assemblies = xamarin_compute_trusted_platform_assemblies ();
 	char *native_dll_search_directories = xamarin_compute_native_dll_search_directories ();
+	char *system_corelib_directory = xamarin_compute_system_corelib_directory ();
 	const char *startupHooks = getenv ("DOTNET_STARTUP_HOOKS");
 
 	// All the properties we pass here must also be listed in the _RuntimeConfigReservedProperties item group
@@ -2415,6 +2441,7 @@ xamarin_vm_initialize ()
 		"TRUSTED_PLATFORM_ASSEMBLIES",
 		"NATIVE_DLL_SEARCH_DIRECTORIES",
 		"RUNTIME_IDENTIFIER",
+		"SYSTEM_CORELIB_DIRECTORY", // the directory that contains System.Private.CoreLib.dll (must come before STARTUP_HOOKS, because we might not pass STARTUP_HOOKS)
 		"STARTUP_HOOKS", // must be last entry (because we just decrement propertyCount to not pass it if it's not set)
 	};
 	const char *propertyValues[] = {
@@ -2424,6 +2451,7 @@ xamarin_vm_initialize ()
 		trusted_platform_assemblies,
 		native_dll_search_directories,
 		RUNTIMEIDENTIFIER,
+		system_corelib_directory,
 		startupHooks,
 	};
 	static_assert (sizeof (propertyKeys) == sizeof (propertyValues), "The number of keys and values must be the same.");
@@ -2437,6 +2465,7 @@ xamarin_vm_initialize ()
 	xamarin_free (pinvokeOverride);
 	xamarin_free (trusted_platform_assemblies);
 	xamarin_free (native_dll_search_directories);
+	xamarin_free (system_corelib_directory);
 
 	if (!rv)
 		xamarin_assertion_message ("Failed to initialize the VM");


### PR DESCRIPTION
dotnet/runtime#128278 removed the TPA-scanning fallback in CoreCLR's `BindToSystem`, which broke scenarios (like ours) where `coreclr` isn't located next to `System.Private.CoreLib.dll`. dotnet/runtime#128734 added a new well-known host property, `SYSTEM_CORELIB_DIRECTORY`, that lets the host explicitly point the runtime at the directory containing CoreLib instead of relying on implicit scanning.

This PR makes us use that property:

- Added `xamarin_compute_system_corelib_directory ()` in `runtime/runtime.m`, which looks for `System.Private.CoreLib.dll` in the bundle directory and the runtimeidentifier-specific subdirectory, and returns the directory that contains it.
- Pass its result as the `SYSTEM_CORELIB_DIRECTORY` property when initializing the runtime in `xamarin_vm_initialize`.
- Registered `SYSTEM_CORELIB_DIRECTORY` in the `_RuntimeConfigReservedProperties` list in `Xamarin.Shared.Sdk.targets` (all properties passed to the VM must be listed there).

Notes for reviewers:

- If CoreLib can't be found, the helper returns an empty string. An empty value is treated by the runtime as if the property wasn't set, so behavior is unchanged in that case.
- The property is placed before `STARTUP_HOOKS` in the key/value arrays because `STARTUP_HOOKS` must stay last (it's conditionally dropped by decrementing the property count).

Depends on dotnet/runtime#128734 flowing into our runtime pack.

Fixes: #25578

🤖 Pull request created by Copilot