### PR TITLE
[tests] Add an iOS variation to the PerformanceTests.PrepareAssemblies_CoreCLR test.

### DIFF
--- a/tests/dotnet/UnitTests/PerformanceTests.cs
+++ b/tests/dotnet/UnitTests/PerformanceTests.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
+		[TestCase (ApplePlatform.iOS)]
 		[TestCase (ApplePlatform.MacOSX)]
 		public void PrepareAssemblies_CoreCLR (ApplePlatform platform)
 		{


### PR DESCRIPTION
Some takeaways (numbers further below):

* macOS is always faster with PreparAssemblies=true.
* iOS (with PrepareAssemblies=true) is faster when not trimming, and slower when trimming. This is expected (we're loading assemblies more often now), but there's work in progress to mitigate this at least somewhat.
* iOS/CoreCLR is faster than iOS/MonoVM, especially the untrimmed builds for the simulator. MySimpleApp went from ~58s to ~19s. monotouch-test went from 1:52 to 0:57.

---------------------------------------------------

# PrepareAssemblies performance report (iOS/MonoVM)

## Summary

| Project        | Runtime identifier | Link mode | PrepareAssemblies=false | PrepareAssemblies=true | Difference   |
| -------------- | ------------------ | --------- | ----------------------- | ---------------------- | ------------ |
| monotouch-test | ios-arm64          | None      |  00:02:25.59            |  00:02:21.94           | -00:00:03.64 |
| monotouch-test | ios-arm64          | SdkOnly   |  00:01:30.61            |  00:01:49.14           |  00:00:18.53 |
| monotouch-test | iossimulator-arm64 | None      |  00:01:52.07            |  00:01:49.71           | -00:00:02.35 |
| monotouch-test | iossimulator-arm64 | SdkOnly   |  00:01:25.40            |  00:01:30.69           |  00:00:05.28 |
| MySimpleApp    | ios-arm64          | None      |  00:01:20.19            |  00:01:22.45           |  00:00:02.26 |
| MySimpleApp    | ios-arm64          | SdkOnly   |  00:00:23.75            |  00:00:46.02           |  00:00:22.26 |
| MySimpleApp    | iossimulator-arm64 | None      |  00:00:58.91            |  00:00:57.09           | -00:00:01.81 |
| MySimpleApp    | iossimulator-arm64 | SdkOnly   |  00:00:23.24            |  00:00:29.38           |  00:00:06.13 |

# PrepareAssemblies performance report (iOS/CoreCLR)

## Summary

| Project        | Runtime identifier | Link mode | PrepareAssemblies=false | PrepareAssemblies=true | Difference   |
| -------------- | ------------------ | --------- | ----------------------- | ---------------------- | ------------ |
| monotouch-test | ios-arm64          | None      |  00:01:28.94            |  00:01:24.61           | -00:00:04.32 |
| monotouch-test | ios-arm64          | SdkOnly   |  00:01:13.96            |  00:01:30.39           |  00:00:16.43 |
| monotouch-test | iossimulator-arm64 | None      |  00:01:20.85            |  00:00:57.66           | -00:00:23.19 |
| monotouch-test | iossimulator-arm64 | SdkOnly   |  00:01:04.81            |  00:01:06.30           |  00:00:01.48 |
| MySimpleApp    | ios-arm64          | None      |  00:00:43.96            |  00:00:57.27           |  00:00:13.31 |
| MySimpleApp    | ios-arm64          | SdkOnly   |  00:00:23.22            |  00:00:44.68           |  00:00:21.46 |
| MySimpleApp    | iossimulator-arm64 | None      |  00:00:55.92            |  00:00:19.06           | -00:00:36.86 |
| MySimpleApp    | iossimulator-arm64 | SdkOnly   |  00:00:30.09            |  00:00:37.19           |  00:00:07.10 |

# PrepareAssemblies performance report (macOS/CoreCLR)

## Summary

| Project        | Runtime identifier | Link mode | PrepareAssemblies=false | PrepareAssemblies=true | Difference   |
| -------------- | ------------------ | --------- | ----------------------- | ---------------------- | ------------ |
| monotouch-test | osx-arm64          | None      |  00:00:59.73            |  00:00:49.58           | -00:00:10.15 |
| monotouch-test | osx-arm64          | SdkOnly   |  00:00:58.11            |  00:00:55.34           | -00:00:02.76 |
| MySimpleApp    | osx-arm64          | None      |  00:00:13.71            |  00:00:10.61           | -00:00:03.10 |
| MySimpleApp    | osx-arm64          | SdkOnly   |  00:00:13.57            |  00:00:11.19           | -00:00:02.38 |