### PR TITLE
[ci] Fix /apply-gist to read gists unauthenticated (the Actions token can't).

### DIFF
--- a/.github/workflows/apply-gist.yml
+++ b/.github/workflows/apply-gist.yml
@@ -91,6 +91,7 @@ jobs:
           const resp = await fetch(`https://api.github.com/gists/${process.env.GIST_ID}`, {
             headers: {
               'Accept': 'application/vnd.github+json',
+              'X-GitHub-Api-Version': '2022-11-28',
               'User-Agent': 'dotnet-macios-apply-gist',
             },
           });
@@ -145,7 +146,10 @@ jobs:
 
         # Download gist metadata to get file URLs. The Gists API isn't accessible to the
         # GitHub Actions token (a GitHub App installation token), so fetch it unauthenticated.
-        GIST_JSON=$(curl -sSL -H "Accept: application/vnd.github+json" -H "User-Agent: dotnet-macios-apply-gist" "https://api.github.com/gists/$GIST_ID")
+        if ! GIST_JSON=$(curl -fSL -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "User-Agent: dotnet-macios-apply-gist" "https://api.github.com/gists/$GIST_ID"); then
+            echo "Failed to fetch gist '$GIST_ID' (404/403/rate limit?)." >&2
+            exit 1
+        fi
         echo "$GIST_JSON" | python3 -c "
         import json, sys, urllib.request, os, re
 

--- a/.github/workflows/apply-gist.yml
+++ b/.github/workflows/apply-gist.yml
@@ -96,7 +96,8 @@ jobs:
             },
           });
           if (!resp.ok) {
-            core.setFailed(`Failed to fetch gist '${process.env.GIST_ID}': ${resp.status} ${resp.statusText}`);
+            const body = await resp.text().catch(() => '');
+            core.setFailed(`Failed to fetch gist '${process.env.GIST_ID}': ${resp.status} ${resp.statusText}${body ? `\n${body}` : ''}`);
             return;
           }
           const gist = await resp.json();

--- a/.github/workflows/apply-gist.yml
+++ b/.github/workflows/apply-gist.yml
@@ -85,9 +85,20 @@ jobs:
             'vs-mobiletools-engineering-service2',
           ];
 
-          const { data: gist } = await github.rest.gists.get({
-            gist_id: process.env.GIST_ID,
+          // The Gists API isn't accessible to the GitHub Actions token (a GitHub App
+          // installation token), so fetch the gist unauthenticated instead. Secret gists
+          // are readable by anyone who knows the id, which is all we need here.
+          const resp = await fetch(`https://api.github.com/gists/${process.env.GIST_ID}`, {
+            headers: {
+              'Accept': 'application/vnd.github+json',
+              'User-Agent': 'dotnet-macios-apply-gist',
+            },
           });
+          if (!resp.ok) {
+            core.setFailed(`Failed to fetch gist '${process.env.GIST_ID}': ${resp.status} ${resp.statusText}`);
+            return;
+          }
+          const gist = await resp.json();
           if (!gist.owner) {
             core.setFailed('Gist has no owner (anonymous or deleted). Cannot verify ownership.');
             return;
@@ -127,14 +138,14 @@ jobs:
     - name: Download and apply gist files
       env:
         GIST_ID: ${{ steps.parse.outputs.gist_id }}
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         EXPECTED_DIR="tests/dotnet/UnitTests/expected"
         mkdir -p "$EXPECTED_DIR"
         export EXPECTED_DIR
 
-        # Download gist metadata to get file URLs
-        GIST_JSON=$(gh api "gists/$GIST_ID")
+        # Download gist metadata to get file URLs. The Gists API isn't accessible to the
+        # GitHub Actions token (a GitHub App installation token), so fetch it unauthenticated.
+        GIST_JSON=$(curl -sSL -H "Accept: application/vnd.github+json" -H "User-Agent: dotnet-macios-apply-gist" "https://api.github.com/gists/$GIST_ID")
         echo "$GIST_JSON" | python3 -c "
         import json, sys, urllib.request, os, re
 


### PR DESCRIPTION

The `/apply-gist` workflow read the gist via the GitHub REST Gists API using the
default `GITHUB_TOKEN`, which is a GitHub App installation token. That token can't
access the Gists API at all, so the "Validate gist owner" step failed with
`403 Resource not accessible by integration` and the workflow never applied the
files.

Secret gists are readable by anyone who knows the id without authentication, so
this fetches the gist metadata unauthenticated (a plain `fetch`/`curl` against
`api.github.com`) in both the owner-validation and download steps. This keeps the
approved-owner security check intact and needs no additional secrets.

Note: `issue_comment` workflows always run from the default branch, so `/apply-gist`
only picks up this fix once it's merged to `main`.

🤖 Pull request created by Copilot