### PR TITLE
[Foundation] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/foundation.cs
+++ b/src/foundation.cs
@@ -14387,11 +14387,17 @@ namespace Foundation {
 
 		[NoMac]
 		[MacCatalyst (13, 1)]
+		[Deprecated (PlatformName.iOS, 27, 0, message: "Use Background Assets instead.")]
+		[Deprecated (PlatformName.TvOS, 27, 0, message: "Use Background Assets instead.")]
+		[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use Background Assets instead.")]
 		[Export ("preservationPriorityForTag:")]
 		double GetPreservationPriority (NSString tag);
 
 		[NoMac]
 		[MacCatalyst (13, 1)]
+		[Deprecated (PlatformName.iOS, 27, 0, message: "Use Background Assets instead.")]
+		[Deprecated (PlatformName.TvOS, 27, 0, message: "Use Background Assets instead.")]
+		[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use Background Assets instead.")]
 		[Export ("setPreservationPriority:forTags:")]
 		void SetPreservationPriority (double priority, NSSet<NSString> tags);
 
@@ -14411,6 +14417,9 @@ namespace Foundation {
 
 	[NoMac]
 	[MacCatalyst (13, 1)]
+	[Deprecated (PlatformName.iOS, 27, 0, message: "Use Background Assets instead.")]
+	[Deprecated (PlatformName.TvOS, 27, 0, message: "Use Background Assets instead.")]
+	[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use Background Assets instead.")]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface NSBundleResourceRequest : NSProgressReporting {
@@ -14684,6 +14693,10 @@ namespace Foundation {
 	[BaseType (typeof (NSObject))]
 	[DesignatedDefaultCtor]
 	partial interface NSItemProvider : NSCopying {
+		[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use the 'NSItemProvider (INSItemProviderWriting)' constructor instead.")]
+		[Deprecated (PlatformName.iOS, 27, 0, message: "Use the 'NSItemProvider (INSItemProviderWriting)' constructor instead.")]
+		[Deprecated (PlatformName.TvOS, 27, 0, message: "Use the 'NSItemProvider (INSItemProviderWriting)' constructor instead.")]
+		[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use the 'NSItemProvider (INSItemProviderWriting)' constructor instead.")]
 		[DesignatedInitializer]
 		[Export ("initWithItem:typeIdentifier:")]
 		NativeHandle Constructor ([NullAllowed] NSObject item, string typeIdentifier);
@@ -14694,12 +14707,20 @@ namespace Foundation {
 		[Export ("registeredTypeIdentifiers", ArgumentSemantic.Copy)]
 		string [] RegisteredTypeIdentifiers { get; }
 
+		[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use the 'RegisterObject' method instead.")]
+		[Deprecated (PlatformName.iOS, 27, 0, message: "Use the 'RegisterObject' method instead.")]
+		[Deprecated (PlatformName.TvOS, 27, 0, message: "Use the 'RegisterObject' method instead.")]
+		[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use the 'RegisterObject' method instead.")]
 		[Export ("registerItemForTypeIdentifier:loadHandler:")]
 		void RegisterItemForTypeIdentifier (string typeIdentifier, NSItemProviderLoadHandler loadHandler);
 
 		[Export ("hasItemConformingToTypeIdentifier:")]
 		bool HasItemConformingTo (string typeIdentifier);
 
+		[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use the 'LoadObject' method instead.")]
+		[Deprecated (PlatformName.iOS, 27, 0, message: "Use the 'LoadObject' method instead.")]
+		[Deprecated (PlatformName.TvOS, 27, 0, message: "Use the 'LoadObject' method instead.")]
+		[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use the 'LoadObject' method instead.")]
 		[Async (XmlDocs = """
 			<param name="typeIdentifier">To be added.</param>
 			<param name="options">To be added.</param>

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-Foundation.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-Foundation.todo
@@ -1,3 +1,0 @@
-!deprecated-attribute-missing! NSItemProvider::initWithItem:typeIdentifier: missing a [Deprecated] attribute
-!deprecated-attribute-missing! NSItemProvider::loadItemForTypeIdentifier:options:completionHandler: missing a [Deprecated] attribute
-!deprecated-attribute-missing! NSItemProvider::registerItemForTypeIdentifier:loadHandler: missing a [Deprecated] attribute

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-Foundation.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-Foundation.todo
@@ -1,6 +1,0 @@
-!deprecated-attribute-missing! NSBundle::preservationPriorityForTag: missing a [Deprecated] attribute
-!deprecated-attribute-missing! NSBundle::setPreservationPriority:forTags: missing a [Deprecated] attribute
-!deprecated-attribute-missing! NSBundleResourceRequest missing a [Deprecated] attribute
-!deprecated-attribute-missing! NSItemProvider::initWithItem:typeIdentifier: missing a [Deprecated] attribute
-!deprecated-attribute-missing! NSItemProvider::loadItemForTypeIdentifier:options:completionHandler: missing a [Deprecated] attribute
-!deprecated-attribute-missing! NSItemProvider::registerItemForTypeIdentifier:loadHandler: missing a [Deprecated] attribute

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-Foundation.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-Foundation.todo
@@ -1,3 +1,0 @@
-!deprecated-attribute-missing! NSItemProvider::initWithItem:typeIdentifier: missing a [Deprecated] attribute
-!deprecated-attribute-missing! NSItemProvider::loadItemForTypeIdentifier:options:completionHandler: missing a [Deprecated] attribute
-!deprecated-attribute-missing! NSItemProvider::registerItemForTypeIdentifier:loadHandler: missing a [Deprecated] attribute

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-Foundation.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-Foundation.todo
@@ -1,6 +1,0 @@
-!deprecated-attribute-missing! NSBundle::preservationPriorityForTag: missing a [Deprecated] attribute
-!deprecated-attribute-missing! NSBundle::setPreservationPriority:forTags: missing a [Deprecated] attribute
-!deprecated-attribute-missing! NSBundleResourceRequest missing a [Deprecated] attribute
-!deprecated-attribute-missing! NSItemProvider::initWithItem:typeIdentifier: missing a [Deprecated] attribute
-!deprecated-attribute-missing! NSItemProvider::loadItemForTypeIdentifier:options:completionHandler: missing a [Deprecated] attribute
-!deprecated-attribute-missing! NSItemProvider::registerItemForTypeIdentifier:loadHandler: missing a [Deprecated] attribute


### PR DESCRIPTION
## Summary

- deprecate the NSBundle on-demand resource APIs and NSBundleResourceRequest in favor of Background Assets
- deprecate legacy NSItemProvider item initialization, registration, and loading APIs in favor of the managed object-based APIs
- remove the resolved Foundation xtro todo files for every supported platform

## Validation

- `make world` before implementation and after the binding changes
- clean xtro generation/classification: sanity passed
- clean cecil tests: 112 passed, 4 skipped
- clean AppSizeTest run: 16 expected skips under beta Xcode, 0 failures
- iOS 27 Beta 3 introspection: 44 passed
- tvOS 27 Beta 3 introspection: 43 passed
- macOS introspection: 32 passed, 2 expected host-version ignores
- Mac Catalyst introspection: 39 passed, 4 expected ignores