### PR TITLE
[dotnet] Add Xcode 27.0 packages for .NET 10.

### DIFF
--- a/Make.versions
+++ b/Make.versions
@@ -125,7 +125,12 @@ SUPPORTED_API_VERSIONS_TVOS+=net10.0-26.0
 SUPPORTED_API_VERSIONS_MACOS+=net10.0-26.0
 SUPPORTED_API_VERSIONS_MACCATALYST+=net10.0-26.0
 
-# Add beta versions here!
+# Add beta versions here! (using BETA_API_VERSIONS_* variables)
+
+BETA_API_VERSIONS_IOS+=net10.0-27.0
+BETA_API_VERSIONS_TVOS+=net10.0-27.0
+BETA_API_VERSIONS_MACOS+=net10.0-27.0
+BETA_API_VERSIONS_MACCATALYST+=net10.0-27.0
 
 # Don't change these (even if there aren't any beta versions)!
 

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -18,15 +18,19 @@ This file should be imported by eng/Versions.props
     <MicrosoftTemplateEngineAuthoringTasksPackageVersion>10.0.400-preview.26360.120</MicrosoftTemplateEngineAuthoringTasksPackageVersion>
     <!-- dotnet-macios dependencies -->
     <MicrosoftiOSSdknet100_260PackageVersion>26.0.11017</MicrosoftiOSSdknet100_260PackageVersion>
+    <MicrosoftiOSSdknet100_270PackageVersion>27.0.10241-xcode27.0</MicrosoftiOSSdknet100_270PackageVersion>
     <MicrosoftiOSSdknet90_185PackageVersion>18.5.9227</MicrosoftiOSSdknet90_185PackageVersion>
     <MicrosoftiOSSdknet90_265PackageVersion>26.5.9004</MicrosoftiOSSdknet90_265PackageVersion>
     <MicrosoftMacCatalystSdknet100_260PackageVersion>26.0.11017</MicrosoftMacCatalystSdknet100_260PackageVersion>
+    <MicrosoftMacCatalystSdknet100_270PackageVersion>27.0.10241-xcode27.0</MicrosoftMacCatalystSdknet100_270PackageVersion>
     <MicrosoftMacCatalystSdknet90_185PackageVersion>18.5.9227</MicrosoftMacCatalystSdknet90_185PackageVersion>
     <MicrosoftMacCatalystSdknet90_265PackageVersion>26.5.9004</MicrosoftMacCatalystSdknet90_265PackageVersion>
     <MicrosoftmacOSSdknet100_260PackageVersion>26.0.11017</MicrosoftmacOSSdknet100_260PackageVersion>
+    <MicrosoftmacOSSdknet100_270PackageVersion>27.0.10241-xcode27.0</MicrosoftmacOSSdknet100_270PackageVersion>
     <MicrosoftmacOSSdknet90_155PackageVersion>15.5.9227</MicrosoftmacOSSdknet90_155PackageVersion>
     <MicrosoftmacOSSdknet90_265PackageVersion>26.5.9004</MicrosoftmacOSSdknet90_265PackageVersion>
     <MicrosofttvOSSdknet100_260PackageVersion>26.0.11017</MicrosofttvOSSdknet100_260PackageVersion>
+    <MicrosofttvOSSdknet100_270PackageVersion>27.0.10241-xcode27.0</MicrosofttvOSSdknet100_270PackageVersion>
     <MicrosofttvOSSdknet90_185PackageVersion>18.5.9227</MicrosofttvOSSdknet90_185PackageVersion>
     <MicrosofttvOSSdknet90_265PackageVersion>26.5.9004</MicrosofttvOSSdknet90_265PackageVersion>
     <!-- dotnet-xharness dependencies -->
@@ -52,15 +56,19 @@ This file should be imported by eng/Versions.props
     <MicrosoftTemplateEngineAuthoringTasksVersion>$(MicrosoftTemplateEngineAuthoringTasksPackageVersion)</MicrosoftTemplateEngineAuthoringTasksVersion>
     <!-- dotnet-macios dependencies -->
     <MicrosoftiOSSdknet100_260Version>$(MicrosoftiOSSdknet100_260PackageVersion)</MicrosoftiOSSdknet100_260Version>
+    <MicrosoftiOSSdknet100_270Version>$(MicrosoftiOSSdknet100_270PackageVersion)</MicrosoftiOSSdknet100_270Version>
     <MicrosoftiOSSdknet90_185Version>$(MicrosoftiOSSdknet90_185PackageVersion)</MicrosoftiOSSdknet90_185Version>
     <MicrosoftiOSSdknet90_265Version>$(MicrosoftiOSSdknet90_265PackageVersion)</MicrosoftiOSSdknet90_265Version>
     <MicrosoftMacCatalystSdknet100_260Version>$(MicrosoftMacCatalystSdknet100_260PackageVersion)</MicrosoftMacCatalystSdknet100_260Version>
+    <MicrosoftMacCatalystSdknet100_270Version>$(MicrosoftMacCatalystSdknet100_270PackageVersion)</MicrosoftMacCatalystSdknet100_270Version>
     <MicrosoftMacCatalystSdknet90_185Version>$(MicrosoftMacCatalystSdknet90_185PackageVersion)</MicrosoftMacCatalystSdknet90_185Version>
     <MicrosoftMacCatalystSdknet90_265Version>$(MicrosoftMacCatalystSdknet90_265PackageVersion)</MicrosoftMacCatalystSdknet90_265Version>
     <MicrosoftmacOSSdknet100_260Version>$(MicrosoftmacOSSdknet100_260PackageVersion)</MicrosoftmacOSSdknet100_260Version>
+    <MicrosoftmacOSSdknet100_270Version>$(MicrosoftmacOSSdknet100_270PackageVersion)</MicrosoftmacOSSdknet100_270Version>
     <MicrosoftmacOSSdknet90_155Version>$(MicrosoftmacOSSdknet90_155PackageVersion)</MicrosoftmacOSSdknet90_155Version>
     <MicrosoftmacOSSdknet90_265Version>$(MicrosoftmacOSSdknet90_265PackageVersion)</MicrosoftmacOSSdknet90_265Version>
     <MicrosofttvOSSdknet100_260Version>$(MicrosofttvOSSdknet100_260PackageVersion)</MicrosofttvOSSdknet100_260Version>
+    <MicrosofttvOSSdknet100_270Version>$(MicrosofttvOSSdknet100_270PackageVersion)</MicrosofttvOSSdknet100_270Version>
     <MicrosofttvOSSdknet90_185Version>$(MicrosofttvOSSdknet90_185PackageVersion)</MicrosofttvOSSdknet90_185Version>
     <MicrosofttvOSSdknet90_265Version>$(MicrosofttvOSSdknet90_265PackageVersion)</MicrosofttvOSSdknet90_265Version>
     <!-- dotnet-xharness dependencies -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -93,6 +93,23 @@
       <Uri>https://github.com/dotnet/macios</Uri>
       <Sha>23eb1c2c9465fe76c810c8a69982c1254161f4b0</Sha>
     </Dependency>
+    <!-- This is a subscription of the .NET 10/Xcode 27.0 versions of our packages -->
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_27.0" Version="27.0.10241-xcode27.0">
+      <Uri>https://github.com/dotnet/macios</Uri>
+      <Sha>6807aae9f1f542afdcca3552940930793cb9ae7f</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.macOS.Sdk.net10.0_27.0" Version="27.0.10241-xcode27.0">
+      <Uri>https://github.com/dotnet/macios</Uri>
+      <Sha>6807aae9f1f542afdcca3552940930793cb9ae7f</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.iOS.Sdk.net10.0_27.0" Version="27.0.10241-xcode27.0">
+      <Uri>https://github.com/dotnet/macios</Uri>
+      <Sha>6807aae9f1f542afdcca3552940930793cb9ae7f</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_27.0" Version="27.0.10241-xcode27.0">
+      <Uri>https://github.com/dotnet/macios</Uri>
+      <Sha>6807aae9f1f542afdcca3552940930793cb9ae7f</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="10.0.0-beta.26360.120">


### PR DESCRIPTION
This can be selected by doing this in the csproj:

```xml
<TargetFramework>net10.0-ios27.0</TargetFramework>
<NoWarn>$(NoWarn);XCODE_27_0_PREVIEW</NoWarn>
```