### PR TITLE
[ThreadNetwork] Update bindings up to Xcode 27 Beta 3

### DIFF
--- a/src/threadnetwork.cs
+++ b/src/threadnetwork.cs
@@ -2,6 +2,8 @@ using CoreFoundation;
 
 namespace ThreadNetwork {
 
+	delegate void THClientEnableCredentialSharingModeCompletionHandler ([NullAllowed] NSError error);
+
 	[iOS (15, 0), MacCatalyst (16, 1), NoTV]
 	[BaseType (typeof (NSObject))]
 	interface THClient {
@@ -44,6 +46,11 @@ namespace ThreadNetwork {
 		[Async]
 		[Export ("isPreferredNetworkAvailableWithCompletion:")]
 		void IsPreferredNetworkAvailable (Action<bool> completion);
+
+		[Mac (27, 0), iOS (27, 0), MacCatalyst (27, 0)]
+		[Async]
+		[Export ("enableCredentialSharingModeWithExtendedPANId:completion:")]
+		void EnableCredentialSharingMode (NSData extendedPanId, THClientEnableCredentialSharingModeCompletionHandler completion);
 	}
 
 	[iOS (15, 0), MacCatalyst (16, 1), NoTV]

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -26381,6 +26381,8 @@ M:ThreadNetwork.THClient.CheckPreferredNetwork(Foundation.NSData,System.Action{S
 M:ThreadNetwork.THClient.CheckPreferredNetworkAsync(Foundation.NSData)
 M:ThreadNetwork.THClient.DeleteCredentialsForBorderAgent(Foundation.NSData,System.Action{Foundation.NSError})
 M:ThreadNetwork.THClient.DeleteCredentialsForBorderAgentAsync(Foundation.NSData)
+M:ThreadNetwork.THClient.EnableCredentialSharingMode(Foundation.NSData,ThreadNetwork.THClientEnableCredentialSharingModeCompletionHandler)
+M:ThreadNetwork.THClient.EnableCredentialSharingModeAsync(Foundation.NSData)
 M:ThreadNetwork.THClient.IsPreferredNetworkAvailable(System.Action{System.Boolean})
 M:ThreadNetwork.THClient.IsPreferredNetworkAvailableAsync
 M:ThreadNetwork.THClient.RetrieveAllActiveCredentials(System.Action{Foundation.NSSet{ThreadNetwork.THCredentials},Foundation.NSError})
@@ -61316,6 +61318,7 @@ T:Symbols.NSSymbolVariableColorEffect
 T:Symbols.NSSymbolWiggleEffect
 T:System.Net.Http.NSUrlSessionHandlerTrustOverrideForUrlCallback
 T:ThreadNetwork.THClient
+T:ThreadNetwork.THClientEnableCredentialSharingModeCompletionHandler
 T:ThreadNetwork.THCredentials
 T:TouchController.TCButton
 T:TouchController.TCButtonDescriptor

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-ThreadNetwork.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-ThreadNetwork.todo
@@ -1,1 +1,0 @@
-!missing-selector! THClient::enableCredentialSharingModeWithExtendedPANId:completion: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-ThreadNetwork.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-ThreadNetwork.todo
@@ -1,1 +1,0 @@
-!missing-selector! THClient::enableCredentialSharingModeWithExtendedPANId:completion: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-ThreadNetwork.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-ThreadNetwork.todo
@@ -1,1 +1,0 @@
-!missing-selector! THClient::enableCredentialSharingModeWithExtendedPANId:completion: not bound


### PR DESCRIPTION
Bind the new `enableCredentialSharingModeWithExtendedPANId:completion:` selector on `THClient`, introduced in the Xcode 27 SDK. The API is available on iOS, Mac Catalyst and macOS 27.0 (ThreadNetwork is not available on tvOS).

The completion handler is bound as a named delegate (`THClientEnableCredentialSharingModeCompletionHandler`) with a `[NullAllowed] NSError` parameter, matching the native `_Nullable` error, and `[Async]` generates the `Task`-based overload.

This resolves the `!missing-selector!` entries in the iOS/macOS/ MacCatalyst ThreadNetwork `.todo` files.