### PR TITLE
[DeviceDiscoveryExtension] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/devicediscoveryextension.cs
+++ b/src/devicediscoveryextension.cs
@@ -63,12 +63,21 @@ namespace DeviceDiscoveryExtension {
 		[Export ("url", ArgumentSemantic.Copy)]
 		NSUrl Url { get; set; }
 
+		[Deprecated (PlatformName.iOS, 27, 0, message: "Please use MediaDeviceExtension")]
+		[Deprecated (PlatformName.MacOSX, 27, 0, message: "Please use MediaDeviceExtension")]
+		[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Please use MediaDeviceExtension")]
 		[Export ("mediaPlaybackState", ArgumentSemantic.Assign)]
 		DDDeviceMediaPlaybackState MediaPlaybackState { get; set; }
 
+		[Deprecated (PlatformName.iOS, 27, 0, message: "Please use MediaDeviceExtension")]
+		[Deprecated (PlatformName.MacOSX, 27, 0, message: "Please use MediaDeviceExtension")]
+		[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Please use MediaDeviceExtension")]
 		[NullAllowed, Export ("mediaContentTitle")]
 		string MediaContentTitle { get; set; }
 
+		[Deprecated (PlatformName.iOS, 27, 0, message: "Please use MediaDeviceExtension")]
+		[Deprecated (PlatformName.MacOSX, 27, 0, message: "Please use MediaDeviceExtension")]
+		[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Please use MediaDeviceExtension")]
 		[NullAllowed, Export ("mediaContentSubtitle")]
 		string MediaContentSubtitle { get; set; }
 

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-DeviceDiscoveryExtension.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-DeviceDiscoveryExtension.todo
@@ -1,6 +1,0 @@
-!deprecated-attribute-missing! DDDevice::mediaContentSubtitle missing a [Deprecated] attribute
-!deprecated-attribute-missing! DDDevice::mediaContentTitle missing a [Deprecated] attribute
-!deprecated-attribute-missing! DDDevice::mediaPlaybackState missing a [Deprecated] attribute
-!deprecated-attribute-missing! DDDevice::setMediaContentSubtitle: missing a [Deprecated] attribute
-!deprecated-attribute-missing! DDDevice::setMediaContentTitle: missing a [Deprecated] attribute
-!deprecated-attribute-missing! DDDevice::setMediaPlaybackState: missing a [Deprecated] attribute


### PR DESCRIPTION
## Summary

- add Xcode 27.0 deprecation metadata for `DDDevice.MediaPlaybackState`, `MediaContentTitle`, and `MediaContentSubtitle`
- apply matching iOS, macOS, and Mac Catalyst deprecations for cross-platform availability consistency
- remove the resolved DeviceDiscoveryExtension xtro todo file

## Validation

- fresh `make world` before editing
- post-edit `make world`
- clean xtro generation/classification: sanity passed on all platforms
- clean Cecil suite: 112 passed, 4 skipped, 0 failed
- iOS 27 introspection: 44 passed, 0 failed
- tvOS 27 introspection: 43 passed, 0 failed
- macOS introspection: 32 passed, 2 host-version-gated, 0 failed
- Mac Catalyst: all non-constructor fixtures passed; the full constructor fixture hits the known terminal-only TCC privacy crash while constructing `CLLocationButton`
- clean filtered AppSizeTest: 16 skipped as expected under Xcode 27 Beta 3, 0 failed