### PR TITLE
[AVRouting] Update bindings to Xcode 27 beta 3

### DIFF
--- a/src/avrouting.cs
+++ b/src/avrouting.cs
@@ -144,7 +144,7 @@ namespace AVRouting {
 		[Export ("sharedRoutingPlaybackArbiter")]
 		AVRoutingPlaybackArbiter SharedInstance { get; }
 
-		[TV (26, 0), NoMacCatalyst, NoMac, NoiOS]
+		[TV (26, 0), MacCatalyst (27, 0), NoMac, iOS (27, 0)]
 		[NullAllowed]
 		[Export ("preferredParticipantForNonMixableAudioRoutes", ArgumentSemantic.Weak)]
 		IAVRoutingPlaybackParticipant PreferredParticipantForNonMixableAudioRoutes { get; set; }

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-AVRouting.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-AVRouting.todo
@@ -1,2 +1,0 @@
-!missing-selector! AVRoutingPlaybackArbiter::preferredParticipantForNonMixableAudioRoutes not bound
-!missing-selector! AVRoutingPlaybackArbiter::setPreferredParticipantForNonMixableAudioRoutes: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-AVRouting.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-AVRouting.todo
@@ -1,2 +1,0 @@
-!missing-selector! AVRoutingPlaybackArbiter::preferredParticipantForNonMixableAudioRoutes not bound
-!missing-selector! AVRoutingPlaybackArbiter::setPreferredParticipantForNonMixableAudioRoutes: not bound


### PR DESCRIPTION
Copilot-Session: a2f89802-f8e5-47e4-b952-e587ce2a9491