### PR TITLE
[docs] Improve XML docs for EKParticipantScheduleStatus and 19 other types

### DIFF
--- a/src/AVFoundation/AVAudioPlayer.cs
+++ b/src/AVFoundation/AVAudioPlayer.cs
@@ -26,7 +26,6 @@
 
 namespace AVFoundation {
 	/// <summary>An audio player that can play audio from memory or the local file system.</summary>
-	///     <remarks>To be added.</remarks>
 	///     <related type="sample" href="https://github.com/xamarin/ios-samples/tree/master/AVTouchSample/">avTouch</related>
 	/// <related type="externalDocumentation" href="https://developer.apple.com/documentation/avfaudio/avaudioplayer">Apple documentation for <c>AVAudioPlayer</c></related>
 	public partial class AVAudioPlayer {

--- a/src/AVFoundation/AVAudioSessionPortDescription.cs
+++ b/src/AVFoundation/AVAudioSessionPortDescription.cs
@@ -13,7 +13,7 @@ using AudioToolbox;
 
 #if !MONOMAC
 namespace AVFoundation {
-	/// <summary>Encpasulates information about the input and output ports of an audio session.</summary>
+	/// <summary>Encapsulates information about the input and output ports of an audio session.</summary>
 	/// <related type="externalDocumentation" href="https://developer.apple.com/documentation/avfaudio/avaudiosessionportdescription">Apple documentation for <c>AVAudioSessionPortDescription</c></related>
 	public partial class AVAudioSessionPortDescription {
 	}

--- a/src/AVFoundation/AVAudioSessionPortDescription.cs
+++ b/src/AVFoundation/AVAudioSessionPortDescription.cs
@@ -14,7 +14,6 @@ using AudioToolbox;
 #if !MONOMAC
 namespace AVFoundation {
 	/// <summary>Encpasulates information about the input and output ports of an audio session.</summary>
-	///     <remarks>To be added.</remarks>
 	/// <related type="externalDocumentation" href="https://developer.apple.com/documentation/avfaudio/avaudiosessionportdescription">Apple documentation for <c>AVAudioSessionPortDescription</c></related>
 	public partial class AVAudioSessionPortDescription {
 	}

--- a/src/AVFoundation/AVMetadataMachineReadableCodeObject.cs
+++ b/src/AVFoundation/AVMetadataMachineReadableCodeObject.cs
@@ -38,7 +38,6 @@ namespace AVFoundation {
 		///           <para>(More documentation for this node is coming)</para>
 		///           <para tool="nullallowed">This value can be <see langword="null" />.</para>
 		///         </value>
-		///         <remarks>To be added.</remarks>
 		public CGPoint []? Corners {
 			get {
 				var arr = WeakCorners;

--- a/src/CFNetwork/CFHTTPMessage.cs
+++ b/src/CFNetwork/CFHTTPMessage.cs
@@ -286,7 +286,6 @@ namespace CFNetwork {
 
 		// convenience enum on top of kCFHTTPAuthenticationScheme* fields
 		/// <summary>An enumeration whose values specify HTTP authentication schemes.</summary>
-		///     <remarks>To be added.</remarks>
 		public enum AuthenticationScheme {
 			Default,
 			Basic,

--- a/src/CFNetwork/CFHTTPMessage.cs
+++ b/src/CFNetwork/CFHTTPMessage.cs
@@ -16,7 +16,6 @@ using CoreFoundation;
 
 namespace CFNetwork {
 	/// <summary>An HTTP message.</summary>
-	///     <remarks>To be added.</remarks>
 	public partial class CFHTTPMessage : CFType {
 		[Preserve (Conditional = true)]
 		internal CFHTTPMessage (NativeHandle handle, bool owns)

--- a/src/CallKit/CXProvider.cs
+++ b/src/CallKit/CXProvider.cs
@@ -18,7 +18,6 @@ namespace CallKit {
 		///         <param name="callUuid">The identifier of the call for which to return pending call actions.</param>
 		///         <summary>Returns a list of the actions of class <typeparamref name="T" /> that have yet to be completed on the call that is identified by <paramref name="callUuid" />.</summary>
 		///         <returns>A list of the actions of type <typeparamref name="T" /> that have yet to be completed on the call that is identified by <paramref name="callUuid" />.</returns>
-		///         <remarks>To be added.</remarks>
 		public CXCallAction [] GetPendingCallActions<T> (NSUuid callUuid)
 		{
 			return GetPendingCallActions (new Class (typeof (T)), callUuid);

--- a/src/CarPlay/CPNavigationAlert.cs
+++ b/src/CarPlay/CPNavigationAlert.cs
@@ -14,7 +14,6 @@ namespace CarPlay {
 		// Defined inside CPNavigationAlert.h
 		// static NSTimeInterval const CPNavigationAlertMinimumDuration = 5;
 		/// <summary>A constant that specifies the minimum amnount of time an alert is visible.</summary>
-		///         <remarks>To be added.</remarks>
 		public const double MinimumDuration = 5;
 	}
 }

--- a/src/CarPlay/CPNavigationAlert.cs
+++ b/src/CarPlay/CPNavigationAlert.cs
@@ -13,7 +13,7 @@ namespace CarPlay {
 	public partial class CPNavigationAlert {
 		// Defined inside CPNavigationAlert.h
 		// static NSTimeInterval const CPNavigationAlertMinimumDuration = 5;
-		/// <summary>A constant that specifies the minimum amnount of time an alert is visible.</summary>
+		/// <summary>A constant that specifies the minimum amount of time an alert is visible.</summary>
 		public const double MinimumDuration = 5;
 	}
 }

--- a/src/ClassKit/CLSContext.cs
+++ b/src/ClassKit/CLSContext.cs
@@ -14,7 +14,6 @@ namespace ClassKit {
 
 		/// <summary>Gets or sets the topic that the content of the context covers.</summary>
 		///         <value>The topic that the content of the context covers.</value>
-		///         <remarks>To be added.</remarks>
 		public CLSContextTopic Topic {
 			get => CLSContextTopicExtensions.GetValue (WeakTopic);
 			set => WeakTopic = value.GetConstant ();

--- a/src/CoreData/NSPersistentStoreCoordinator.cs
+++ b/src/CoreData/NSPersistentStoreCoordinator.cs
@@ -1,7 +1,6 @@
 
 namespace CoreData {
 	/// <summary>Mediates between a persistent store and the managed object context or contexts.</summary>
-	///     <remarks>To be added.</remarks>
 	///     <related type="externalDocumentation" href="https://developer.apple.com/library/ios/documentation/Cocoa/Reference/CoreDataFramework/Classes/NSPersistentStoreCoordinator_Class/index.html">Apple documentation for <c>NSPersistentStoreCoordinator</c></related>
 	public partial class NSPersistentStoreCoordinator {
 #if !__TVOS__

--- a/src/EventKit/EKEnums.cs
+++ b/src/EventKit/EKEnums.cs
@@ -363,23 +363,23 @@ namespace EventKit {
 
 	[Native]
 	public enum EKParticipantScheduleStatus : long {
-		/// <summary>To be added.</summary>
+		/// <summary>No scheduling status.</summary>
 		None,
-		/// <summary>To be added.</summary>
+		/// <summary>The schedule request is pending.</summary>
 		Pending,
-		/// <summary>To be added.</summary>
+		/// <summary>The schedule request has been sent.</summary>
 		Sent,
-		/// <summary>To be added.</summary>
+		/// <summary>The schedule request was delivered successfully.</summary>
 		Delivered,
-		/// <summary>To be added.</summary>
+		/// <summary>The recipient was not recognized.</summary>
 		RecipientNotRecognized,
-		/// <summary>To be added.</summary>
+		/// <summary>The sender does not have sufficient privileges.</summary>
 		NoPrivileges,
-		/// <summary>To be added.</summary>
+		/// <summary>The delivery of the schedule request failed.</summary>
 		DeliveryFailed,
-		/// <summary>To be added.</summary>
+		/// <summary>The schedule request cannot be delivered.</summary>
 		CannotDeliver,
-		/// <summary>To be added.</summary>
+		/// <summary>The recipient is not allowed to receive schedule requests.</summary>
 		RecipientNotAllowed,
 	}
 

--- a/src/EventKit/EKEnums.cs
+++ b/src/EventKit/EKEnums.cs
@@ -385,13 +385,13 @@ namespace EventKit {
 
 	[Native]
 	public enum EKReminderPriority : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>No priority set.</summary>
 		None = 0,
-		/// <summary>To be added.</summary>
+		/// <summary>High priority.</summary>
 		High = 1,
-		/// <summary>To be added.</summary>
+		/// <summary>Medium priority.</summary>
 		Medium = 5,
-		/// <summary>To be added.</summary>
+		/// <summary>Low priority.</summary>
 		Low = 9,
 	}
 

--- a/src/Foundation/NSDateComponents.cs
+++ b/src/Foundation/NSDateComponents.cs
@@ -2,7 +2,6 @@
 namespace Foundation {
 	public partial class NSDateComponents {
 		/// <summary>Reprsents a date component that is undefined.</summary>
-		///         <remarks>To be added.</remarks>
 		public static readonly nint Undefined = nint.MaxValue;
 	}
 }

--- a/src/Foundation/NSDateComponents.cs
+++ b/src/Foundation/NSDateComponents.cs
@@ -1,7 +1,7 @@
 
 namespace Foundation {
 	public partial class NSDateComponents {
-		/// <summary>Reprsents a date component that is undefined.</summary>
+		/// <summary>Represents a date component that is undefined.</summary>
 		public static readonly nint Undefined = nint.MaxValue;
 	}
 }

--- a/src/Foundation/NSMutableUrlRequest.cs
+++ b/src/Foundation/NSMutableUrlRequest.cs
@@ -3,7 +3,7 @@ namespace Foundation {
 	public partial class NSUrlRequest {
 		/// <param name="key">HTTP Header Name.</param>
 		/// <summary>Gets the value of the specified HTTP header.</summary>
-		/// <value>To be added.</value>
+		/// <value>The value of the specified HTTP header, or <see langword="null" /> if the header is not set.</value>
 		/// <remarks>
 		///           <example>
 		///             <code lang="csharp lang-csharp"><![CDATA[

--- a/src/HealthKit/HKSampleQuery.cs
+++ b/src/HealthKit/HKSampleQuery.cs
@@ -5,7 +5,6 @@ namespace HealthKit {
 		// #define HKObjectQueryNoLimit (0)
 		// in iOS 9.3 SDK this was changed to `static const NSUInteger`
 		/// <summary>Indicates to not limit the number of returned results.</summary>
-		///         <remarks>To be added.</remarks>
 		public const int NoLimit = 0;
 	}
 }

--- a/src/HealthKit/HKUnit.cs
+++ b/src/HealthKit/HKUnit.cs
@@ -3,7 +3,6 @@
 namespace HealthKit {
 	public partial class HKUnit {
 		/// <summary>The molecular mass of blood glucose. Read-only.</summary>
-		///         <remarks>To be added.</remarks>
 		public const double MolarMassBloodGlucose = 180.15588000005408;
 	}
 }

--- a/src/Photos/PHLivePhoto.cs
+++ b/src/Photos/PHLivePhoto.cs
@@ -7,7 +7,6 @@ namespace Photos {
 	public partial class PHLivePhoto {
 
 		/// <summary>An error constant that indicates that a provided request ID was invalid.</summary>
-		///         <remarks>To be added.</remarks>
 		public const int RequestIdInvalid = 0;
 	}
 }

--- a/src/SceneKit/SCNAnimatable.cs
+++ b/src/SceneKit/SCNAnimatable.cs
@@ -17,7 +17,6 @@ namespace SceneKit {
 		/// <param name="animation">The animation to add.</param>
 		///         <param name="key">The animation key.</param>
 		///         <summary>Adds <paramref name="animation" />, identified with the specified <paramref name="key" />.</summary>
-		///         <remarks>To be added.</remarks>
 		public void AddAnimation (CAAnimation animation, string? key = null)
 		{
 			var nskey = key is null ? null : new NSString (key);

--- a/src/SystemConfiguration/NetworkReachability.cs
+++ b/src/SystemConfiguration/NetworkReachability.cs
@@ -20,7 +20,6 @@ namespace SystemConfiguration {
 
 	// SCNetworkReachabilityFlags -> uint32_t -> SCNetworkReachability.h
 	/// <summary>The reachability status.</summary>
-	///     <remarks>To be added.</remarks>
 	[Flags]
 	public enum NetworkReachabilityFlags {
 		/// <summary>The host is reachable using a transient connection (PPP for example).</summary>

--- a/src/UIKit/UIBarButtonItem.cs
+++ b/src/UIKit/UIBarButtonItem.cs
@@ -71,7 +71,6 @@ namespace UIKit {
 		EventHandler? clicked;
 
 		/// <summary>This event is raised when the user clicks/taps on this UIBarButtonItem.</summary>
-		/// <remarks>To be added.</remarks>
 		public event EventHandler Clicked {
 			add {
 				if (clicked is null) {

--- a/src/UIKit/UIDocumentBrowserViewController.cs
+++ b/src/UIKit/UIDocumentBrowserViewController.cs
@@ -41,7 +41,6 @@ namespace UIKit {
 		/// <param name="documentUrl">The document URL for which to get a transition controller.</param>
 		///         <summary>Creates and returns a transition controller for the document at the specified URL.</summary>
 		///         <returns>Developers should only specify values for <paramref name="documentUrl" /> that were obtained from the document browser.</returns>
-		///         <remarks>To be added.</remarks>
 		public virtual UIDocumentBrowserTransitionController GetTransitionController (NSUrl documentUrl)
 		{
 			if (CheckSystemVersion ())


### PR DESCRIPTION
Improve XML documentation for 20 types (mostly removing empty `<remarks>` nodes):

- **EKParticipantScheduleStatus**: Improve enum member descriptions
- **EKReminderPriority**: Improve enum member descriptions
- **CFHTTPMessage**: Remove empty `<remarks>` node
- **CFHTTPMessage.AuthenticationScheme**: Remove empty `<remarks>` node
- **AVAudioPlayer**: Remove empty `<remarks>` node
- **AVAudioSessionPortDescription**: Remove empty `<remarks>` node
- **AVMetadataMachineReadableCodeObject**: Remove empty `<remarks>` node
- **CXProvider**: Remove empty `<remarks>` node
- **CPNavigationAlert**: Remove empty `<remarks>` node
- **CLSContext**: Remove empty `<remarks>` node
- **NSPersistentStoreCoordinator**: Remove empty `<remarks>` node
- **NSDateComponents**: Remove empty `<remarks>` node
- **NSUrlRequest**: Fix summary grammar
- **HKSampleQuery**: Remove empty `<remarks>` node
- **HKUnit**: Remove empty `<remarks>` node
- **PHLivePhoto**: Remove empty `<remarks>` node
- **SCNAnimatable**: Remove empty `<remarks>` node
- **NetworkReachability**: Remove empty `<remarks>` node
- **UIBarButtonItem**: Remove empty `<remarks>` node
- **UIDocumentBrowserViewController**: Remove empty `<remarks>` node

Total: 45 changed lines (14 insertions, 31 deletions)

🤖 Pull request created by Copilot