### PR TITLE
[CoreVideo] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/corevideo.cs
+++ b/src/corevideo.cs
@@ -500,6 +500,10 @@ namespace CoreVideo {
 		[MacCatalyst (26, 0), TV (26, 0), Mac (26, 0), iOS (26, 0)]
 		[Field ("kCVImageBufferDisplayMaskRectangleStereoRightKey")]
 		NSString DisplayMaskRectangleStereoRightKey { get; }
+
+		[TV (17, 0), Mac (14, 0), iOS (17, 0), MacCatalyst (17, 0)]
+		[Field ("kCVImageBufferHorizontalDisparityAdjustmentKey")]
+		NSString HorizontalDisparityAdjustmentKey { get; }
 	}
 
 	[MacCatalyst (13, 1)]

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreVideo.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreVideo.todo
@@ -1,1 +1,0 @@
-!missing-field! kCVImageBufferHorizontalDisparityAdjustmentKey not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreVideo.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreVideo.todo
@@ -1,1 +1,0 @@
-!missing-field! kCVImageBufferHorizontalDisparityAdjustmentKey not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreVideo.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreVideo.todo
@@ -1,1 +1,0 @@
-!missing-field! kCVImageBufferHorizontalDisparityAdjustmentKey not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-CoreVideo.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-CoreVideo.todo
@@ -1,1 +1,0 @@
-!missing-field! kCVImageBufferHorizontalDisparityAdjustmentKey not bound


### PR DESCRIPTION
## Summary

- Bind `kCVImageBufferHorizontalDisparityAdjustmentKey` as `CVImageBuffer.HorizontalDisparityAdjustmentKey`.
- Preserve the native introduction versions: macOS 14.0 and iOS, tvOS, and Mac Catalyst 17.0.
- Remove the resolved CoreVideo xtro todo files for all four platforms.

## Validation

- `make world` before and after the binding change.
- Clean xtro regeneration and four-platform classification: sanity passed.
- Clean cecil test run: passed.
- Clean `AppSizeTest` run: all 16 cases skipped by the beta-Xcode guard, with no failures.
- Introspection: iOS 44/44, tvOS 43/43, macOS 32/32. Mac Catalyst hit the known TCC abort in the unrelated `CLLocationButton` ctor fixture; all 14 remaining fixtures passed or were expectedly ignored, including `iOSApiFieldTest` 3/3.