### PR TITLE
[CoreMedia] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/coremedia.cs
+++ b/src/coremedia.cs
@@ -240,6 +240,10 @@ namespace CoreMedia {
 	enum CMFormatDescriptionLogTransferFunction {
 		[Field ("kCMFormatDescriptionLogTransferFunction_AppleLog")]
 		AppleLog,
+
+		[MacCatalyst (27, 0), TV (27, 0), Mac (27, 0), iOS (27, 0)]
+		[Field ("kCMFormatDescriptionLogTransferFunction_AppleLog2")]
+		AppleLog2,
 	}
 
 	[iOS (17, 0), TV (17, 0), MacCatalyst (17, 0)]
@@ -1298,6 +1302,10 @@ namespace CoreMedia {
 		[MacCatalyst (26, 0), TV (26, 0), Mac (26, 0), iOS (26, 0)]
 		[Field ("kCMMetadataIdentifier_QuickTimeMetadataPresentationImmersiveMedia")]
 		QuickTimeMetadataPresentationImmersiveMedia,
+
+		[MacCatalyst (27, 0), TV (27, 0), Mac (27, 0), iOS (27, 0)]
+		[Field ("kCMMetadataIdentifier_ITUT_T35MetadataSMPTE2094_50")]
+		ITUT_T35MetadataSMPTE2094_50,
 	}
 
 	enum CMMetadataBaseDataType {
@@ -1383,5 +1391,13 @@ namespace CoreMedia {
 		[MacCatalyst (26, 0), TV (26, 0), Mac (26, 0), iOS (26, 0)]
 		[Field ("kCMMetadataBaseDataType_ExtendedRasterRectangleValue")]
 		ExtendedRasterRectangleValue,
+
+		[MacCatalyst (27, 0), TV (27, 0), Mac (27, 0), iOS (27, 0)]
+		[Field ("kCMMetadataBaseDataType_MacRoman")]
+		MacRoman,
+
+		[MacCatalyst (27, 0), TV (27, 0), Mac (27, 0), iOS (27, 0)]
+		[Field ("kCMMetadataBaseDataType_ISOLatin1")]
+		IsoLatin1,
 	}
 }

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -2530,6 +2530,7 @@ F:CoreMedia.CMFormatDescriptionFieldDetail.TemporalTopFirst
 F:CoreMedia.CMFormatDescriptionHeroEye.Left
 F:CoreMedia.CMFormatDescriptionHeroEye.Right
 F:CoreMedia.CMFormatDescriptionLogTransferFunction.AppleLog
+F:CoreMedia.CMFormatDescriptionLogTransferFunction.AppleLog2
 F:CoreMedia.CMFormatDescriptionProjectionKind.AppleImmersiveVideo
 F:CoreMedia.CMFormatDescriptionProjectionKind.Equirectangular
 F:CoreMedia.CMFormatDescriptionProjectionKind.HalfEquirectangular
@@ -2558,8 +2559,10 @@ F:CoreMedia.CMMetadataBaseDataType.ExtendedRasterRectangleValue
 F:CoreMedia.CMMetadataBaseDataType.Float32
 F:CoreMedia.CMMetadataBaseDataType.Float64
 F:CoreMedia.CMMetadataBaseDataType.Gif
+F:CoreMedia.CMMetadataBaseDataType.IsoLatin1
 F:CoreMedia.CMMetadataBaseDataType.Jpeg
 F:CoreMedia.CMMetadataBaseDataType.Json
+F:CoreMedia.CMMetadataBaseDataType.MacRoman
 F:CoreMedia.CMMetadataBaseDataType.PerspectiveTransformF64
 F:CoreMedia.CMMetadataBaseDataType.Png
 F:CoreMedia.CMMetadataBaseDataType.PointF32
@@ -2578,6 +2581,7 @@ F:CoreMedia.CMMetadataBaseDataType.UInt64
 F:CoreMedia.CMMetadataBaseDataType.UInt8
 F:CoreMedia.CMMetadataBaseDataType.Utf16
 F:CoreMedia.CMMetadataBaseDataType.Utf8
+F:CoreMedia.CMMetadataIdentifier.ITUT_T35MetadataSMPTE2094_50
 F:CoreMedia.CMMetadataIdentifier.QuickTimeMetadataDirection_Facing
 F:CoreMedia.CMMetadataIdentifier.QuickTimeMetadataDisplayMaskRectangleMono
 F:CoreMedia.CMMetadataIdentifier.QuickTimeMetadataDisplayMaskRectangleStereoLeft

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreMedia.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreMedia.todo
@@ -1,5 +1,0 @@
-!missing-field! kCMFormatDescriptionLogTransferFunction_AppleLog2 not bound
-!missing-field! kCMMetadataBaseDataType_ISOLatin1 not bound
-!missing-field! kCMMetadataBaseDataType_MacRoman not bound
-!missing-field! kCMMetadataDataType_QuickTimeMetadataSMPTE2094_50 not bound
-!missing-field! kCMMetadataIdentifier_ITUT_T35MetadataSMPTE2094_50 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-CoreMedia.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-CoreMedia.ignore
@@ -136,7 +136,9 @@
 !missing-pinvoke! CMBufferQueueGetMinPresentationTimeStamp is not bound
 !missing-pinvoke! CMBufferQueueGetTypeID is not bound
 !missing-pinvoke! CMBufferQueueCopyHead is not bound
+## The kCMMetadataDataType_* family and related registry APIs are intentionally unbound.
 !missing-field! kCMMetadataDataType_QuickTimeMetadataMilliLux not bound
+!missing-field! kCMMetadataDataType_QuickTimeMetadataSMPTE2094_50 not bound
 !missing-field! kCMMetadataDataType_QuickTimeMetadataUUID not bound
 
 !missing-pinvoke! CMBufferQueueInstallTrigger is not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreMedia.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreMedia.todo
@@ -1,5 +1,0 @@
-!missing-field! kCMFormatDescriptionLogTransferFunction_AppleLog2 not bound
-!missing-field! kCMMetadataBaseDataType_ISOLatin1 not bound
-!missing-field! kCMMetadataBaseDataType_MacRoman not bound
-!missing-field! kCMMetadataDataType_QuickTimeMetadataSMPTE2094_50 not bound
-!missing-field! kCMMetadataIdentifier_ITUT_T35MetadataSMPTE2094_50 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreMedia.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreMedia.todo
@@ -1,5 +1,0 @@
-!missing-field! kCMFormatDescriptionLogTransferFunction_AppleLog2 not bound
-!missing-field! kCMMetadataBaseDataType_ISOLatin1 not bound
-!missing-field! kCMMetadataBaseDataType_MacRoman not bound
-!missing-field! kCMMetadataDataType_QuickTimeMetadataSMPTE2094_50 not bound
-!missing-field! kCMMetadataIdentifier_ITUT_T35MetadataSMPTE2094_50 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-CoreMedia.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-CoreMedia.todo
@@ -1,5 +1,0 @@
-!missing-field! kCMFormatDescriptionLogTransferFunction_AppleLog2 not bound
-!missing-field! kCMMetadataBaseDataType_ISOLatin1 not bound
-!missing-field! kCMMetadataBaseDataType_MacRoman not bound
-!missing-field! kCMMetadataDataType_QuickTimeMetadataSMPTE2094_50 not bound
-!missing-field! kCMMetadataIdentifier_ITUT_T35MetadataSMPTE2094_50 not bound


### PR DESCRIPTION
## Summary

- Bind the Xcode 27 CoreMedia constants for Apple Log 2, MacRoman and ISO Latin 1 metadata base data types, and the SMPTE 2094-50 metadata identifier across iOS, tvOS, macOS, and Mac Catalyst.
- Append the new smart-enum members so all previously shipped managed enum ordinals remain unchanged.
- Keep `kCMMetadataDataType_QuickTimeMetadataSMPTE2094_50` in the shared xtro ignore list with the intentionally unbound `kCMMetadataDataType_*` family and registry APIs.
- Remove the four resolved platform CoreMedia todo files and refresh the Cecil documentation baseline.

## API updates

- `CMFormatDescriptionLogTransferFunction.AppleLog2`
- `CMMetadataBaseDataType.MacRoman`
- `CMMetadataBaseDataType.IsoLatin1`
- `CMMetadataIdentifier.ITUT_T35MetadataSMPTE2094_50`

All new managed members are available on iOS 27.0, tvOS 27.0, macOS 27.0, and Mac Catalyst 27.0.

## Validation

- `make world`
- Clean xtro generation, classification, and sanity: passed
- Clean Cecil suite: 112 passed, 4 expected skipped, 0 failed
- iOS 27.0 introspection: 44 passed, 0 failed
- tvOS 27.0 introspection: 43 passed, 0 failed
- macOS introspection: 32 passed, 0 failed, 2 expected ignored
- Mac Catalyst introspection: 39 passed, 0 failed, 4 expected ignored
- Filtered `AppSizeTest`: 0 failed, 16 expected beta-Xcode skips