### PR TITLE
[CoreNFC] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/corenfc.cs
+++ b/src/corenfc.cs
@@ -55,6 +55,13 @@ namespace CoreNFC {
 		NdefReaderSessionErrorTagUpdateFailure = 401,
 		NdefReaderSessionErrorTagSizeTooSmall = 402,
 		NdefReaderSessionErrorZeroLengthMessage = 403,
+
+		/// <summary>Location authorization was denied by the user.</summary>
+		PaymentTagReaderSessionErrorLocationAuthorizationDenied = 500,
+		/// <summary>Active restrictions prevent the app from using location services.</summary>
+		PaymentTagReaderSessionErrorLocationServiceRestricted,
+		/// <summary>The location was provided by an accessory or simulated in software instead of produced by on-device hardware.</summary>
+		PaymentTagReaderSessionErrorOnDeviceLocationUnavailable,
 	}
 
 	//[NoTV, NoMac]

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreNFC.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreNFC.todo
@@ -1,3 +1,0 @@
-!missing-enum-value! NFCReaderError native value NFCPaymentTagReaderSessionErrorLocationAuthorizationDenied = 500 not bound
-!missing-enum-value! NFCReaderError native value NFCPaymentTagReaderSessionErrorLocationServiceRestricted = 501 not bound
-!missing-enum-value! NFCReaderError native value NFCPaymentTagReaderSessionErrorOnDeviceLocationUnavailable = 502 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreNFC.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreNFC.todo
@@ -1,3 +1,0 @@
-!missing-enum-value! NFCReaderError native value NFCPaymentTagReaderSessionErrorLocationAuthorizationDenied = 500 not bound
-!missing-enum-value! NFCReaderError native value NFCPaymentTagReaderSessionErrorLocationServiceRestricted = 501 not bound
-!missing-enum-value! NFCReaderError native value NFCPaymentTagReaderSessionErrorOnDeviceLocationUnavailable = 502 not bound


### PR DESCRIPTION
## Summary

- Bind the three CoreNFC payment tag reader session location errors introduced by the Xcode 27.0 Beta 3 SDK.
- Add documented `NFCReaderError` values for denied authorization, restricted location services, and unavailable on-device location on iOS and Mac Catalyst.
- Remove the resolved iOS and Mac Catalyst CoreNFC xtro todo files.
- Keep the new fields free of per-member availability attributes, as required for error enum members by the cecil validation rules.

## Validation

- `make world` before and after the binding changes
- Clean xtro generation/classification: sanity passed
- Clean cecil suite: 116 tests passed
- iOS 27 introspection: 44 passed, 0 failed
- tvOS 27 introspection: 43 passed, 0 failed
- macOS introspection: 32 passed, 0 failed
- Mac Catalyst introspection: 39 passed, 0 failed
- App size suite invoked from clean outputs; all 16 cases were intentionally skipped because app-size validation is disabled for beta Xcode
