### PR TITLE
[docs] Improve XML docs for DoubleClick events and NSEdgeInsets

### DIFF
--- a/src/AppKit/Defs.cs
+++ b/src/AppKit/Defs.cs
@@ -24,23 +24,18 @@
 #nullable enable
 
 namespace AppKit {
-	/// <summary>To be added.</summary>
-	///     <remarks>To be added.</remarks>
+	/// <summary>Defines the inset distances for views.</summary>
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("maccatalyst")]
 	[StructLayout (LayoutKind.Sequential)]
 	public struct NSEdgeInsets {
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>The top edge inset value.</summary>
 		public nfloat Top;
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>The left edge inset value.</summary>
 		public nfloat Left;
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>The bottom edge inset value.</summary>
 		public nfloat Bottom;
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>The right edge inset value.</summary>
 		public nfloat Right;
 
 		public NSEdgeInsets (nfloat top, nfloat left, nfloat bottom, nfloat right)

--- a/src/AppKit/DoubleWrapper.cs
+++ b/src/AppKit/DoubleWrapper.cs
@@ -30,8 +30,7 @@
 namespace AppKit {
 
 	public partial class NSBrowser {
-		/// <summary>To be added.</summary>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Occurs when the user double-clicks the control.</summary>
 		public event EventHandler DoubleClick {
 			add {
 				Target = ActionDispatcher.SetupDoubleAction (Target, value);
@@ -44,8 +43,7 @@ namespace AppKit {
 	}
 
 	public partial class NSMatrix {
-		/// <summary>To be added.</summary>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Occurs when the user double-clicks the control.</summary>
 		public event EventHandler DoubleClick {
 			add {
 				Target = ActionDispatcher.SetupDoubleAction (Target, value);
@@ -58,8 +56,7 @@ namespace AppKit {
 	}
 
 	public partial class NSPathCell {
-		/// <summary>To be added.</summary>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Occurs when the user double-clicks the control.</summary>
 		public event EventHandler DoubleClick {
 			add {
 				Target = ActionDispatcher.SetupDoubleAction (Target, value);
@@ -72,8 +69,7 @@ namespace AppKit {
 	}
 
 	public partial class NSPathControl {
-		/// <summary>To be added.</summary>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Occurs when the user double-clicks the control.</summary>
 		public event EventHandler DoubleClick {
 			add {
 				Target = ActionDispatcher.SetupDoubleAction (Target, value);
@@ -86,8 +82,7 @@ namespace AppKit {
 	}
 
 	public partial class NSStatusItem {
-		/// <summary>To be added.</summary>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Occurs when the user double-clicks the control.</summary>
 		public event EventHandler DoubleClick {
 			add {
 				Target = ActionDispatcher.SetupDoubleAction (Target, value);
@@ -100,8 +95,7 @@ namespace AppKit {
 	}
 
 	public partial class NSTableView {
-		/// <summary>To be added.</summary>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Occurs when the user double-clicks the control.</summary>
 		public event EventHandler DoubleClick {
 			add {
 				Target = ActionDispatcher.SetupDoubleAction (Target, value);


### PR DESCRIPTION
Improve XML documentation for:
- DoubleClick events in AppKit (`NSTableView`, `NSOutlineView`, `NSBrowser`)
- `NSEdgeInsets` struct

Changes:
- Replace boilerplate 'To be added.' with meaningful descriptions
- Remove empty XML doc nodes
- Fix formatting and indentation

🤖 Pull request created by Copilot