### PR TITLE
[dotnet] Make the RecommendedXcodeVersion MSBuild property public

### DIFF
--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -1259,7 +1259,7 @@ $ dotnet build -getProperty:RecommendedXcodeVersion myProject.csproj
 26.6
 ```
 
-Note: the version number may contain more than 2 digits ("26.6.1" for instance). Only the two first digits are taken into account when validating the installed Xcode version.
+Note: the version number may contain more than 2 components ("26.6.1" for instance). Only the first two components (major and minor) are taken into account when validating the installed Xcode version.
 
 ## ReferenceNativeSymbol
 

--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -1244,6 +1244,23 @@ The product definition template (`.plist`) to be used when creating the product 
 
 Only applicable to macOS and Mac Catalyst apps.
 
+## RecommendedXcodeVersion
+
+The version of Xcode recommended for use with this version of .NET for iOS, tvOS, macOS and Mac Catalyst.
+
+This is the Xcode version the build validates against (see [ValidateXcodeVersion](#validatexcodeversion)); using a different version is likely to produce problems later on in the build process.
+
+This property is read-only: it's computed by the SDK and shouldn't be set in project files.
+
+You can get the recommended Xcode version for a project by running:
+
+```shell
+$ dotnet build -getProperty:RecommendedXcodeVersion myProject.csproj
+26.6
+```
+
+Note: the version number may contain more than 2 digits ("26.6.1" for instance). Only the two first digits are taken into account when validating the installed Xcode version.
+
 ## ReferenceNativeSymbol
 
 See [ReferenceNativeSymbol](build-items.md#referencenativesymbol)

--- a/dotnet/targets/Microsoft.Sdk.Versions.template.props
+++ b/dotnet/targets/Microsoft.Sdk.Versions.template.props
@@ -11,7 +11,9 @@
 		<_XamarinIsPreviewRelease>@XCODE_IS_PREVIEW@</_XamarinIsPreviewRelease>
 		<_XamarinDotNetVersion>@DOTNET_TFM@</_XamarinDotNetVersion>
 		<_XamarinPackSuffix>@DOTNET_TFM@_@NUGET_OS_VERSION@</_XamarinPackSuffix>
-		<_RecommendedXcodeVersion>@XCODE_VERSION@</_RecommendedXcodeVersion>
+		<RecommendedXcodeVersion>@XCODE_VERSION@</RecommendedXcodeVersion>
+		<!-- Keep setting the underscored (private) version too, in case anybody depends on it being set. -->
+		<_RecommendedXcodeVersion>$(RecommendedXcodeVersion)</_RecommendedXcodeVersion>
 	</PropertyGroup>
 
 	<ItemGroup>@VALID_RUNTIME_IDENTIFIERS@

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -2764,13 +2764,13 @@
 		<!-- we only want to validate major.minor, not any revision or build numbers -->
 		<PropertyGroup>
 			<_XcodeVersionMajorMinorOnly>$([System.Version]::Parse('$(_XcodeVersion)').Major).$([System.Version]::Parse('$(_XcodeVersion)').Minor)</_XcodeVersionMajorMinorOnly>
-			<_RecommendedXcodeVersionMajorMinorOnly>$([System.Version]::Parse('$(_RecommendedXcodeVersion)').Major).$([System.Version]::Parse('$(_RecommendedXcodeVersion)').Minor)</_RecommendedXcodeVersionMajorMinorOnly>
+			<_RecommendedXcodeVersionMajorMinorOnly>$([System.Version]::Parse('$(RecommendedXcodeVersion)').Major).$([System.Version]::Parse('$(RecommendedXcodeVersion)').Minor)</_RecommendedXcodeVersionMajorMinorOnly>
 			<_IsMatchingXcode Condition="'$(_RecommendedXcodeVersionMajorMinorOnly)' == '$(_XcodeVersionMajorMinorOnly)'">true</_IsMatchingXcode>
 		</PropertyGroup>
 		<MacDevMessage
 			Error="true"
 			ResourceName="E0191"
-			FormatArguments="$(_PlatformName);$(_ShortPackageVersion);$(_RecommendedXcodeVersion);$(_XcodeVersion)"
+			FormatArguments="$(_PlatformName);$(_ShortPackageVersion);$(RecommendedXcodeVersion);$(_XcodeVersion)"
 			Condition="'$(_IsMatchingXcode)' != 'true'"
 		/>
 	</Target>


### PR DESCRIPTION
The Xcode version recommended for a given .NET for iOS/tvOS/macOS/Mac Catalyst
build was only available as the internal `_RecommendedXcodeVersion` property, so
there was no supported way for a project to read it.

This makes it a public `RecommendedXcodeVersion` property and documents it (with a
`dotnet build -getProperty:RecommendedXcodeVersion` example). The internal
`_RecommendedXcodeVersion` property is still set (derived from the public one) in
case anybody depends on it being set.

Ref: https://github.com/dotnet/macios/issues/25818

🤖 Pull request created by Copilot