### PR TITLE
Ad-hoc sign mlaunch binary and .app bundle before packing

### DIFF
--- a/tools/mlaunch/Makefile
+++ b/tools/mlaunch/Makefile
@@ -24,8 +24,9 @@ $$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/bin/mlaunch: $$(DOWNLOAD_STAMP_FILE)
 	$$(Q) chmod a+x $$(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/tools/bin/mlaunch
 	$$(Q) chmod a+x $$(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/tools/lib/mlaunch/mlaunch.app/Contents/MacOS/mlaunch
 	# Ad-hoc sign for macOS 26+ Gatekeeper compatibility in CI runners
-	$$(Q) codesign --force --sign - $$(DOTNET_DESTDIR)/$$($(1)_NUGET_SDK_NAME)/tools/lib/mlaunch/mlaunch.app/Contents/MacOS/mlaunch
-	$$(Q) codesign --force --sign - $$(DOTNET_DESTDIR)/$$($(1)_NUGET_SDK_NAME)/tools/lib/mlaunch/mlaunch.app
+	$$(Q) if [ "$(UNAME_S)" = Darwin ]; then codesign --force --sign - $$(DOTNET_DESTDIR)/$$($(1)_NUGET_SDK_NAME)/tools/bin/mlaunch; fi
+	$$(Q) if [ "$(UNAME_S)" = Darwin ]; then codesign --force --sign - $$(DOTNET_DESTDIR)/$$($(1)_NUGET_SDK_NAME)/tools/lib/mlaunch/mlaunch.app/Contents/MacOS/mlaunch; fi
+	$$(Q) if [ "$(UNAME_S)" = Darwin ]; then codesign --force --sign - $$(DOTNET_DESTDIR)/$$($(1)_NUGET_SDK_NAME)/tools/lib/mlaunch/mlaunch.app; fi
 endef
 
 $(foreach platform,$(DOTNET_PLATFORMS_MOBILE),$(eval $(call DotNetInstall,$(platform))))

--- a/tools/mlaunch/Makefile
+++ b/tools/mlaunch/Makefile
@@ -23,6 +23,9 @@ $$(DOTNET_DESTDIR)/Microsoft.$(1).Sdk/tools/bin/mlaunch: $$(DOWNLOAD_STAMP_FILE)
 	$$(Q) $$(CP) -R $(TOP)/packages/microsoft.tools.mlaunch/$$(MLAUNCH_NUGET_VERSION)/mlaunch/lib/mlaunch $$(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/tools/lib
 	$$(Q) chmod a+x $$(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/tools/bin/mlaunch
 	$$(Q) chmod a+x $$(DOTNET_DESTDIR)/$($(1)_NUGET_SDK_NAME)/tools/lib/mlaunch/mlaunch.app/Contents/MacOS/mlaunch
+	# Ad-hoc sign for macOS 26+ Gatekeeper compatibility in CI runners
+	$$(Q) codesign --force --sign - $$(DOTNET_DESTDIR)/$$($(1)_NUGET_SDK_NAME)/tools/lib/mlaunch/mlaunch.app/Contents/MacOS/mlaunch
+	$$(Q) codesign --force --sign - $$(DOTNET_DESTDIR)/$$($(1)_NUGET_SDK_NAME)/tools/lib/mlaunch/mlaunch.app
 endef
 
 $(foreach platform,$(DOTNET_PLATFORMS_MOBILE),$(eval $(call DotNetInstall,$(platform))))


### PR DESCRIPTION
## Problem

`dotnet run --device` on macOS 26+ GitHub Actions CI runners fails with:

```
Unhandled exception: An error occurred trying to start process .../tools/bin/mlaunch with working directory ... No such file or directory
```

The mlaunch binary exists and is executable, but macOS 26+ Gatekeeper rejects unsigned Mach-O binaries with ENOENT at execve() when spawned from processes without TCC exemptions (like CI runners).

## Fix

Ad-hoc sign the mlaunch binary and the .app bundle after chmod in the tools/mlaunch Makefile. Ad-hoc signing (codesign --sign -) does not require an Apple Developer certificate and satisfies macOS Gatekeeper on modern systems.