### PR TITLE
[assembly-preparer] Speed up InlineDlfcnMethodsStep.

### DIFF
--- a/tests/dotnet/UnitTests/PerformanceTests.cs
+++ b/tests/dotnet/UnitTests/PerformanceTests.cs
@@ -7,8 +7,20 @@ namespace Xamarin.Tests {
 	[TestFixture]
 	public class PerformanceTests : TestBaseClass {
 		[Test]
-		[TestCase (ApplePlatform.iOS, true)]
-		public void PrepareAssemblies (ApplePlatform platform, bool useMonoRuntime)
+		[TestCase (ApplePlatform.iOS)]
+		public void PrepareAssemblies_MonoVM (ApplePlatform platform)
+		{
+			PrepareAssemblies (platform, true);
+		}
+
+		[Test]
+		[TestCase (ApplePlatform.MacOSX)]
+		public void PrepareAssemblies_CoreCLR (ApplePlatform platform)
+		{
+			PrepareAssemblies (platform, false);
+		}
+
+		void PrepareAssemblies (ApplePlatform platform, bool useMonoRuntime)
 		{
 			Configuration.IgnoreIfIgnoredPlatform (platform);
 

--- a/tools/dotnet-linker/Steps/InlineDlfcnMethodsStep.cs
+++ b/tools/dotnet-linker/Steps/InlineDlfcnMethodsStep.cs
@@ -37,6 +37,34 @@ public class InlineDlfcnMethodsStep : AssemblyModifierStep {
 		base.TryProcess ();
 	}
 
+	protected override bool ModifyAssembly (AssemblyDefinition assembly)
+	{
+		// Dlfcn calls can only appear in assemblies that reference (or, for the platform assembly, define)
+		// ObjCRuntime.Dlfcn, which is only the platform assembly and binding libraries. Skip everything else
+		// (e.g. the BCL and most user assemblies) without iterating all their types, methods and instructions.
+		if (!ReferencesDlfcn (assembly))
+			return false;
+
+		return base.ModifyAssembly (assembly);
+	}
+
+	bool ReferencesDlfcn (AssemblyDefinition assembly)
+	{
+		// Dlfcn lives in the product assembly, so an assembly that doesn't even reference the product assembly
+		// (the BCL, most third-party code) can't possibly call it. This only looks at the assembly references,
+		// so it's the cheapest check - do it first.
+		if (!Configuration.Profile.IsOrReferencesProductAssembly (assembly))
+			return false;
+
+		// The product assembly defines (and calls) Dlfcn itself.
+		if (Configuration.Profile.IsProductAssembly (assembly))
+			return true;
+
+		// Otherwise (binding libraries, user code that references the product assembly) it must reference the
+		// Dlfcn type specifically - this scans the type reference table, so it's the most expensive check.
+		return assembly.MainModule.HasTypeReference ("ObjCRuntime.Dlfcn");
+	}
+
 	string? current_framework;
 	protected override bool ProcessType (TypeDefinition type)
 	{
@@ -44,6 +72,14 @@ public class InlineDlfcnMethodsStep : AssemblyModifierStep {
 		if (type.HasMethods) {
 			if (Frameworks.TryGetFramework (App, type, out Framework? framework) && framework.IsFrameworkUnavailable (App)) {
 				App.Log (3, $"Type {type.FullName} appears to be part of the '{framework.Name}' framework, which is not available in the current SDK. Skipping inlining Dlfcn calls for this type.");
+				return modified;
+			}
+
+			// If the type isn't available in the simulator, and we're building for the simulator, then don't
+			// inline any of its methods. Checking this once per type (instead of once per method) avoids
+			// re-scanning the declaring type's availability attributes for every method.
+			if (DerivedLinkContext.App.IsSimulatorBuild && DerivedLinkContext.HasAvailabilityAttributesShowingUnavailableInSimulator (type)) {
+				App.Log (3, $"Type {type.FullName} is not available in the simulator. Skipping inlining Dlfcn calls for this type.");
 				return modified;
 			}
 
@@ -523,13 +559,10 @@ public class InlineDlfcnMethodsStep : AssemblyModifierStep {
 			return modified; // don't process the Dlfcn methods themselves
 
 		if (DerivedLinkContext.App.IsSimulatorBuild) {
-			// if the method or its declaring type aren't available in the simulator, and we're building for the simulator, then don't inline.
+			// if the method isn't available in the simulator, and we're building for the simulator, then don't inline.
+			// (the declaring type's availability is checked once per type in ProcessType.)
 			if (DerivedLinkContext.HasAvailabilityAttributesShowingUnavailableInSimulator (method, method)) {
 				App.Log (3, $"Method {method.FullName} is not available in the simulator. Skipping inlining Dlfcn calls for this method.");
-				return modified;
-			}
-			if (DerivedLinkContext.HasAvailabilityAttributesShowingUnavailableInSimulator (method.DeclaringType, method)) {
-				App.Log (3, $"Type {method.DeclaringType.FullName} is not available in the simulator. Skipping inlining Dlfcn calls for this type.");
 				return modified;
 			}
 		}


### PR DESCRIPTION
InlineDlfcnMethodsStep iterated every type and every method (and every
instruction of every method with a body) in every assembly, looking for calls to
ObjCRuntime.Dlfcn to inline. Two changes make this cheaper:

* Skip whole assemblies that can't contain Dlfcn calls. Dlfcn lives in the
  product assembly, so an assembly that neither is nor references the product
  assembly (the BCL, most third-party code) can't call it. Check that (cheapest
  first: the assembly references, then whether it's the product assembly, then
  finally whether it references the Dlfcn type) once per assembly and skip the
  whole thing - types, methods and instructions - otherwise.

* Check the declaring type's simulator availability once per type in ProcessType
  instead of once per method. It only depends on the type, so recomputing it for
  every method (each call scans the type's availability attributes) was wasteful.

For monotouch-test's assemblies (MySimpleApp, ios simulator) this cut the time
spent in InlineDlfcnMethodsStep roughly in half for link None (2.85s -> 1.65s,
dominated by the un-skippable product assembly) and ~6x for SdkOnly (1.58s ->
0.27s).

Verified with monotouch-test on iOS (0 failed) with the inline-dlfcn-methods-strict
and inline-dlfcn-methods-compat variations (which exercise the actual inlining)
as well as release|linksdk.

Build performance on iOS (MonoVM):

| Project        | Runtime identifier | Link mode | PrepareAssemblies=false | PrepareAssemblies=true | Difference   |
| -------------- | ------------------ | --------- | ----------------------- | ---------------------- | ------------ |
| monotouch-test | ios-arm64          | None      |  00:02:19.76            |  00:02:13.53           | -00:00:06.23 |
| monotouch-test | ios-arm64          | SdkOnly   |  00:01:26.94            |  00:01:47.17           |  00:00:20.22 |
| monotouch-test | iossimulator-arm64 | None      |  00:01:45.58            |  00:01:43.90           | -00:00:01.68 |
| monotouch-test | iossimulator-arm64 | SdkOnly   |  00:01:18.42            |  00:01:23.84           |  00:00:05.42 |
| MySimpleApp    | ios-arm64          | None      |  00:01:14.39            |  00:01:16.94           |  00:00:02.54 |
| MySimpleApp    | ios-arm64          | SdkOnly   |  00:00:22.02            |  00:00:45.90           |  00:00:23.87 |
| MySimpleApp    | iossimulator-arm64 | None      |  00:00:53.94            |  00:00:54.32           |  00:00:00.37 |
| MySimpleApp    | iossimulator-arm64 | SdkOnly   |  00:00:19.17            |  00:00:25.65           |  00:00:06.47 |

Build performance on macOS (CoreCLR):

| Project        | Runtime identifier | Link mode | PrepareAssemblies=false | PrepareAssemblies=true | Difference   |
| -------------- | ------------------ | --------- | ----------------------- | ---------------------- | ------------ |
| monotouch-test | osx-arm64          | None      |  00:00:56.09            |  00:00:51.21           | -00:00:04.87 |
| monotouch-test | osx-arm64          | SdkOnly   |  00:00:53.56            |  00:00:52.37           | -00:00:01.18 |
| MySimpleApp    | osx-arm64          | None      |  00:00:09.83            |  00:00:09.50           | -00:00:00.33 |
| MySimpleApp    | osx-arm64          | SdkOnly   |  00:00:09.44            |  00:00:08.84           | -00:00:00.60 |