### PR TITLE
[tools] Skip resource stripping for (hot) reloadable assemblies. Fixes #26076

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -699,6 +699,7 @@
 				IntermediateOutputPath=$(DeviceSpecificIntermediateOutputPath)
 				InvariantGlobalization=$(InvariantGlobalization)
 				HybridGlobalization=$(HybridGlobalization)
+				HotReloadCompatibleBuild=$(HotReloadCompatibleBuild)
 				ItemsDirectory=$(_LinkerItemsDirectory)
 				IsAppExtension=$(IsAppExtension)
 				IsSimulatorBuild=$(_SdkIsSimulator)

--- a/tests/assembly-preparer/BaseClass.cs
+++ b/tests/assembly-preparer/BaseClass.cs
@@ -44,12 +44,11 @@ public abstract class BaseClass {
 	// returns true if the test assembly was modified
 	public bool AssertPrepareCode (ApplePlatform platform, bool isCoreCLR, Action<AssemblyPreparer>? configure, string code, out string outputPath)
 	{
-		var preparer = CreatePreparer (platform, isCoreCLR, configure, code, out var testInfo);
+		using var preparer = CreatePreparer (platform, isCoreCLR, configure, code, out var testInfo);
 		AssertPrepare (preparer);
 
 		outputPath = testInfo.OutputPath;
 		Console.WriteLine ("Output assembly: " + outputPath);
-		preparer.Dispose ();
 		return testInfo.InputPath != testInfo.OutputPath;
 	}
 

--- a/tests/assembly-preparer/BaseClass.cs
+++ b/tests/assembly-preparer/BaseClass.cs
@@ -44,6 +44,19 @@ public abstract class BaseClass {
 	// returns true if the test assembly was modified
 	public bool AssertPrepareCode (ApplePlatform platform, bool isCoreCLR, Action<AssemblyPreparer>? configure, string code, out string outputPath)
 	{
+		var preparer = CreatePreparer (platform, isCoreCLR, configure, code, out var testInfo);
+		AssertPrepare (preparer);
+
+		outputPath = testInfo.OutputPath;
+		Console.WriteLine ("Output assembly: " + outputPath);
+		preparer.Dispose ();
+		return testInfo.InputPath != testInfo.OutputPath;
+	}
+
+	// Builds the provided code into a Test.dll and returns an AssemblyPreparer configured for it, without
+	// running any preparation steps. Use this when a test needs to run a custom set of steps.
+	public AssemblyPreparer CreatePreparer (ApplePlatform platform, bool isCoreCLR, Action<AssemblyPreparer>? configure, string code, out AssemblyPreparerInfo testInfo, string extraCsproj = "", string extraConfig = "", IEnumerable<(string FileName, byte [] Content)>? extraFiles = null)
+	{
 		Configuration.IgnoreIfIgnoredPlatform (platform);
 
 		var csproj = $@"
@@ -53,10 +66,16 @@ public abstract class BaseClass {
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<UseFloatingTargetPlatformVersion>true</UseFloatingTargetPlatformVersion>
 	</PropertyGroup>
+	{extraCsproj}
 </Project>
     ";
 
 		var tmpdir = Xamarin.Cache.CreateTemporaryDirectory ();
+
+		if (extraFiles is not null) {
+			foreach (var extraFile in extraFiles)
+				File.WriteAllBytes (Path.Combine (tmpdir, extraFile.FileName), extraFile.Content);
+		}
 
 		var config = $@"
 		AreAnyAssembliesTrimmed=true
@@ -67,6 +86,7 @@ public abstract class BaseClass {
 		SdkDevPath={Configuration.XcodeLocation}
 		SdkVersion={Configuration.GetSdkVersion (platform)}
 		TargetFramework={TargetFramework.GetTargetFramework (platform)}
+		{extraConfig}
 		";
 		var configpath = Path.Combine (tmpdir, "config.txt");
 		File.WriteAllText (configpath, config);
@@ -87,12 +107,8 @@ public abstract class BaseClass {
 		var preparer = new AssemblyPreparer (logger, infos, configpath);
 		if (configure is not null)
 			configure (preparer);
-		AssertPrepare (preparer);
 
-		var testInfo = infos.Single (v => Path.GetFileNameWithoutExtension (v.InputPath) == "Test");
-		outputPath = testInfo.OutputPath;
-		Console.WriteLine ("Output assembly: " + outputPath);
-		preparer.Dispose ();
-		return testInfo.InputPath != testInfo.OutputPath;
+		testInfo = infos.Single (v => Path.GetFileNameWithoutExtension (v.InputPath) == "Test");
+		return preparer;
 	}
 }

--- a/tests/assembly-preparer/RemoveUserResourcesSubStepTests.cs
+++ b/tests/assembly-preparer/RemoveUserResourcesSubStepTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text;
+
+using MonoTouch.Tuner;
+
+using Xamarin.Linker;
+
+namespace AssemblyPreparerTests;
+
+public class RemoveUserResourcesSubStepTests : BaseClass {
+	static string GetContentPrefix (ApplePlatform platform)
+	{
+		switch (platform) {
+		case ApplePlatform.iOS:
+		case ApplePlatform.TVOS:
+		case ApplePlatform.MacCatalyst:
+			return "__monotouch_content_";
+		case ApplePlatform.MacOSX:
+			return "__xammac_content_";
+		default:
+			throw new NotImplementedException (platform.ToString ());
+		}
+	}
+
+	// Builds a user assembly with an embedded MonoTouch/XamMac content resource, then runs the
+	// RemoveUserResourcesSubStep with the provided value of HotReloadCompatibleBuild and returns the
+	// resource names still present in the (in-memory) assembly after the step ran.
+	List<string> GetResourcesAfterStep (ApplePlatform platform, bool isCoreCLR, bool hotReloadCompatibleBuild)
+	{
+		var prefix = GetContentPrefix (platform);
+		var resourceName = prefix + "TestResource.bin";
+		var content = Encoding.UTF8.GetBytes ("This is an embedded user resource.");
+
+		var extraCsproj = $@"
+	<ItemGroup>
+		<EmbeddedResource Include=""TestResource.bin"">
+			<LogicalName>{resourceName}</LogicalName>
+		</EmbeddedResource>
+	</ItemGroup>";
+
+		var code = @"
+		using Foundation;
+		class MyClass : NSObject {
+		}";
+
+		var extraConfig = $"HotReloadCompatibleBuild={(hotReloadCompatibleBuild ? "true" : "false")}";
+
+		using var preparer = CreatePreparer (platform, isCoreCLR, p => p.Registrar = RegistrarMode.Dynamic, code, out var testInfo, extraCsproj: extraCsproj, extraConfig: extraConfig, extraFiles: new [] { ("TestResource.bin", content) });
+
+		var context = preparer.Configuration.DerivedLinkContext;
+		new LoadAssembliesStep ().Process (context);
+		new RemoveUserResourcesSubStep ().Process (context);
+
+		var testAssembly = context.GetAssemblies ().Single (v => v.Name.Name == "Test");
+		return testAssembly.MainModule.Resources.Select (v => v.Name).ToList ();
+	}
+
+	[Test]
+	[TestCase (ApplePlatform.iOS, false)]
+	[TestCase (ApplePlatform.TVOS, false)]
+	[TestCase (ApplePlatform.MacCatalyst, false)]
+	[TestCase (ApplePlatform.MacOSX, true)]
+	public void ResourceRemovedByDefault (ApplePlatform platform, bool isCoreCLR)
+	{
+		var prefix = GetContentPrefix (platform);
+		var resources = GetResourcesAfterStep (platform, isCoreCLR, hotReloadCompatibleBuild: false);
+		Assert.That (resources, Has.None.StartsWith (prefix), "The user resource should be stripped when HotReloadCompatibleBuild is disabled.");
+	}
+
+	[Test]
+	[TestCase (ApplePlatform.iOS, false)]
+	[TestCase (ApplePlatform.TVOS, false)]
+	[TestCase (ApplePlatform.MacCatalyst, false)]
+	[TestCase (ApplePlatform.MacOSX, true)]
+	public void ResourceKeptForHotReload (ApplePlatform platform, bool isCoreCLR)
+	{
+		var prefix = GetContentPrefix (platform);
+		var resourceName = prefix + "TestResource.bin";
+		var resources = GetResourcesAfterStep (platform, isCoreCLR, hotReloadCompatibleBuild: true);
+
+		// The resource must be left untouched: the step must not remove it (and thus not upgrade the
+		// user assembly to AssemblyAction.Save, which is what would break Hot Reload).
+		Assert.That (resources, Has.Some.EqualTo (resourceName), "The user resource must be kept when HotReloadCompatibleBuild is enabled.");
+	}
+}

--- a/tools/dotnet-linker/LinkerConfiguration.cs
+++ b/tools/dotnet-linker/LinkerConfiguration.cs
@@ -37,6 +37,9 @@ namespace Xamarin.Linker {
 		public string IntermediateLinkDir { get; private set; } = string.Empty;
 		public bool InvariantGlobalization { get; private set; }
 		public bool HybridGlobalization { get; private set; }
+		// The value of the $(HotReloadCompatibleBuild) MSBuild property. When enabled, steps that
+		// re-serialize user assemblies (breaking Hot Reload) must leave reloadable assemblies untouched.
+		public bool HotReloadCompatibleBuild { get; private set; }
 		public InlineDlfcnMethodsMode InlineDlfcnMethods { get; set; }
 		public bool InlineDlfcnMethodsEnabled => InlineDlfcnMethods != InlineDlfcnMethodsMode.Disabled;
 		public InlineClassGetHandleMode InlineClassGetHandle { get; set; }
@@ -349,6 +352,10 @@ namespace Xamarin.Linker {
 				{ "FrameworkAssembly", (
 					new LoadValue ((key, value) => FrameworkAssemblies.Add (value)),
 					new SaveValue ((key, storage) => storage.AddRange (FrameworkAssemblies.OrderBy (v => v).Select (v => $"{key}={v}")))
+				)},
+				{ "HotReloadCompatibleBuild", (
+					new LoadValue ((key, value) => HotReloadCompatibleBuild = string.Equals ("true", value, StringComparison.OrdinalIgnoreCase)),
+					new SaveValue ((key, storage) => saveOptionalDefaultFalseBool (key, HotReloadCompatibleBuild, storage))
 				)},
 				{ "InlineDlfcnMethods", (
 					new LoadValue ((key, value) => {

--- a/tools/linker/RemoveUserResourcesSubStep.cs
+++ b/tools/linker/RemoveUserResourcesSubStep.cs
@@ -84,6 +84,11 @@ namespace Xamarin.Linker {
 		bool ModifyAssembly (AssemblyDefinition assembly)
 #endif
 		{
+			// Skipping resource stripping keeps the user assembly byte-identical (avoids the Copy -> Save
+			// upgrade below), which is required for Hot Reload to work with reloadable (user) assemblies.
+			if (Configuration.HotReloadCompatibleBuild)
+				return false;
+
 			if (App.Profile.IsProductAssembly (assembly) || App.Profile.IsSdkAssembly (assembly))
 				return false;
 

--- a/tools/linker/RemoveUserResourcesSubStep.cs
+++ b/tools/linker/RemoveUserResourcesSubStep.cs
@@ -74,6 +74,12 @@ namespace Xamarin.Linker {
 #else
 		protected override void Process (AssemblyDefinition assembly)
 		{
+			// In Hot Reload compatible builds, don't strip resources from reloadable (non-linked) assemblies,
+			// because doing so would upgrade the assembly from Copy to Save below, re-serializing it and
+			// breaking Hot Reload. Linked assemblies are re-saved regardless, so stripping them is fine.
+			if (Configuration.HotReloadCompatibleBuild && Annotations.GetAction (assembly) != AssemblyAction.Link)
+				return;
+
 			var modified = ModifyAssembly (assembly);
 
 			// we'll need to save (if we're not linking) this assembly
@@ -84,10 +90,12 @@ namespace Xamarin.Linker {
 		bool ModifyAssembly (AssemblyDefinition assembly)
 #endif
 		{
-			// Skipping resource stripping keeps the user assembly byte-identical (avoids the Copy -> Save
-			// upgrade below), which is required for Hot Reload to work with reloadable (user) assemblies.
+#if ASSEMBLY_PREPARER
+			// In the assembly-preparer any modification re-serializes (saves) the assembly, which breaks Hot
+			// Reload. So skip resource stripping entirely for Hot Reload compatible builds.
 			if (Configuration.HotReloadCompatibleBuild)
 				return false;
+#endif
 
 			if (App.Profile.IsProductAssembly (assembly) || App.Profile.IsSdkAssembly (assembly))
 				return false;


### PR DESCRIPTION
`RemoveUserResourcesSubStep` strips embedded MonoTouch/XamMac content/page
resources (and native libraries listed in `[LinkWith]`) from user assemblies.
To do so it upgrades the user assembly from `AssemblyAction.Copy` to `Save`,
which re-serializes the assembly and breaks Hot Reload.

## Approach

When `$(HotReloadCompatibleBuild)` is enabled, skip resource stripping for
user (reloadable) assemblies. Since the step already only ever touches user
assemblies, an early return at the top of `ModifyAssembly` cleanly "skips
reloadable assemblies" and avoids the `Copy -> Save` upgrade, leaving the
assembly byte-identical. Release builds don't enable the property, so their
app size is unaffected. The embedded resources stay in the app for Hot Reload
builds, a minor app-size cost limited to that configuration.

The fix works in both compilation modes the step is built into (the
`ExceptionalSubStep` used by the dotnet-linker and the `AssemblyModifierStep`
used by the assembly-preparer); both expose `Configuration`.

## Property plumbing

This issue depends on #26072, which introduces the `$(HotReloadCompatibleBuild)`
MSBuild property. That isn't merged yet, so this PR includes the minimal
self-contained plumbing needed to consume it: a `HotReloadCompatibleBuild`
value on `LinkerConfiguration` plus passing it through `_CustomLinkerOptions`
(which feeds both the trimmer and the assembly-preparer). The property's
canonical default value and documentation are intentionally left to #26072,
so this change is dormant until the property is actually set. Expect a trivial
merge conflict with the sibling PR for #26075, which touches the same plumbing.

## Testing

Added `RemoveUserResourcesSubStepTests` in the assembly-preparer test suite: it
builds a user assembly with an embedded content resource and verifies the
resource is stripped by default but kept when `HotReloadCompatibleBuild=true`,
across iOS, tvOS, Mac Catalyst and macOS.

Fixes https://github.com/dotnet/macios/issues/26076

🤖 Pull request created by Copilot