### PR TITLE
[src] It's no longer necessary to ensure the runtime has been initialized from managed code.

### DIFF
--- a/src/AppKit/NSApplication.cs
+++ b/src/AppKit/NSApplication.cs
@@ -55,8 +55,6 @@ namespace AppKit {
 				throw new InvalidOperationException ("Init has already been invoked; it can only be invoked once");
 			}
 
-			Runtime.EnsureInitialized ();
-
 			initialized = true;
 
 			if (Runtime.DynamicRegistrationSupported)

--- a/src/ObjCRuntime/Runtime.mac.cs
+++ b/src/ObjCRuntime/Runtime.mac.cs
@@ -60,17 +60,6 @@ namespace ObjCRuntime {
 		delegate void initialize_func ();
 		unsafe delegate sbyte* get_sbyteptr_func ();
 
-		[DllImport ("__Internal")]
-		extern static void xamarin_initialize ();
-
-		internal static void EnsureInitialized ()
-		{
-			if (initialized)
-				return;
-
-			xamarin_initialize ();
-		}
-
 		unsafe static void InitializePlatform (InitializationOptions* options)
 		{
 			string basePath = AppDomain.CurrentDomain.BaseDirectory;


### PR DESCRIPTION
It was necessary to ensure `xamarin_initialize` was called when Xamarin.Mac was hosted inside another application (such as Visual Studio for Mac).

.NET for macOS no longer supports being hosted inside another application, so this code can be removed.