### PR TITLE
[linker] Convert the Runtime.Arch optimization to a trimmer feature switch. Fixes #26106.

### DIFF
--- a/builds/Versions-MacCatalyst.plist.in
+++ b/builds/Versions-MacCatalyst.plist.in
@@ -157,8 +157,6 @@
 	<key>Optimizations</key>
 	<dict>
 		<!-- The key is the value to be passed to mtouch. The string is a very short description. Any IDE UI should also point to the documentation for the optimizations. -->
-		<key>inline-runtime-arch</key>
-		<string>Inline NSObject.IsDirectBinding</string>
 		<key>dead-code-elimination</key>
 		<string>Dead code elimination</string>
 		<key>remove-uithread-checks</key>

--- a/builds/Versions-iOS.plist.in
+++ b/builds/Versions-iOS.plist.in
@@ -177,8 +177,6 @@
 	<key>Optimizations</key>
 	<dict>
 		<!-- The key is the value to be passed to mtouch. The string is a very short description. Any IDE UI should also point to the documentation for the optimizations. -->
-		<key>inline-runtime-arch</key>
-		<string>Inline NSObject.IsDirectBinding</string>
 		<key>dead-code-elimination</key>
 		<string>Dead code elimination</string>
 		<key>remove-uithread-checks</key>

--- a/builds/Versions-macOS.plist.in
+++ b/builds/Versions-macOS.plist.in
@@ -98,8 +98,6 @@
 	<key>Optimizations</key>
 	<dict>
 		<!-- The key is the value to be passed to mmp. The string is a very short description. Any IDE UI should also point to the documentation for the optimizations. -->
-		<key>inline-runtime-arch</key>
-		<string>Inline Runtime.Arch</string>
 		<key>inline-isdirectbinding</key>
 		<string>Inline NSObject.IsDirectBinding</string>
 		<key>dead-code-elimination</key>

--- a/builds/Versions-tvOS.plist.in
+++ b/builds/Versions-tvOS.plist.in
@@ -127,8 +127,6 @@
 	<key>Optimizations</key>
 	<dict>
 		<!-- The key is the value to be passed to mtouch. The string is a very short description. Any IDE UI should also point to the documentation for the optimizations. -->
-		<key>inline-runtime-arch</key>
-		<string>Inline NSObject.IsDirectBinding</string>
 		<key>dead-code-elimination</key>
 		<string>Dead code elimination</string>
 		<key>remove-uithread-checks</key>

--- a/docs/website/optimizations.md
+++ b/docs/website/optimizations.md
@@ -143,37 +143,6 @@ never subclassed).
 The default behavior can be overridden by passing
 `--optimize=[+|-]inline-isdirectbinding` to mtouch/mmp.
 
-## Inline Runtime.Arch
-
-This optimization will change the following type of code:
-
-```csharp
-if (Runtime.Arch == Arch.DEVICE) {
-    Console.WriteLine ("Running on device");
-} else {
-    Console.WriteLine ("Running in the simulator");
-}
-```
-
-into the following (when building for device):
-
-```csharp
-if (Arch.DEVICE == Arch.DEVICE) {
-    Console.WriteLine ("Running on device");
-} else {
-    Console.WriteLine ("Running in the simulator");
-}
-```
-
-This optimization requires the linker to be enabled, and is only applied to
-methods with the `[BindingImpl (BindingImplOptions.Optimizable)]` attribute.
-
-It is always enabled by default for Xamarin.iOS (it's not available for
-Xamarin.Mac).
-
-The default behavior can be overridden by passing
-`--optimize=[+|-]inline-runtime-arch` to mtouch.
-
 ## Dead code elimination
 
 This optimization will change the following type of code:

--- a/src/ILLink.Substitutions.iOS.xml
+++ b/src/ILLink.Substitutions.iOS.xml
@@ -10,6 +10,8 @@
       <method signature="System.Boolean get_IsNativeAOT()" body="stub" feature="ObjCRuntime.Runtime.IsNativeAOT" featurevalue="true" value="true" />
       <method signature="System.Int32 GetRuntimeArch()" body="stub" feature="ObjCRuntime.Runtime.Arch.IsSimulator" featurevalue="false" value="0" />
       <method signature="System.Int32 GetRuntimeArch()" body="stub" feature="ObjCRuntime.Runtime.Arch.IsSimulator" featurevalue="true" value="1" />
+      <field name="Arch" feature="ObjCRuntime.Runtime.Arch.IsSimulator" featurevalue="false" value="DEVICE" />
+      <field name="Arch" feature="ObjCRuntime.Runtime.Arch.IsSimulator" featurevalue="true" value="SIMULATOR" />
       <method signature="System.Boolean get_IsManagedStaticRegistrar()" body="stub" feature="ObjCRuntime.Runtime.IsManagedStaticRegistrar" featurevalue="false" value="false" />
       <method signature="System.Boolean get_IsManagedStaticRegistrar()" body="stub" feature="ObjCRuntime.Runtime.IsManagedStaticRegistrar" featurevalue="true" value="true" />
       <method signature="System.Boolean get_DynamicRegistrationSupported()" body="stub" feature="ObjCRuntime.Runtime.DynamicRegistrationSupported" featurevalue="false" value="false" />

--- a/src/ILLink.Substitutions.tvOS.xml
+++ b/src/ILLink.Substitutions.tvOS.xml
@@ -10,6 +10,8 @@
       <method signature="System.Boolean get_IsNativeAOT()" body="stub" feature="ObjCRuntime.Runtime.IsNativeAOT" featurevalue="true" value="true" />
       <method signature="System.Int32 GetRuntimeArch()" body="stub" feature="ObjCRuntime.Runtime.Arch.IsSimulator" featurevalue="false" value="0" />
       <method signature="System.Int32 GetRuntimeArch()" body="stub" feature="ObjCRuntime.Runtime.Arch.IsSimulator" featurevalue="true" value="1" />
+      <field name="Arch" feature="ObjCRuntime.Runtime.Arch.IsSimulator" featurevalue="false" value="DEVICE" />
+      <field name="Arch" feature="ObjCRuntime.Runtime.Arch.IsSimulator" featurevalue="true" value="SIMULATOR" />
       <method signature="System.Boolean get_IsManagedStaticRegistrar()" body="stub" feature="ObjCRuntime.Runtime.IsManagedStaticRegistrar" featurevalue="false" value="false" />
       <method signature="System.Boolean get_IsManagedStaticRegistrar()" body="stub" feature="ObjCRuntime.Runtime.IsManagedStaticRegistrar" featurevalue="true" value="true" />
       <method signature="System.Boolean get_DynamicRegistrationSupported()" body="stub" feature="ObjCRuntime.Runtime.DynamicRegistrationSupported" featurevalue="false" value="false" />

--- a/tests/dotnet/UnitTests/expected/MacCatalyst-MonoVM-interpreter-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacCatalyst-MonoVM-interpreter-size.txt
@@ -1,9 +1,9 @@
-AppBundleSize: 5,793,562 bytes (5,657.8 KB = 5.5 MB)
+AppBundleSize: 5,793,834 bytes (5,658.0 KB = 5.5 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    1,109 bytes (1.1 KB = 0.0 MB)
+    1,077 bytes (1.1 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
-    4,573,224 bytes (4,466.0 KB = 4.4 MB)
+    4,573,528 bytes (4,466.3 KB = 4.4 MB)
 Contents/MonoBundle/Microsoft.MacCatalyst.dll:
     157,696 bytes (154.0 KB = 0.2 MB)
 Contents/MonoBundle/runtimeconfig.bin:

--- a/tests/dotnet/UnitTests/expected/MacCatalyst-MonoVM-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacCatalyst-MonoVM-size.txt
@@ -1,9 +1,9 @@
-AppBundleSize: 16,383,638 bytes (15,999.6 KB = 15.6 MB)
+AppBundleSize: 16,383,926 bytes (15,999.9 KB = 15.6 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    1,109 bytes (1.1 KB = 0.0 MB)
+    1,077 bytes (1.1 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
-    13,876,536 bytes (13,551.3 KB = 13.2 MB)
+    13,876,856 bytes (13,551.6 KB = 13.2 MB)
 Contents/MonoBundle/aot-instances.aotdata.arm64:
     1,045,352 bytes (1,020.9 KB = 1.0 MB)
 Contents/MonoBundle/Microsoft.MacCatalyst.aotdata.arm64:

--- a/tests/dotnet/UnitTests/expected/MacCatalyst-NativeAOT-TrimmableStatic-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacCatalyst-NativeAOT-TrimmableStatic-size.txt
@@ -1,7 +1,7 @@
-AppBundleSize: 13,916,973 bytes (13,590.8 KB = 13.3 MB)
+AppBundleSize: 13,916,941 bytes (13,590.8 KB = 13.3 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    1,109 bytes (1.1 KB = 0.0 MB)
+    1,077 bytes (1.1 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
     13,913,960 bytes (13,587.9 KB = 13.3 MB)
 Contents/MonoBundle/runtimeconfig.bin:

--- a/tests/dotnet/UnitTests/expected/MacCatalyst-NativeAOT-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacCatalyst-NativeAOT-size.txt
@@ -1,7 +1,7 @@
-AppBundleSize: 6,144,997 bytes (6,001.0 KB = 5.9 MB)
+AppBundleSize: 6,144,965 bytes (6,000.9 KB = 5.9 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    1,109 bytes (1.1 KB = 0.0 MB)
+    1,077 bytes (1.1 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
     6,142,072 bytes (5,998.1 KB = 5.9 MB)
 Contents/MonoBundle/runtimeconfig.bin:

--- a/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-TrimmableStatic-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-TrimmableStatic-size.txt
@@ -1,9 +1,9 @@
-AppBundleSize: 258,029,785 bytes (251,982.2 KB = 246.1 MB)
+AppBundleSize: 258,030,168 bytes (251,982.6 KB = 246.1 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    740 bytes (0.7 KB = 0.0 MB)
+    755 bytes (0.7 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
-    7,387,384 bytes (7,214.2 KB = 7.0 MB)
+    7,387,752 bytes (7,214.6 KB = 7.0 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/_Microsoft.macOS.TypeMap.dll:
     4,847,616 bytes (4,734.0 KB = 4.6 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/_SizeTestApp.TypeMap.dll:

--- a/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-size.txt
@@ -1,13 +1,13 @@
-AppBundleSize: 248,407,959 bytes (242,585.9 KB = 236.9 MB)
+AppBundleSize: 248,409,350 bytes (242,587.3 KB = 236.9 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    740 bytes (0.7 KB = 0.0 MB)
+    755 bytes (0.7 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
-    8,029,192 bytes (7,841.0 KB = 7.7 MB)
+    8,029,544 bytes (7,841.4 KB = 7.7 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.CSharp.dll:
     892,752 bytes (871.8 KB = 0.9 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.macOS.dll:
-    37,167,104 bytes (36,296.0 KB = 35.4 MB)
+    37,167,616 bytes (36,296.5 KB = 35.4 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.Core.dll:
     1,334,608 bytes (1,303.3 KB = 1.3 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.dll:
@@ -355,7 +355,7 @@ Contents/MonoBundle/.xamarin/osx-arm64/WindowsBase.dll:
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.CSharp.dll:
     795,984 bytes (777.3 KB = 0.8 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.macOS.dll:
-    37,167,104 bytes (36,296.0 KB = 35.4 MB)
+    37,167,616 bytes (36,296.5 KB = 35.4 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.Core.dll:
     1,166,160 bytes (1,138.8 KB = 1.1 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.dll:

--- a/tests/dotnet/UnitTests/expected/MacOSX-NativeAOT-TrimmableStatic-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacOSX-NativeAOT-TrimmableStatic-size.txt
@@ -1,7 +1,7 @@
-AppBundleSize: 32,590,412 bytes (31,826.6 KB = 31.1 MB)
+AppBundleSize: 32,590,427 bytes (31,826.6 KB = 31.1 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    740 bytes (0.7 KB = 0.0 MB)
+    755 bytes (0.7 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
     29,501,112 bytes (28,809.7 KB = 28.1 MB)
 Contents/MonoBundle/libSystem.Globalization.Native.dylib:

--- a/tests/dotnet/UnitTests/expected/MacOSX-NativeAOT-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacOSX-NativeAOT-size.txt
@@ -1,7 +1,7 @@
-AppBundleSize: 15,885,626 bytes (15,513.3 KB = 15.1 MB)
+AppBundleSize: 15,885,641 bytes (15,513.3 KB = 15.1 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    740 bytes (0.7 KB = 0.0 MB)
+    755 bytes (0.7 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
     12,796,408 bytes (12,496.5 KB = 12.2 MB)
 Contents/MonoBundle/libSystem.Globalization.Native.dylib:

--- a/tests/dotnet/UnitTests/expected/TVOS-MonoVM-interpreter-preservedapis.txt
+++ b/tests/dotnet/UnitTests/expected/TVOS-MonoVM-interpreter-preservedapis.txt
@@ -794,14 +794,6 @@ Microsoft.tvOS.dll:ObjCRuntime.Selector.GetName(System.IntPtr)
 Microsoft.tvOS.dll:ObjCRuntime.Selector.sel_getName(System.IntPtr)
 Microsoft.tvOS.dll:ObjCRuntime.Selector.sel_isMapped(System.IntPtr)
 Microsoft.tvOS.dll:ObjCRuntime.Selector.sel_registerName(System.IntPtr)
-Microsoft.tvOS.dll:ObjCRuntime.Stret
-Microsoft.tvOS.dll:ObjCRuntime.Stret.AlignAndAdd(System.Type, System.Int32, System.Int32, System.Int32&)
-Microsoft.tvOS.dll:ObjCRuntime.Stret.GetTypeName(System.Type)
-Microsoft.tvOS.dll:ObjCRuntime.Stret.GetValueTypeSize(System.Type, System.Collections.Generic.List`1<System.Type>, System.Object)
-Microsoft.tvOS.dll:ObjCRuntime.Stret.GetValueTypeSize(System.Type, System.Type, System.Collections.Generic.List`1<System.Type>, System.Int32&, System.Int32&, System.Object)
-Microsoft.tvOS.dll:ObjCRuntime.Stret.IsBuiltInType(System.Type, out System.Int32&)
-Microsoft.tvOS.dll:ObjCRuntime.Stret.IsBuiltInType(System.Type)
-Microsoft.tvOS.dll:ObjCRuntime.Stret.X86_64NeedStret(System.Type, System.Object)
 Microsoft.tvOS.dll:ObjCRuntime.StringEqualityComparer
 Microsoft.tvOS.dll:ObjCRuntime.StringEqualityComparer ObjCRuntime.RegistrarHelper::StringEqualityComparer
 Microsoft.tvOS.dll:ObjCRuntime.StringEqualityComparer..ctor()
@@ -6529,7 +6521,6 @@ System.Private.CoreLib.dll:System.Int32 System.Runtime.InteropServices.CallingCo
 System.Private.CoreLib.dll:System.Int32 System.Runtime.InteropServices.CharSet::value__
 System.Private.CoreLib.dll:System.Int32 System.Runtime.InteropServices.DllImportSearchPath::value__
 System.Private.CoreLib.dll:System.Int32 System.Runtime.InteropServices.FieldOffsetAttribute::<Value>k__BackingField
-System.Private.CoreLib.dll:System.Int32 System.Runtime.InteropServices.FieldOffsetAttribute::Value()
 System.Private.CoreLib.dll:System.Int32 System.Runtime.InteropServices.GCHandleType::value__
 System.Private.CoreLib.dll:System.Int32 System.Runtime.InteropServices.Marshal::SystemDefaultCharSize
 System.Private.CoreLib.dll:System.Int32 System.Runtime.InteropServices.Marshal::SystemMaxDBCSCharSize
@@ -10794,7 +10785,6 @@ System.Private.CoreLib.dll:System.Runtime.InteropServices.DllImportSearchPath Sy
 System.Private.CoreLib.dll:System.Runtime.InteropServices.DllImportSearchPath System.Runtime.InteropServices.DllImportSearchPath::UserDirectories
 System.Private.CoreLib.dll:System.Runtime.InteropServices.FieldOffsetAttribute
 System.Private.CoreLib.dll:System.Runtime.InteropServices.FieldOffsetAttribute..ctor(System.Int32)
-System.Private.CoreLib.dll:System.Runtime.InteropServices.FieldOffsetAttribute.get_Value()
 System.Private.CoreLib.dll:System.Runtime.InteropServices.GCHandle
 System.Private.CoreLib.dll:System.Runtime.InteropServices.GCHandle..ctor(System.IntPtr)
 System.Private.CoreLib.dll:System.Runtime.InteropServices.GCHandle..ctor(System.Object, System.Runtime.InteropServices.GCHandleType)

--- a/tests/dotnet/UnitTests/expected/TVOS-MonoVM-interpreter-size.txt
+++ b/tests/dotnet/UnitTests/expected/TVOS-MonoVM-interpreter-size.txt
@@ -1,15 +1,15 @@
-AppBundleSize: 3,573,661 bytes (3,489.9 KB = 3.4 MB)
+AppBundleSize: 3,571,124 bytes (3,487.4 KB = 3.4 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Info.plist:
-    1,128 bytes (1.1 KB = 0.0 MB)
+    1,143 bytes (1.1 KB = 0.0 MB)
 Microsoft.tvOS.dll:
-    154,624 bytes (151.0 KB = 0.1 MB)
+    152,064 bytes (148.5 KB = 0.1 MB)
 PkgInfo:
     8 bytes (0.0 KB = 0.0 MB)
 runtimeconfig.bin:
     1,405 bytes (1.4 KB = 0.0 MB)
 SizeTestApp:
-    2,366,528 bytes (2,311.1 KB = 2.3 MB)
+    2,366,536 bytes (2,311.1 KB = 2.3 MB)
 SizeTestApp.dll:
     7,680 bytes (7.5 KB = 0.0 MB)
 System.Private.CoreLib.aotdata.arm64:

--- a/tests/dotnet/UnitTests/expected/TVOS-MonoVM-size.txt
+++ b/tests/dotnet/UnitTests/expected/TVOS-MonoVM-size.txt
@@ -1,9 +1,9 @@
-AppBundleSize: 9,283,113 bytes (9,065.5 KB = 8.9 MB)
+AppBundleSize: 9,283,136 bytes (9,065.6 KB = 8.9 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 aot-instances.aotdata.arm64:
     827,728 bytes (808.3 KB = 0.8 MB)
 Info.plist:
-    1,128 bytes (1.1 KB = 0.0 MB)
+    1,143 bytes (1.1 KB = 0.0 MB)
 Microsoft.tvOS.aotdata.arm64:
     22,872 bytes (22.3 KB = 0.0 MB)
 Microsoft.tvOS.dll:
@@ -13,7 +13,7 @@ PkgInfo:
 runtimeconfig.bin:
     1,481 bytes (1.4 KB = 0.0 MB)
 SizeTestApp:
-    7,185,592 bytes (7,017.2 KB = 6.9 MB)
+    7,185,600 bytes (7,017.2 KB = 6.9 MB)
 SizeTestApp.aotdata.arm64:
     1,464 bytes (1.4 KB = 0.0 MB)
 SizeTestApp.dll:

--- a/tests/dotnet/UnitTests/expected/TVOS-NativeAOT-TrimmableStatic-size.txt
+++ b/tests/dotnet/UnitTests/expected/TVOS-NativeAOT-TrimmableStatic-size.txt
@@ -1,7 +1,7 @@
-AppBundleSize: 12,531,409 bytes (12,237.7 KB = 12.0 MB)
+AppBundleSize: 12,531,424 bytes (12,237.7 KB = 12.0 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Info.plist:
-    1,128 bytes (1.1 KB = 0.0 MB)
+    1,143 bytes (1.1 KB = 0.0 MB)
 PkgInfo:
     8 bytes (0.0 KB = 0.0 MB)
 runtimeconfig.bin:

--- a/tests/dotnet/UnitTests/expected/TVOS-NativeAOT-size.txt
+++ b/tests/dotnet/UnitTests/expected/TVOS-NativeAOT-size.txt
@@ -1,7 +1,7 @@
-AppBundleSize: 6,065,672 bytes (5,923.5 KB = 5.8 MB)
+AppBundleSize: 6,065,687 bytes (5,923.5 KB = 5.8 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Info.plist:
-    1,128 bytes (1.1 KB = 0.0 MB)
+    1,143 bytes (1.1 KB = 0.0 MB)
 PkgInfo:
     8 bytes (0.0 KB = 0.0 MB)
 runtimeconfig.bin:

--- a/tests/dotnet/UnitTests/expected/iOS-MonoVM-interpreter-preservedapis.txt
+++ b/tests/dotnet/UnitTests/expected/iOS-MonoVM-interpreter-preservedapis.txt
@@ -794,14 +794,6 @@ Microsoft.iOS.dll:ObjCRuntime.Selector.GetName(System.IntPtr)
 Microsoft.iOS.dll:ObjCRuntime.Selector.sel_getName(System.IntPtr)
 Microsoft.iOS.dll:ObjCRuntime.Selector.sel_isMapped(System.IntPtr)
 Microsoft.iOS.dll:ObjCRuntime.Selector.sel_registerName(System.IntPtr)
-Microsoft.iOS.dll:ObjCRuntime.Stret
-Microsoft.iOS.dll:ObjCRuntime.Stret.AlignAndAdd(System.Type, System.Int32, System.Int32, System.Int32&)
-Microsoft.iOS.dll:ObjCRuntime.Stret.GetTypeName(System.Type)
-Microsoft.iOS.dll:ObjCRuntime.Stret.GetValueTypeSize(System.Type, System.Collections.Generic.List`1<System.Type>, System.Object)
-Microsoft.iOS.dll:ObjCRuntime.Stret.GetValueTypeSize(System.Type, System.Type, System.Collections.Generic.List`1<System.Type>, System.Int32&, System.Int32&, System.Object)
-Microsoft.iOS.dll:ObjCRuntime.Stret.IsBuiltInType(System.Type, out System.Int32&)
-Microsoft.iOS.dll:ObjCRuntime.Stret.IsBuiltInType(System.Type)
-Microsoft.iOS.dll:ObjCRuntime.Stret.X86_64NeedStret(System.Type, System.Object)
 Microsoft.iOS.dll:ObjCRuntime.StringEqualityComparer
 Microsoft.iOS.dll:ObjCRuntime.StringEqualityComparer ObjCRuntime.RegistrarHelper::StringEqualityComparer
 Microsoft.iOS.dll:ObjCRuntime.StringEqualityComparer..ctor()
@@ -6529,7 +6521,6 @@ System.Private.CoreLib.dll:System.Int32 System.Runtime.InteropServices.CallingCo
 System.Private.CoreLib.dll:System.Int32 System.Runtime.InteropServices.CharSet::value__
 System.Private.CoreLib.dll:System.Int32 System.Runtime.InteropServices.DllImportSearchPath::value__
 System.Private.CoreLib.dll:System.Int32 System.Runtime.InteropServices.FieldOffsetAttribute::<Value>k__BackingField
-System.Private.CoreLib.dll:System.Int32 System.Runtime.InteropServices.FieldOffsetAttribute::Value()
 System.Private.CoreLib.dll:System.Int32 System.Runtime.InteropServices.GCHandleType::value__
 System.Private.CoreLib.dll:System.Int32 System.Runtime.InteropServices.Marshal::SystemDefaultCharSize
 System.Private.CoreLib.dll:System.Int32 System.Runtime.InteropServices.Marshal::SystemMaxDBCSCharSize
@@ -10794,7 +10785,6 @@ System.Private.CoreLib.dll:System.Runtime.InteropServices.DllImportSearchPath Sy
 System.Private.CoreLib.dll:System.Runtime.InteropServices.DllImportSearchPath System.Runtime.InteropServices.DllImportSearchPath::UserDirectories
 System.Private.CoreLib.dll:System.Runtime.InteropServices.FieldOffsetAttribute
 System.Private.CoreLib.dll:System.Runtime.InteropServices.FieldOffsetAttribute..ctor(System.Int32)
-System.Private.CoreLib.dll:System.Runtime.InteropServices.FieldOffsetAttribute.get_Value()
 System.Private.CoreLib.dll:System.Runtime.InteropServices.GCHandle
 System.Private.CoreLib.dll:System.Runtime.InteropServices.GCHandle..ctor(System.IntPtr)
 System.Private.CoreLib.dll:System.Runtime.InteropServices.GCHandle..ctor(System.Object, System.Runtime.InteropServices.GCHandleType)

--- a/tests/dotnet/UnitTests/expected/iOS-MonoVM-interpreter-size.txt
+++ b/tests/dotnet/UnitTests/expected/iOS-MonoVM-interpreter-size.txt
@@ -1,9 +1,9 @@
-AppBundleSize: 3,573,973 bytes (3,490.2 KB = 3.4 MB)
+AppBundleSize: 3,571,428 bytes (3,487.7 KB = 3.4 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Info.plist:
-    1,152 bytes (1.1 KB = 0.0 MB)
+    1,167 bytes (1.1 KB = 0.0 MB)
 Microsoft.iOS.dll:
-    154,624 bytes (151.0 KB = 0.1 MB)
+    152,064 bytes (148.5 KB = 0.1 MB)
 PkgInfo:
     8 bytes (0.0 KB = 0.0 MB)
 runtimeconfig.bin:

--- a/tests/dotnet/UnitTests/expected/iOS-MonoVM-size.txt
+++ b/tests/dotnet/UnitTests/expected/iOS-MonoVM-size.txt
@@ -1,9 +1,9 @@
-AppBundleSize: 9,299,537 bytes (9,081.6 KB = 8.9 MB)
+AppBundleSize: 9,299,552 bytes (9,081.6 KB = 8.9 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 aot-instances.aotdata.arm64:
     827,728 bytes (808.3 KB = 0.8 MB)
 Info.plist:
-    1,152 bytes (1.1 KB = 0.0 MB)
+    1,167 bytes (1.1 KB = 0.0 MB)
 Microsoft.iOS.aotdata.arm64:
     23,216 bytes (22.7 KB = 0.0 MB)
 Microsoft.iOS.dll:

--- a/tests/dotnet/UnitTests/expected/iOS-NativeAOT-TrimmableStatic-size.txt
+++ b/tests/dotnet/UnitTests/expected/iOS-NativeAOT-TrimmableStatic-size.txt
@@ -1,7 +1,7 @@
-AppBundleSize: 14,136,248 bytes (13,804.9 KB = 13.5 MB)
+AppBundleSize: 14,136,263 bytes (13,804.9 KB = 13.5 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Info.plist:
-    1,152 bytes (1.1 KB = 0.0 MB)
+    1,167 bytes (1.1 KB = 0.0 MB)
 PkgInfo:
     8 bytes (0.0 KB = 0.0 MB)
 runtimeconfig.bin:

--- a/tests/dotnet/UnitTests/expected/iOS-NativeAOT-size.txt
+++ b/tests/dotnet/UnitTests/expected/iOS-NativeAOT-size.txt
@@ -1,7 +1,7 @@
-AppBundleSize: 6,082,400 bytes (5,939.8 KB = 5.8 MB)
+AppBundleSize: 6,082,415 bytes (5,939.9 KB = 5.8 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Info.plist:
-    1,152 bytes (1.1 KB = 0.0 MB)
+    1,167 bytes (1.1 KB = 0.0 MB)
 PkgInfo:
     8 bytes (0.0 KB = 0.0 MB)
 runtimeconfig.bin:

--- a/tools/common/Optimizations.cs
+++ b/tools/common/Optimizations.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Bundler {
 			"dead-code-elimination",
 			"inline-isdirectbinding",
 			"inline-intptr-size", // this optimization has been removed, but leave it here so that we won't break customers trying to enable/disable it
-			"inline-runtime-arch",
+			"inline-runtime-arch", // this optimization has been removed (replaced by a trimmer feature switch), but leave it here so that we won't break customers trying to enable/disable it
 			"blockliteral-setupblock",
 			"register-protocols",
 			"inline-dynamic-registration-supported",
@@ -36,7 +36,7 @@ namespace Xamarin.Bundler {
 			/* Opt.DeadCodeElimination                */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.TVOS, ApplePlatform.MacCatalyst },
 			/* Opt.InlineIsDirectBinding              */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.TVOS, ApplePlatform.MacCatalyst },
 			/* Opt.InlineIntPtrSize                   */ new ApplePlatform [] {                                                                                        },
-			/* Opt.InlineRuntimeArch                  */ new ApplePlatform [] { ApplePlatform.iOS,                       ApplePlatform.TVOS                            },
+			/* Opt.InlineRuntimeArch                  */ new ApplePlatform [] {                                                                                        },
 			/* Opt.BlockLiteralSetupBlock             */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.TVOS, ApplePlatform.MacCatalyst },
 			/* Opt.RegisterProtocols                  */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.TVOS, ApplePlatform.MacCatalyst },
 			/* Opt.InlineDynamicRegistrationSupported */ new ApplePlatform [] { ApplePlatform.iOS, ApplePlatform.MacOSX, ApplePlatform.TVOS, ApplePlatform.MacCatalyst },
@@ -246,11 +246,8 @@ namespace Xamarin.Bundler {
 			// The default behavior for InlineIntPtrSize depends on the assembly being linked,
 			// which means we can't set it to a global constant. It's handled in the OptimizeGeneratedCodeSubStep directly.
 
-			if (app.Platform != ApplePlatform.MacOSX) {
-				// By default we always inline calls to Runtime.Arch
-				if (!InlineRuntimeArch.HasValue)
-					InlineRuntimeArch = true;
-			}
+			// The inline-runtime-arch optimization has been removed (the value is now folded by
+			// the trimmer using the ObjCRuntime.Runtime.Arch.IsSimulator feature switch).
 
 			// We try to optimize calls to BlockLiteral.SetupBlock and certain BlockLiteral constructors if the static registrar is enabled
 			if (!OptimizeBlockLiteralSetupBlock.HasValue) {

--- a/tools/dotnet-linker/OptimizeGeneratedCodeStep.cs
+++ b/tools/dotnet-linker/OptimizeGeneratedCodeStep.cs
@@ -29,7 +29,6 @@ namespace Xamarin.Linker.Steps {
 					LinkContext = DerivedLinkContext,
 					InlineIsArm64CallingConvention = App.InlineIsArm64CallingConventionForCurrentAbi,
 					Optimizations = App.Optimizations,
-					Device = App.IsDeviceBuild,
 				};
 			}
 			return OptimizeGeneratedCode.OptimizeMethod (data, method);

--- a/tools/linker/CoreOptimizeGeneratedCode.cs
+++ b/tools/linker/CoreOptimizeGeneratedCode.cs
@@ -34,7 +34,6 @@ namespace Xamarin.Linker {
 					LinkContext = LinkContext,
 					InlineIsArm64CallingConvention = LinkContext.App.InlineIsArm64CallingConventionForCurrentAbi,
 					Optimizations = LinkContext.App.Optimizations,
-					Device = LinkContext.App.IsDeviceBuild,
 				};
 			}
 			OptimizeGeneratedCode.OptimizeMethod (data, method);

--- a/tools/linker/OptimizeGeneratedCode.cs
+++ b/tools/linker/OptimizeGeneratedCode.cs
@@ -602,10 +602,6 @@ namespace Xamarin.Linker {
 			case "IsARM64CallingConvention":
 				modified |= ProcessIsARM64CallingConvention (data, caller, ins);
 				break;
-			case "Arch":
-				// https://app.asana.com/0/77259014252/77812690163
-				modified |= ProcessRuntimeArch (data, caller, ins);
-				break;
 			}
 			return modified;
 		}
@@ -990,29 +986,6 @@ namespace Xamarin.Linker {
 			return true;
 		}
 
-		static bool ProcessRuntimeArch (OptimizeGeneratedCodeData data, MethodDefinition caller, Instruction ins)
-		{
-			const string operation = "inline Runtime.Arch";
-
-			if (data.Optimizations.InlineRuntimeArch != true)
-				return false;
-
-			// Verify we're checking the right Arch field
-			var fr = ins.Operand as FieldReference;
-			if (fr is null || !fr.DeclaringType.Is (Namespaces.ObjCRuntime, "Runtime"))
-				return false;
-
-			// Verify a few assumptions before doing anything
-			if (!ValidateInstruction (data.App, caller, ins, operation, Code.Ldsfld))
-				return false;
-
-			// We're fine, inline the Runtime.Arch condition
-			// The enum values are Runtime.DEVICE = 0 and Runtime.SIMULATOR = 1,
-			ins.OpCode = data.Device ? OpCodes.Ldc_I4_0 : OpCodes.Ldc_I4_1;
-			ins.Operand = null;
-			return true;
-		}
-
 		// Returns the type of the value pushed on the stack by the given instruction.
 		// Returns null for unknown instructions, or for instructions that don't push anything on the stack.
 		static TypeReference? GetPushedType (MethodDefinition method, Instruction ins)
@@ -1205,7 +1178,6 @@ namespace Xamarin.Linker {
 	public class OptimizeGeneratedCodeData {
 		public required Xamarin.Tuner.DerivedLinkContext LinkContext;
 		public required Optimizations Optimizations;
-		public required bool Device;
 
 		public MethodDefinition? SetupBlockImplDefinition;
 		public MethodDefinition? BlockCtorDefinition;


### PR DESCRIPTION
Convert the `Runtime.Arch` optimization from the hand-written IL rewrite in `OptimizeGeneratedCode` (`ProcessRuntimeArch`, which inlined `ObjCRuntime.Runtime.Arch` — device vs. simulator) to an ILLink field substitution, so the trimmer folds the constant branch instead.

The `ObjCRuntime.Runtime.Arch.IsSimulator` feature switch is already wired up in `Xamarin.Shared.Sdk.targets` (via `RuntimeHostConfigurationOption`) and already stubs `GetRuntimeArch()`. The only missing piece was the `Arch` static field itself: I added a `<field>` substitution keyed on the same feature so ILLink folds `ldsfld ObjCRuntime.Runtime::Arch` reads to a constant and removes the dead branches — the same net effect as the old step:

```xml
<field name="Arch" feature="ObjCRuntime.Runtime.Arch.IsSimulator" featurevalue="false" value="DEVICE" />
<field name="Arch" feature="ObjCRuntime.Runtime.Arch.IsSimulator" featurevalue="true"  value="SIMULATOR" />
```

(Added to `ILLink.Substitutions.iOS.xml` and `.tvOS.xml`; the `Arch` field only exists on iOS/tvOS, so macOS/Mac Catalyst don't need it.)

Additional cleanup:

* Removed `ProcessRuntimeArch` and the `"Arch"` case in `ProcessLoadStaticField`, plus the now-unused `Device` field on `OptimizeGeneratedCodeData` and its assignments.
* Marked `inline-runtime-arch` as removed (mirroring `inline-intptr-size`): kept the option name for back-compat, emptied its list of valid platforms, and dropped the default-enable logic.
* Removed the `inline-runtime-arch` entries from the `Versions-*.plist.in` files and the "Inline Runtime.Arch" section from `docs/website/optimizations.md`.

Fixes https://github.com/dotnet/macios/issues/26106.

🤖 Pull request created by Copilot