### PR TITLE
[Accounts] Fix ACFacebookAudience.OnlyMe mapping in SetPermissions

### DIFF
--- a/src/Accounts/AccountStoreOptions.cs
+++ b/src/Accounts/AccountStoreOptions.cs
@@ -104,7 +104,7 @@ namespace Accounts {
 				v = ACFacebookAudienceValue.Friends;
 				break;
 			case ACFacebookAudience.OnlyMe:
-				v = ACFacebookAudienceValue.Friends;
+				v = ACFacebookAudienceValue.OnlyMe;
 				break;
 			default:
 				throw new ArgumentOutOfRangeException ("audience");


### PR DESCRIPTION
## Summary

`AccountStoreOptions.SetPermissions` mapped `ACFacebookAudience.OnlyMe` to `ACFacebookAudienceValue.Friends` in its switch statement, so callers could never actually request the `OnlyMe` audience — it silently behaved like `Friends`.

This changes the `ACFacebookAudience.OnlyMe` case to use `ACFacebookAudienceValue.OnlyMe` (the field is defined in `src/accounts.cs` via `[Field ("ACFacebookAudienceOnlyMe")]`).

The change is minimal and surgical — a single line.

🤖 Pull request created by Copilot