### PR TITLE
[xtro] Report extra/unknown managed selectors with no native declaration. Fixes #26053.

### DIFF
--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CloudKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CloudKit.ignore
@@ -1,3 +1,10 @@
 !missing-null-allowed! 'System.Void CloudKit.CKContainer::FetchAllLongLivedOperationIDs(System.Action`2<Foundation.NSDictionary`2<Foundation.NSString,Foundation.NSOperation>,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void CloudKit.CKContainer::FetchAllLongLivedOperationIDs(System.Action`2<Foundation.NSDictionary`2<Foundation.NSString,Foundation.NSOperation>,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #1
 !missing-null-allowed! 'System.Void CloudKit.CKContainer::FetchLongLivedOperation(System.String[],System.Action`2<Foundation.NSDictionary`2<Foundation.NSString,Foundation.NSOperation>,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #1
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! CKSubscription::predicate not found
+!unknown-selector! CKSubscription::recordType not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreSpotlight.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreSpotlight.ignore
@@ -7,3 +7,13 @@
 !missing-null-allowed! 'System.Void CoreSpotlight.CSSearchableIndex::FetchData(System.String,System.String,UniformTypeIdentifiers.UTType,System.Action`2<Foundation.NSData,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #1
 !missing-null-allowed! 'System.Void CoreSpotlight.CSSearchableIndex::Index(CoreSpotlight.CSSearchableItem[],System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void CoreSpotlight.CSSearchQuery::set_CompletionHandler(System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'value' block parameter #0
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! CSSearchableIndex::initWithName:protectionClass:bundleIdentifier:options: not found
+!unknown-selector! CSSearchableIndex::provideDataForBundle:identifier:type:completionHandler: not found
+!unknown-selector! CSSearchableItemAttributeSet::moveFrom: not found
+!unknown-selector! CSSuggestion::score not found
+!unknown-selector! CSSuggestion::suggestionDataSources not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-Foundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-Foundation.ignore
@@ -487,3 +487,9 @@
 !missing-null-allowed! 'System.Void Foundation.NSFilePresenter::AccommodatePresentedItemEviction(System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void Foundation.NSFileProviderService::GetFileProviderConnection(System.Action`2<Foundation.NSXpcConnection,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void Foundation.NSFileProviderService::GetFileProviderConnection(System.Action`2<Foundation.NSXpcConnection,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #1
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! NSInputStream::_setCFClientFlags:callback:context: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-Messages.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-Messages.ignore
@@ -7,3 +7,9 @@
 !missing-null-allowed! 'System.Void Messages.MSConversation::SendMessage(Messages.MSMessage,System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void Messages.MSConversation::SendSticker(Messages.MSSticker,System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void Messages.MSConversation::SendText(System.String,System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! MSSticker::initWithFileURL:identifier:localizedDescription: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-Metal.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-Metal.ignore
@@ -1,8 +1,3 @@
-## [Notification] in protocol - https://bugzilla.xamarin.com/show_bug.cgi?id=59342
-!missing-field! MTLDeviceRemovalRequestedNotification not bound
-!missing-field! MTLDeviceWasAddedNotification not bound
-!missing-field! MTLDeviceWasRemovedNotification not bound
-
 ## bound selectors with no native declaration reachable from the class in the current SDK headers:
 ## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
 ## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-MetalPerformanceShaders.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-MetalPerformanceShaders.ignore
@@ -1,12 +1,5 @@
-# adding these since weak delegate exists in base class
-!missing-selector! PKCanvasView::delegate not bound
-!missing-selector! PKCanvasView::setDelegate: not bound
-
-# removed in XAMCORE_5_0
-!extra-protocol-member! unexpected selector PKCanvasViewDelegate::canvasView:didRefineStrokes:withNewStrokes: found
-
 ## bound selectors with no native declaration reachable from the class in the current SDK headers:
 ## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
 ## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
 ## (baseline for https://github.com/dotnet/macios/issues/26053)
-!unknown-selector! +PKInkingTool::invertColor: not found
+!unknown-selector! MPSCNNKernel::sourceRegionForDestinationSize: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-ModelIO.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-ModelIO.ignore
@@ -1,12 +1,7 @@
-# adding these since weak delegate exists in base class
-!missing-selector! PKCanvasView::delegate not bound
-!missing-selector! PKCanvasView::setDelegate: not bound
-
-# removed in XAMCORE_5_0
-!extra-protocol-member! unexpected selector PKCanvasViewDelegate::canvasView:didRefineStrokes:withNewStrokes: found
-
 ## bound selectors with no native declaration reachable from the class in the current SDK headers:
 ## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
 ## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
 ## (baseline for https://github.com/dotnet/macios/issues/26053)
-!unknown-selector! +PKInkingTool::invertColor: not found
+!unknown-selector! MDLAsset::componentConformingToProtocol: not found
+!unknown-selector! MDLAsset::components not found
+!unknown-selector! MDLAsset::setComponent:forProtocol: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-PencilKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-PencilKit.ignore
@@ -1,3 +1,9 @@
 # adding these since weak delegate exists in base class
 !missing-selector! PKCanvasView::delegate not bound
 !missing-selector! PKCanvasView::setDelegate: not bound
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! +PKInkingTool::invertColor: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-SensorKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-SensorKit.ignore
@@ -1,2 +1,8 @@
 # results from initial block parameter nullability analysis
 !missing-null-allowed! 'System.Void SensorKit.SRSensorReader::RequestAuthorization(Foundation.NSSet`1<Foundation.NSString>,System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completion' block parameter #0
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! SRFaceMetrics::faceAnchor not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-StoreKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-StoreKit.ignore
@@ -1,3 +1,9 @@
 # results from initial block parameter nullability analysis
 !missing-null-allowed! 'System.Void StoreKit.SKStoreProductViewController::LoadProduct(Foundation.NSDictionary,StoreKit.SKAdImpression,System.Action`2<System.Boolean,Foundation.NSError>)' is missing a '?' on parameter 'callback' block parameter #1
 !missing-null-allowed! 'System.Void StoreKit.SKStoreProductViewController::LoadProduct(Foundation.NSDictionary,System.Action`2<System.Boolean,Foundation.NSError>)' is missing a '?' on parameter 'callback' block parameter #1
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! SKAdImpression::initWithSourceAppStoreItemIdentifier:advertisedAppStoreItemIdentifier:adNetworkIdentifier:adCampaignIdentifier:adImpressionIdentifier:timestamp:signature:version: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-UIKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-UIKit.ignore
@@ -410,3 +410,11 @@
 !missing-null-allowed! 'System.Void UIKit.UIPasteboard::DetectValues(Foundation.NSSet`1<Foundation.NSString>,Foundation.NSIndexSet,System.Action`2<Foundation.NSDictionary`2<Foundation.NSString,Foundation.NSObject>[],Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #1
 !missing-null-allowed! 'System.Void UIKit.UIPasteboard::DetectValues(Foundation.NSSet`1<Foundation.NSString>,System.Action`2<Foundation.NSDictionary`2<Foundation.NSString,Foundation.NSObject>,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void UIKit.UIPasteboard::DetectValues(Foundation.NSSet`1<Foundation.NSString>,System.Action`2<Foundation.NSDictionary`2<Foundation.NSString,Foundation.NSObject>,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #1
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! +UIFocusDebugger::checkFocusGroupTreeForEnvironment: not found
+!unknown-selector! UIDocumentBrowserAction::imageOnlyForContextMenu not found
+!unknown-selector! UIDocumentBrowserAction::setImageOnlyForContextMenu: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-WebKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-WebKit.ignore
@@ -1,12 +1,5 @@
-# adding these since weak delegate exists in base class
-!missing-selector! PKCanvasView::delegate not bound
-!missing-selector! PKCanvasView::setDelegate: not bound
-
-# removed in XAMCORE_5_0
-!extra-protocol-member! unexpected selector PKCanvasViewDelegate::canvasView:didRefineStrokes:withNewStrokes: found
-
 ## bound selectors with no native declaration reachable from the class in the current SDK headers:
 ## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
 ## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
 ## (baseline for https://github.com/dotnet/macios/issues/26053)
-!unknown-selector! +PKInkingTool::invertColor: not found
+!unknown-selector! WKPreferences::textInteractionEnabled not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-AVFoundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-AVFoundation.ignore
@@ -33,3 +33,9 @@
 !missing-null-allowed! 'System.Void AVFoundation.AVMutableMovie::LoadTracksWithMediaCharacteristic(System.String,System.Action`2<Foundation.NSArray`1<AVFoundation.AVMovieTrack>,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #1
 !missing-null-allowed! 'System.Void AVFoundation.AVMutableMovie::LoadTracksWithMediaType(System.String,System.Action`2<Foundation.NSArray`1<AVFoundation.AVMovieTrack>,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void AVFoundation.AVMutableMovie::LoadTracksWithMediaType(System.String,System.Action`2<Foundation.NSArray`1<AVFoundation.AVMovieTrack>,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #1
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! AVPlayerItem::setInterstitialTimeRanges: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-AccessorySetupKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-AccessorySetupKit.ignore
@@ -1,12 +1,5 @@
-# adding these since weak delegate exists in base class
-!missing-selector! PKCanvasView::delegate not bound
-!missing-selector! PKCanvasView::setDelegate: not bound
-
-# removed in XAMCORE_5_0
-!extra-protocol-member! unexpected selector PKCanvasViewDelegate::canvasView:didRefineStrokes:withNewStrokes: found
-
 ## bound selectors with no native declaration reachable from the class in the current SDK headers:
 ## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
 ## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
 ## (baseline for https://github.com/dotnet/macios/issues/26053)
-!unknown-selector! +PKInkingTool::invertColor: not found
+!unknown-selector! ASPickerDisplayItem::setDescriptor: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-CarPlay.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-CarPlay.ignore
@@ -6,3 +6,9 @@
 !missing-null-allowed! 'System.Void CarPlay.CPInterfaceController::PresentTemplate(CarPlay.CPTemplate,System.Boolean,System.Action`2<System.Boolean,Foundation.NSError>)' is missing a '?' on parameter 'completion' block parameter #1
 !missing-null-allowed! 'System.Void CarPlay.CPInterfaceController::PushTemplate(CarPlay.CPTemplate,System.Boolean,System.Action`2<System.Boolean,Foundation.NSError>)' is missing a '?' on parameter 'completion' block parameter #1
 !missing-null-allowed! 'System.Void CarPlay.CPInterfaceController::SetRootTemplate(CarPlay.CPTemplate,System.Boolean,System.Action`2<System.Boolean,Foundation.NSError>)' is missing a '?' on parameter 'completion' block parameter #1
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! CPListImageRowItem::setImageTitles: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-CloudKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-CloudKit.ignore
@@ -1,3 +1,12 @@
 !missing-null-allowed! 'System.Void CloudKit.CKContainer::FetchAllLongLivedOperationIDs(System.Action`2<Foundation.NSDictionary`2<Foundation.NSString,Foundation.NSOperation>,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void CloudKit.CKContainer::FetchAllLongLivedOperationIDs(System.Action`2<Foundation.NSDictionary`2<Foundation.NSString,Foundation.NSOperation>,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #1
 !missing-null-allowed! 'System.Void CloudKit.CKContainer::FetchLongLivedOperation(System.String[],System.Action`2<Foundation.NSDictionary`2<Foundation.NSString,Foundation.NSOperation>,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #1
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! CKSubscription::predicate not found
+!unknown-selector! CKSubscription::recordType not found
+!unknown-selector! CKSubscription::setZoneID: not found
+!unknown-selector! CKSubscription::zoneID not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreSpotlight.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreSpotlight.ignore
@@ -7,3 +7,13 @@
 !missing-null-allowed! 'System.Void CoreSpotlight.CSSearchableIndex::FetchData(System.String,System.String,UniformTypeIdentifiers.UTType,System.Action`2<Foundation.NSData,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #1
 !missing-null-allowed! 'System.Void CoreSpotlight.CSSearchableIndex::Index(CoreSpotlight.CSSearchableItem[],System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void CoreSpotlight.CSSearchQuery::set_CompletionHandler(System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'value' block parameter #0
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! CSSearchableIndex::initWithName:protectionClass:bundleIdentifier:options: not found
+!unknown-selector! CSSearchableIndex::provideDataForBundle:identifier:type:completionHandler: not found
+!unknown-selector! CSSearchableItemAttributeSet::moveFrom: not found
+!unknown-selector! CSSuggestion::score not found
+!unknown-selector! CSSuggestion::suggestionDataSources not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-DeviceDiscoveryUI.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-DeviceDiscoveryUI.ignore
@@ -1,12 +1,7 @@
-# adding these since weak delegate exists in base class
-!missing-selector! PKCanvasView::delegate not bound
-!missing-selector! PKCanvasView::setDelegate: not bound
-
-# removed in XAMCORE_5_0
-!extra-protocol-member! unexpected selector PKCanvasViewDelegate::canvasView:didRefineStrokes:withNewStrokes: found
-
 ## bound selectors with no native declaration reachable from the class in the current SDK headers:
 ## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
 ## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
 ## (baseline for https://github.com/dotnet/macios/issues/26053)
-!unknown-selector! +PKInkingTool::invertColor: not found
+!unknown-selector! +DDDevicePickerViewController::isSupportedForBrowseDescriptor:parameters: not found
+!unknown-selector! DDDevicePickerViewController::initWithBrowseDescriptor:parameters: not found
+!unknown-selector! DDDevicePickerViewController::setDevicePickerCompletionHandler: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-Foundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-Foundation.ignore
@@ -16,3 +16,9 @@
 !missing-null-allowed! 'System.Void Foundation.NSFilePresenter::AccommodatePresentedItemEviction(System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void Foundation.NSFileProviderService::GetFileProviderConnection(System.Action`2<Foundation.NSXpcConnection,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void Foundation.NSFileProviderService::GetFileProviderConnection(System.Action`2<Foundation.NSXpcConnection,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #1
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! NSInputStream::_setCFClientFlags:callback:context: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-GLKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-GLKit.ignore
@@ -57,3 +57,9 @@
 !missing-release-attribute-on-return-value! ModelIO.IMDLMeshBuffer GLKit.GLKMeshBufferAllocator::CreateBuffer(System.UIntPtr,ModelIO.MDLMeshBufferType)'s selector's ('newBuffer:type:') Objective-C method family ('new') indicates that the native method returns a retained object, and as such a '[return: Release]' attribute is required.
 !missing-release-attribute-on-return-value! ModelIO.IMDLMeshBufferZone GLKit.GLKMeshBufferAllocator::CreateZone(Foundation.NSNumber[],Foundation.NSNumber[])'s selector's ('newZoneForBuffersWithSize:andType:') Objective-C method family ('new') indicates that the native method returns a retained object, and as such a '[return: Release]' attribute is required.
 !missing-release-attribute-on-return-value! ModelIO.IMDLMeshBufferZone GLKit.GLKMeshBufferAllocator::CreateZone(System.UIntPtr)'s selector's ('newZone:') Objective-C method family ('new') indicates that the native method returns a retained object, and as such a '[return: Release]' attribute is required.
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! GLKViewController::update not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-Messages.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-Messages.ignore
@@ -7,3 +7,9 @@
 !missing-null-allowed! 'System.Void Messages.MSConversation::SendMessage(Messages.MSMessage,System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void Messages.MSConversation::SendSticker(Messages.MSSticker,System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void Messages.MSConversation::SendText(System.String,System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! MSSticker::initWithFileURL:identifier:localizedDescription: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-Metal.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-Metal.ignore
@@ -1,8 +1,3 @@
-## [Notification] in protocol - https://bugzilla.xamarin.com/show_bug.cgi?id=59342
-!missing-field! MTLDeviceRemovalRequestedNotification not bound
-!missing-field! MTLDeviceWasAddedNotification not bound
-!missing-field! MTLDeviceWasRemovedNotification not bound
-
 ## bound selectors with no native declaration reachable from the class in the current SDK headers:
 ## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
 ## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-MetalPerformanceShaders.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-MetalPerformanceShaders.ignore
@@ -9,3 +9,9 @@
 !missing-designated-initializer! MPSCNNNeuronSigmoid::initWithDevice: is missing an [DesignatedInitializer] attribute
 !missing-designated-initializer! MPSCNNNeuronSoftPlus::initWithDevice:a:b: is missing an [DesignatedInitializer] attribute
 !missing-designated-initializer! MPSCNNNeuronTanH::initWithDevice:a:b: is missing an [DesignatedInitializer] attribute
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! MPSCNNKernel::sourceRegionForDestinationSize: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-ModelIO.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-ModelIO.ignore
@@ -1,12 +1,7 @@
-# adding these since weak delegate exists in base class
-!missing-selector! PKCanvasView::delegate not bound
-!missing-selector! PKCanvasView::setDelegate: not bound
-
-# removed in XAMCORE_5_0
-!extra-protocol-member! unexpected selector PKCanvasViewDelegate::canvasView:didRefineStrokes:withNewStrokes: found
-
 ## bound selectors with no native declaration reachable from the class in the current SDK headers:
 ## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
 ## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
 ## (baseline for https://github.com/dotnet/macios/issues/26053)
-!unknown-selector! +PKInkingTool::invertColor: not found
+!unknown-selector! MDLAsset::componentConformingToProtocol: not found
+!unknown-selector! MDLAsset::components not found
+!unknown-selector! MDLAsset::setComponent:forProtocol: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-UIKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-UIKit.ignore
@@ -414,3 +414,11 @@
 !missing-null-allowed! 'System.Void UIKit.UIPasteboard::DetectValues(Foundation.NSSet`1<Foundation.NSString>,Foundation.NSIndexSet,System.Action`2<Foundation.NSDictionary`2<Foundation.NSString,Foundation.NSObject>[],Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #1
 !missing-null-allowed! 'System.Void UIKit.UIPasteboard::DetectValues(Foundation.NSSet`1<Foundation.NSString>,System.Action`2<Foundation.NSDictionary`2<Foundation.NSString,Foundation.NSObject>,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void UIKit.UIPasteboard::DetectValues(Foundation.NSSet`1<Foundation.NSString>,System.Action`2<Foundation.NSDictionary`2<Foundation.NSString,Foundation.NSObject>,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #1
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! +UIFocusDebugger::checkFocusGroupTreeForEnvironment: not found
+!unknown-selector! UIDocumentBrowserAction::imageOnlyForContextMenu not found
+!unknown-selector! UIDocumentBrowserAction::setImageOnlyForContextMenu: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-VideoSubscriberAccount.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-VideoSubscriberAccount.ignore
@@ -5,3 +5,10 @@
 !missing-null-allowed! 'System.Void VideoSubscriberAccount.VSUserAccountManager::UpdateUserAccount(VideoSubscriberAccount.VSUserAccount,System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completion' block parameter #0
 !missing-null-allowed! 'VideoSubscriberAccount.VSAccountManagerResult VideoSubscriberAccount.VSAccountManager::Enqueue(VideoSubscriberAccount.VSAccountMetadataRequest,System.Action`2<VideoSubscriberAccount.VSAccountMetadata,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'VideoSubscriberAccount.VSAccountManagerResult VideoSubscriberAccount.VSAccountManager::Enqueue(VideoSubscriberAccount.VSAccountMetadataRequest,System.Action`2<VideoSubscriberAccount.VSAccountMetadata,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #1
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! VSUserAccount::isDeleted not found
+!unknown-selector! VSUserAccount::setDeleted: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-WebKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-WebKit.ignore
@@ -1,12 +1,5 @@
-# adding these since weak delegate exists in base class
-!missing-selector! PKCanvasView::delegate not bound
-!missing-selector! PKCanvasView::setDelegate: not bound
-
-# removed in XAMCORE_5_0
-!extra-protocol-member! unexpected selector PKCanvasViewDelegate::canvasView:didRefineStrokes:withNewStrokes: found
-
 ## bound selectors with no native declaration reachable from the class in the current SDK headers:
 ## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
 ## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
 ## (baseline for https://github.com/dotnet/macios/issues/26053)
-!unknown-selector! +PKInkingTool::invertColor: not found
+!unknown-selector! WKPreferences::textInteractionEnabled not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-AppKit.ignore
@@ -1524,3 +1524,29 @@
 !missing-null-allowed! 'System.Void AppKit.NSDocument::SavePresentedItemChanges(System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void AppKit.NSTextContentManager::SynchronizeTextLayoutManagers(System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !extra-null-allowed! 'System.Void AppKit.NSFilePromiseReceiver::ReceivePromisedFiles(Foundation.NSUrl,Foundation.NSDictionary,Foundation.NSOperationQueue,System.Action`2<Foundation.NSUrl,Foundation.NSError>)' has an extraneous '?' on parameter 'reader' block parameter #0
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! +NSCollectionLayoutGroup::horizontalGroupWithLayoutSize:repeatingSubitem:count: not found
+!unknown-selector! +NSCollectionLayoutGroup::verticalGroupWithLayoutSize:repeatingSubitem:count: not found
+!unknown-selector! +NSMenu::accessibilityElementWithRole:frame:label:parent: not found
+!unknown-selector! +NSMenuItem::accessibilityElementWithRole:frame:label:parent: not found
+!unknown-selector! +NSViewAnimation::defaultAnimationForKey: not found
+!unknown-selector! NSDiffableDataSourceSnapshot::reconfiguredItemIdentifiers not found
+!unknown-selector! NSDiffableDataSourceSnapshot::reconfigureItemsWithIdentifiers: not found
+!unknown-selector! NSDiffableDataSourceSnapshot::reloadedItemIdentifiers not found
+!unknown-selector! NSDiffableDataSourceSnapshot::reloadedSectionIdentifiers not found
+!unknown-selector! NSMenu::accessibilityAddChildElement: not found
+!unknown-selector! NSMenu::accessibilityFrameInParentSpace not found
+!unknown-selector! NSMenu::setAccessibilityFrameInParentSpace: not found
+!unknown-selector! NSMenuItem::accessibilityAddChildElement: not found
+!unknown-selector! NSMenuItem::accessibilityFrameInParentSpace not found
+!unknown-selector! NSMenuItem::setAccessibilityFrameInParentSpace: not found
+!unknown-selector! NSSharingCollaborationModeRestriction::setAlertRecoverySuggestionButtonLaunchURL: not found
+!unknown-selector! NSTextField::automaticTextCompletionEnabled: not found
+!unknown-selector! NSViewAnimation::animationForKey: not found
+!unknown-selector! NSViewAnimation::animations not found
+!unknown-selector! NSViewAnimation::animator not found
+!unknown-selector! NSViewAnimation::setAnimations: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-AuthenticationServices.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-AuthenticationServices.ignore
@@ -21,3 +21,9 @@
 !missing-null-allowed! 'System.Void AuthenticationServices.ASCredentialIdentityStore::SaveCredentialIdentityEntries(AuthenticationServices.IASCredentialIdentity[],System.Action`2<System.Boolean,Foundation.NSError>)' is missing a '?' on parameter 'completion' block parameter #1
 !missing-null-allowed! 'System.Void AuthenticationServices.ASSettingsHelper::OpenCredentialProviderAppSettings(System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void AuthenticationServices.ASSettingsHelper::OpenVerificationCodeAppSettings(System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! +ASWebAuthenticationSessionWebBrowserSessionManager::registerDefaultsForASWASInSetupAssistantIfNeeded not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-CloudKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-CloudKit.ignore
@@ -1,3 +1,12 @@
 !missing-null-allowed! 'System.Void CloudKit.CKContainer::FetchAllLongLivedOperationIDs(System.Action`2<Foundation.NSDictionary`2<Foundation.NSString,Foundation.NSOperation>,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void CloudKit.CKContainer::FetchAllLongLivedOperationIDs(System.Action`2<Foundation.NSDictionary`2<Foundation.NSString,Foundation.NSOperation>,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #1
 !missing-null-allowed! 'System.Void CloudKit.CKContainer::FetchLongLivedOperation(System.String[],System.Action`2<Foundation.NSDictionary`2<Foundation.NSString,Foundation.NSOperation>,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #1
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! CKSubscription::predicate not found
+!unknown-selector! CKSubscription::recordType not found
+!unknown-selector! CKSubscription::setZoneID: not found
+!unknown-selector! CKSubscription::zoneID not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreSpotlight.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreSpotlight.ignore
@@ -7,3 +7,13 @@
 !missing-null-allowed! 'System.Void CoreSpotlight.CSSearchableIndex::FetchData(System.String,System.String,UniformTypeIdentifiers.UTType,System.Action`2<Foundation.NSData,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #1
 !missing-null-allowed! 'System.Void CoreSpotlight.CSSearchableIndex::Index(CoreSpotlight.CSSearchableItem[],System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void CoreSpotlight.CSSearchQuery::set_CompletionHandler(System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'value' block parameter #0
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! CSSearchableIndex::initWithName:protectionClass:bundleIdentifier:options: not found
+!unknown-selector! CSSearchableIndex::provideDataForBundle:identifier:type:completionHandler: not found
+!unknown-selector! CSSearchableItemAttributeSet::moveFrom: not found
+!unknown-selector! CSSuggestion::score not found
+!unknown-selector! CSSuggestion::suggestionDataSources not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-FSKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-FSKit.ignore
@@ -4,3 +4,10 @@
 
 ## debugDescripion is already bound on NSObject
 !missing-selector! FSFileName::debugDescription not bound
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! +FSBlockDeviceResource::proxyResourceForBSDName: not found
+!unknown-selector! +FSBlockDeviceResource::proxyResourceForBSDName:isWritable: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-FileProvider.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-FileProvider.ignore
@@ -26,3 +26,9 @@
 !missing-null-allowed! 'System.Void FileProvider.NSFileProviderManager::SignalErrorResolved(Foundation.NSError,System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void FileProvider.NSFileProviderManager::WaitForChangesOnItemsBelowItem(System.String,System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void FileProvider.NSFileProviderManager::WaitForStabilization(System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! NSFileProviderManager::checkDomainsCanBeStored:onVolumeAtURL:unsupportedReason:error: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-Foundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-Foundation.ignore
@@ -563,3 +563,11 @@
 !missing-null-allowed! 'System.Void Foundation.NSFilePresenter::AccommodatePresentedItemEviction(System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void Foundation.NSFileProviderService::GetFileProviderConnection(System.Action`2<Foundation.NSXpcConnection,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void Foundation.NSFileProviderService::GetFileProviderConnection(System.Action`2<Foundation.NSXpcConnection,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #1
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! NSInputStream::_setCFClientFlags:callback:context: not found
+!unknown-selector! NSProgress::acknowledgeWithSuccess: not found
+!unknown-selector! NSProgress::setAcknowledgementHandler:forAppBundleIdentifier: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-ImageCaptureCore.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-ImageCaptureCore.ignore
@@ -114,3 +114,12 @@
 ## new @required on existing protocols are breaking changes
 !incorrect-protocol-member! ICCameraDeviceDelegate::cameraDevice:didReceiveThumbnail:forItem:error: is REQUIRED and should be abstract
 !incorrect-protocol-member! ICCameraDeviceDelegate::cameraDevice:didReceiveThumbnailForItem: is OPTIONAL and should NOT be abstract
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! ICDevice::buttonPressed not found
+!unknown-selector! ICDevice::fwGUID not found
+!unknown-selector! ICDevice::hasConfigurableWiFiInterface not found
+!unknown-selector! ICDevice::isShared not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-MetalPerformanceShaders.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-MetalPerformanceShaders.ignore
@@ -9,3 +9,9 @@
 !missing-designated-initializer! MPSCNNNeuronSigmoid::initWithDevice: is missing an [DesignatedInitializer] attribute
 !missing-designated-initializer! MPSCNNNeuronSoftPlus::initWithDevice:a:b: is missing an [DesignatedInitializer] attribute
 !missing-designated-initializer! MPSCNNNeuronTanH::initWithDevice:a:b: is missing an [DesignatedInitializer] attribute
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! MPSCNNKernel::sourceRegionForDestinationSize: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-ModelIO.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-ModelIO.ignore
@@ -1,12 +1,7 @@
-# adding these since weak delegate exists in base class
-!missing-selector! PKCanvasView::delegate not bound
-!missing-selector! PKCanvasView::setDelegate: not bound
-
-# removed in XAMCORE_5_0
-!extra-protocol-member! unexpected selector PKCanvasViewDelegate::canvasView:didRefineStrokes:withNewStrokes: found
-
 ## bound selectors with no native declaration reachable from the class in the current SDK headers:
 ## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
 ## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
 ## (baseline for https://github.com/dotnet/macios/issues/26053)
-!unknown-selector! +PKInkingTool::invertColor: not found
+!unknown-selector! MDLAsset::componentConformingToProtocol: not found
+!unknown-selector! MDLAsset::components not found
+!unknown-selector! MDLAsset::setComponent:forProtocol: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-VideoSubscriberAccount.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-VideoSubscriberAccount.ignore
@@ -2,3 +2,10 @@
 !missing-null-allowed! 'System.Void VideoSubscriberAccount.VSUserAccountManager::QueryUserAccounts(VideoSubscriberAccount.VSUserAccountQueryOptions,System.Action`2<Foundation.NSArray`1<VideoSubscriberAccount.VSUserAccount>,Foundation.NSError>)' is missing a '?' on parameter 'completion' block parameter #0
 !missing-null-allowed! 'System.Void VideoSubscriberAccount.VSUserAccountManager::QueryUserAccounts(VideoSubscriberAccount.VSUserAccountQueryOptions,System.Action`2<Foundation.NSArray`1<VideoSubscriberAccount.VSUserAccount>,Foundation.NSError>)' is missing a '?' on parameter 'completion' block parameter #1
 !missing-null-allowed! 'System.Void VideoSubscriberAccount.VSUserAccountManager::UpdateUserAccount(VideoSubscriberAccount.VSUserAccount,System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completion' block parameter #0
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! VSUserAccount::isDeleted not found
+!unknown-selector! VSUserAccount::setDeleted: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-VideoToolbox.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-VideoToolbox.ignore
@@ -1,2 +1,11 @@
 # Removed in XAMCORE_5_0
 !extra-protocol-member! unexpected selector VTFrameProcessorConfiguration::+processorSupported found
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! +VTLowLatencyFrameInterpolationConfiguration::processorSupported not found
+!unknown-selector! +VTLowLatencySuperResolutionScalerConfiguration::processorSupported not found
+!unknown-selector! +VTSuperResolutionScalerConfiguration::processorSupported not found
+!unknown-selector! +VTTemporalNoiseFilterConfiguration::processorSupported not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-WebKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-WebKit.ignore
@@ -28,3 +28,8 @@
 # enabled for XAMCORE 5, else breaking change
 !missing-protocol-conformance! WKWebView should conform to NSTextFinderClient (defined in 'WKNSTextFinderClient' category)
 
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! WKPreferences::textInteractionEnabled not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-CloudKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-CloudKit.ignore
@@ -2,3 +2,12 @@
 ## In reality the selectors only answer in the simulator, not on AppleTV devices
 !missing-selector! CKContainer::fetchAllLongLivedOperationIDsWithCompletionHandler: not bound
 !missing-selector! CKContainer::fetchLongLivedOperationWithID:completionHandler: not bound
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! CKSubscription::predicate not found
+!unknown-selector! CKSubscription::recordType not found
+!unknown-selector! CKSubscription::setZoneID: not found
+!unknown-selector! CKSubscription::zoneID not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-Foundation.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-Foundation.ignore
@@ -14,3 +14,9 @@
 !missing-selector! NSXPCInterface::XPCTypeForSelector:argumentIndex:ofReply: not bound
 
 !missing-null-allowed! 'System.Void Foundation.NSBundleResourceRequest::BeginAccessingResources(System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! NSInputStream::_setCFClientFlags:callback:context: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-GLKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-GLKit.ignore
@@ -57,3 +57,9 @@
 !missing-release-attribute-on-return-value! ModelIO.IMDLMeshBuffer GLKit.GLKMeshBufferAllocator::CreateBuffer(System.UIntPtr,ModelIO.MDLMeshBufferType)'s selector's ('newBuffer:type:') Objective-C method family ('new') indicates that the native method returns a retained object, and as such a '[return: Release]' attribute is required.
 !missing-release-attribute-on-return-value! ModelIO.IMDLMeshBufferZone GLKit.GLKMeshBufferAllocator::CreateZone(Foundation.NSNumber[],Foundation.NSNumber[])'s selector's ('newZoneForBuffersWithSize:andType:') Objective-C method family ('new') indicates that the native method returns a retained object, and as such a '[return: Release]' attribute is required.
 !missing-release-attribute-on-return-value! ModelIO.IMDLMeshBufferZone GLKit.GLKMeshBufferAllocator::CreateZone(System.UIntPtr)'s selector's ('newZone:') Objective-C method family ('new') indicates that the native method returns a retained object, and as such a '[return: Release]' attribute is required.
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! GLKViewController::update not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-Metal.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-Metal.ignore
@@ -3,3 +3,14 @@
 !extra-enum-value! Managed value 25 for MTLArgumentType.PrimitiveAccelerationStructure not found in native headers
 !extra-enum-value! Managed value 26 for MTLArgumentType.InstanceAccelerationStructure not found in native headers
 !extra-enum-value! Managed value 27 for MTLArgumentType.IntersectionFunctionTable not found in native headers
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! MTLLinkedFunctions::motionTransformBuffer not found
+!unknown-selector! MTLLinkedFunctions::motionTransformBufferOffset not found
+!unknown-selector! MTLLinkedFunctions::motionTransformCount not found
+!unknown-selector! MTLLinkedFunctions::setMotionTransformBuffer: not found
+!unknown-selector! MTLLinkedFunctions::setMotionTransformBufferOffset: not found
+!unknown-selector! MTLLinkedFunctions::setMotionTransformCount: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-MetalPerformanceShaders.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-MetalPerformanceShaders.ignore
@@ -9,3 +9,9 @@
 !missing-designated-initializer! MPSCNNNeuronSigmoid::initWithDevice: is missing an [DesignatedInitializer] attribute
 !missing-designated-initializer! MPSCNNNeuronSoftPlus::initWithDevice:a:b: is missing an [DesignatedInitializer] attribute
 !missing-designated-initializer! MPSCNNNeuronTanH::initWithDevice:a:b: is missing an [DesignatedInitializer] attribute
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! MPSCNNKernel::sourceRegionForDestinationSize: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-ModelIO.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-ModelIO.ignore
@@ -1,12 +1,7 @@
-# adding these since weak delegate exists in base class
-!missing-selector! PKCanvasView::delegate not bound
-!missing-selector! PKCanvasView::setDelegate: not bound
-
-# removed in XAMCORE_5_0
-!extra-protocol-member! unexpected selector PKCanvasViewDelegate::canvasView:didRefineStrokes:withNewStrokes: found
-
 ## bound selectors with no native declaration reachable from the class in the current SDK headers:
 ## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
 ## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
 ## (baseline for https://github.com/dotnet/macios/issues/26053)
-!unknown-selector! +PKInkingTool::invertColor: not found
+!unknown-selector! MDLAsset::componentConformingToProtocol: not found
+!unknown-selector! MDLAsset::components not found
+!unknown-selector! MDLAsset::setComponent:forProtocol: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-UIKit.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-UIKit.ignore
@@ -361,3 +361,9 @@
 !missing-null-allowed! 'System.Void UIKit.UIImage::PrepareThumbnail(CoreGraphics.CGSize,System.Action`1<UIKit.UIImage>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'System.Void UIKit.UIImageReader::GetImage(Foundation.NSData,System.Action`1<UIKit.UIImage>)' is missing a '?' on parameter 'completion' block parameter #0
 !missing-null-allowed! 'System.Void UIKit.UIImageReader::GetImage(Foundation.NSUrl,System.Action`1<UIKit.UIImage>)' is missing a '?' on parameter 'completion' block parameter #0
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! +UIFocusDebugger::checkFocusGroupTreeForEnvironment: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-VideoSubscriberAccount.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-VideoSubscriberAccount.ignore
@@ -5,3 +5,10 @@
 !missing-null-allowed! 'System.Void VideoSubscriberAccount.VSUserAccountManager::UpdateUserAccount(VideoSubscriberAccount.VSUserAccount,System.Action`1<Foundation.NSError>)' is missing a '?' on parameter 'completion' block parameter #0
 !missing-null-allowed! 'VideoSubscriberAccount.VSAccountManagerResult VideoSubscriberAccount.VSAccountManager::Enqueue(VideoSubscriberAccount.VSAccountMetadataRequest,System.Action`2<VideoSubscriberAccount.VSAccountMetadata,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #0
 !missing-null-allowed! 'VideoSubscriberAccount.VSAccountManagerResult VideoSubscriberAccount.VSAccountManager::Enqueue(VideoSubscriberAccount.VSAccountMetadataRequest,System.Action`2<VideoSubscriberAccount.VSAccountMetadata,Foundation.NSError>)' is missing a '?' on parameter 'completionHandler' block parameter #1
+
+## bound selectors with no native declaration reachable from the class in the current SDK headers:
+## private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on
+## the class, managed callback infrastructure, or API Apple removed/privatized - kept for compatibility
+## (baseline for https://github.com/dotnet/macios/issues/26053)
+!unknown-selector! VSUserAccount::isDeleted not found
+!unknown-selector! VSUserAccount::setDeleted: not found

--- a/tests/xtro-sharpie/xtro-sharpie/SelectorCheck.cs
+++ b/tests/xtro-sharpie/xtro-sharpie/SelectorCheck.cs
@@ -4,6 +4,10 @@
 // !missing-selector!
 //             if headers defines a selector for which we have no bindings
 //
+// !unknown-selector!
+//             if we have a managed [Export] selector for which the current SDK headers have no
+//             matching native declaration (e.g. Apple removed or privatized the selector)
+//
 
 using System.Diagnostics;
 using System.Runtime.Serialization;
@@ -15,9 +19,169 @@ namespace Extrospection {
 		HashSet<string> qualified_selectors = new HashSet<string> ();
 		Dictionary<string, List<Tuple<MethodDefinition, Helpers.ArgumentSemantic>>> qualified_properties = new Dictionary<string, List<Tuple<MethodDefinition, Helpers.ArgumentSemantic>>> ();
 
+		// Reverse check (managed -> native): report managed [Export] selectors that no longer have
+		// a native declaration in the current SDK headers (e.g. Apple removed or privatized the
+		// selector) so the stale binding can be removed.
+		//
+		// A managed selector 'Type::selector' is considered valid if 'selector' is part of the
+		// *effective* set of selectors for the native class 'Type', which is:
+		//   * the selectors declared directly on the class (and its categories);
+		//   * plus the selectors declared on every base class (and their categories);
+		//   * plus the selectors of every protocol adopted by the class or its base classes -
+		//     both the protocols declared in the headers and the protocols the managed binding
+		//     declares conformance to (Apple often implements a protocol, e.g. NSCoding/NSCopying,
+		//     without declaring the conformance on the class) - transitively through protocol
+		//     inheritance.
+		// This mirrors how managed bindings inline category and protocol members into a class, so
+		// those aren't mis-reported as extra, while still catching a selector that Apple removed
+		// from a specific class even if the same selector name still exists on some other class.
+
+		// native class (or category base) name -> selectors declared on it (with '+' for class selectors)
+		Dictionary<string, HashSet<string>> type_selectors = new (StringComparer.Ordinal);
+		// native protocol name -> selectors declared on it (with '+' for class selectors)
+		Dictionary<string, HashSet<string>> protocol_selectors = new (StringComparer.Ordinal);
+		// native class name -> its superclass name
+		Dictionary<string, string> type_super = new (StringComparer.Ordinal);
+		// native class name -> protocols it adopts (from the interface and its categories)
+		Dictionary<string, HashSet<string>> type_protocols = new (StringComparer.Ordinal);
+		// native protocol name -> protocols it inherits from
+		Dictionary<string, HashSet<string>> protocol_bases = new (StringComparer.Ordinal);
+		// native class name -> protocols the *managed* binding declares it conforms to. Apple often
+		// omits a protocol conformance (e.g. NSCoding, NSCopying) from a class' header even though
+		// the class implements it, so we trust the managed binding for the set of adopted protocols.
+		Dictionary<string, HashSet<string>> managed_type_protocols = new (StringComparer.Ordinal);
+		// native class names whose definition we've seen (so we can tell a removed selector apart
+		// from a removed type - the latter is reported by the '!unknown-type!' check instead)
+		HashSet<string> known_types = new (StringComparer.Ordinal);
+		// memoized effective selector sets, keyed by native class name
+		Dictionary<string, HashSet<string>> effective_selectors = new (StringComparer.Ordinal);
+		// Frameworks that were actually parsed natively. Managed selectors from frameworks that
+		// weren't parsed (e.g. excluded from the sharpie run) must not be reported.
+		HashSet<string> parsed_frameworks = new HashSet<string> (StringComparer.Ordinal);
+		List<(string Framework, string QualifiedName, string Type, string Selector)> managed_selectors = new List<(string, string, string, string)> ();
+
 		public SelectorCheck (BindingResult bindingResult)
 			: base (bindingResult)
 		{
+		}
+
+		static HashSet<string> GetOrCreate (Dictionary<string, HashSet<string>> map, string key)
+		{
+			if (!map.TryGetValue (key, out var set))
+				map [key] = set = new HashSet<string> (StringComparer.Ordinal);
+			return set;
+		}
+
+		void AddNativeSelector (Decl? container, string? selector, bool isClassMember)
+		{
+			if (container is null || string.IsNullOrEmpty (selector))
+				return;
+
+			var value = isClassMember ? "+" + selector : selector;
+			switch (container) {
+			case ObjCProtocolDecl protocol:
+				GetOrCreate (protocol_selectors, protocol.Name).Add (value);
+				break;
+			case ObjCCategoryDecl category:
+				GetOrCreate (type_selectors, category.ClassInterface.Name).Add (value);
+				break;
+			case ObjCInterfaceDecl @interface:
+				GetOrCreate (type_selectors, @interface.Name).Add (value);
+				break;
+			}
+
+			var framework = Helpers.GetFramework (container);
+			if (framework is not null)
+				parsed_frameworks.Add (framework);
+		}
+
+		// Computes (and memoizes) the effective set of selectors reachable from a native class:
+		// its own selectors plus those of all its base classes and all adopted protocols.
+		HashSet<string> GetEffectiveSelectors (string typeName)
+		{
+			if (effective_selectors.TryGetValue (typeName, out var cached))
+				return cached;
+
+			var result = new HashSet<string> (StringComparer.Ordinal);
+			var protocols = new HashSet<string> (StringComparer.Ordinal);
+
+			// walk the class hierarchy, collecting selectors and adopted protocols
+			var seenTypes = new HashSet<string> (StringComparer.Ordinal);
+			var current = typeName;
+			while (current is not null && seenTypes.Add (current)) {
+				if (type_selectors.TryGetValue (current, out var sels))
+					result.UnionWith (sels);
+				if (type_protocols.TryGetValue (current, out var protos))
+					protocols.UnionWith (protos);
+				if (managed_type_protocols.TryGetValue (current, out var mprotos))
+					protocols.UnionWith (mprotos);
+				type_super.TryGetValue (current, out current);
+			}
+
+			// expand the adopted protocols transitively and collect their selectors
+			var pending = new Queue<string> (protocols);
+			var seenProtocols = new HashSet<string> (StringComparer.Ordinal);
+			while (pending.Count > 0) {
+				var protocol = pending.Dequeue ();
+				if (!seenProtocols.Add (protocol))
+					continue;
+				if (protocol_selectors.TryGetValue (protocol, out var sels))
+					result.UnionWith (sels);
+				if (protocol_bases.TryGetValue (protocol, out var bases)) {
+					foreach (var b in bases)
+						pending.Enqueue (b);
+				}
+			}
+
+			effective_selectors [typeName] = result;
+			return result;
+		}
+
+		// We only report extra selectors for publicly visible types: internal helper types (e.g. the
+		// various managed dispatcher/proxy types) use fabricated selectors that never map to a native
+		// declaration and would be permanent noise. This mirrors how the '!unknown-type!' check skips
+		// internal types.
+		static bool IsPubliclyVisible (TypeDefinition type)
+		{
+			if (type.IsNested)
+				return (type.IsNestedPublic || type.IsNestedFamily || type.IsNestedFamilyOrAssembly) && IsPubliclyVisible (type.DeclaringType);
+			return type.IsPublic;
+		}
+
+		// splits '[+]Type::selector' into the native type name and the selector (keeping the leading
+		// '+' on the selector for class selectors)
+		static bool TrySplitQualifiedName (string qualifiedName, out string type, out string selector)
+		{
+			type = selector = "";
+			var isStatic = qualifiedName.Length > 0 && qualifiedName [0] == '+';
+			var body = isStatic ? qualifiedName.Substring (1) : qualifiedName;
+			var idx = body.IndexOf ("::", StringComparison.Ordinal);
+			if (idx < 0)
+				return false;
+			type = body.Substring (0, idx);
+			selector = (isStatic ? "+" : "") + body.Substring (idx + 2);
+			return true;
+		}
+
+		// collect the protocols the managed binding declares each type conforms to
+		public override void VisitManagedType (TypeDefinition type)
+		{
+			if (!type.HasInterfaces)
+				return;
+
+			// skip protocols themselves - we only care about concrete classes here
+			if (type.IsProtocol ())
+				return;
+
+			var nativeName = type.GetName ();
+			if (string.IsNullOrEmpty (nativeName))
+				return;
+
+			foreach (var iface in type.Interfaces) {
+				var protocolName = ObjCInterfaceCheck.GetProtocolName (iface.InterfaceType.Resolve ());
+				if (!string.IsNullOrEmpty (protocolName))
+					GetOrCreate (managed_type_protocols, nativeName).Add (protocolName);
+			}
 		}
 
 		// most selectors will be found in [Export] attribtues
@@ -45,6 +209,10 @@ namespace Extrospection {
 						}
 
 						qualified_selectors.Add (methodDefinition);
+
+						// record it for the reverse (managed -> native) check (public API only)
+						if (IsPubliclyVisible (type) && TrySplitQualifiedName (methodDefinition, out var selectorType, out var selector))
+							managed_selectors.Add ((Helpers.GetFramework (type), methodDefinition, selectorType, selector));
 					}
 
 					break;
@@ -54,6 +222,11 @@ namespace Extrospection {
 
 		public override void VisitObjCPropertyDecl (ObjCPropertyDecl decl)
 		{
+			// collect the native property accessor selectors for the reverse (managed -> native)
+			// check (including protocol members, so inlined protocol properties aren't mis-reported)
+			AddNativeSelector (decl.DeclContext as Decl, decl.GetterMethodDecl?.Name, decl.GetterMethodDecl?.IsClassMethod == true);
+			AddNativeSelector (decl.DeclContext as Decl, decl.SetterMethodDecl?.Name, decl.SetterMethodDecl?.IsClassMethod == true);
+
 			// protocol members are checked in ObjCProtocolCheck
 			if (decl.DeclContext is ObjCProtocolDecl)
 				return;
@@ -87,6 +260,10 @@ namespace Extrospection {
 
 		public override void VisitObjCMethodDecl (ObjCMethodDecl decl)
 		{
+			// collect the native selector for the reverse (managed -> native) check (including
+			// protocol and category members, so inlined selectors aren't mis-reported as extra)
+			AddNativeSelector (decl.DeclContext as Decl, decl.GetSelector (), decl.IsClassMethod);
+
 			// protocol members are checked in ObjCProtocolCheck
 			if (decl.DeclContext is ObjCProtocolDecl)
 				return;
@@ -131,6 +308,45 @@ namespace Extrospection {
 				Log.On (framework).Add ($"!missing-selector! {name} not bound");
 		}
 
+		public override void VisitObjCInterfaceDecl (ObjCInterfaceDecl decl)
+		{
+			// collect the native class hierarchy for the reverse (managed -> native) check
+			if (!decl.IsThisDeclarationADefinition)
+				return;
+
+			var name = decl.Name;
+			known_types.Add (name);
+
+			var super = decl.SuperClass?.Name;
+			if (!string.IsNullOrEmpty (super))
+				type_super [name] = super;
+
+			foreach (var protocol in decl.Protocols)
+				GetOrCreate (type_protocols, name).Add (protocol.Name);
+
+			var framework = Helpers.GetFramework (decl);
+			if (framework is not null)
+				parsed_frameworks.Add (framework);
+		}
+
+		public override void VisitObjCCategoryDecl (ObjCCategoryDecl decl)
+		{
+			// a category can add protocol conformances to the class it extends
+			var name = decl.ClassInterface.Name;
+			foreach (var protocol in decl.Protocols)
+				GetOrCreate (type_protocols, name).Add (protocol.Name);
+		}
+
+		public override void VisitObjCProtocolDecl (ObjCProtocolDecl decl)
+		{
+			// collect the native protocol inheritance for the reverse (managed -> native) check
+			if (!decl.IsThisDeclarationADefinition)
+				return;
+
+			foreach (var protocol in decl.Protocols)
+				GetOrCreate (protocol_bases, decl.Name).Add (protocol.Name);
+		}
+
 		static string GetCategoryBase (ObjCCategoryDecl category)
 		{
 			// I really dislike doing this
@@ -146,6 +362,25 @@ namespace Extrospection {
 				return "UIResponder";
 			default:
 				return Helpers.GetManagedName (category.ClassInterface.Name);
+			}
+		}
+
+		public override void EndVisit ()
+		{
+			// At this stage we've collected the full native class/protocol hierarchy. A managed
+			// [Export] selector is stale if it's not part of the effective set of selectors for its
+			// native class (the class' own selectors plus those of all its base classes and adopted
+			// protocols) - report it so the binding can be removed.
+			foreach (var entry in managed_selectors) {
+				// skip frameworks that weren't parsed natively (e.g. excluded from the sharpie run)
+				if (!parsed_frameworks.Contains (entry.Framework))
+					continue;
+				// if the whole native type is gone that's reported by the '!unknown-type!' check
+				if (!known_types.Contains (entry.Type))
+					continue;
+				if (GetEffectiveSelectors (entry.Type).Contains (entry.Selector))
+					continue;
+				Log.On (entry.Framework).Add ($"!unknown-selector! {entry.QualifiedName} not found");
 			}
 		}
 	}

--- a/tests/xtro-sharpie/xtro-sharpie/SelectorCheck.cs
+++ b/tests/xtro-sharpie/xtro-sharpie/SelectorCheck.cs
@@ -178,7 +178,10 @@ namespace Extrospection {
 				return;
 
 			foreach (var iface in type.Interfaces) {
-				var protocolName = ObjCInterfaceCheck.GetProtocolName (iface.InterfaceType.Resolve ());
+				var ifaceType = iface.InterfaceType.Resolve ();
+				if (ifaceType is null)
+					continue;
+				var protocolName = ObjCInterfaceCheck.GetProtocolName (ifaceType);
 				if (!string.IsNullOrEmpty (protocolName))
 					GetOrCreate (managed_type_protocols, nativeName).Add (protocolName);
 			}
@@ -224,8 +227,8 @@ namespace Extrospection {
 		{
 			// collect the native property accessor selectors for the reverse (managed -> native)
 			// check (including protocol members, so inlined protocol properties aren't mis-reported)
-			AddNativeSelector (decl.DeclContext as Decl, decl.GetterMethodDecl?.Name, decl.GetterMethodDecl?.IsClassMethod == true);
-			AddNativeSelector (decl.DeclContext as Decl, decl.SetterMethodDecl?.Name, decl.SetterMethodDecl?.IsClassMethod == true);
+			AddNativeSelector (decl.DeclContext as Decl, decl.GetterMethodDecl?.GetSelector (), decl.GetterMethodDecl?.IsClassMethod == true);
+			AddNativeSelector (decl.DeclContext as Decl, decl.SetterMethodDecl?.GetSelector (), decl.SetterMethodDecl?.IsClassMethod == true);
 
 			// protocol members are checked in ObjCProtocolCheck
 			if (decl.DeclContext is ObjCProtocolDecl)


### PR DESCRIPTION
xtro only validated selectors native → managed (`!missing-selector!`). It never flagged the reverse: a managed `[Export]` selector with no matching native declaration in the current SDK headers. When Apple removes or privatizes a selector, the managed binding becomes stale but xtro stayed silent, and introspection can't detect a privatized-but-still-implemented selector (a `respondsToSelector:` call still returns true).

This adds a reverse check to `SelectorCheck` that reports `!unknown-selector!` for a managed `Type::selector` when `selector` is not part of the effective set of selectors for the native class `Type`, which is:

- the selectors declared directly on the class (and its categories);
- plus the selectors declared on every base class (and their categories);
- plus the selectors of every adopted protocol, transitively through protocol inheritance.

The set of adopted protocols is taken from both the headers and the managed binding: Apple frequently implements a protocol (e.g. `NSCoding`, `NSCopying`) without declaring the conformance on the class, and the managed binding is the authority on which protocols a class inlines — crediting them avoids a large number of false positives (this alone reduced the reported entries from ~450 to 144).

Additional false-positive guards:

- Only publicly visible managed types are checked (internal dispatcher/proxy helper types use fabricated selectors), mirroring the `!unknown-type!` check.
- Managed types whose native name has no declaration in the headers are skipped (that's the `!unknown-type!` case).
- Frameworks not parsed natively (e.g. excluded from the sharpie run) are skipped.

The pre-existing bindings surfaced by the new check (private/SPI selectors, protocol/category members Apple inlines without declaring the conformance on the class, managed callback infrastructure, and API Apple dropped) are added to the per-platform `.ignore` files as the reviewed baseline; any new occurrence will now fail the build — the deterministic signal requested in the issue.

Fixes https://github.com/dotnet/macios/issues/26053.

🤖 Pull request created by Copilot
