### PR TITLE
[scripts] Rebuild generate-frameworks-constants when its linked tools/common sources change

### DIFF
--- a/scripts/generate-frameworks-constants/fragment.mk
+++ b/scripts/generate-frameworks-constants/fragment.mk
@@ -1,2 +1,2 @@
 include $(TOP)/scripts/template.mk
-$(eval $(call TemplateScript,GENERATE_FRAMEWORKS_CONSTANTS,generate-frameworks-constants))
+$(eval $(call TemplateScript,GENERATE_FRAMEWORKS_CONSTANTS,generate-frameworks-constants,$(TOP)/tools/common/Frameworks.cs $(TOP)/tools/common/ApplePlatform.cs $(TOP)/tools/common/SdkVersions.cs $(TOP)/tools/common/StringUtils.cs $(TOP)/tools/common/NullableAttributes.cs))

--- a/scripts/template.mk
+++ b/scripts/template.mk
@@ -3,6 +3,6 @@ $(1)=$(TOP)/scripts/$(2)/bin/Debug/$(2).dll
 $(1)_EXEC=$(DOTNET) exec $$($(1))
 ALL_SCRIPTS+=$(TOP)/scripts/$(2)/bin/Debug/$(2).dll
 
-$$($(1)): $$(wildcard $$(TOP)/scripts/$(2)/*.cs) $$(wildcard $$(TOP)/scripts/$(2)/*.csproj)
+$$($(1)): $$(wildcard $$(TOP)/scripts/$(2)/*.cs) $$(wildcard $$(TOP)/scripts/$(2)/*.csproj) $(3)
 	$$(Q) $$(DOTNET) build $(TOP)/scripts/$(2)/*.csproj /bl:$$(TOP)/scripts/$(2)/msbuild.binlog $$(DOTNET_BUILD_VERBOSITY)
 endef


### PR DESCRIPTION
## Why

Editing `tools/common/Frameworks.cs` does not cause the `generate-frameworks-constants` tool to be rebuilt, so `make` keeps a stale DLL that regenerates an out-of-date `Constants.generated.cs`. When a new `<Framework>Library` constant is added, the build then fails with `CS0117: 'Constants' does not contain a definition for '<Framework>Library'`.

## Root cause

`generate-frameworks-constants.csproj` compiles five files from `tools/common` as *linked* items (`Frameworks.cs`, `ApplePlatform.cs`, `SdkVersions.cs`, `StringUtils.cs`, `NullableAttributes.cs`). But the tool's make rule, generated by `TemplateScript` in `scripts/template.mk`, only listed the tool's own `scripts/<tool>/*.cs` and `*.csproj` as prerequisites. So a change to any linked `tools/common` file never marked `bin/Debug/generate-frameworks-constants.dll` out of date.

## Approach

Rather than adding a blanket `tools/common/*.cs` prerequisite (which would over-rebuild unrelated scripts and still miss other tools' linked sources), I extended `TemplateScript` to accept an optional list of extra prerequisites, and passed the five linked files for this specific tool via `scripts/generate-frameworks-constants/fragment.mk`. This keeps the fix scoped and reusable by any other script that links external sources.

## Verification

Verified in an isolated makefile test that the tool's DLL is reported "up to date" when its prerequisites are older, and rebuilds when `Frameworks.cs` is touched newer.

Fixes: #26052

🤖 Pull request created by Copilot