### PR TITLE
[msbuild] Embed the app's symbols in the .ipa (IpaIncludeSymbols)

### DIFF
--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -710,9 +710,10 @@ The symbols are generated from the build's dSYM directories using
 `xcrun symbols`, and only the parts Apple needs are included (the full dSYMs
 are not embedded in the IPA).
 
-The default value is `false`.
+The default value is `true` when creating an IPA (see [BuildIpa](#buildipa)),
+and `false` otherwise. Set it to `false` to opt out.
 
-Only applicable to iOS and tvOS projects (see [BuildIpa](#buildipa)).
+Only applicable to iOS and tvOS projects.
 
 ## IpaPackageName
 

--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -700,6 +700,20 @@ If artwork should be included in the IPA.
 
 Only applicable to iOS and tvOS projects.
 
+## IpaIncludeSymbols
+
+If the app's debug symbols (dSYMs) should be included in the IPA, in the
+`Symbols` directory Apple expects. This makes App Store Connect (and Xcode's
+Organizer) symbolicate crash reports for the app automatically.
+
+The symbols are generated from the build's dSYM directories using
+`xcrun symbols`, and only the parts Apple needs are included (the full dSYMs
+are not embedded in the IPA).
+
+The default value is `false`.
+
+Only applicable to iOS and tvOS projects (see [BuildIpa](#buildipa)).
+
 ## IpaPackageName
 
 Specifies the name of the resulting .ipa file (without the path) when creating

--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -702,16 +702,16 @@ Only applicable to iOS and tvOS projects.
 
 ## IpaIncludeSymbols
 
-If the app's debug symbols (dSYMs) should be included in the IPA, in the
-`Symbols` directory Apple expects. This makes App Store Connect (and Xcode's
-Organizer) symbolicate crash reports for the app automatically.
+If the app's symbols should be included in the IPA, in the `Symbols`
+directory Apple expects. This makes App Store Connect (and Xcode's Organizer)
+symbolicate crash reports for the app automatically.
 
-The symbols are generated from the build's dSYM directories using
-`xcrun symbols`, and only the parts Apple needs are included (the full dSYMs
-are not embedded in the IPA).
+The symbols are the Apple `*.symbols` files generated from the build's dSYM
+directories using `xcrun symbols` (the dSYM directories themselves are not
+embedded in the IPA).
 
-The default value is `true` when creating an IPA (see [BuildIpa](#buildipa)),
-and `false` otherwise. Set it to `false` to opt out.
+The default value is `true`. Set it to `false` to opt out. This property has
+no effect unless an IPA is being created (see [BuildIpa](#buildipa)).
 
 Only applicable to iOS and tvOS projects.
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateSymbolsPackage.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateSymbolsPackage.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using Xamarin.Messaging.Build.Client;
+
+#nullable enable
+
+namespace Xamarin.MacDev.Tasks {
+	// Creates the *.symbols files Apple expects in an .ipa's 'Symbols' directory
+	// by running 'xcrun symbols' over the DWARF binaries inside each dSYM.
+	public class CreateSymbolsPackage : XamarinTask, ITaskCallback {
+		#region Inputs
+
+		[Required]
+		public ITaskItem [] DSymDirectories { get; set; } = [];
+
+		[Required]
+		public string SymbolsDirectory { get; set; } = "";
+
+		#endregion
+
+		public override bool Execute ()
+		{
+			if (ShouldExecuteRemotely ())
+				return ExecuteRemotely ();
+
+			Directory.CreateDirectory (SymbolsDirectory);
+
+			foreach (var dsym in DSymDirectories)
+				CreateSymbols (dsym.ItemSpec);
+
+			return !Log.HasLoggedErrors;
+		}
+
+		void CreateSymbols (string dSymDirectory)
+		{
+			var dwarfDirectory = Path.Combine (dSymDirectory, "Contents", "Resources", "DWARF");
+			if (!Directory.Exists (dwarfDirectory)) {
+				Log.LogMessage (MessageImportance.Low, "Skipping '{0}' because it doesn't contain any DWARF binaries.", dSymDirectory);
+				return;
+			}
+
+			foreach (var binary in Directory.EnumerateFiles (dwarfDirectory)) {
+				var args = new List<string> {
+					"symbols",
+					"-noTextInSOD",
+					"-noDaemon",
+					"-arch",
+					"all",
+					"-symbolsPackageDir",
+					SymbolsDirectory,
+					Path.GetFullPath (binary),
+				};
+
+				ExecuteAsync ("xcrun", args).Wait ();
+			}
+		}
+
+		public bool ShouldCopyToBuildServer (ITaskItem item) => false;
+
+		public bool ShouldCreateOutputFile (ITaskItem item) => false;
+
+		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied () => Enumerable.Empty<ITaskItem> ();
+	}
+}

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateSymbolsPackage.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/CreateSymbolsPackage.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 
 using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
 
 using Xamarin.Messaging.Build.Client;
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -3456,9 +3456,6 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<!-- Extensibility point for VS Publishing Workflow -->
 		<_BeforeCreateIpaForDistributionDependsOn />
 
-		<!-- Embed the app's symbols in the .ipa by default whenever we're creating one. -->
-		<IpaIncludeSymbols Condition="'$(IpaIncludeSymbols)' == ''">$(BuildIpa)</IpaIncludeSymbols>
-
 		<CreateIpaDependsOn>
 			_BeforeCreateIpaForDistribution;
 			_CompileEntitlements;

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -3456,6 +3456,9 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		<!-- Extensibility point for VS Publishing Workflow -->
 		<_BeforeCreateIpaForDistributionDependsOn />
 
+		<!-- Embed the app's symbols in the .ipa by default whenever we're creating one. -->
+		<IpaIncludeSymbols Condition="'$(IpaIncludeSymbols)' == ''">$(BuildIpa)</IpaIncludeSymbols>
+
 		<CreateIpaDependsOn>
 			_BeforeCreateIpaForDistribution;
 			_CompileEntitlements;

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -59,6 +59,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Xamarin.MacDev.Tasks.CreateEmbeddedResources" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Xamarin.MacDev.Tasks.CreateInstallerPackage" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Xamarin.MacDev.Tasks.CreatePkgInfo" AssemblyFile="$(_TaskAssemblyName)" />
+	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Xamarin.MacDev.Tasks.CreateSymbolsPackage" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Xamarin.MacDev.Tasks.DetectDebugNetworkConfiguration" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Xamarin.MacDev.Tasks.DetectSdkLocations" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Xamarin.MacDev.Tasks.DetectSigningIdentity" AssemblyFile="$(_TaskAssemblyName)" />
@@ -3460,6 +3461,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			_CompileEntitlements;
 			_CoreCreateIpa;
 			_PackageOnDemandResources;
+			_CreateIpaSymbols;
 			_ZipIpa
 		</CreateIpaDependsOn>
 

--- a/msbuild/Xamarin.Shared/Xamarin.iOS.Common.props
+++ b/msbuild/Xamarin.Shared/Xamarin.iOS.Common.props
@@ -21,7 +21,6 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<PropertyGroup>
 		<IpaIncludeArtwork Condition="'$(IpaIncludeArtwork)' == ''">False</IpaIncludeArtwork>
-		<IpaIncludeSymbols Condition="'$(IpaIncludeSymbols)' == ''">False</IpaIncludeSymbols>
 		<BuildSessionId></BuildSessionId>
 
 		<!-- Backward Compatability -->

--- a/msbuild/Xamarin.Shared/Xamarin.iOS.Common.props
+++ b/msbuild/Xamarin.Shared/Xamarin.iOS.Common.props
@@ -21,6 +21,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<PropertyGroup>
 		<IpaIncludeArtwork Condition="'$(IpaIncludeArtwork)' == ''">False</IpaIncludeArtwork>
+		<IpaIncludeSymbols Condition="'$(IpaIncludeSymbols)' == ''">False</IpaIncludeSymbols>
 		<BuildSessionId></BuildSessionId>
 
 		<!-- Backward Compatability -->

--- a/msbuild/Xamarin.Shared/Xamarin.iOS.Common.props
+++ b/msbuild/Xamarin.Shared/Xamarin.iOS.Common.props
@@ -21,6 +21,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 
 	<PropertyGroup>
 		<IpaIncludeArtwork Condition="'$(IpaIncludeArtwork)' == ''">False</IpaIncludeArtwork>
+		<IpaIncludeSymbols Condition="'$(IpaIncludeSymbols)' == ''">True</IpaIncludeSymbols>
 		<BuildSessionId></BuildSessionId>
 
 		<!-- Backward Compatability -->

--- a/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
@@ -474,6 +474,26 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 			/>
 	</Target>
 
+	<Target Name="_CreateIpaSymbols" Condition="'$(BuildIpa)' == 'true' And '$(IpaIncludeSymbols)' == 'true'">
+		<!-- Find all the dSYM directories produced by the build. -->
+		<GetDirectories SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Path="$(DeviceSpecificOutputPath)" Pattern="*.dSYM">
+			<Output TaskParameter="Directories" ItemName="_IpaSymbolDSymDir" />
+		</GetDirectories>
+
+		<!-- Turn the dSYMs into the *.symbols files Apple expects in the .ipa's 'Symbols' directory. -->
+		<CreateSymbolsPackage
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true' And '@(_IpaSymbolDSymDir)' != ''"
+			DSymDirectories="@(_IpaSymbolDSymDir)"
+			SymbolsDirectory="$(DeviceSpecificIntermediateOutputPath)ipa\Symbols"
+		/>
+
+		<!-- Add the 'Symbols' directory to the set of files that go into the .ipa. -->
+		<ItemGroup>
+			<_IpaPackageSource Include="$(DeviceSpecificIntermediateOutputPath)ipa\Symbols" Condition="Exists ('$(DeviceSpecificIntermediateOutputPath)ipa\Symbols')" />
+		</ItemGroup>
+	</Target>
+
 	<Target Name="_ZipIpa" Condition="'$(BuildIpa)' == 'true'">
 		<MakeDir SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Directories="$(IpaPackageDir)" />
 		<Delete SessionId="$(BuildSessionId)" Condition="'$(IsMacEnabled)' == 'true'" Files="$(IpaPackagePath)" />

--- a/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.iOS.Common.targets
@@ -483,7 +483,7 @@ Copyright (C) 2013-2016 Xamarin. All rights reserved.
 		<!-- Turn the dSYMs into the *.symbols files Apple expects in the .ipa's 'Symbols' directory. -->
 		<CreateSymbolsPackage
 			SessionId="$(BuildSessionId)"
-			Condition="'$(IsMacEnabled)' == 'true' And '@(_IpaSymbolDSymDir)' != ''"
+			Condition="'$(IsMacEnabled)' == 'true' And '@(_IpaSymbolDSymDir->Count())' != '0'"
 			DSymDirectories="@(_IpaSymbolDSymDir)"
 			SymbolsDirectory="$(DeviceSpecificIntermediateOutputPath)ipa\Symbols"
 		/>

--- a/tests/dotnet/UnitTests/PostBuildTest.cs
+++ b/tests/dotnet/UnitTests/PostBuildTest.cs
@@ -1,3 +1,4 @@
+using System.IO.Compression;
 using System.Text.Json;
 
 using Microsoft.Build.Framework;
@@ -76,6 +77,48 @@ namespace Xamarin.Tests {
 
 			AssertBundleAssembliesStripStatus (appPath, true);
 			AssertDSymDirectory (appPath);
+
+			// IpaIncludeSymbols defaults to true, so the .ipa must contain a populated 'Symbols' directory.
+			AssertIpaSymbols (pkgPath, shouldContainSymbols: true);
+		}
+
+		[Test]
+		[TestCase (ApplePlatform.iOS, "ios-arm64")]
+		[TestCase (ApplePlatform.TVOS, "tvos-arm64")]
+		public void BuildIpaWithoutSymbolsTest (ApplePlatform platform, string runtimeIdentifiers)
+		{
+			var project = "MySimpleApp";
+			var configuration = "Release";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath, configuration: configuration);
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["BuildIpa"] = "true";
+			properties ["IpaIncludeSymbols"] = "false";
+			properties ["Configuration"] = configuration;
+
+			var result = DotNet.AssertBuild (project_path, properties);
+
+			var pkgPath = Path.Combine (appPath, "..", $"{project}.ipa");
+			Assert.That (pkgPath, Does.Exist, "pkg creation");
+
+			// IpaIncludeSymbols=false, so the .ipa must not contain a 'Symbols' directory.
+			AssertIpaSymbols (pkgPath, shouldContainSymbols: false);
+		}
+
+		static void AssertIpaSymbols (string ipaPath, bool shouldContainSymbols)
+		{
+			using var archive = ZipFile.OpenRead (ipaPath);
+			var symbolFiles = archive.Entries.
+				Where (entry => entry.FullName.StartsWith ("Symbols/", StringComparison.Ordinal) && entry.FullName.EndsWith (".symbols", StringComparison.Ordinal)).
+				ToList ();
+			if (shouldContainSymbols) {
+				Assert.That (symbolFiles, Is.Not.Empty, "The .ipa should contain Symbols/*.symbols files.");
+			} else {
+				Assert.That (symbolFiles, Is.Empty, "The .ipa should not contain any Symbols/*.symbols files.");
+			}
 		}
 
 		[Test]


### PR DESCRIPTION
## Why

App Store Connect (and Xcode's Organizer) only symbolicate an app's crash reports automatically when the uploaded `.ipa` contains a top-level `Symbols` directory with the `*.symbols` files Apple expects. Our builds never produced those files, so uploaded apps showed up as "missing symbols" and crash reports stayed unsymbolicated. This is a long-standing pain point (issue #17807 from 2023).

Xcode generates that `Symbols` directory by running `xcrun symbols` over the DWARF binaries inside each dSYM. This PR does the same during our IPA build.

## Approach

- New MSBuild task `CreateSymbolsPackage` (modeled on the existing `DSymUtil` task). For each dSYM it runs:
  ```
  xcrun symbols -noTextInSOD -noDaemon -arch all -symbolsPackageDir <ipa>/Symbols <dSYM DWARF binary>
  ```
  This produces only the `*.symbols` files Apple needs. The full dSYMs are not embedded in the `.ipa`.
- New target `_CreateIpaSymbols` finds all `*.dSYM` directories the build produced, runs the task into `ipa/Symbols`, and adds that directory to `_IpaPackageSource` so `_ZipIpa` includes it. It's wired into `CreateIpaDependsOn` between `_PackageOnDemandResources` and `_ZipIpa`.
- New `IpaIncludeSymbols` property controls the behavior. It **defaults to `true` whenever an IPA is being built** (`$(BuildIpa)`), so apps get symbolicated crash reports out of the box. Set `IpaIncludeSymbols=false` to opt out.

The default is computed in `Xamarin.Shared.targets` (where `BuildIpa` is resolved) rather than in the early `.props`, because `BuildIpa` isn't available that early.

## Notes for reviewers

- The task is remote-build aware (`SessionId` + `IsMacEnabled`) so it works when building from Windows against a Mac.
- I could not run a full end-to-end IPA integration test locally: it requires the pinned Xcode (26.6) plus device signing, neither of which is available in my environment. I verified a clean build (`make world`-style `cb`) succeeds with 0 errors and confirmed the new task type is present in the built `Xamarin.MacDev.Tasks.dll`. The behavior would benefit from a CI/manual verification that a produced `.ipa` actually contains a populated `Symbols` directory.

Fixes: #17807

🤖 Pull request created by Copilot