### PR TITLE
[dotnet-linker] Gate the TypeMap proxy-attribute workaround to .NET 10 only. Fixes #25276

### DIFF
--- a/src/ObjCRuntime/Class.cs
+++ b/src/ObjCRuntime/Class.cs
@@ -316,6 +316,11 @@ namespace ObjCRuntime {
 		unsafe static IntPtr FindClass (Type type, out bool is_custom_type)
 		{
 			if (Runtime.IsTrimmableStaticRegistrar) {
+				// Generic types are registered using their generic type definition (the type maps are
+				// keyed by the open generic type), so look for that instead of the closed generic type.
+				if (type.IsGenericType)
+					type = type.GetGenericTypeDefinition ();
+
 				if (TypeMaps.TryGetNSObjectProxyAttribute (type, out var proxyAttribute)) {
 					var rv = proxyAttribute.GetClassHandle (out is_custom_type);
 #if LOG_TRIMMABLE_TYPEMAP

--- a/src/ObjCRuntime/TypeMaps.cs
+++ b/src/ObjCRuntime/TypeMaps.cs
@@ -268,6 +268,9 @@ static class TypeMaps {
 		}
 
 		// workaround for https://github.com/dotnet/runtime/issues/127004
+		// The fix is only available in .NET 11+, so we still need the workaround for .NET 10.
+		// Tracking issue: https://github.com/dotnet/macios/issues/25276
+#if !NET11_0_OR_GREATER
 		proxyAttribute = protocol.GetCustomAttribute<ProtocolProxyAttribute> (false);
 		if (proxyAttribute is not null) {
 #if LOG_TRIMMABLE_TYPEMAP
@@ -275,6 +278,7 @@ static class TypeMaps {
 #endif
 			return true;
 		}
+#endif // !NET11_0_OR_GREATER
 
 #if LOG_TRIMMABLE_TYPEMAP
 		Runtime.NSLog ($"TryGetProtocolProxyAttribute ({protocol}) did not find proxy attribute anywhere");
@@ -338,6 +342,9 @@ static class TypeMaps {
 		proxyAttribute = null;
 
 		// workaround for https://github.com/dotnet/runtime/issues/127004
+		// The fix is only available in .NET 11+, so we still need the workaround for .NET 10.
+		// Tracking issue: https://github.com/dotnet/macios/issues/25276
+#if !NET11_0_OR_GREATER
 		proxyAttribute = managedType.GetCustomAttribute<NSObjectProxyAttribute> (false);
 		if (proxyAttribute is not null) {
 #if LOG_TRIMMABLE_TYPEMAP
@@ -348,6 +355,7 @@ static class TypeMaps {
 #if LOG_TRIMMABLE_TYPEMAP
 		Runtime.NSLog ($"TryGetNSObjectProxyAttribute ({managedType}): did not find proxy attribute on the type itself");
 #endif
+#endif // !NET11_0_OR_GREATER
 		// end workaround for https://github.com/dotnet/runtime/issues/127004
 
 		if (!NSObjectProxyTypes.TryGetValue (managedType, out var proxyType)) {

--- a/tools/dotnet-linker/Steps/TrimmableRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/TrimmableRegistrarStep.cs
@@ -238,6 +238,11 @@ namespace Xamarin.Linker {
 			// If we need to modify an assembly that's not the typemap assembly, do it after we've finished writing the typemap assembly,
 			// to avoid having to switch between assemblies (we cache a lot of stuff, and those caches will have to be re-created for every switch).
 			var postActionsByAssembly = new Dictionary<AssemblyDefinition, List<Action<AssemblyDefinition>>> ();
+
+			// The fix for https://github.com/dotnet/runtime/issues/127004 is only available in .NET 11+, so we
+			// still need the workaround (adding the proxy type's attribute to the source type) for .NET 10.
+			// Tracking issue: https://github.com/dotnet/macios/issues/25276
+			var needsTypeMapWorkaround = App.TargetFramework.Version.Major <= 10;
 			void addPostAction (AssemblyDefinition assembly, Action<AssemblyDefinition> action)
 			{
 				if (!postActionsByAssembly.TryGetValue (assembly, out var actions)) {
@@ -485,10 +490,12 @@ namespace Xamarin.Linker {
 
 						// We also add the proxy type as an attribute to the type, as a workaround for https://github.com/dotnet/runtime/issues/127004
 						// Tracking issue: https://github.com/dotnet/macios/issues/25276
-						addPostAction (td.Module.Assembly, assembly => {
-							var attribute = new CustomAttribute (assembly.MainModule.ImportReference (ctor)); // don't use abr.CreateAttribute here, because the ctor has already been marked
-							td.CustomAttributes.Add (attribute);
-						});
+						if (needsTypeMapWorkaround) {
+							addPostAction (td.Module.Assembly, assembly => {
+								var attribute = new CustomAttribute (assembly.MainModule.ImportReference (ctor)); // don't use abr.CreateAttribute here, because the ctor has already been marked
+								td.CustomAttributes.Add (attribute);
+							});
+						}
 
 						/*
 						 * Add the [TypeMapAssociation] attribute for this type and its proxy
@@ -577,10 +584,12 @@ namespace Xamarin.Linker {
 
 						// We also add the proxy type as an attribute to the type, as a workaround for https://github.com/dotnet/runtime/issues/127004
 						// Tracking issue: https://github.com/dotnet/macios/issues/25276
-						addPostAction (td.Module.Assembly, assembly => {
-							var attribute = new CustomAttribute (assembly.MainModule.ImportReference (ctor)); // don't use abr.CreateAttribute here, because the ctor has already been marked
-							td.CustomAttributes.Add (attribute);
-						});
+						if (needsTypeMapWorkaround) {
+							addPostAction (td.Module.Assembly, assembly => {
+								var attribute = new CustomAttribute (assembly.MainModule.ImportReference (ctor)); // don't use abr.CreateAttribute here, because the ctor has already been marked
+								td.CustomAttributes.Add (attribute);
+							});
+						}
 					}
 				}
 


### PR DESCRIPTION
The workaround for https://github.com/dotnet/runtime/issues/127004 (adding the proxy type's attribute to the source type so ILLink's TypeMapHandler keeps the TypeMapAssociation) is no longer needed once the ILLink fix is available.

The fix is only present in .NET 11+, so keep the workaround for .NET 10 and only stop applying it for .NET 11+:

* In `TrimmableRegistrarStep`, only add the proxy attribute to the source type when targeting .NET 10 or earlier.
* In `TypeMaps` (runtime), only read the workaround attribute from the source type for .NET 10 or earlier (gated with `!NET11_0_OR_GREATER`).

A separate validation-only PR targeting `net11.0` (#26019) confirms everything still pass on .NET 11 with the workaround disabled (except the AppSizeTest test failed because NativeAOT app sizes went down ("App size changed significantly (-16,413 bytes)") - which is both expected and desirable).

Fixes https://github.com/dotnet/macios/issues/25276

🤖 Pull request created by Copilot