### PR TITLE
[CI] Add build_macos_tests to publish-results stage dependencies

### DIFF
--- a/tools/devops/automation/templates/tests/publish-results.yml
+++ b/tools/devops/automation/templates/tests/publish-results.yml
@@ -48,6 +48,7 @@ stages:
   - simulator_tests
   - windows_integration
   - linux_build_verification
+  - build_macos_tests
   condition: and(succeededOrFailed(), ${{ parameters.condition }})
 
   jobs:


### PR DESCRIPTION
The commit 235e08fc added code to check the build_macos_tests status
from stageDependencies, but the publish-results stage didn't list
`build_macos_tests` in its dependsOn. Azure DevOps only includes stages
in stageDependencies if they're in the dependsOn chain, so the check
was always silently skipped.

🤖 Pull request created by Copilot