### PR TITLE
[assembly-preparer] Fix IL2036 unresolved type in DynamicDependency with link-all. Fixes #26017

### DIFF
--- a/tools/dotnet-linker/AppBundleRewriter.cs
+++ b/tools/dotnet-linker/AppBundleRewriter.cs
@@ -1563,7 +1563,10 @@ namespace Xamarin.Linker {
 			var attribute = CreateAttribute (DynamicDependencyAttribute_ctor__DynamicallyAccessedMemberTypes_Type);
 			// typed as 'int' because that's how the linker expects it: https://github.com/dotnet/runtime/blob/3c5ad6c677b4a3d12bc6a776d654558cca2c36a9/src/tools/illink/src/linker/Linker/DynamicDependency.cs#L97
 			attribute.ConstructorArguments.Add (new CustomAttributeArgument (System_Diagnostics_CodeAnalysis_DynamicallyAccessedMemberTypes, (int) memberTypes));
-			attribute.ConstructorArguments.Add (new CustomAttributeArgument (System_Type, type));
+			// Import the type into the current assembly, otherwise Cecil will serialize the Type argument
+			// without an assembly-qualified name when 'type' is a TypeDefinition from another assembly (because
+			// a TypeDefinition's Scope is its own module), and the trimmer won't be able to resolve it (IL2036).
+			attribute.ConstructorArguments.Add (new CustomAttributeArgument (System_Type, CurrentAssembly.MainModule.ImportReference (type)));
 			return attribute;
 		}
 


### PR DESCRIPTION
When building with `PrepareAssemblies=true` and link all (`MtouchLink=Full`), ILLink failed with:

```
error IL2036: <Module>..cctor(): Unresolved type 'Foundation.NSExpression' in 'DynamicDependencyAttribute'.
error NETSDK1144: Optimizing assemblies for size failed.
```

The assembly-preparer's `ApplyPreserveAttributeStep` translates `[Preserve (typeof (X))]` into a `[DynamicDependency]` attribute on the module's static constructor. `CreateDynamicDependencyAttribute (DynamicallyAccessedMemberTypes, TypeDefinition)` passed the raw cross-assembly `TypeDefinition` as the `Type` argument. Cecil serializes such an argument *without* an assembly-qualified name, because a `TypeDefinition`'s `Scope` is its own module (so `RequiresFullyQualifiedName` returns false). The resulting attribute referenced `Foundation.NSExpression` with no assembly, which ILLink couldn't resolve once the app assembly was trimmed in full-link mode.

Fix: import the type into the current assembly's module before using it as the `Type` argument, so Cecil emits a proper assembly-qualified name (`Foundation.NSExpression, Microsoft.iOS, ...`).

This only affected the assembly-preparer path: the regular linker step emits an XML descriptor instead of `[DynamicDependency]` attributes. It also only surfaced with link all, since the module cctor's attributes are only processed by ILLink when the app assembly is trimmed.

No new test is needed: on .NET 11 (where `PrepareAssemblies` defaults to true) the existing xharness `monotouch-test` "Release (link all)" variation builds monotouch-test with link all + PrepareAssemblies, and monotouch-test contains `[assembly: Preserve (typeof (NSExpression))]` (`tests/monotouch-test/Foundation/NSExpressionTest.cs`), which reproduces this exact failure.


Fixes https://github.com/dotnet/macios/issues/26017

🤖 Pull request created by Copilot
