### PR TITLE
Add common Apple application artifact metadata

### DIFF
--- a/docs/building-apps/build-items.md
+++ b/docs/building-apps/build-items.md
@@ -264,6 +264,17 @@ The following metadata is set:
 * `IsDirectory`: `true` for `.app` and `.xcarchive` outputs; `false` for `.ipa` and `.pkg` outputs.
 * `PlatformName`: The Apple platform name, such as `iOS`, `tvOS`, `macOS`, or `MacCatalyst`.
 * `BundleIdentifier`: The resolved app bundle identifier.
+* `ApplicationId`: The resolved app bundle identifier.
+* `ApplicationTitle`: The final `CFBundleDisplayName` value.
+* `ApplicationName`: The final `CFBundleDisplayName` value, falling back to `CFBundleName` when `CFBundleDisplayName` isn't set.
+* `ApplicationDisplayVersion`: The final `CFBundleShortVersionString` value.
+* `ApplicationVersion`: The final `CFBundleVersion` value.
+
+The shared application metadata is read from the compiled app bundle
+`Info.plist`, so values supplied by a custom manifest take precedence over
+single-project properties. Values that are resolved or localized by Apple at a
+later stage are returned as written in the compiled manifest; the build does
+not choose a locale.
 
 Example:
 

--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -571,10 +571,10 @@ A semi-colon delimited property that can be used to extend the
 the platform build has collected `@(ApplicationArtifact)` items and before
 `GetApplicationArtifacts` or `Publish` returns them.
 
-This can be used by SDKs such as .NET MAUI to add shared application metadata
-to platform-produced artifacts. Extension targets should update existing
-`@(ApplicationArtifact)` items to add metadata; they should only add new items
-when introducing additional artifacts.
+Apple platform builds populate the common application metadata documented for
+[ApplicationArtifact](build-items.md#applicationartifact) before targets in
+this property execute. Extension targets can update or override that metadata,
+and should only add new items when introducing additional artifacts.
 
 Example:
 

--- a/dotnet/SingleProject.md
+++ b/dotnet/SingleProject.md
@@ -20,6 +20,12 @@ Info.plist in the project doesn't already contain entries for these keys):
 This is only enabled if the `GenerateApplicationManifest` is set to `true`
 (which is the default for all supported .NET versions)
 
+Final application outputs expose these values as common metadata on
+`@(ApplicationArtifact)`. The metadata is read back from the compiled
+`Info.plist`, so explicit values in a custom manifest win even when the
+corresponding single-project properties are set. `ApplicationName` uses
+`CFBundleDisplayName` when present and otherwise falls back to `CFBundleName`.
+
 Additionally, `$(ApplicationDisplayVersion)` will overwrite the value for `$(Version)`,
 so the following properties will be set with the same value:
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ReadAppManifest.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ReadAppManifest.cs
@@ -71,9 +71,9 @@ namespace Xamarin.MacDev.Tasks {
 
 			CFBundleExecutable = plist.GetCFBundleExecutable ();
 			CFBundleDisplayName = plist?.GetCFBundleDisplayName ();
-			CFBundleName = plist?.Get<PString> (ManifestKeys.CFBundleName)?.Value;
+			CFBundleName = plist?.GetCFBundleName ();
 			CFBundleIdentifier = plist?.GetCFBundleIdentifier ();
-			CFBundleShortVersionString = plist?.Get<PString> (ManifestKeys.CFBundleShortVersionString)?.Value;
+			CFBundleShortVersionString = plist?.GetCFBundleShortVersionString ();
 			CFBundleVersion = plist?.GetCFBundleVersion ();
 			CLKComplicationGroup = plist?.Get<PString> (ManifestKeys.CLKComplicationGroup)?.Value;
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/ReadAppManifest.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/ReadAppManifest.cs
@@ -24,7 +24,13 @@ namespace Xamarin.MacDev.Tasks {
 		public string? CFBundleDisplayName { get; set; }
 
 		[Output]
+		public string? CFBundleName { get; set; }
+
+		[Output]
 		public string? CFBundleIdentifier { get; set; }
+
+		[Output]
+		public string? CFBundleShortVersionString { get; set; }
 
 		[Output]
 		public string? CFBundleVersion { get; set; }
@@ -65,7 +71,9 @@ namespace Xamarin.MacDev.Tasks {
 
 			CFBundleExecutable = plist.GetCFBundleExecutable ();
 			CFBundleDisplayName = plist?.GetCFBundleDisplayName ();
+			CFBundleName = plist?.Get<PString> (ManifestKeys.CFBundleName)?.Value;
 			CFBundleIdentifier = plist?.GetCFBundleIdentifier ();
+			CFBundleShortVersionString = plist?.Get<PString> (ManifestKeys.CFBundleShortVersionString)?.Value;
 			CFBundleVersion = plist?.GetCFBundleVersion ();
 			CLKComplicationGroup = plist?.Get<PString> (ManifestKeys.CLKComplicationGroup)?.Value;
 

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -729,7 +729,9 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			>
 			<Output TaskParameter="CFBundleExecutable" PropertyName="_ExecutableName" />
 			<Output TaskParameter="CFBundleDisplayName" PropertyName="_CFBundleDisplayName" />
+			<Output TaskParameter="CFBundleName" PropertyName="_CFBundleName" />
 			<Output TaskParameter="CFBundleIdentifier" PropertyName="_BundleIdentifier" />
+			<Output TaskParameter="CFBundleShortVersionString" PropertyName="_CFBundleShortVersionString" />
 			<Output TaskParameter="CFBundleVersion" PropertyName="_CFBundleVersion" />
 			<Output TaskParameter="CLKComplicationGroup" PropertyName="_CLKComplicationGroup" />
 			<Output TaskParameter="MinimumOSVersion" PropertyName="_MinimumOSVersion" />
@@ -3540,7 +3542,36 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 	<Target Name="CreateIpa" Condition="'$(_CanArchive)' == 'true' And '$(SdkIsDesktop)' != 'true'" DependsOnTargets="$(CreateIpaDependsOn)" />
 
-	<Target Name="GetApplicationArtifacts" DependsOnTargets="Build;$(GetApplicationArtifactsDependsOn)" Returns="@(ApplicationArtifact)" />
+	<Target Name="_AddAppleApplicationArtifactMetadata"
+		AfterTargets="Build"
+		BeforeTargets="BeforeDisconnect"
+		Condition="'@(ApplicationArtifact)' != '' And '$(_AppBundleManifestPath)' != '' And (Exists('$(_AppBundleManifestPath)') Or '$(IsRemoteBuild)' == 'true')">
+		<ReadAppManifest
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			AppManifest="$(_AppBundleManifestPath)"
+			SdkDevPath="$(_SdkDevPath)"
+			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
+			>
+			<Output TaskParameter="CFBundleDisplayName" PropertyName="_ApplicationArtifactCFBundleDisplayName" />
+			<Output TaskParameter="CFBundleName" PropertyName="_ApplicationArtifactCFBundleName" />
+			<Output TaskParameter="CFBundleShortVersionString" PropertyName="_ApplicationArtifactCFBundleShortVersionString" />
+			<Output TaskParameter="CFBundleVersion" PropertyName="_ApplicationArtifactCFBundleVersion" />
+		</ReadAppManifest>
+
+		<ItemGroup>
+			<ApplicationArtifact Update="@(ApplicationArtifact)">
+				<ApplicationId>%(ApplicationArtifact.BundleIdentifier)</ApplicationId>
+				<ApplicationTitle>$(_ApplicationArtifactCFBundleDisplayName)</ApplicationTitle>
+				<ApplicationName Condition="'$(_ApplicationArtifactCFBundleDisplayName)' != ''">$(_ApplicationArtifactCFBundleDisplayName)</ApplicationName>
+				<ApplicationName Condition="'$(_ApplicationArtifactCFBundleDisplayName)' == ''">$(_ApplicationArtifactCFBundleName)</ApplicationName>
+				<ApplicationDisplayVersion>$(_ApplicationArtifactCFBundleShortVersionString)</ApplicationDisplayVersion>
+				<ApplicationVersion>$(_ApplicationArtifactCFBundleVersion)</ApplicationVersion>
+			</ApplicationArtifact>
+		</ItemGroup>
+	</Target>
+
+	<Target Name="GetApplicationArtifacts" DependsOnTargets="Build;_AddAppleApplicationArtifactMetadata;$(GetApplicationArtifactsDependsOn)" Returns="@(ApplicationArtifact)" />
 
 	<PropertyGroup>
 		<PrepareAssemblies Condition="'$(PrepareAssemblies)' == ''">false</PrepareAssemblies>

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -3542,10 +3542,16 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 	<Target Name="CreateIpa" Condition="'$(_CanArchive)' == 'true' And '$(SdkIsDesktop)' != 'true'" DependsOnTargets="$(CreateIpaDependsOn)" />
 
+	<PropertyGroup>
+		<GetApplicationArtifactsDependsOn>
+			Build;
+			_AddAppleApplicationArtifactMetadata;
+			$(GetApplicationArtifactsDependsOn);
+		</GetApplicationArtifactsDependsOn>
+	</PropertyGroup>
+
 	<Target Name="_AddAppleApplicationArtifactMetadata"
-		AfterTargets="Build"
-		BeforeTargets="BeforeDisconnect"
-		Condition="'@(ApplicationArtifact)' != '' And '$(_AppBundleManifestPath)' != '' And (Exists('$(_AppBundleManifestPath)') Or '$(IsRemoteBuild)' == 'true')">
+		Condition="'@(ApplicationArtifact->Count())' != '0' And '$(_AppBundleManifestPath)' != '' And (Exists('$(_AppBundleManifestPath)') Or '$(IsRemoteBuild)' == 'true')">
 		<ReadAppManifest
 			SessionId="$(BuildSessionId)"
 			Condition="'$(IsMacEnabled)' == 'true'"
@@ -3571,7 +3577,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		</ItemGroup>
 	</Target>
 
-	<Target Name="GetApplicationArtifacts" DependsOnTargets="Build;_AddAppleApplicationArtifactMetadata;$(GetApplicationArtifactsDependsOn)" Returns="@(ApplicationArtifact)" />
+	<Target Name="GetApplicationArtifacts" DependsOnTargets="$(GetApplicationArtifactsDependsOn)" Returns="@(ApplicationArtifact)" />
 
 	<PropertyGroup>
 		<PrepareAssemblies Condition="'$(PrepareAssemblies)' == ''">false</PrepareAssemblies>

--- a/tests/dotnet/MySimpleAppWithArtifactMetadata/Info.plist
+++ b/tests/dotnet/MySimpleAppWithArtifactMetadata/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.xamarin.customartifactmetadata</string>
+	<key>CFBundleName</key>
+	<string>Custom Bundle Name</string>
+	<key>CFBundleShortVersionString</key>
+	<string>9.8.7</string>
+	<key>CFBundleVersion</key>
+	<string>123</string>
+</dict>
+</plist>

--- a/tests/dotnet/MySimpleAppWithArtifactMetadata/InfoWithoutDisplayName.plist
+++ b/tests/dotnet/MySimpleAppWithArtifactMetadata/InfoWithoutDisplayName.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>com.xamarin.customartifactmetadata</string>
+	<key>CFBundleName</key>
+	<string>Fallback Bundle Name</string>
+	<key>CFBundleShortVersionString</key>
+	<string>9.8.7</string>
+	<key>CFBundleVersion</key>
+	<string>123</string>
+</dict>
+</plist>

--- a/tests/dotnet/MySimpleAppWithArtifactMetadata/shared.csproj
+++ b/tests/dotnet/MySimpleAppWithArtifactMetadata/shared.csproj
@@ -15,9 +15,10 @@
 
 	<ItemGroup>
 		<Compile Include="../*.cs" />
+		<None Include="../$(CustomApplicationManifest)" Link="Info.plist" Condition="'$(CustomApplicationManifest)' != ''" />
 	</ItemGroup>
 
-	<Target Name="AddMauiApplicationArtifactMetadata">
+	<Target Name="AddMauiApplicationArtifactMetadata" Condition="'$(ExpectedAugmentedPackageFormat)' != ''">
 		<ItemGroup>
 			<_MauiObservedAppArtifact Include="@(ApplicationArtifact)" Condition="'%(ApplicationArtifact.PackageFormat)' == 'app'" />
 			<_MauiObservedPackageArtifact Include="@(ApplicationArtifact)" Condition="'%(ApplicationArtifact.PackageFormat)' == '$(ExpectedAugmentedPackageFormat)'" />

--- a/tests/dotnet/UnitTests/PostBuildTest.cs
+++ b/tests/dotnet/UnitTests/PostBuildTest.cs
@@ -139,6 +139,57 @@ namespace Xamarin.Tests {
 		}
 
 		[Test]
+		[TestCase (ApplePlatform.iOS, "iossimulator-arm64", null, true)]
+		[TestCase (ApplePlatform.TVOS, "tvossimulator-arm64", null, true)]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64", null, true)]
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64", null, true)]
+		[TestCase (ApplePlatform.iOS, "iossimulator-arm64", "Info.plist", true)]
+		[TestCase (ApplePlatform.MacOSX, "osx-arm64", "Info.plist", false)]
+		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64", "InfoWithoutDisplayName.plist", false)]
+		public void ApplicationArtifactMetadataTest (ApplePlatform platform, string runtimeIdentifiers, string? customApplicationManifest, bool generateApplicationManifest)
+		{
+			var project = "MySimpleAppWithArtifactMetadata";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var project_path = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
+			Clean (project_path);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["GenerateApplicationManifest"] = generateApplicationManifest ? "true" : "false";
+			if (customApplicationManifest is not null)
+				properties ["CustomApplicationManifest"] = customApplicationManifest;
+
+			var outputs = GetApplicationArtifacts (project_path, properties);
+			var appOutput = AssertApplicationArtifact (outputs, appPath, platform, "app", isDirectory: true);
+
+			if (customApplicationManifest is null) {
+				AssertApplicationMetadata (
+					appOutput,
+					"com.xamarin.mysimpleappwithartifactmetadata",
+					"MySimpleAppWithArtifactMetadata",
+					"MySimpleAppWithArtifactMetadata",
+					"3.14",
+					"3.14");
+			} else if (customApplicationManifest == "InfoWithoutDisplayName.plist") {
+				AssertApplicationMetadata (
+					appOutput,
+					"com.xamarin.customartifactmetadata",
+					"",
+					"Fallback Bundle Name",
+					"9.8.7",
+					"123");
+			} else {
+				AssertApplicationMetadata (
+					appOutput,
+					"com.xamarin.customartifactmetadata",
+					"$(PRODUCT_NAME)",
+					"$(PRODUCT_NAME)",
+					"9.8.7",
+					"123");
+			}
+		}
+
+		[Test]
 		[TestCase (ApplePlatform.iOS, "ios-arm64", "ipa")]
 		[TestCase (ApplePlatform.MacCatalyst, "maccatalyst-arm64", "pkg")]
 		public void GetApplicationArtifactsDependsOnTest (ApplePlatform platform, string runtimeIdentifiers, string packageFormat)
@@ -551,6 +602,10 @@ namespace Xamarin.Tests {
 			Assert.That (output.GetMetadata ("IsDirectory"), Is.EqualTo (isDirectory ? "true" : "false"), "IsDirectory");
 			Assert.That (output.GetMetadata ("PlatformName"), Is.EqualTo (platform.AsString ()), "PlatformName");
 			Assert.That (output.GetMetadata ("BundleIdentifier"), Is.Not.Empty, "BundleIdentifier");
+			Assert.That (output.GetMetadata ("ApplicationId"), Is.EqualTo (output.GetMetadata ("BundleIdentifier")), "ApplicationId");
+			Assert.That (output.GetMetadata ("ApplicationName"), Is.Not.Empty, "ApplicationName");
+			Assert.That (output.GetMetadata ("ApplicationDisplayVersion"), Is.Not.Empty, "ApplicationDisplayVersion");
+			Assert.That (output.GetMetadata ("ApplicationVersion"), Is.Not.Empty, "ApplicationVersion");
 			Assert.That (output.GetMetadata ("ArtifactKind"), Is.Null.Or.Empty, "ArtifactKind");
 			Assert.That (output.GetMetadata ("AppBundlePath"), Is.Null.Or.Empty, "AppBundlePath");
 			Assert.That (output.GetMetadata ("CodeSigned"), Is.Null.Or.Empty, "CodeSigned");
@@ -587,6 +642,10 @@ namespace Xamarin.Tests {
 			Assert.That (GetMetadata (output, "IsDirectory"), Is.EqualTo (isDirectory ? "true" : "false"), "IsDirectory");
 			Assert.That (GetMetadata (output, "PlatformName"), Is.EqualTo (platform.AsString ()), "PlatformName");
 			Assert.That (GetMetadata (output, "BundleIdentifier"), Is.Not.Empty, "BundleIdentifier");
+			Assert.That (GetMetadata (output, "ApplicationId"), Is.EqualTo (GetMetadata (output, "BundleIdentifier")), "ApplicationId");
+			Assert.That (GetMetadata (output, "ApplicationName"), Is.Not.Empty, "ApplicationName");
+			Assert.That (GetMetadata (output, "ApplicationDisplayVersion"), Is.Not.Empty, "ApplicationDisplayVersion");
+			Assert.That (GetMetadata (output, "ApplicationVersion"), Is.Not.Empty, "ApplicationVersion");
 			Assert.That (GetMetadata (output, "ArtifactKind"), Is.Empty, "ArtifactKind");
 			Assert.That (GetMetadata (output, "AppBundlePath"), Is.Empty, "AppBundlePath");
 			Assert.That (GetMetadata (output, "CodeSigned"), Is.Empty, "CodeSigned");
@@ -603,6 +662,17 @@ namespace Xamarin.Tests {
 			var fullPath = GetMetadata (matchingOutputs [0], "FullPath");
 			Assert.That (fullPath, Does.Exist, packageFormat);
 			return AssertApplicationArtifact (outputs, fullPath, platform, packageFormat, isDirectory);
+		}
+
+		static void AssertApplicationMetadata (JsonElement output, string applicationId, string applicationTitle, string applicationName, string applicationDisplayVersion, string applicationVersion)
+		{
+			Assert.Multiple (() => {
+				Assert.That (GetMetadata (output, "ApplicationId"), Is.EqualTo (applicationId), "ApplicationId");
+				Assert.That (GetMetadata (output, "ApplicationTitle"), Is.EqualTo (applicationTitle), "ApplicationTitle");
+				Assert.That (GetMetadata (output, "ApplicationName"), Is.EqualTo (applicationName), "ApplicationName");
+				Assert.That (GetMetadata (output, "ApplicationDisplayVersion"), Is.EqualTo (applicationDisplayVersion), "ApplicationDisplayVersion");
+				Assert.That (GetMetadata (output, "ApplicationVersion"), Is.EqualTo (applicationVersion), "ApplicationVersion");
+			});
 		}
 
 		static string GetMetadata (JsonElement item, string name)

--- a/tests/dotnet/UnitTests/PostBuildTest.cs
+++ b/tests/dotnet/UnitTests/PostBuildTest.cs
@@ -602,10 +602,6 @@ namespace Xamarin.Tests {
 			Assert.That (output.GetMetadata ("IsDirectory"), Is.EqualTo (isDirectory ? "true" : "false"), "IsDirectory");
 			Assert.That (output.GetMetadata ("PlatformName"), Is.EqualTo (platform.AsString ()), "PlatformName");
 			Assert.That (output.GetMetadata ("BundleIdentifier"), Is.Not.Empty, "BundleIdentifier");
-			Assert.That (output.GetMetadata ("ApplicationId"), Is.EqualTo (output.GetMetadata ("BundleIdentifier")), "ApplicationId");
-			Assert.That (output.GetMetadata ("ApplicationName"), Is.Not.Empty, "ApplicationName");
-			Assert.That (output.GetMetadata ("ApplicationDisplayVersion"), Is.Not.Empty, "ApplicationDisplayVersion");
-			Assert.That (output.GetMetadata ("ApplicationVersion"), Is.Not.Empty, "ApplicationVersion");
 			Assert.That (output.GetMetadata ("ArtifactKind"), Is.Null.Or.Empty, "ArtifactKind");
 			Assert.That (output.GetMetadata ("AppBundlePath"), Is.Null.Or.Empty, "AppBundlePath");
 			Assert.That (output.GetMetadata ("CodeSigned"), Is.Null.Or.Empty, "CodeSigned");

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ReadAppManifestTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/ReadAppManifestTaskTests.cs
@@ -29,6 +29,26 @@ namespace Xamarin.MacDev.Tasks {
 		}
 
 		[Test]
+		public void ReadsApplicationMetadata ()
+		{
+			var task = CreateTask (createDictionary: (plist) => {
+				plist ["CFBundleDisplayName"] = "$(PRODUCT_NAME)";
+				plist ["CFBundleName"] = "Bundle Name";
+				plist ["CFBundleIdentifier"] = "com.xamarin.custom";
+				plist ["CFBundleShortVersionString"] = "2.3.4";
+				plist ["CFBundleVersion"] = "42";
+			});
+			ExecuteTask (task);
+			Assert.Multiple (() => {
+				Assert.That (task.CFBundleDisplayName, Is.EqualTo ("$(PRODUCT_NAME)"), "CFBundleDisplayName");
+				Assert.That (task.CFBundleName, Is.EqualTo ("Bundle Name"), "CFBundleName");
+				Assert.That (task.CFBundleIdentifier, Is.EqualTo ("com.xamarin.custom"), "CFBundleIdentifier");
+				Assert.That (task.CFBundleShortVersionString, Is.EqualTo ("2.3.4"), "CFBundleShortVersionString");
+				Assert.That (task.CFBundleVersion, Is.EqualTo ("42"), "CFBundleVersion");
+			});
+		}
+
+		[Test]
 		public void MacCatalystVersionConversion ()
 		{
 			var task = CreateTask (platform: ApplePlatform.MacCatalyst, (plist) => {


### PR DESCRIPTION
## Summary

Adds producer-owned common application metadata to every Apple `@(ApplicationArtifact)` item.

- Extends `ReadAppManifest` with `CFBundleName` and `CFBundleShortVersionString`.
- Reads metadata from the final compiled app bundle `Info.plist`, so custom manifest values win.
- Preserves unresolved or localized plist references as written instead of selecting a locale.
- Stamps `.app`, `.ipa`, `.pkg`, and `.xcarchive` artifacts with `ApplicationId`, `ApplicationTitle`, `ApplicationName`, `ApplicationDisplayVersion`, and `ApplicationVersion` while retaining existing Apple metadata.
- Runs before downstream `GetApplicationArtifactsDependsOn` extensions, preserving their ability to override producer metadata.
- Documents the common metadata contract and adds task/post-build coverage across Apple platforms, output formats, generated/custom manifests, `GenerateApplicationManifest=false`, `GetApplicationArtifacts`, and `Publish`.

Follow-up to dotnet/macios#25723. Coordinated with dotnet/maui#35973 and dotnet/android#12123.

## Validation

- `ReadAppManifestTaskTests`: 3 passed, 0 failed.
- `ApplicationArtifactMetadataTest`: 7 passed, 0 failed.
- Desktop package/extension/Publish metadata tests: 6 passed, 0 failed.
- Final `git diff --check`: passed.
- XML validation for the changed targets, project, and plist fixtures: passed.
- The relevant MSBuild/product components compiled successfully; the broader top-level build later stopped in unrelated DevOps YAML validation because `yamllint` is not installed.

The tvOS device IPA test could not run in this environment because no matching provisioning profile is installed. The other four environment failures from the combined artifact run were rerun successfully with `ProductBuildPath=/usr/bin/productbuild`.