### PR TITLE
[NativeAOT] Warn if a post-ILC postprocessing step modifies a managed assembly

### DIFF
--- a/tools/assembly-preparer/AssemblyPreparer.cs
+++ b/tools/assembly-preparer/AssemblyPreparer.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.Serialization;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -208,7 +209,16 @@ public class AssemblyPreparer : IDisposable {
 			new DoneStep (),
 		};
 
-		return RunSteps (steps, out exceptions);
+		var rv = RunSteps (steps, out exceptions);
+
+		// If postprocessing runs after ILC has already compiled the assemblies, then no step should
+		// modify an assembly (the change would be silently lost). Report a warning if we detect this.
+		if (configuration.Application.XamarinRuntime == XamarinRuntime.NativeAOT  && configuration.ModifiedAssemblies.Any ()) {
+			foreach (var name in configuration.ModifiedAssemblies.Select (v => v.Name.Name).OrderBy (v => v))
+				exceptions.Add (ErrorHelper.CreateWarning (99, $"The assembly '{name}' was modified during post-ILC postprocessing, but this is useless because the NativeAOT compiler (ILC) has already compiled it."));
+		}
+
+		return rv;
 	}
 
 	bool RunSteps (IList<ConfigurationAwareStep> steps, out List<ProductException> exceptions)

--- a/tools/assembly-preparer/AssemblyPreparer.cs
+++ b/tools/assembly-preparer/AssemblyPreparer.cs
@@ -213,7 +213,7 @@ public class AssemblyPreparer : IDisposable {
 
 		// If postprocessing runs after ILC has already compiled the assemblies, then no step should
 		// modify an assembly (the change would be silently lost). Report a warning if we detect this.
-		if (configuration.Application.XamarinRuntime == XamarinRuntime.NativeAOT  && configuration.ModifiedAssemblies.Any ()) {
+		if (configuration.Application.XamarinRuntime == XamarinRuntime.NativeAOT && configuration.ModifiedAssemblies.Any ()) {
 			foreach (var name in configuration.ModifiedAssemblies.Select (v => v.Name.Name).OrderBy (v => v))
 				exceptions.Add (ErrorHelper.CreateWarning (99, $"The assembly '{name}' was modified during post-ILC postprocessing, but this is useless because the NativeAOT compiler (ILC) has already compiled it."));
 		}

--- a/tools/dotnet-linker/AppBundleRewriter.cs
+++ b/tools/dotnet-linker/AppBundleRewriter.cs
@@ -1817,13 +1817,13 @@ namespace Xamarin.Linker {
 						&& method.Parameters [1].ParameterType.Is (ns2, cls2));
 		}
 
-		internal void ImplementConstructNSObjectFactoryMethod (Tuner.DerivedLinkContext context, TypeDefinition type, MethodReference ctor)
+		internal bool ImplementConstructNSObjectFactoryMethod (Tuner.DerivedLinkContext context, TypeDefinition type, MethodReference ctor)
 		{
 			var abr = this;
 
 			// skip creating the factory for NSObject itself
 			if (type.Is ("Foundation", "NSObject"))
-				return;
+				return false;
 
 			// Make sure the type implements INSObjectFactory, otherwise we can't override the _Xamarin_ConstructNSObject method from it.
 			AddTypeInterfaceImplementation (abr, context, type, abr.Foundation_INSObjectFactory);
@@ -1855,20 +1855,22 @@ namespace Xamarin.Linker {
 			} else {
 				context.Annotations.Mark (createInstanceMethod);
 			}
+
+			return true;
 		}
 
-		internal void ImplementConstructINativeObjectFactoryMethod (Tuner.DerivedLinkContext context, TypeDefinition type, MethodReference? ctor)
+		internal bool ImplementConstructINativeObjectFactoryMethod (Tuner.DerivedLinkContext context, TypeDefinition type, MethodReference? ctor)
 		{
 			var abr = this;
 
 			// skip creating the factory for NSObject itself
 			if (type.Is ("Foundation", "NSObject"))
-				return;
+				return false;
 
 			// If the type is a subclass of NSObject, we prefer the NSObject "IntPtr" constructor
 			MethodReference? nsobjectConstructor = type.IsNSObject (context) ? AppBundleRewriter.FindNSObjectConstructor (type) : null;
 			if (nsobjectConstructor is null && ctor is null)
-				return;
+				return false;
 
 			// Make sure the type implements INativeObject, otherwise we can't override the _Xamarin_ConstructINativeObject method from it.
 			AddTypeInterfaceImplementation (abr, context, type, abr.ObjCRuntime_INativeObject);
@@ -1937,6 +1939,8 @@ namespace Xamarin.Linker {
 			} else {
 				context.Annotations.Mark (createInstanceMethod);
 			}
+
+			return true;
 		}
 
 		static void AddTypeInterfaceImplementation (AppBundleRewriter abr, Tuner.DerivedLinkContext context, TypeDefinition type, TypeReference iface)

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -194,7 +194,7 @@ namespace Xamarin.Linker {
 				abr.SaveCurrentAssembly ();
 
 			// TODO: Move this to a separate "MakeEverythingWorkWithNativeAOTStep" linker step
-			if (App.XamarinRuntime == XamarinRuntime.NativeAOT && Configuration.Profile.IsProductAssembly (assembly)) {
+			if (App.XamarinRuntime == XamarinRuntime.NativeAOT && Configuration.Profile.IsProductAssembly (assembly) && !App.IsPostProcessingAssemblies) {
 				ImplementNSObjectRegisterToggleRefMethodStub ();
 			}
 
@@ -266,13 +266,14 @@ namespace Xamarin.Linker {
 						CollectUnmanagedCallersMethod (method, infos, proxyInterfaces);
 					} else {
 						CreateUnmanagedCallersMethod (method, infos, proxyInterfaces);
+						modified = true;
 					}
 				} catch (Exception e) {
 					AddException (ErrorHelper.CreateError (99, e, "Failed to create an UnmanagedCallersOnly trampoline for {0}: {1}", method.FullName, e.Message));
 				}
 			}
 
-			return true;
+			return modified;
 		}
 
 		void ProcessMethod (MethodDefinition method, HashSet<MethodDefinition> methods_to_wrap)

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -220,9 +220,9 @@ namespace Xamarin.Linker {
 						var ctor = abr.CurrentAssembly.MainModule.ImportReference (ctorRef);
 
 						// Implement INSObjectFactory._Xamarin_ConstructNSObject
-						abr.ImplementConstructNSObjectFactoryMethod (DerivedLinkContext, type, ctor);
+						modified |= abr.ImplementConstructNSObjectFactoryMethod (DerivedLinkContext, type, ctor);
 						// Implement INativeObject._Xamarin_ConstructINativeObject
-						abr.ImplementConstructINativeObjectFactoryMethod (DerivedLinkContext, type, ctor);
+						modified |= abr.ImplementConstructINativeObjectFactoryMethod (DerivedLinkContext, type, ctor);
 					}
 				} else if (type.IsNativeObject ()) {
 					var ctorRef = AppBundleRewriter.FindINativeObjectConstructor (type);
@@ -230,7 +230,7 @@ namespace Xamarin.Linker {
 						var ctor = abr.CurrentAssembly.MainModule.ImportReference (ctorRef);
 
 						// Implement INativeObject._Xamarin_ConstructINativeObject
-						abr.ImplementConstructINativeObjectFactoryMethod (DerivedLinkContext, type, ctor);
+						modified |= abr.ImplementConstructINativeObjectFactoryMethod (DerivedLinkContext, type, ctor);
 					}
 				}
 			}


### PR DESCRIPTION
When the assembly postprocessing pipeline runs after ILC has compiled the
assemblies (the trimmable-static + NativeAOT + PrepareAssemblies reorder), the
managed assemblies are frozen: ILC already consumed them, so any IL modification
at that point is silently lost. This adds a guard that emits a warning if any step
modifies an assembly in that scenario, so such useless modifications are surfaced
instead of going unnoticed.

To avoid spurious warnings, two "modifications" in the post-ILC pass are fixed:

* ManagedRegistrarStep.ProcessType unconditionally reported the assembly as
  modified. During post-processing it only *collects* information about trampolines
  already created in the PrepareAssemblies pass (a read-only operation), so it now
  reports the actual modification state and doesn't trigger a redundant save.

* The NSObject.RegisterToggleRef stub (which only exists to let ILC trim the
  method) was still being applied post-ILC, uselessly modifying the frozen product
  assembly. It's already applied during the PrepareAssemblies pass before ILC runs,
  so it's now skipped once the assemblies are frozen.

Copilot-Session: 2b6450f9-2ad9-4e89-823a-3cc6e2f33f53