### PR TITLE
[dotnet] Set a default PublishRuntimeIdentifier again. Fixes #24547

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -150,15 +150,19 @@
 
 	</PropertyGroup>
 
+	<!-- Opt out of two SDK behaviors around PublishRuntimeIdentifier. These must be set unconditionally (regardless of whether the user or we set a PublishRuntimeIdentifier or a RuntimeIdentifier), otherwise the SDK might compute a default PublishRuntimeIdentifier (the host portable RID) and/or append it to RuntimeIdentifiers, which confuses our build. -->
+	<PropertyGroup>
+		<!-- Disable the default PublishRuntimeIdentifier behavior: https://github.com/dotnet/sdk/pull/52566 -->
+		<UseDefaultPublishRuntimeIdentifier>false</UseDefaultPublishRuntimeIdentifier>
+		<!-- Don't append PublishRuntimeIdentifier to RuntimeIdentifiers: we use RuntimeIdentifiers to mean "build for all these RIDs", and appending the publish RID confuses our build: https://github.com/dotnet/sdk/pull/54291 / https://github.com/dotnet/macios/issues/24547 -->
+		<AppendPublishRuntimeIdentifierToRuntimeIdentifiers>false</AppendPublishRuntimeIdentifierToRuntimeIdentifiers>
+	</PropertyGroup>
+
 	<!-- Set the default RuntimeIdentifier when publishing.
 	     Only do this if the user didn't specify a RuntimeIdentifier, otherwise the SDK will override the user's RuntimeIdentifier with our default PublishRuntimeIdentifier when publishing (which would, for instance, turn a simulator build into a device build). Note that we can't check '$(RuntimeIdentifier)' == '' here, because we've already computed a default RuntimeIdentifier by this point; instead we check the _XamarinUsingDefaultRuntimeIdentifier property we set when the user didn't specify a RuntimeIdentifier. -->
 	<PropertyGroup Condition="'$(PublishRuntimeIdentifier)' == '' And '$(_XamarinUsingDefaultRuntimeIdentifier)' == 'true'">
 		<PublishRuntimeIdentifier Condition="'$(_PlatformName)' == 'iOS'">ios-arm64</PublishRuntimeIdentifier>
 		<PublishRuntimeIdentifier Condition="'$(_PlatformName)' == 'tvOS'">tvos-arm64</PublishRuntimeIdentifier>
-		<!-- Disable the default PublishRuntimeIdentifier behavior: https://github.com/dotnet/sdk/pull/52566 -->
-		<UseDefaultPublishRuntimeIdentifier>false</UseDefaultPublishRuntimeIdentifier>
-		<!-- Don't append PublishRuntimeIdentifier to RuntimeIdentifiers: we use RuntimeIdentifiers to mean "build for all these RIDs", and appending the publish RID confuses our build: https://github.com/dotnet/sdk/pull/54291 / https://github.com/dotnet/macios/issues/24547 -->
-		<AppendPublishRuntimeIdentifierToRuntimeIdentifiers>false</AppendPublishRuntimeIdentifierToRuntimeIdentifiers>
 	</PropertyGroup>
 
 	<!-- Now that we know the runtime identifier, we can determine if we're building for a simulator -->

--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -152,12 +152,12 @@
 
 	<!-- Set the default RuntimeIdentifier when publishing -->
 	<PropertyGroup Condition="'$(PublishRuntimeIdentifier)' == ''">
-		<!--
 		<PublishRuntimeIdentifier Condition="'$(_PlatformName)' == 'iOS'">ios-arm64</PublishRuntimeIdentifier>
 		<PublishRuntimeIdentifier Condition="'$(_PlatformName)' == 'tvOS'">tvos-arm64</PublishRuntimeIdentifier>
-		-->
 		<!-- Disable the default PublishRuntimeIdentifier behavior: https://github.com/dotnet/sdk/pull/52566 -->
 		<UseDefaultPublishRuntimeIdentifier>false</UseDefaultPublishRuntimeIdentifier>
+		<!-- Don't append PublishRuntimeIdentifier to RuntimeIdentifiers: we use RuntimeIdentifiers to mean "build for all these RIDs", and appending the publish RID confuses our build: https://github.com/dotnet/sdk/pull/54291 / https://github.com/dotnet/macios/issues/24547 -->
+		<AppendPublishRuntimeIdentifierToRuntimeIdentifiers>false</AppendPublishRuntimeIdentifierToRuntimeIdentifiers>
 	</PropertyGroup>
 
 	<!-- Now that we know the runtime identifier, we can determine if we're building for a simulator -->

--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -150,8 +150,9 @@
 
 	</PropertyGroup>
 
-	<!-- Set the default RuntimeIdentifier when publishing -->
-	<PropertyGroup Condition="'$(PublishRuntimeIdentifier)' == ''">
+	<!-- Set the default RuntimeIdentifier when publishing.
+	     Only do this if the user didn't specify a RuntimeIdentifier, otherwise the SDK will override the user's RuntimeIdentifier with our default PublishRuntimeIdentifier when publishing (which would, for instance, turn a simulator build into a device build). Note that we can't check '$(RuntimeIdentifier)' == '' here, because we've already computed a default RuntimeIdentifier by this point; instead we check the _XamarinUsingDefaultRuntimeIdentifier property we set when the user didn't specify a RuntimeIdentifier. -->
+	<PropertyGroup Condition="'$(PublishRuntimeIdentifier)' == '' And '$(_XamarinUsingDefaultRuntimeIdentifier)' == 'true'">
 		<PublishRuntimeIdentifier Condition="'$(_PlatformName)' == 'iOS'">ios-arm64</PublishRuntimeIdentifier>
 		<PublishRuntimeIdentifier Condition="'$(_PlatformName)' == 'tvOS'">tvos-arm64</PublishRuntimeIdentifier>
 		<!-- Disable the default PublishRuntimeIdentifier behavior: https://github.com/dotnet/sdk/pull/52566 -->

--- a/tests/dotnet/UnitTests/PostBuildTest.cs
+++ b/tests/dotnet/UnitTests/PostBuildTest.cs
@@ -540,6 +540,31 @@ namespace Xamarin.Tests {
 			Assert.That (runtimeIdentifiers, Does.Not.Contain (expectedPublishRuntimeIdentifier), "RuntimeIdentifiers");
 		}
 
+		[TestCase (ApplePlatform.iOS, "ios-arm64")]
+		[TestCase (ApplePlatform.TVOS, "tvos-arm64")]
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64")]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64")]
+		public void PublishRuntimeIdentifierEscapeHatchesAreAlwaysSet (ApplePlatform platform, string runtimeIdentifier)
+		{
+			var project = "MySimpleApp";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+
+			var project_path = GetProjectPath (project, platform: platform);
+
+			var properties = GetDefaultProperties ();
+			properties ["RuntimeIdentifier"] = runtimeIdentifier;
+
+			// These properties opt out of SDK behavior around PublishRuntimeIdentifier, and must be set even when the
+			// user specified a RuntimeIdentifier, otherwise the SDK might compute a default PublishRuntimeIdentifier
+			// (the host portable RID) and append it to RuntimeIdentifiers, which confuses our build:
+			// https://github.com/dotnet/macios/issues/24547
+			var useDefaultPublishRuntimeIdentifier = DotNet.GetProperty (project_path, "UseDefaultPublishRuntimeIdentifier", properties);
+			var appendPublishRuntimeIdentifierToRuntimeIdentifiers = DotNet.GetProperty (project_path, "AppendPublishRuntimeIdentifierToRuntimeIdentifiers", properties);
+
+			Assert.That (useDefaultPublishRuntimeIdentifier, Is.EqualTo ("false"), "UseDefaultPublishRuntimeIdentifier");
+			Assert.That (appendPublishRuntimeIdentifierToRuntimeIdentifiers, Is.EqualTo ("false"), "AppendPublishRuntimeIdentifierToRuntimeIdentifiers");
+		}
+
 		[Test]
 		[TestCase (ApplePlatform.iOS, "iossimulator-arm64")]
 		[TestCase (ApplePlatform.MacOSX, "osx-arm64")]

--- a/tests/dotnet/UnitTests/PostBuildTest.cs
+++ b/tests/dotnet/UnitTests/PostBuildTest.cs
@@ -521,6 +521,25 @@ namespace Xamarin.Tests {
 			Assert.That (appPath, Does.Exist, "App existence");
 		}
 
+		[TestCase (ApplePlatform.iOS, "ios-arm64")]
+		[TestCase (ApplePlatform.TVOS, "tvos-arm64")]
+		public void PublishRuntimeIdentifierNotAppendedToRuntimeIdentifiers (ApplePlatform platform, string expectedPublishRuntimeIdentifier)
+		{
+			var project = "MySimpleApp";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+
+			var project_path = GetProjectPath (project, platform: platform);
+
+			var properties = GetDefaultProperties ();
+			var publishRuntimeIdentifier = DotNet.GetProperty (project_path, "PublishRuntimeIdentifier", properties);
+			var runtimeIdentifiers = DotNet.GetProperty (project_path, "RuntimeIdentifiers", properties);
+
+			Assert.That (publishRuntimeIdentifier, Is.EqualTo (expectedPublishRuntimeIdentifier), "PublishRuntimeIdentifier");
+			// We use RuntimeIdentifiers to mean "build for all these RIDs", so PublishRuntimeIdentifier must not be
+			// appended to RuntimeIdentifiers (this used to confuse our build): https://github.com/dotnet/macios/issues/24547
+			Assert.That (runtimeIdentifiers, Does.Not.Contain (expectedPublishRuntimeIdentifier), "RuntimeIdentifiers");
+		}
+
 		[Test]
 		[TestCase (ApplePlatform.iOS, "iossimulator-arm64")]
 		[TestCase (ApplePlatform.MacOSX, "osx-arm64")]


### PR DESCRIPTION
Now that dotnet/sdk#54291 has merged and is available in our bundled SDK, we can set a default `PublishRuntimeIdentifier` again.

## Background

We previously had to stop setting `PublishRuntimeIdentifier` because the .NET SDK appends it to `RuntimeIdentifiers`. We use `RuntimeIdentifiers` to mean "build for all these RIDs" (not just "restore for these RIDs"), so the appended publish RID left both `RuntimeIdentifier` and `RuntimeIdentifiers` set at the same time, which our build rejects with a validation error.

## Change

- Re-enable the default `PublishRuntimeIdentifier` (`ios-arm64` / `tvos-arm64`).
- Opt out of the SDK appending it to `RuntimeIdentifiers` via the new escape hatch `AppendPublishRuntimeIdentifierToRuntimeIdentifiers=false` (added in dotnet/sdk#54291).
- Add a regression test verifying `PublishRuntimeIdentifier` is set but is not appended to `RuntimeIdentifiers`.

Validated with a clean build; the new test passes for iOS and tvOS.

Fixes https://github.com/dotnet/macios/issues/24547

🤖 Pull request created by Copilot