### PR TITLE
[linker] Trim [ProtocolMember] attributes with trimmable-static + PrepareAssemblies

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -817,6 +817,15 @@
 			<RuntimeHostConfigurationOption Include="ObjCRuntime.Runtime.Arch.IsSimulator" Value="$(_IsSimulatorFeature)" Trim="true" />
 			<RuntimeHostConfigurationOption Include="ObjCRuntime.Runtime.IsManagedStaticRegistrar" Value="$(_IsManagedStaticRegistrarFeature)" Trim="true" />
 			<RuntimeHostConfigurationOption Include="ObjCRuntime.Runtime.IsTrimmableStaticRegistrar" Value="$(_IsTrimmableStaticRegistrarFeature)" Trim="true" />
+			<!--
+				When using the trimmable static registrar together with PrepareAssemblies, we can tell the trimmer to
+				remove the [ProtocolMember] attributes. This makes it possible to trim away types that are only
+				referenced from these attributes (such as generic types in optional protocol members).
+				The assembly-preparer's post-processing pass still needs these attributes (it runs the registrar again
+				after the trimmer), so it reads them from the pre-trim (prepared) assemblies instead.
+				See src/TrimAttributes.LinkDescription.xml and tools/assembly-preparer/AssemblyPreparer.cs.
+			-->
+			<RuntimeHostConfigurationOption Include="ObjCRuntime.TrimProtocolMemberAttributes" Value="true" Trim="true" Condition="'$(Registrar)' == 'trimmable-static' And '$(PrepareAssemblies)' == 'true'" />
 			<RuntimeHostConfigurationOption Include="ObjCRuntime.Runtime.IsNativeAOT" Value="$(_IsNativeAOTFeature)" Trim="true" />
 			<RuntimeHostConfigurationOption Include="ObjCRuntime.Runtime.IsCoreCLR" Value="true" Trim="true" Condition="'$(UseMonoRuntime)' != 'true'" />
 			<RuntimeHostConfigurationOption Include="ObjCRuntime.Runtime.IsCoreCLR" Value="false" Trim="true" Condition="'$(UseMonoRuntime)' == 'true'" />

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/PrepareAssemblies.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/PrepareAssemblies.cs
@@ -38,6 +38,10 @@ namespace Xamarin.MacDev.Tasks {
 
 		public bool PostProcessing { get; set; }
 
+		// The pre-trim (untrimmed) assemblies (the trimmer's input), used during post-processing to read
+		// the [ProtocolMember] attributes the trimmer removed from the post-trim assemblies.
+		public ITaskItem [] PreTrimAssemblies { get; set; } = [];
+
 		#region Outputs
 		[Output]
 		public ITaskItem [] OutputAssemblies { get; set; } = [];
@@ -66,6 +70,7 @@ namespace Xamarin.MacDev.Tasks {
 				var infos = InputAssemblies.Select (GetAssemblyInfo).ToArray ();
 				using var preparer = new AssemblyPreparer (this, infos, OptionsFile?.ItemSpec ?? "");
 				preparer.MakeReproPath = MakeReproPath;
+				preparer.PreTrimAssemblies.AddRange (PreTrimAssemblies.Select (v => v.ItemSpec));
 				bool rv;
 				List<ProductException> exceptions;
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -3628,6 +3628,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			OptionsFile="$(_CustomLinkerOptionsFile)"
 			OutputDirectory="$(_PostprocessedAssembliesDirectory)"
 			Postprocessing="true"
+			PreTrimAssemblies="@(ManagedAssemblyToLink)"
 			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
 		>
 			<Output TaskParameter="OutputAssemblies" ItemName="_PostProcessedAssemblies" />

--- a/src/TrimAttributes.LinkDescription.xml
+++ b/src/TrimAttributes.LinkDescription.xml
@@ -302,6 +302,20 @@
     </type>
   </assembly>
 
+  <!--
+    When using the trimmable static registrar together with PrepareAssemblies, the [ProtocolMember] attributes are only
+    consumed by the assembly-preparer's registrar (not by any runtime code), so the trimmer no longer needs them and can
+    remove them. Removing them here (as opposed to in our custom RemoveAttributesStep, which runs after the mark step)
+    means the trimmer won't mark the types referenced from these attributes, so those types can be trimmed away as well
+    (for instance generic types used only in optional protocol members). The assembly-preparer's post-processing pass
+    (which runs the registrar again after the trimmer) reads these attributes from the pre-trim assemblies instead.
+  -->
+  <assembly fullname="*" feature="ObjCRuntime.TrimProtocolMemberAttributes" featurevalue="true">
+    <type fullname="Foundation.ProtocolMemberAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+  </assembly>
+
   <!-- Suppress the IL2026 warning from System.StartupHookProvider.ProcessStartupHooks when we're the ones enabling StartupHookSupport -->
   <assembly fullname="System.Private.CoreLib" feature="ObjCRuntime.SuppressStartupHookTrimWarning" featurevalue="true">
     <type fullname="System.StartupHookProvider">

--- a/tests/common/test-variations.csproj
+++ b/tests/common/test-variations.csproj
@@ -194,6 +194,7 @@
 
 	<PropertyGroup Condition="$(_TestVariationForComparison.Contains('|prepare-assemblies|'))">
 		<PrepareAssemblies>true</PrepareAssemblies>
+		<DefineConstants>$(DefineConstants);PREPARE_ASSEMBLIES</DefineConstants>
 		<_TestVariationApplied>true</_TestVariationApplied>
 	</PropertyGroup>
 

--- a/tests/linker/link all/LinkAllTest.cs
+++ b/tests/linker/link all/LinkAllTest.cs
@@ -496,12 +496,19 @@ namespace LinkAll {
 #endif
 		}
 
+#if PREPARE_ASSEMBLIES
+		// https://github.com/dotnet/macios/issues/11280
+		// When using the trimmable static registrar together with PrepareAssemblies, the [ProtocolMember] attributes
+		// are only needed by the assembly-preparer's registrar (not at runtime), so the trimmer is told to remove
+		// them. This means the trimmer won't mark the types referenced from these attributes, so a generic type that's
+		// only referenced from an optional protocol member (like NSSet<T> below) can be trimmed away.
 		[Test]
-		[Ignore ("BUG https://github.com/dotnet/macios/issues/11280")]
 		public void LinkedAwayGenericTypeAsOptionalMemberInProtocol ()
 		{
+			if (!global::XamarinTests.ObjCRuntime.Registrar.IsTrimmableStaticRegistrar)
+				Assert.Ignore ("This test only applies to the trimmable static registrar.");
+
 			// https://github.com/dotnet/macios/issues/3523
-			// This test will fail at build time if it regresses (usually these types of build tests go into monotouch-test, but monotouch-test uses NSSet<T> elsewhere, which this test requires to be linked away).
 			Assert.That (typeof (NSObject).Assembly.GetType (NamespacePrefix + "Foundation.NSSet`1"), Is.Null, "NSSet<T> must be linked away, otherwise this test is useless");
 		}
 
@@ -512,6 +519,7 @@ namespace LinkAll {
 		internal sealed class ProtocolWithGenericsInOptionalMemberWrapper : BaseWrapper, IProtocolWithGenericsInOptionalMember {
 			public ProtocolWithGenericsInOptionalMemberWrapper (IntPtr handle, bool owns) : base (handle, owns) { }
 		}
+#endif // PREPARE_ASSEMBLIES
 
 		[Test]
 		public void NoFatCorlib ()

--- a/tools/assembly-preparer/AssemblyPreparer.cs
+++ b/tools/assembly-preparer/AssemblyPreparer.cs
@@ -340,6 +340,6 @@ class PreTrimAssemblyResolver : Xamarin.Bundler.CoreResolver {
 			if (loaded is not null)
 				return loaded;
 		}
-		throw new NotImplementedException ($"Unable to resolve the pre-trim assembly reference {name}");
+		throw new AssemblyResolutionException (name);
 	}
 }

--- a/tools/assembly-preparer/AssemblyPreparer.cs
+++ b/tools/assembly-preparer/AssemblyPreparer.cs
@@ -28,6 +28,12 @@ public class AssemblyPreparer : IDisposable {
 
 	public string MakeReproPath { get; set; } = "";
 
+	// The pre-trim (untrimmed) assemblies. Used during post-processing with the trimmable static
+	// registrar to read [ProtocolMember] attributes that the trimmer has removed. This is the complete
+	// set of assemblies that were fed into the trimmer (ILLink's input), so it forms a self-contained
+	// metadata universe separate from the post-trim assemblies.
+	public List<string> PreTrimAssemblies { get; } = new List<string> ();
+
 	public RegistrarMode Registrar {
 		get => configuration.Application.Registrar;
 		set => configuration.Application.Registrar = value;
@@ -164,9 +170,29 @@ public class AssemblyPreparer : IDisposable {
 		return RunSteps (steps, out exceptions);
 	}
 
+	// Load the pre-trim (untrimmed) assemblies so the trimmable static registrar can read the
+	// [ProtocolMember] attributes the trimmer removed from the post-trim assemblies. The pre-trim
+	// assemblies are loaded into their own resolver (a separate, self-contained metadata universe from
+	// the post-trim assemblies), and stored on the Application for the registrar to consult. There's no
+	// fallback to the post-trim resolver: the pre-trim set is complete (it's the trimmer's input), and
+	// falling back would mix the two universes and resolve trimmed-away references incorrectly.
+	void LoadPreTrimAssemblies ()
+	{
+		if (PreTrimAssemblies.Count == 0)
+			return;
+
+		if (configuration.Application.Registrar != RegistrarMode.TrimmableStatic)
+			return;
+
+		var resolver = new PreTrimAssemblyResolver (configuration.Logger, PreTrimAssemblies);
+		configuration.Application.PreTrimAssemblyResolver = resolver;
+	}
+
 	public bool PostProcess (out List<ProductException> exceptions)
 	{
 		configuration.Application.IsPostProcessingAssemblies = true;
+
+		LoadPreTrimAssemblies ();
 
 		var steps = new ConfigurationAwareStep [] {
 			// All the same steps as the custom trimmer steps that are run after sweeping in Xamarin.Shared.Sdk.targets (and in the same order).
@@ -287,5 +313,33 @@ public class AssemblyPreparerInfo {
 		OutputPath = outputPath;
 		IsTrimmable = isTrimmable;
 		TrimMode = trimMode;
+	}
+}
+
+// A resolver for the pre-trim (untrimmed) assemblies. It's given the complete set of assemblies that
+// were fed into the trimmer (ILLink's input), so it forms a self-contained metadata universe: it loads
+// assemblies lazily from that set on demand and never falls back to the post-trim resolver (which would
+// mix the two universes and resolve trimmed-away references incorrectly).
+class PreTrimAssemblyResolver : Xamarin.Bundler.CoreResolver {
+	readonly IToolLog log;
+	readonly Dictionary<string, string> paths = new Dictionary<string, string> ();
+
+	public PreTrimAssemblyResolver (IToolLog log, IEnumerable<string> assemblyPaths)
+	{
+		this.log = log;
+		foreach (var path in assemblyPaths)
+			paths [Path.GetFileNameWithoutExtension (path)] = path;
+	}
+
+	public override AssemblyDefinition Resolve (AssemblyNameReference name, ReaderParameters parameters)
+	{
+		if (cache.TryGetValue (name.Name, out var assembly))
+			return assembly;
+		if (paths.TryGetValue (name.Name, out var path)) {
+			var loaded = Load (log, path);
+			if (loaded is not null)
+				return loaded;
+		}
+		throw new NotImplementedException ($"Unable to resolve the pre-trim assembly reference {name}");
 	}
 }

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -84,6 +84,11 @@ namespace Xamarin.Bundler {
 #if ASSEMBLY_PREPARER
 		public bool InCustomTrimmerStep = false;
 		public bool IsPostProcessingAssemblies;
+		// When post-processing assemblies with the trimmable static registrar, the [ProtocolMember] attributes
+		// have been removed by the trimmer, so the registrar reads them from the pre-trim (untrimmed) assemblies
+		// instead. This resolver provides access to the pre-trim assemblies (a separate metadata universe from
+		// the post-trim assemblies), and is null when not applicable.
+		public Mono.Cecil.IAssemblyResolver? PreTrimAssemblyResolver;
 #else
 		public bool InCustomTrimmerStep = true;
 		public bool IsPostProcessingAssemblies => PrepareAssemblies && InCustomTrimmerStep;

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -1530,6 +1530,20 @@ namespace Registrar {
 		protected override IEnumerable<ProtocolMemberAttribute> GetProtocolMemberAttributes (TypeReference type)
 		{
 			var td = type.Resolve ();
+			if (td is null)
+				yield break;
+
+#if ASSEMBLY_PREPARER
+			// When post-processing assemblies with the trimmable static registrar, the [ProtocolMember]
+			// attributes have been removed by the trimmer, so read them from the pre-trim (untrimmed)
+			// assemblies instead.
+			if (App.IsPostProcessingAssemblies && App.PreTrimAssemblyResolver is not null) {
+				var preTrimAssembly = App.PreTrimAssemblyResolver.Resolve (td.Module.Assembly.Name);
+				var preTrimType = preTrimAssembly?.MainModule.GetType (td.FullName);
+				if (preTrimType is not null)
+					td = preTrimType;
+			}
+#endif
 
 			foreach (var ca in GetCustomAttributes (td, Foundation, StringConstants.ProtocolMemberAttribute)) {
 				var rv = new ProtocolMemberAttribute ();


### PR DESCRIPTION
When using the trimmable static registrar together with PrepareAssemblies, the
[ProtocolMember] attributes are only consumed by the assembly-preparer's registrar,
not by any runtime code. This means we can tell the trimmer to remove them, which in
turn lets the trimmer trim away any types that are only referenced from these
attributes (for instance generic types used only in optional protocol members, like
NSSet<T>).

The catch is that the assembly-preparer runs the registrar again in its post-processing
pass, which runs *after* the trimmer, so by then the attributes are gone. To handle
this, the post-processing registrar reads the [ProtocolMember] attributes from the
pre-trim (untrimmed) assemblies instead. The pre-trim assemblies (the trimmer's input,
i.e. @(ManagedAssemblyToLink)) are loaded into their own self-contained resolver, a
separate metadata universe from the post-trim assemblies with no cross-resolution.

Also re-adds the LinkedAwayGenericTypeAsOptionalMemberInProtocol test (removed earlier
because the pattern was no longer trimmed), gated on the new PREPARE_ASSEMBLIES compile
define so it only runs in the prepare-assemblies test variations.

Fixes #11280

Copilot-Session: 37c85f10-1fe0-4940-8465-1c7b980d8ded