### PR TITLE
[build] Hide stale build failure comment when a re-run succeeds

### DIFF
--- a/tools/devops/automation/templates/build/build.yml
+++ b/tools/devops/automation/templates/build/build.yml
@@ -238,13 +238,16 @@ steps:
 
   # report the result of the build.
   - pwsh: |
-      # Only report failures, not successes.
-      if (("$Env:AGENT_JOBSTATUS" -eq "Succeeded") -or ("$Env:AGENT_JOBSTATUS" -eq "SucceededWithIssues")) {
-        Write-Host "Build passed, skipping comment."
-        return
-      }
       Import-Module $Env:SYSTEM_DEFAULTWORKINGDIRECTORY\$Env:BUILD_REPOSITORY_TITLE\tools\devops\automation\scripts\MaciosCI.psd1
       $githubComments = New-GitHubCommentsObjectFromUrl -Url "$(Build.Repository.Uri)" -Token $(GitHub.Token) -Hash $Env:COMMENT_HASH
+      # Only report failures, not successes. However, if the build succeeded, we
+      # still hide any previous "Build failed" comment for this job (which may
+      # have been posted by an earlier failing run of the same commit).
+      if (("$Env:AGENT_JOBSTATUS" -eq "Succeeded") -or ("$Env:AGENT_JOBSTATUS" -eq "SucceededWithIssues")) {
+        Write-Host "Build passed, hiding any previous build failure comment instead of posting a new comment."
+        $githubComments.HandlePreviousCommentHiding("build $(System.JobDisplayName)")
+        return
+      }
       $commentMessage = [System.Text.StringBuilder]::new()
       $commentTitle = "Build failed ($(System.JobDisplayName))"
       $commentIcon = ":fire:"


### PR DESCRIPTION
Since 6d24fb6d ([build] Only report build failures, not successes) we stopped posting a comment on successful builds. That introduced a side effect: if a build first fails (posting a "Build failed" comment) and then passes on a re-run of the same commit, the stale failure comment was never hidden, leaving misleading output on the PR.

The reason is that hiding previous same-id comments only happened inside `NewCommentFromMessage` (via `HandlePreviousCommentHiding`), which the success path now skips by returning early.

This change makes the "Report build result" step, on success, call `$githubComments.HandlePreviousCommentHiding("build $(System.JobDisplayName)")` before returning. That hides any previous build failure comment for the same job while still not posting a new "Build passed" comment. The existing safeguards apply: comments are only hidden when the current commit is the latest in the PR, and nothing happens when not running in a PR context.

🤖 Pull request created by Copilot