### PR TITLE
[docs] Improve XML docs for UIImage, UIView, and 11 other types

### DIFF
--- a/src/CoreAnimation/CALayer.cs
+++ b/src/CoreAnimation/CALayer.cs
@@ -143,8 +143,7 @@ namespace CoreAnimation {
 		}
 
 		/// <summary>Gets the contents format for the layer.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <value>The format used for the layer's contents.</value>
 		[SupportedOSPlatform ("tvos")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]

--- a/src/CoreImage/CIColor.cs
+++ b/src/CoreImage/CIColor.cs
@@ -17,9 +17,8 @@ using UIKit;
 namespace CoreImage {
 	public partial class CIColor {
 
-		/// <summary>Gets the color components, including the alpha channel if it is present, as an array of floating point numbers that are each in the range [0,1].</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets the color components, including the alpha channel if present, as an array of floating point numbers in the range [0,1].</summary>
+		/// <value>An array of color component values.</value>
 		public nfloat [] Components {
 			get {
 				var n = NumberOfComponents;

--- a/src/CoreML/MLDictionaryFeatureProvider.cs
+++ b/src/CoreML/MLDictionaryFeatureProvider.cs
@@ -13,9 +13,8 @@ namespace CoreML {
 	public partial class MLDictionaryFeatureProvider {
 
 		/// <param name="featureName">The feature name of the requested value.</param>
-		/// <summary>Retrieves the <see cref="CoreML.MLFeatureValue" /> for the specified <paramref name="featureName" />.</summary>
-		/// <value>To be added.</value>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Retrieves the <see cref="MLFeatureValue" /> for the specified <paramref name="featureName" />.</summary>
+		/// <value>The feature value associated with the specified name, or <see langword="null" /> if not found.</value>
 		public MLFeatureValue? this [string featureName] {
 			get { return GetFeatureValue (featureName); }
 		}

--- a/src/CoreML/MLMultiArrayConstraint.cs
+++ b/src/CoreML/MLMultiArrayConstraint.cs
@@ -12,8 +12,7 @@
 namespace CoreML {
 	public partial class MLMultiArrayConstraint {
 		/// <summary>Gets an array of array dimensions for the multidimensional arrays.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <value>An array of dimension sizes.</value>
 		public nint [] Shape {
 			get {
 				return MLMultiArray.ConvertArray (_Shape);

--- a/src/Foundation/NSUndoManager.cs
+++ b/src/Foundation/NSUndoManager.cs
@@ -13,8 +13,7 @@
 namespace Foundation {
 	public partial class NSUndoManager {
 		/// <summary>Returns the modes governing the types of input handled during a cycle of the run loop.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <value>An array of run loop modes in which the undo manager accepts undo and redo operations.</value>
 		public NSRunLoopMode [] RunLoopModes {
 			get {
 				var modes = WeakRunLoopModes;

--- a/src/HomeKit/HMActionSet.cs
+++ b/src/HomeKit/HMActionSet.cs
@@ -3,9 +3,8 @@
 namespace HomeKit {
 
 	partial class HMActionSet {
-		/// <summary>What kind of <see cref="HomeKit.HMActionSetType" /><c>this</c> is&gt;.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets the type of this action set.</summary>
+		/// <value>The <see cref="HMActionSetType" /> that this action set belongs to.</value>
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("tvos")]
 		[SupportedOSPlatform ("maccatalyst")]

--- a/src/ReplayKit/RPBroadcastConfiguration.cs
+++ b/src/ReplayKit/RPBroadcastConfiguration.cs
@@ -39,12 +39,8 @@ using AVFoundation;
 
 namespace ReplayKit {
 	public partial class RPBroadcastConfiguration {
-		/// <summary>To be added.</summary>
-		///         <value>
-		///           <para>(More documentation for this node is coming)</para>
-		///           <para tool="nullallowed">This value can be <see langword="null" />.</para>
-		///         </value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets or sets the video compression properties for the broadcast.</summary>
+		/// <value>The video compression settings, or <see langword="null" /> if not set.</value>
 		public AVVideoCodecSettings? VideoCompressionProperties {
 			get {
 				var weak = WeakVideoCompressionProperties;

--- a/src/Security/Policy.cs
+++ b/src/Security/Policy.cs
@@ -35,7 +35,6 @@ using CoreFoundation;
 namespace Security {
 
 	/// <summary>Encapsulates a security policy. A policy comprises a set of rules that specify how to evaluate a certificate for a certain level of trust.</summary>
-	///     <remarks>To be added.</remarks>
 	public partial class SecPolicy : NativeObject {
 		[Preserve (Conditional = true)]
 		internal SecPolicy (NativeHandle handle, bool owns)
@@ -73,7 +72,7 @@ namespace Security {
 		}
 
 		/// <summary>Type identifier for the Security.SecPolicy type.</summary>
-		///         <returns>To be added.</returns>
+		///         <returns>The Core Foundation type identifier for <see cref="SecPolicy" />.</returns>
 		///         <remarks>
 		///           <para>The returned token is the CoreFoundation type identifier (CFType) that has been assigned to this class.</para>
 		///           <para>This can be used to determine type identity between different CoreFoundation objects.</para>

--- a/src/UIKit/UIImage.cs
+++ b/src/UIKit/UIImage.cs
@@ -23,7 +23,6 @@ namespace UIKit {
 		/// <param name="image">The image saved.</param>
 		///     <param name="error">Errors, if any.</param>
 		///     <summary>A delegate signature for getting a notification when the file has been saved.</summary>
-		///     <remarks>To be added.</remarks>
 		public delegate void SaveStatus (UIImage image, NSError error);
 
 		[DllImport (Constants.UIKitLibrary)]

--- a/src/UIKit/UIView.cs
+++ b/src/UIKit/UIView.cs
@@ -246,7 +246,7 @@ namespace UIKit {
 
 		/// <param name="afterScreenUpdates">If <see langword="true" />, the capture occurs after screen updating has finished.</param>
 		///         <summary>Performs a screen-capture of the <see cref="UIKit.UIView" />.</summary>
-		///         <returns><see langword="true" /> if the snapshot was captured successfully; otherwise, <see langword="false" />.</returns>
+		///         <returns>A <see cref="UIKit.UIImage" /> containing the captured snapshot of the view.</returns>
 		///         <remarks>
 		///           <para>This method is slower than <see cref="UIKit.UIView.SnapshotView(System.Boolean)" />.</para>
 		///         </remarks>

--- a/src/UIKit/UIView.cs
+++ b/src/UIKit/UIView.cs
@@ -246,7 +246,7 @@ namespace UIKit {
 
 		/// <param name="afterScreenUpdates">If <see langword="true" />, the capture occurs after screen updating has finished.</param>
 		///         <summary>Performs a screen-capture of the <see cref="UIKit.UIView" />.</summary>
-		///         <returns>To be added.</returns>
+		///         <returns><see langword="true" /> if the snapshot was captured successfully; otherwise, <see langword="false" />.</returns>
 		///         <remarks>
 		///           <para>This method is slower than <see cref="UIKit.UIView.SnapshotView(System.Boolean)" />.</para>
 		///         </remarks>

--- a/src/VideoToolbox/VTCompressionSession.cs
+++ b/src/VideoToolbox/VTCompressionSession.cs
@@ -18,7 +18,6 @@ using CoreVideo;
 
 namespace VideoToolbox {
 	/// <summary>Turns uncompressed frames into compressed video frames</summary>
-	///     <remarks>To be added.</remarks>
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("maccatalyst")]

--- a/src/VideoToolbox/VTDecompressionSession.cs
+++ b/src/VideoToolbox/VTDecompressionSession.cs
@@ -88,7 +88,7 @@ namespace VideoToolbox {
 
 
 		/// <summary>Create a new <see cref="VTDecompressionSession" /> instance.</summary>
-		/// <param name="outputCallback">To be added.</param>
+		/// <param name="outputCallback">The callback to invoke when a frame has been decompressed.</param>
 		/// <param name="formatDescription">A format description for the source video frames.</param>
 		/// <param name="decoderSpecification">Optionally specify which decoder to use</param>
 		/// <param name="destinationImageBufferAttributes">Optionally specify any requirements for the decoded frames.</param>

--- a/src/Vision/VNRequest.cs
+++ b/src/Vision/VNRequest.cs
@@ -14,7 +14,7 @@ namespace Vision {
 
 		/// <typeparam name="T">The subclass of <see cref="Vision.VNObservation" /> produced.</typeparam>
 		///         <summary>Gets the detected objects, as an array of the specified subclass of <see cref="Vision.VNObservation" />.</summary>
-		///         <returns>To be added.</returns>
+		///         <returns>An array of detected observations of type <typeparamref name="T" />, or <see langword="null" /> if the request has not been processed.</returns>
 		///         <remarks>
 		///           <para>The following example shows how one might retrieve the results of a <see cref="Vision.VNDetectFaceRectanglesRequest" />:</para>
 		///           <example>

--- a/src/Vision/VNRequest.cs
+++ b/src/Vision/VNRequest.cs
@@ -14,7 +14,7 @@ namespace Vision {
 
 		/// <typeparam name="T">The subclass of <see cref="Vision.VNObservation" /> produced.</typeparam>
 		///         <summary>Gets the detected objects, as an array of the specified subclass of <see cref="Vision.VNObservation" />.</summary>
-		///         <returns>An array of detected observations of type <typeparamref name="T" />, or <see langword="null" /> if the request has not been processed.</returns>
+		///         <returns>An array of detected observations of type <typeparamref name="T" />, or <see langword="null" /> if the request has not been processed or failed.</returns>
 		///         <remarks>
 		///           <para>The following example shows how one might retrieve the results of a <see cref="Vision.VNDetectFaceRectanglesRequest" />:</para>
 		///           <example>


### PR DESCRIPTION
Improve XML documentation for 13 types (removing empty nodes, fixing summaries):

- **UIImage**: Remove empty `<remarks>` node
- **UIView**: Fix summary
- **VTCompressionSession**: Remove empty `<remarks>` node
- **VTDecompressionSession**: Fix summary
- **VNRequest**: Fix summary
- **SecPolicy**: Remove empty `<remarks>` node, fix summary
- **RPBroadcastConfiguration**: Remove empty nodes
- **HMActionSet**: Remove empty nodes
- **CALayer**: Remove empty `<remarks>` node
- **CIColor**: Remove empty nodes
- **MLDictionaryFeatureProvider**: Remove empty nodes
- **MLMultiArrayConstraint**: Remove empty nodes
- **NSUndoManager**: Remove empty nodes

Total: 43 changed lines (15 insertions, 28 deletions)

🤖 Pull request created by Copilot