### PR TITLE
[assembly-preparer] Don't run the preserve/optimize/mark steps when not trimming.

### DIFF
--- a/tools/assembly-preparer/AssemblyPreparer.cs
+++ b/tools/assembly-preparer/AssemblyPreparer.cs
@@ -130,15 +130,21 @@ public class AssemblyPreparer : IDisposable {
 			new ComputeMethodOverridesStep (),
 			new CoreTypeMapStep (),
 			new CollectFieldsStep (), // ProcessExportedFields
-			new PreserveProtocolsStep (),
-			new PreserveSmartEnumConversionsStep (),
-			new PreserveBlockCodeStep (),
-			new OptimizeGeneratedCodeStep (),
-			new ApplyPreserveAttributeStep (),
-			new MarkForStaticRegistrarStep (),
-			new MarkNSObjectsStep (),
-			new InlineDlfcnMethodsStep (),
 		};
+
+		// These steps only do anything for assemblies that are being trimmed (their IsActiveFor requires
+		// AssemblyAction.Link), so don't even add them to the list when nothing's being trimmed.
+		if (configuration.Application.AreAnyAssembliesTrimmed) {
+			steps.Add (new PreserveProtocolsStep ());
+			steps.Add (new PreserveSmartEnumConversionsStep ());
+			steps.Add (new PreserveBlockCodeStep ());
+			steps.Add (new OptimizeGeneratedCodeStep ());
+			steps.Add (new ApplyPreserveAttributeStep ());
+			steps.Add (new MarkForStaticRegistrarStep ());
+			steps.Add (new MarkNSObjectsStep ());
+		}
+
+		steps.Add (new InlineDlfcnMethodsStep ());
 
 		// Only add RegistrarRemovalTrackingStep if it's needed:
 		// * If the user explicitly set $(DynamicRegistrationSupported), we don't need to compute the value (it's


### PR DESCRIPTION
PreserveProtocolsStep, PreserveSmartEnumConversionsStep, PreserveBlockCodeStep,
OptimizeGeneratedCodeStep, ApplyPreserveAttributeStep, MarkForStaticRegistrarStep
and MarkNSObjectsStep only do work for assemblies that are being trimmed (their
IsActiveFor requires the assembly's action to be AssemblyAction.Link). When
nothing is being trimmed no assembly has that action, so these steps are no-ops
that just iterate every assembly checking IsActiveFor. Don't add them to the step
list at all in that case (gated on AreAnyAssembliesTrimmed), which matches how the
ILLink path guards the same steps (on _AreAnyAssembliesTrimmed in
Xamarin.Shared.Sdk.targets).

Verified with monotouch-test on iOS (3675 tests, 0 failed) both with trimming
(release|linksdk - the steps still run) and without (link None - the steps are
skipped).

Before build times:

| Project        | Runtime identifier | Link mode | PrepareAssemblies=false | PrepareAssemblies=true | Difference   |
| -------------- | ------------------ | --------- | ----------------------- | ---------------------- | ------------ |
| monotouch-test | ios-arm64          | None      |  00:02:12.42            |  00:02:17.27           |  00:00:04.84 |
| monotouch-test | ios-arm64          | SdkOnly   |  00:01:29.23            |  00:01:52.19           |  00:00:22.95 |
| monotouch-test | iossimulator-arm64 | None      |  00:01:44.58            |  00:01:47.33           |  00:00:02.74 |
| monotouch-test | iossimulator-arm64 | SdkOnly   |  00:01:16.03            |  00:01:27.52           |  00:00:11.49 |
| MySimpleApp    | ios-arm64          | None      |  00:01:16.71            |  00:01:18.90           |  00:00:02.19 |
| MySimpleApp    | ios-arm64          | SdkOnly   |  00:00:20.77            |  00:00:44.71           |  00:00:23.94 |
| MySimpleApp    | iossimulator-arm64 | None      |  00:00:52.84            |  00:00:56.09           |  00:00:03.25 |
| MySimpleApp    | iossimulator-arm64 | SdkOnly   |  00:00:19.74            |  00:00:28.54           |  00:00:08.80 |

After build times:

| Project        | Runtime identifier | Link mode | PrepareAssemblies=false | PrepareAssemblies=true | Difference   |
| -------------- | ------------------ | --------- | ----------------------- | ---------------------- | ------------ |
| monotouch-test | ios-arm64          | None      |  00:02:18.08            |  00:02:22.85           |  00:00:04.76 |
| monotouch-test | ios-arm64          | SdkOnly   |  00:01:34.83            |  00:01:55.70           |  00:00:20.87 |
| monotouch-test | iossimulator-arm64 | None      |  00:01:52.98            |  00:01:49.63           | -00:00:03.34 |
| monotouch-test | iossimulator-arm64 | SdkOnly   |  00:01:21.16            |  00:01:24.04           |  00:00:02.87 |
| MySimpleApp    | ios-arm64          | None      |  00:01:15.93            |  00:01:22.34           |  00:00:06.41 |
| MySimpleApp    | ios-arm64          | SdkOnly   |  00:00:21.54            |  00:00:44.93           |  00:00:23.39 |
| MySimpleApp    | iossimulator-arm64 | None      |  00:00:57.90            |  00:00:57.86           | -00:00:00.04 |
| MySimpleApp    | iossimulator-arm64 | SdkOnly   |  00:00:21.41            |  00:00:27.36           |  00:00:05.95 |

🤖 Pull request created by Copilot
