### PR TITLE
[devops] Fix apidiff GitHub comment step failing on git ancestry check Fixes #26107

### DIFF
--- a/tools/devops/automation/scripts/GitHub.Tests.ps1
+++ b/tools/devops/automation/scripts/GitHub.Tests.ps1
@@ -225,6 +225,60 @@ Describe 'Convert-Markdown' {
     }
 }
 
+Describe 'Test-GitIsAncestor' {
+    It 'returns true and does not leak a non-zero exit code when the commit is an ancestor' {
+        InModuleScope 'GitHub' {
+            $head = (& git rev-parse HEAD).Trim()
+            $parent = (& git rev-parse HEAD~1).Trim()
+            $global:LASTEXITCODE = 0
+            $result = Test-GitIsAncestor -Commit $parent -Branch $head
+            $result | Should -Be $true
+            $global:LASTEXITCODE | Should -Be 0
+        }
+    }
+
+    It 'returns false and does not leak a non-zero exit code when the commit is not an ancestor' {
+        InModuleScope 'GitHub' {
+            $head = (& git rev-parse HEAD).Trim()
+            $parent = (& git rev-parse HEAD~1).Trim()
+            $global:LASTEXITCODE = 0
+            $result = Test-GitIsAncestor -Commit $head -Branch $parent
+            $result | Should -Be $false
+            $global:LASTEXITCODE | Should -Be 0
+        }
+    }
+
+    It 'does not leak a non-zero exit code when the branch cannot be resolved' {
+        InModuleScope 'GitHub' {
+            $head = (& git rev-parse HEAD).Trim()
+            $global:LASTEXITCODE = 0
+            { Test-GitIsAncestor -Commit $head -Branch "origin/this-branch-does-not-exist-26107" } | Should -Throw
+            $global:LASTEXITCODE | Should -Be 0
+        }
+    }
+}
+
+Describe 'Get-GitCommitParents' {
+    It 'returns the parents and does not leak a non-zero exit code for a valid commit' {
+        InModuleScope 'GitHub' {
+            $head = (& git rev-parse HEAD).Trim()
+            $parent = (& git rev-parse HEAD~1).Trim()
+            $global:LASTEXITCODE = 0
+            $result = Get-GitCommitParents -Commit $head
+            $result | Should -Contain $parent
+            $global:LASTEXITCODE | Should -Be 0
+        }
+    }
+
+    It 'does not leak a non-zero exit code when the commit cannot be resolved' {
+        InModuleScope 'GitHub' {
+            $global:LASTEXITCODE = 0
+            { Get-GitCommitParents -Commit "this-commit-does-not-exist-26107" } | Should -Throw
+            $global:LASTEXITCODE | Should -Be 0
+        }
+    }
+}
+
 Describe 'IsCurrentCommitLatestInPR' {
     Context 'when in PR context' {
         BeforeAll {

--- a/tools/devops/automation/scripts/GitHub.psm1
+++ b/tools/devops/automation/scripts/GitHub.psm1
@@ -48,8 +48,11 @@ function Get-GitCommitParents {
         $Commit
     )
 
-    $output = & git rev-list --parents -n 1 -- $Commit 2>$null
-    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($output)) {
+    $output = & git rev-list --parents -n 1 $Commit 2>$null
+    $exitCode = $LASTEXITCODE
+    # Reset $LASTEXITCODE so the native git exit code doesn't leak out and fail the enclosing task.
+    $global:LASTEXITCODE = 0
+    if ($exitCode -ne 0 -or [string]::IsNullOrWhiteSpace($output)) {
         throw [System.InvalidOperationException]::new("Failed to get parent commits for '$Commit'.")
     }
 
@@ -73,7 +76,10 @@ function Test-GitIsAncestor {
     )
 
     & git merge-base --is-ancestor -- $Commit $Branch 2>$null
-    switch ($LASTEXITCODE) {
+    $exitCode = $LASTEXITCODE
+    # Reset $LASTEXITCODE so the native git exit code doesn't leak out and fail the enclosing task.
+    $global:LASTEXITCODE = 0
+    switch ($exitCode) {
         0 { return $true }
         1 { return $false }
         default { throw [System.InvalidOperationException]::new("Failed to determine whether '$Commit' is an ancestor of '$Branch'.") }


### PR DESCRIPTION
The "Publish GitHub comment for change detection" step in the apidiff pipeline intermittently failed (marking builds `partiallySucceeded`) with:

```
Error checking if current commit is latest in PR: Failed to determine whether '<commit>' is an ancestor of 'origin/<target_branch>'.
```

## Root cause

The git helpers `Test-GitIsAncestor` (`git merge-base --is-ancestor`) and `Get-GitCommitParents` (`git rev-list`) in `GitHub.psm1` leave a non-zero `$LASTEXITCODE` behind. `IsCurrentCommitLatestInPR` catches the thrown exception and returns `true` (so the comment is still computed), but the leaked native git exit code propagates to the end of the Azure DevOps `pwsh` inline script (which ends with `exit $LASTEXITCODE`), so the step is reported as failed.

This happens on the Windows apidiff agents when `origin/<target_branch>` isn't available in the shallow clone (merge-base exits with a non-0/1 code), and also in the ordinary "not an ancestor" (exit 1) case.

## Fix

- Capture the git exit code and reset `$LASTEXITCODE` to 0 in both helpers so it never leaks out and fails the enclosing task.
- Fix a pre-existing bug: `git rev-list --parents -n 1 -- $Commit` placed `--` before the commit, so git treated it as a pathspec and always failed with usage exit 129 — meaning merge-parent detection never actually worked. Removed the erroneous `--`.
- Added Pester tests covering both helpers, verifying the return value and that `$LASTEXITCODE` stays 0 across the ancestor, non-ancestor and unresolvable-ref cases.

Fixes https://github.com/dotnet/macios/issues/26107

🤖 Pull request created by Copilot