### PR TITLE
[docs] Improve XML docs for MPSImageScale, NEFilterFlow, and 11 other types

### DIFF
--- a/src/AVFoundation/AVAssetTrack.cs
+++ b/src/AVFoundation/AVAssetTrack.cs
@@ -6,8 +6,7 @@ namespace AVFoundation {
 		/// <summary>
 		/// An array of <see cref="CoreMedia.CMFormatDescription" />s that describe the formats of the samples in the <see cref="AVFoundation.AVAssetTrack" />.
 		/// </summary>
-		/// <value>To be added.</value>
-		/// <remarks>To be added.</remarks>
+		/// <value>An array of format descriptions for this track.</value>
 		public CMFormatDescription [] FormatDescriptions {
 			get {
 				return (Array.ConvertAll (FormatDescriptionsAsObjects,

--- a/src/AVFoundation/AVContentKeyResponse.cs
+++ b/src/AVFoundation/AVContentKeyResponse.cs
@@ -15,9 +15,8 @@ namespace AVFoundation {
 	public partial class AVContentKeyResponse {
 
 		/// <param name="fairPlayStreamingKeyResponseData">The Fair Play key data from which to create a response.</param>
-		///         <summary>Creates and returns a new response object from the provided key data.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Creates and returns a new response object from the provided key data.</summary>
+		/// <returns>A new <see cref="AVContentKeyResponse" /> created from the specified key data.</returns>
 		public static AVContentKeyResponse Create (NSData fairPlayStreamingKeyResponseData) => Create (fairPlayStreamingKeyResponseData, AVContentKeyResponseDataType.FairPlayStreamingKeyResponseData);
 
 		public static AVContentKeyResponse Create (NSData data, AVContentKeyResponseDataType dataType = AVContentKeyResponseDataType.FairPlayStreamingKeyResponseData)

--- a/src/AVFoundation/AVPlayerLayer.cs
+++ b/src/AVFoundation/AVPlayerLayer.cs
@@ -14,8 +14,7 @@ using CoreVideo;
 namespace AVFoundation {
 	public partial class AVPlayerLayer {
 		/// <summary>Gets or sets the attributes of the client visual buffer.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <value>The pixel buffer attributes, or <see langword="null" /> if none are set.</value>
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("maccatalyst")]

--- a/src/AppKit/NSActionCell.cs
+++ b/src/AppKit/NSActionCell.cs
@@ -36,8 +36,7 @@ namespace AppKit {
 		NSObject? target;
 		Selector? action;
 
-		/// <summary>To be added.</summary>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Occurs when the cell is activated by the user.</summary>
 		public event EventHandler Activated {
 			add {
 				target = ActionDispatcher.SetupAction (Target, value);

--- a/src/AppKit/NSColorPickerTouchBarItem.cs
+++ b/src/AppKit/NSColorPickerTouchBarItem.cs
@@ -8,8 +8,7 @@ namespace AppKit {
 		NSObject? target;
 		Selector? action;
 
-		/// <summary>To be added.</summary>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Occurs when the color picker is activated by the user.</summary>
 		public event EventHandler Activated {
 			add {
 				target = ActionDispatcher.SetupAction (Target, value);

--- a/src/AppKit/NSControl.cs
+++ b/src/AppKit/NSControl.cs
@@ -37,8 +37,7 @@ namespace AppKit {
 		NSObject? target;
 		Selector? action;
 
-		/// <summary>To be added.</summary>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Occurs when the control is activated by the user.</summary>
 		public event EventHandler Activated {
 			add {
 				target = ActionDispatcher.SetupAction (Target, value);

--- a/src/AppKit/NSPasteboardReading.cs
+++ b/src/AppKit/NSPasteboardReading.cs
@@ -3,8 +3,7 @@
 #nullable enable
 
 namespace AppKit {
-	/// <summary>To be added.</summary>
-	///     <remarks>To be added.</remarks>
+	/// <summary>Provides methods for reading data from the pasteboard.</summary>
 	public partial interface INSPasteboardReading {
 		[BindingImpl (BindingImplOptions.Optimizable)]
 		public unsafe static T? CreateInstance<T> (NSObject propertyList, NSPasteboardType type) where T : NSObject, INSPasteboardReading

--- a/src/AppKit/NSSliderTouchBarItem.cs
+++ b/src/AppKit/NSSliderTouchBarItem.cs
@@ -8,8 +8,7 @@ namespace AppKit {
 		NSObject? target;
 		Selector? action;
 
-		/// <summary>To be added.</summary>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Occurs when the slider value is changed by the user.</summary>
 		public event EventHandler Activated {
 			add {
 				target = ActionDispatcher.SetupAction (Target, value);

--- a/src/AppKit/NSToolbarItem.cs
+++ b/src/AppKit/NSToolbarItem.cs
@@ -13,8 +13,7 @@ namespace AppKit {
 		NSObject? target;
 		Selector? action;
 
-		/// <summary>To be added.</summary>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Occurs when the toolbar item is activated by the user.</summary>
 		public event EventHandler Activated {
 			add {
 				target = ActionDispatcher.SetupAction (Target, value);

--- a/src/AudioUnit/AUParameter.cs
+++ b/src/AudioUnit/AUParameter.cs
@@ -3,9 +3,8 @@
 namespace AudioUnit {
 	public partial class AUParameter {
 		/// <param name="value">The parameter value to represent as a string.</param>
-		///         <summary>Returns the string representation of the parameter value that corresponds to <paramref name="value" />.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Returns the string representation of the parameter value that corresponds to <paramref name="value" />.</summary>
+		/// <returns>A string representation of the specified parameter value, or the current value if <paramref name="value" /> is <see langword="null" />.</returns>
 		public string GetString (float? value)
 		{
 			unsafe {

--- a/src/MetalPerformanceShaders/MPSImageScale.cs
+++ b/src/MetalPerformanceShaders/MPSImageScale.cs
@@ -9,12 +9,8 @@ namespace MetalPerformanceShaders {
 	public partial class MPSImageScale {
 		static int size_of_scale_transform = Marshal.SizeOf<MPSScaleTransform> ();
 
-		/// <summary>To be added.</summary>
-		///         <value>
-		///           <para>(More documentation for this node is coming)</para>
-		///           <para tool="nullallowed">This value can be <see langword="null" />.</para>
-		///         </value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets or sets the scale transform applied to the image.</summary>
+		/// <value>The scale transform, or <see langword="null" /> if no transform is set.</value>
 		public virtual MPSScaleTransform? ScaleTransform {
 			get {
 				var ptr = _GetScaleTransform ();

--- a/src/NetworkExtension/NEFilterFlow.cs
+++ b/src/NetworkExtension/NEFilterFlow.cs
@@ -7,8 +7,7 @@ namespace NetworkExtension {
 	public partial class NEFilterFlow {
 
 		// NEFilterFlowBytesMax define
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>The maximum number of bytes that can be used for filter flow operations.</summary>
 		public const ulong MaxBytes = ulong.MaxValue;
 	}
 }

--- a/src/VideoSubscriberAccount/VSAccountManager.cs
+++ b/src/VideoSubscriberAccount/VSAccountManager.cs
@@ -30,7 +30,7 @@ namespace VideoSubscriberAccount {
 		}
 
 		/// <summary>Asynchronously checks whether the user has provided permission for the app to access their subscription information.</summary>
-		/// <param name="accessOptions">The options to use when checking access status.</param>
+		/// <param name="accessOptions">If not empty, may specify whether the user should be asked for access permission.</param>
 		/// <returns>A task that represents the asynchronous operation. The task result contains the current <see cref="VSAccountAccessStatus" />.</returns>
 		public Task<VSAccountAccessStatus> CheckAccessStatusAsync (VSAccountManagerAccessOptions accessOptions)
 		{

--- a/src/VideoSubscriberAccount/VSAccountManager.cs
+++ b/src/VideoSubscriberAccount/VSAccountManager.cs
@@ -30,8 +30,8 @@ namespace VideoSubscriberAccount {
 		}
 
 		/// <summary>Asynchronously checks whether the user has provided permission for the app to access their subscription information.</summary>
-		/// <param name="accessOptions">To be added.</param>
-		/// <returns>To be added.</returns>
+		/// <param name="accessOptions">The options to use when checking access status.</param>
+		/// <returns>A task that represents the asynchronous operation. The task result contains the current <see cref="VSAccountAccessStatus" />.</returns>
 		public Task<VSAccountAccessStatus> CheckAccessStatusAsync (VSAccountManagerAccessOptions accessOptions)
 		{
 			if (accessOptions is null)


### PR DESCRIPTION
Improve XML documentation for 13 types (removing empty nodes, fixing summaries):

- **MPSImageScale**: Remove empty nodes
- **NEFilterFlow**: Remove empty nodes
- **VSAccountManager**: Fix summary
- **NSActionCell**: Remove empty nodes
- **NSColorPickerTouchBarItem**: Remove empty nodes
- **NSControl**: Remove empty nodes
- **INSPasteboardReading**: Remove empty nodes
- **NSSliderTouchBarItem**: Remove empty nodes
- **NSToolbarItem**: Remove empty nodes
- **AUParameter**: Remove empty nodes
- **AVAssetTrack**: Remove empty nodes
- **AVContentKeyResponse**: Remove empty nodes
- **AVPlayerLayer**: Remove empty nodes

Total: 49 changed lines (17 insertions, 32 deletions)

🤖 Pull request created by Copilot