### PR TITLE
[release/10.0.1xx] [Signing] Sign unsigned libraries

### DIFF
--- a/dotnet/Workloads/SignList.xml
+++ b/dotnet/Workloads/SignList.xml
@@ -37,18 +37,15 @@
     <Skip Include="Build\System.Threading.Tasks.Extensions.dll" />
     <!-- net10.0 msbuild tools content -->
     <Skip Include="AssemblyStripper.dll" />
-    <Skip Include="BouncyCastle.Cryptography.dll" />
     <Skip Include="ILLink.Tasks.dll" />
     <Skip Include="Microsoft.Win32.SystemEvents.dll" />
     <Skip Include="MonoTargetsTasks.dll" />
-    <Skip Include="MQTTnet.dll" />
     <Skip Include="System.CodeDom.dll" />
     <Skip Include="System.ComponentModel.Composition.dll" />
     <Skip Include="System.Configuration.ConfigurationManager.dll" />
     <Skip Include="System.Diagnostics.EventLog.dll" />
     <Skip Include="System.Diagnostics.EventLog.Messages.dll" />
     <Skip Include="System.Drawing.Common.dll" />
-    <Skip Include="System.Reactive.dll" />
     <Skip Include="System.Resources.Extensions.dll" />
     <Skip Include="System.Security.Cryptography.Pkcs.dll" />
     <Skip Include="System.Security.Cryptography.ProtectedData.dll" />
@@ -58,6 +55,9 @@
   <ItemGroup>
     <ThirdParty Include="BouncyCastle.Crypto.dll" />
     <ThirdParty Include="Renci.SshNet.dll" />
+    <ThirdParty Include="BouncyCastle.Cryptography.dll" />
+    <ThirdParty Include="MQTTnet.dll" />
+    <ThirdParty Include="System.Reactive.dll" />
     <!-- Build.zip -->
     <ThirdParty Include="Mono.Cecil*.dll" />
 


### PR DESCRIPTION
## Summary

- Backport #25966 to `release/10.0.1xx`.
- Move `BouncyCastle.Cryptography.dll`, `MQTTnet.dll`, and `System.Reactive.dll` from `Skip` to `ThirdParty` so the signing pipeline signs these unsigned libraries.

## Validation

- `xmllint --noout dotnet/Workloads/SignList.xml dotnet/Workloads/SignList.targets`
- Verified each moved assembly occurs exactly once in `ThirdParty` and not in `Skip`.
- Verified the branch diff contains only `dotnet/Workloads/SignList.xml` and matches merged commit `58baaa193ef8dce8aa733529c3aae2e196a71475`.
- MSBuild evaluation was not run because the repository-local .NET SDK is not bootstrapped (`make dotnet -C builds`).