### PR TITLE
[xcode27.0] [devops] Recognize the "skipped, incorrect beta version" test summary

### DIFF
--- a/tools/devops/automation/scripts/TestResults.Tests.ps1
+++ b/tools/devops/automation/scripts/TestResults.Tests.ps1
@@ -840,6 +840,27 @@ Describe "TestResults tests" {
         }
     }
 
+    Context "skipped due to beta version mismatch" {
+        BeforeAll {
+            $skipDir = Join-Path -Path $TestDrive -ChildPath "skipped_beta"
+            New-Item -Path $skipDir -ItemType Directory -Force | Out-Null
+            $skipPath = Join-Path -Path $skipDir -ChildPath "TestSummary.md"
+            Set-Content -Path $skipPath -Value "# ⚠️ arm64 - Mac Golden Gate (27): Tests skipped, incorrect beta version`n`nTests skipped: current macOS build version '26A5368g' does not match expected '26A5372a'.`n"
+            $testResult = [TestResult]::new($skipPath, "Succeeded", $testConfig, $attempt)
+        }
+
+        It "is a success" {
+            $testResult.IsSuccess() | Should -Be $true
+        }
+
+        It "does not throw and reports zero passed tests." {
+            $result = $testResult.GetPassedTests()
+            $result.Passed | Should -Be 0
+            $result.Failed | Should -Be 0
+            $testResult.Skipped | Should -Be $true
+        }
+    }
+
     Context "new test summmary results" -Skip {
         It "finds the right stuff" {
             $testDirectory = Join-Path "." "subdir"

--- a/tools/devops/automation/scripts/TestResults.psm1
+++ b/tools/devops/automation/scripts/TestResults.psm1
@@ -64,6 +64,7 @@ class TestResult {
     [bool] $VSDropsPublishFailed
     hidden [int] $Passed
     hidden [int] $Failed
+    hidden [bool] $Skipped = $false
     hidden [string[]] $NotTestSummaryLabels = @()
 
     TestResult (
@@ -188,6 +189,12 @@ class TestResult {
                     } elseif ($content -match $regexp) {
                         $this.Passed = $matches.passed -as [int]
                         Write-Host "`tPassed tests count: $($this.Passed)"
+                    } elseif ($content -match "Tests skipped, incorrect beta version") {
+                        # The tests were skipped because the OS is a beta version that
+                        # doesn't match the expected build version (see run-packaged-macos-tests).
+                        Write-Host "`t`tTests skipped due to beta version mismatch"
+                        $this.Passed = 0
+                        $this.Skipped = $true
                     } else {
                         throw "Unable to understand the test result '$content' for test '$($this.GetLabelWithSuffix(`"`"))'"
                     }
@@ -355,7 +362,9 @@ class ParallelTestsResults {
         $downloadInfo = $this.GetDownloadLinks($testResult)
         $result = $testResult.GetPassedTests()
         $attemptText = $testResult.GetAttemptText()
-        if ($result.Passed -eq 0) {
+        if ($testResult.Skipped) {
+            $stringBuilder.AppendLine(":warning: $($testResult.GetLabelWithSuffix(`"`")): Tests skipped, incorrect beta version.$attemptText $downloadInfo")
+        } elseif ($result.Passed -eq 0) {
             $stringBuilder.AppendLine(":warning: $($testResult.GetLabelWithSuffix(`"`")): No tests selected.$attemptText $downloadInfo")
         } else {
             $stringBuilder.AppendLine(":white_check_mark: $($testResult.GetLabelWithSuffix(`"`")): All $($result.Passed) tests passed.$attemptText $downloadInfo")


### PR DESCRIPTION
PR #26003 made `run-packaged-macos-tests` write a `TestSummary.md` whose first line is `# ⚠️ <title>: Tests skipped, incorrect beta version` when it skips tests because the current OS is a beta build that doesn't match the expected build version.

The CI summary parser (`tools/devops/automation/scripts/TestResults.psm1`) only knew about the "all passed", "no tests selected" and "# Test results" formats, so `GetPassedTests` threw `Unable to understand the test result` and the PR got `:fire: Failed to compute test summaries` comments instead of a proper summary.

This PR:

- Recognizes the skip line in `GetPassedTests` (treating it as zero passed tests, tracked via a new hidden `$Skipped` flag).
- Renders a proper `:warning: ...: Tests skipped, incorrect beta version.` message in the aggregated comment instead of the misleading "No tests selected.".
- Adds a Pester regression test for the skip case.

🤖 Pull request created by Copilot