### PR TITLE
[BackgroundTasks] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/backgroundtasks.cs
+++ b/src/backgroundtasks.cs
@@ -77,6 +77,9 @@ namespace BackgroundTasks {
 	interface BGProcessingTask {
 	}
 
+	[NoMac, iOS (27, 0), TV (27, 0), MacCatalyst (27, 0)]
+	delegate void BGTaskSchedulerSubmitCompletionHandler ([NullAllowed] NSError error);
+
 	[NoMac]
 	[MacCatalyst (13, 1)]
 	[BaseType (typeof (NSObject))]
@@ -90,8 +93,16 @@ namespace BackgroundTasks {
 		[Export ("registerForTaskWithIdentifier:usingQueue:launchHandler:")]
 		bool Register (string identifier, [NullAllowed] DispatchQueue queue, Action<BGTask> launchHandler);
 
+		[Deprecated (PlatformName.iOS, 27, 0, message: "Use 'Submit (BGTaskRequest, BGTaskSchedulerSubmitCompletionHandler)' instead to capture all error conditions.")]
+		[Deprecated (PlatformName.TvOS, 27, 0, message: "Use 'Submit (BGTaskRequest, BGTaskSchedulerSubmitCompletionHandler)' instead to capture all error conditions.")]
+		[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use 'Submit (BGTaskRequest, BGTaskSchedulerSubmitCompletionHandler)' instead to capture all error conditions.")]
 		[Export ("submitTaskRequest:error:")]
 		bool Submit (BGTaskRequest taskRequest, [NullAllowed] out NSError error);
+
+		[iOS (27, 0), TV (27, 0), MacCatalyst (27, 0)]
+		[Async]
+		[Export ("submitTaskRequest:completionHandler:")]
+		void Submit (BGTaskRequest taskRequest, BGTaskSchedulerSubmitCompletionHandler completionHandler);
 
 		[Export ("cancelTaskRequestWithIdentifier:")]
 		void Cancel (string identifier);
@@ -109,7 +120,13 @@ namespace BackgroundTasks {
 		BGContinuedProcessingTaskRequestResources SupportedResources { get; }
 	}
 
-	[TV (17, 0), NoMac, iOS (17, 0), MacCatalyst (17, 0)]
+#if XAMCORE_5_0
+	[NoTV]
+#else
+	[TV (17, 0)]
+	[Obsoleted (PlatformName.TvOS, 27, 0, message: "This type is not available on tvOS 27.0 or later.")]
+#endif
+	[NoMac, iOS (17, 0), MacCatalyst (17, 0)]
 	[BaseType (typeof (BGProcessingTask))]
 	interface BGHealthResearchTask { }
 

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -14673,7 +14673,9 @@ M:BackgroundTasks.BGTaskScheduler.CancelAll
 M:BackgroundTasks.BGTaskScheduler.GetPending(System.Action{BackgroundTasks.BGTaskRequest[]})
 M:BackgroundTasks.BGTaskScheduler.GetPendingAsync
 M:BackgroundTasks.BGTaskScheduler.Register(System.String,CoreFoundation.DispatchQueue,System.Action{BackgroundTasks.BGTask})
+M:BackgroundTasks.BGTaskScheduler.Submit(BackgroundTasks.BGTaskRequest,BackgroundTasks.BGTaskSchedulerSubmitCompletionHandler)
 M:BackgroundTasks.BGTaskScheduler.Submit(BackgroundTasks.BGTaskRequest,Foundation.NSError@)
+M:BackgroundTasks.BGTaskScheduler.SubmitAsync(BackgroundTasks.BGTaskRequest)
 M:BrowserEngineCore.BEAudioSession.#ctor(AVFoundation.AVAudioSession)
 M:BrowserEngineCore.BEAudioSession.SetPreferredOutput(AVFoundation.AVAudioSessionPortDescription,Foundation.NSError@)
 M:BrowserEngineKit.BEAccessibilityRemoteElement.#ctor(System.String,System.Int32)
@@ -57661,6 +57663,7 @@ T:BackgroundTasks.BGTask
 T:BackgroundTasks.BGTaskRequest
 T:BackgroundTasks.BGTaskScheduler
 T:BackgroundTasks.BGTaskSchedulerErrorCode
+T:BackgroundTasks.BGTaskSchedulerSubmitCompletionHandler
 T:BrowserEngineCore.BEAudioSession
 T:BrowserEngineKit.BEAccessibilityContainerType
 T:BrowserEngineKit.BEAccessibilityNotification

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-BackgroundTasks.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-BackgroundTasks.todo
@@ -1,1 +1,0 @@
-!missing-selector! BGTaskScheduler::submitTaskRequest:completionHandler: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-BackgroundTasks.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-BackgroundTasks.todo
@@ -1,2 +1,0 @@
-!deprecated-attribute-missing! BGTaskScheduler::submitTaskRequest:error: missing a [Deprecated] attribute
-!missing-selector! BGTaskScheduler::submitTaskRequest:completionHandler: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-BackgroundTasks.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-BackgroundTasks.todo
@@ -1,3 +1,0 @@
-!deprecated-attribute-missing! BGTaskScheduler::submitTaskRequest:error: missing a [Deprecated] attribute
-!missing-selector! BGTaskScheduler::submitTaskRequest:completionHandler: not bound
-!unknown-type! BGHealthResearchTask bound


### PR DESCRIPTION
## Summary

- bind the Xcode 27 completion-handler `BGTaskScheduler.Submit` API and its generated async overload
- deprecate the synchronous submit API and mark `BGHealthResearchTask` unavailable starting with tvOS 27 while preserving compatibility
- remove the resolved BackgroundTasks xtro todo files and update the documentation baseline

## Testing

- `make world`
- clean xtro generation and classification
- clean cecil test run (116 total)
- introspection: iOS 27 (44/44), tvOS 27 (43/43), macOS (32/32)
- Mac Catalyst unaffected fixtures passed; the full run reproduced the unrelated known `CLLocationButton` TCC crash
- app-size suite completed with all cases skipped as expected for beta Xcode