### PR TITLE
[CoreLocation] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/corelocation.cs
+++ b/src/corelocation.cs
@@ -490,9 +490,18 @@ namespace CoreLocation {
 		///         <value>The default value assumes that the app, in upright portrait mode, represents due North.</value>
 		///         <remarks>To be added.</remarks>
 		[NoTV]
+		[Deprecated (PlatformName.iOS, 27, 0, message: "Use 'HeadingBody' instead.")]
+		[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use 'HeadingBody' instead.")]
 		[MacCatalyst (13, 1)]
+		[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use 'HeadingBody' instead.")]
 		[Export ("headingOrientation", ArgumentSemantic.Assign)]
 		CLDeviceOrientation HeadingOrientation { get; set; }
+
+		/// <summary>Gets or sets the body used as the reference for heading calculations.</summary>
+		/// <value>The reference body, or <see langword="null" /> if no body is set.</value>
+		[NoTV, Mac (27, 0), iOS (27, 0), MacCatalyst (27, 0)]
+		[NullAllowed, Export ("headingBody", ArgumentSemantic.Retain)]
+		ICLBodyIdentifiable HeadingBody { get; set; }
 
 		/// <summary>The most recent heading (direction in which the device is traveling).</summary>
 		///         <value>This value may be <see langword="null" /> if heading updates have not been started.</value>
@@ -1757,6 +1766,8 @@ namespace CoreLocation {
 		[BindAs (typeof (short?))]
 		NSNumber Minor { get; }
 	}
+
+	interface ICLBodyIdentifiable { }
 
 	[TV (27, 0), Mac (27, 0), iOS (27, 0), MacCatalyst (27, 0)]
 	[Protocol]

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreLocation.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreLocation.todo
@@ -1,4 +1,0 @@
-!deprecated-attribute-missing! CLLocationManager::headingOrientation missing a [Deprecated] attribute
-!deprecated-attribute-missing! CLLocationManager::setHeadingOrientation: missing a [Deprecated] attribute
-!missing-selector! CLLocationManager::headingBody not bound
-!missing-selector! CLLocationManager::setHeadingBody: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreLocation.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreLocation.todo
@@ -1,4 +1,0 @@
-!deprecated-attribute-missing! CLLocationManager::headingOrientation missing a [Deprecated] attribute
-!deprecated-attribute-missing! CLLocationManager::setHeadingOrientation: missing a [Deprecated] attribute
-!missing-selector! CLLocationManager::headingBody not bound
-!missing-selector! CLLocationManager::setHeadingBody: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreLocation.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreLocation.todo
@@ -1,4 +1,0 @@
-!deprecated-attribute-missing! CLLocationManager::headingOrientation missing a [Deprecated] attribute
-!deprecated-attribute-missing! CLLocationManager::setHeadingOrientation: missing a [Deprecated] attribute
-!missing-selector! CLLocationManager::headingBody not bound
-!missing-selector! CLLocationManager::setHeadingBody: not bound


### PR DESCRIPTION
## Summary

- Bind `CLLocationManager.HeadingBody` as a nullable retained `ICLBodyIdentifiable` property on iOS, macOS, and Mac Catalyst 27.0.
- Deprecate `HeadingOrientation` on those platforms with `HeadingBody` as its replacement.
- Add the intermediate protocol stub required by API-definition compilation and remove the fully resolved CoreLocation xtro todo files.

## Validation

- `make world`
- Clean xtro generation/classification: sanity passed
- Clean cecil suite: 112 passed, 4 skipped, 0 failed
- iOS 27.0 introspection: 44/44 passed
- tvOS 27.0 introspection: 43/43 passed
- macOS introspection: 32/32 passed, 2 host-version ignores
- Mac Catalyst introspection: 39/39 passed, 4 expected ignores
- AppSizeTest: 16 expected skips under the beta-Xcode guard, 0 failed

All four requested max-reasoning implementation reviews approved the change with no findings.
