### PR TITLE
[CoreGraphics] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/coregraphics.cs
+++ b/src/coregraphics.cs
@@ -14,6 +14,8 @@ namespace CoreGraphics {
 		IturRecommended,
 		ExrGamma,
 		None,
+		[TV (27, 0), Mac (27, 0), iOS (27, 0), MacCatalyst (27, 0)]
+		HeadroomAdaptiveGainCurve = 6,
 	}
 
 	/// <summary>Specifies various boxes for the <see cref="CoreGraphics.CGContextPDF.BeginPage(CoreGraphics.CGPDFPageInfo)" /> method.</summary>

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -2299,6 +2299,7 @@ F:CoreGraphics.CGPdfTagType.WarichuPunctuation
 F:CoreGraphics.CGPdfTagType.WarichuText
 F:CoreGraphics.CGToneMapping.Default
 F:CoreGraphics.CGToneMapping.ExrGamma
+F:CoreGraphics.CGToneMapping.HeadroomAdaptiveGainCurve
 F:CoreGraphics.CGToneMapping.ImageSpecificLumaScaling
 F:CoreGraphics.CGToneMapping.IturRecommended
 F:CoreGraphics.CGToneMapping.None

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreGraphics.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreGraphics.todo
@@ -1,1 +1,0 @@
-!missing-enum-value! CGToneMapping native value kCGToneMappingHeadroomAdaptiveGainCurve = 6 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreGraphics.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreGraphics.todo
@@ -1,1 +1,0 @@
-!missing-enum-value! CGToneMapping native value kCGToneMappingHeadroomAdaptiveGainCurve = 6 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreGraphics.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreGraphics.todo
@@ -1,1 +1,0 @@
-!missing-enum-value! CGToneMapping native value kCGToneMappingHeadroomAdaptiveGainCurve = 6 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-CoreGraphics.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-CoreGraphics.todo
@@ -1,1 +1,0 @@
-!missing-enum-value! CGToneMapping native value kCGToneMappingHeadroomAdaptiveGainCurve = 6 not bound


### PR DESCRIPTION
## Summary

- Add `CGToneMapping.HeadroomAdaptiveGainCurve` with native value `6`.
- Apply iOS, tvOS, macOS, and Mac Catalyst 27.0 availability.
- Update the cecil documentation baseline.
- Remove the resolved CoreGraphics xtro todo files for all four platforms.

## Validation

- `make world` before and after the binding update
- Clean xtro generation and classification: sanity passed
- Clean cecil suite: 116 tests passed
- iOS 27 introspection: 44 tests passed
- tvOS 27 introspection: 43 tests passed
- macOS introspection: 32 tests passed, 2 host-version-gated tests ignored
- Mac Catalyst: all 14 non-constructor fixtures passed individually; the full constructor fixture encounters the known unsigned-app TCC privacy abort
- App-size suite: 16 tests skipped by design while using beta Xcode