### PR TITLE
[CloudKit] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/cloudkit.cs
+++ b/src/cloudkit.cs
@@ -268,6 +268,21 @@ namespace CloudKit {
 		[Static]
 		[Export ("oneTimeURLParticipant")]
 		CKShareParticipant GetOneTimeUrlParticipant ();
+
+		/// <param name="anObject">The object to compare with this participant. May be <see langword="null" />.</param>
+		/// <summary>Determines whether <paramref name="anObject" /> represents the same person as this participant.</summary>
+		/// <returns>
+		///   <see langword="true" /> if <paramref name="anObject" /> represents the same person as this participant;
+		///   otherwise, <see langword="false" />.
+		/// </returns>
+		/// <remarks>
+		///   <para>Equality is based on person identity rather than structural equality. Participants with different roles,
+		///   acceptance statuses, permissions, or other properties may compare equal.</para>
+		/// </remarks>
+		[EditorBrowsable (EditorBrowsableState.Never)]
+		[Export ("isEqual:")]
+		[Override]
+		bool IsEqual ([NullAllowed] NSObject anObject);
 	}
 
 	[MacCatalyst (13, 1)]

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CloudKit.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CloudKit.todo
@@ -1,1 +1,0 @@
-!missing-selector! CKShareParticipant::isEqual: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-CloudKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-CloudKit.ignore
@@ -8,6 +8,9 @@
 !missing-protocol-conformance! CKRecord should conform to CKRecordKeyValueSetting (defined in 'CKRecordKeyValueSettingConformance' category)
 !missing-selector! CKRecord::encryptedValues not bound
 
+# Keep [NullAllowed] to preserve NSObject.IsEqual's nullable override contract and isEqual:nil behavior.
+!extra-null-allowed! 'System.Boolean CloudKit.CKShareParticipant::IsEqual(Foundation.NSObject)' has a extraneous [NullAllowed] on parameter #0
+
 # results from initial block parameter nullability analysis
 !missing-null-allowed! 'System.Void CloudKit.CKAcceptSharesOperation::set_AcceptSharesCompleted(System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'value' block parameter #0
 !missing-null-allowed! 'System.Void CloudKit.CKContainer::AcceptShareMetadata(CloudKit.CKShareMetadata,System.Action`2<CloudKit.CKShare,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-CloudKit.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-CloudKit.todo
@@ -1,1 +1,0 @@
-!missing-selector! CKShareParticipant::isEqual: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-CloudKit.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-CloudKit.todo
@@ -1,1 +1,0 @@
-!missing-selector! CKShareParticipant::isEqual: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-CloudKit.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-CloudKit.todo
@@ -1,1 +1,0 @@
-!missing-selector! CKShareParticipant::isEqual: not bound


### PR DESCRIPTION
## Summary

- Bind `CKShareParticipant.isEqual:` as a nullable managed override.
- Document CloudKit's person-identity equality semantics while preserving the inherited `NSObject.IsEqual` contract.
- Add the shared xtro nullability exception and remove the resolved CloudKit todo files for all four platforms.

## Validation

- `make world`
- Clean xtro regeneration and classification (`Sanity check passed`)
- Clean Cecil tests (112 passed, 4 skipped)
- Introspection: iOS 44/44, tvOS 43/43, macOS 32/32; all non-TCC Mac Catalyst fixtures passed, including selector and signature validation
- AppSizeTest completed with 16 expected skips because Xcode 27 is beta

The full Mac Catalyst constructor fixture still hits the known unrelated TCC privacy abort while constructing `CoreLocationUI.CLLocationButton` in an unsigned desktop run.
