### PR TITLE
[tests] Disable the AppSizeTest on branches using an Xcode beta.

### DIFF
--- a/tests/dotnet/UnitTests/AppSizeTest.cs
+++ b/tests/dotnet/UnitTests/AppSizeTest.cs
@@ -102,6 +102,9 @@ namespace Xamarin.Tests {
 			Configuration.IgnoreIfIgnoredPlatform (platform);
 			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
 
+			if (!Configuration.XcodeIsStable)
+				Assert.Ignore ("Using a beta version of Xcode, so disabling this test (it will need very frequent updates to the known failures, which is better delayed until the final Xcode release)");
+
 			var project = "SizeTestApp";
 			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath, configuration: configuration);
 


### PR DESCRIPTION
On branches that use beta versions of Xcode, we typically do a lot of binding
work, and that mean that frequent updates to the known failures for this test
are necessary. So frequent that it becomes frustrating, and also slows down
pace, because there will be a lot of merge conflicts between PRs that all
update the known failures for this test.

So just disable it when using a beta version of Xcode. Once the branch
switches to a stable version of Xcode, there will be much less binding work,
and we can resume this test.