### PR TITLE
[CryptoTokenKit] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/cryptotokenkit.cs
+++ b/src/cryptotokenkit.cs
@@ -25,6 +25,7 @@ namespace CryptoTokenKit {
 		TokenNotFound = -7,
 		BadParameter = -8,
 		AuthenticationNeeded = -9,
+		InvalidatedDeviceKey = -10,
 	}
 
 #if !STABLE_CRYPTOTOKENKIT

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -3099,6 +3099,7 @@ F:CryptoTokenKit.TKErrorCode.BadParameter
 F:CryptoTokenKit.TKErrorCode.CanceledByUser
 F:CryptoTokenKit.TKErrorCode.CommunicationError
 F:CryptoTokenKit.TKErrorCode.CorruptedData
+F:CryptoTokenKit.TKErrorCode.InvalidatedDeviceKey
 F:CryptoTokenKit.TKErrorCode.NotImplemented
 F:CryptoTokenKit.TKErrorCode.ObjectNotFound
 F:CryptoTokenKit.TKErrorCode.TokenNotFound

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CryptoTokenKit.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CryptoTokenKit.todo
@@ -1,1 +1,0 @@
-!missing-enum-value! TKErrorCode native value TKErrorCodeInvalidatedDeviceKey = -10 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-CryptoTokenKit.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-CryptoTokenKit.todo
@@ -1,1 +1,0 @@
-!missing-enum-value! TKErrorCode native value TKErrorCodeInvalidatedDeviceKey = -10 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-CryptoTokenKit.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-CryptoTokenKit.todo
@@ -1,1 +1,0 @@
-!missing-enum-value! TKErrorCode native value TKErrorCodeInvalidatedDeviceKey = -10 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-CryptoTokenKit.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-CryptoTokenKit.todo
@@ -1,1 +1,0 @@
-!missing-enum-value! TKErrorCode native value TKErrorCodeInvalidatedDeviceKey = -10 not bound


### PR DESCRIPTION
## Summary

- Bind `TKErrorCode.InvalidatedDeviceKey` with the native value `-10`.
- Remove the resolved CryptoTokenKit xtro todo files for iOS, tvOS, macOS, and Mac Catalyst.
- Update the existing CryptoTokenKit documentation known-failure baseline.

## Validation

- `make world` before and after the binding change
- Clean xtro generation/classification: sanity passed on all platforms
- Clean Cecil run: 112 passed, 4 skipped
- Clean AppSizeTest run: 16 expected skips under beta Xcode, 0 failures
- iOS 27 introspection: 44/44 passed
- tvOS 27 introspection: 43/43 passed
- macOS introspection: 32/32 passed, 2 latest-OS checks ignored
- Mac Catalyst: all 14 non-constructor fixtures passed (36 tests, 4 expected ignores); the full constructor sweep is locally blocked by the known unsigned-host TCC abort in `CoreLocationUI.CLLocationButton`, unrelated to this numeric enum binding