### PR TITLE
[assembly-preparer] Compute the method-override map lazily.

### DIFF
--- a/tools/assembly-preparer/ComputeMethodOverridesStep.cs
+++ b/tools/assembly-preparer/ComputeMethodOverridesStep.cs
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 
 namespace MonoTouch.Tuner {
-	// Compute the map of which methods override which other methods, and store it in the Annotations.
+	// Register the assemblies for the method-override map. The map itself is computed lazily, the first time
+	// it's queried through Annotations.GetOverrides, so we don't do the work when nothing ends up needing it.
 	public class ComputeMethodOverridesStep : ConfigurationAwareStep {
 		protected override string Name { get; } = "ComputeMethodOverrides";
 		protected override int ErrorCode { get; } = 2490;

--- a/tools/assembly-preparer/Scaffolding/AnnotationStore.cs
+++ b/tools/assembly-preparer/Scaffolding/AnnotationStore.cs
@@ -9,6 +9,12 @@ namespace Mono.Linker;
 public class AnnotationStore {
 	Dictionary<AssemblyDefinition, AssemblyAction> assemblyActions = new Dictionary<AssemblyDefinition, AssemblyAction> ();
 	Dictionary<MethodDefinition, List<OverrideInformation>> overrides = new Dictionary<MethodDefinition, List<OverrideInformation>> ();
+	// The overrides map is computed lazily (the first time GetOverrides is called) from these fields, so we
+	// don't scan every type in every assembly when nothing ends up querying the map - which is the case when
+	// we're not trimming, because MarkNSObjectsStep (the only consumer) doesn't run then.
+	IEnumerable<AssemblyDefinition>? overridesAssemblies;
+	LinkContext? overridesContext;
+	bool overridesCollected;
 	public AssemblyAction GetAction (AssemblyDefinition assembly)
 	{
 		if (assemblyActions.TryGetValue (assembly, out var action))
@@ -23,20 +29,37 @@ public class AnnotationStore {
 
 	public IEnumerable<OverrideInformation>? GetOverrides (MethodDefinition method)
 	{
+		CollectOverridesIfNeeded ();
 		if (overrides.TryGetValue (method, out var list))
 			return list;
 		return null;
 	}
 
-	// Scan all types in the given assemblies and build the overrides map.
-	// For each method that overrides a base virtual method (or explicitly implements an interface method),
-	// record an OverrideInformation entry keyed by the base method.
+	// Register the assemblies whose method overrides may be queried later. The overrides map itself is only
+	// built the first time GetOverrides is called (see CollectOverridesIfNeeded).
 	public void CollectOverrides (IEnumerable<AssemblyDefinition> assemblies, LinkContext context)
 	{
-		foreach (var assembly in assemblies) {
+		overridesAssemblies = assemblies;
+		overridesContext = context;
+		overridesCollected = false;
+	}
+
+	// Scan all types in the registered assemblies and build the overrides map.
+	// For each method that overrides a base virtual method (or explicitly implements an interface method),
+	// record an OverrideInformation entry keyed by the base method.
+	void CollectOverridesIfNeeded ()
+	{
+		if (overridesCollected)
+			return;
+		overridesCollected = true;
+
+		if (overridesAssemblies is null || overridesContext is null)
+			return;
+
+		foreach (var assembly in overridesAssemblies) {
 			foreach (var module in assembly.Modules) {
 				foreach (var type in module.GetTypes ()) {
-					CollectOverridesForType (type, context);
+					CollectOverridesForType (type, overridesContext);
 				}
 			}
 		}


### PR DESCRIPTION
ComputeMethodOverridesStep used to eagerly scan every type in every assembly to
build the map of which methods override which other methods
(AnnotationStore.CollectOverrides), even though the map's only consumer -
MarkNSObjectsStep, via GetOverrides - only does anything when trimming (its
IsActiveFor requires the assembly's action to be AssemblyAction.Link). So when
nothing is being trimmed the map was built (~0.75s for monotouch-test) but never
queried.

Compute the map lazily instead: CollectOverrides now just records the assemblies
to scan, and the map is built the first time GetOverrides is actually called
(memoized). When not trimming GetOverrides is never called, so the map is never
built and the work is skipped entirely.

Verified with monotouch-test on iOS (3675 tests, 0 failed) both with trimming
(release|linksdk - the map is built lazily and consumed) and without (link None -
the map is never built).

Updated perf numbers:

| Project        | Runtime identifier | Link mode | PrepareAssemblies=false | PrepareAssemblies=true | Difference   |
| -------------- | ------------------ | --------- | ----------------------- | ---------------------- | ------------ |
| monotouch-test | ios-arm64          | None      |  00:02:18.82            |  00:02:21.22           |  00:00:02.39 |
| monotouch-test | ios-arm64          | SdkOnly   |  00:01:32.58            |  00:01:52.19           |  00:00:19.60 |
| monotouch-test | iossimulator-arm64 | None      |  00:01:48.13            |  00:01:45.84           | -00:00:02.28 |
| monotouch-test | iossimulator-arm64 | SdkOnly   |  00:01:18.06            |  00:01:26.86           |  00:00:08.79 |
| MySimpleApp    | ios-arm64          | None      |  00:01:20.10            |  00:01:22.94           |  00:00:02.83 |
| MySimpleApp    | ios-arm64          | SdkOnly   |  00:00:21.01            |  00:00:43.30           |  00:00:22.28 |
| MySimpleApp    | iossimulator-arm64 | None      |  00:00:53.86            |  00:00:54.13           |  00:00:00.27 |
| MySimpleApp    | iossimulator-arm64 | SdkOnly   |  00:00:19.46            |  00:00:29.42           |  00:00:09.96 |

🤖 Pull request created by Copilot
