### PR TITLE
[FileProvider] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/fileprovider.cs
+++ b/src/fileprovider.cs
@@ -304,6 +304,18 @@ namespace FileProvider {
 		DownloadEagerlyAndKeepDownloaded,
 	}
 
+	/// <summary>Specifies how the system materializes a file provider folder's namespace.</summary>
+	[Native]
+	[NoTV, NoMacCatalyst, Mac (27, 0), iOS (27, 0)]
+	public enum NSFileProviderNamespacePolicy : long {
+		/// <summary>Inherits the namespace policy from the parent folder.</summary>
+		Inherited,
+		/// <summary>Materializes a dataless folder's namespace when the folder is accessed.</summary>
+		MaterializeLazily,
+		/// <summary>Keeps the folder's namespace fully materialized and up to date.</summary>
+		MaterializeEagerly,
+	}
+
 	/// <summary>A batch of data to return from an enumerator.</summary>
 	[NoMacCatalyst]
 	[Static]
@@ -758,6 +770,15 @@ namespace FileProvider {
 		[NoTV, NoMacCatalyst, iOS (16, 0)]
 		[Export ("contentPolicy")]
 		NSFileProviderContentPolicy ContentPolicy { get; }
+
+		/// <summary>Gets the policy that controls how the item's namespace is materialized.</summary>
+		[NoTV, NoMacCatalyst, Mac (27, 0), iOS (27, 0)]
+		[Export ("namespacePolicy")]
+		NSFileProviderNamespacePolicy NamespacePolicy {
+			// Keep the generated extension method's availability in sync.
+			[NoTV, NoMacCatalyst, Mac (27, 0), iOS (27, 0)]
+			get;
+		}
 	}
 
 	/// <summary>A shared object that is accessible from both the containing app and the extension.</summary>

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-FileProvider.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-FileProvider.ignore
@@ -1,5 +1,6 @@
 # Documentation as of Xcode 13 as macOS only
 !missing-enum! NSFileProviderFileSystemFlags not bound
 !missing-enum! NSFileProviderDomainTestingModes not bound
-# Header clearly says this enum is not available on Mac Catalyst, not sure why xtro thinks it is.
+# Headers explicitly mark these enums unavailable on Mac Catalyst; xtro drops the enum typedef availability.
 !missing-enum! NSFileProviderContentPolicy not bound
+!missing-enum! NSFileProviderNamespacePolicy not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-FileProvider.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-FileProvider.todo
@@ -1,1 +1,0 @@
-!missing-enum! NSFileProviderNamespacePolicy not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-FileProvider.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-FileProvider.todo
@@ -1,2 +1,0 @@
-!missing-enum! NSFileProviderNamespacePolicy not bound
-!missing-protocol-member! NSFileProviderItem::namespacePolicy not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-FileProvider.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-FileProvider.todo
@@ -1,2 +1,0 @@
-!missing-enum! NSFileProviderNamespacePolicy not bound
-!missing-protocol-member! NSFileProviderItem::namespacePolicy not found


### PR DESCRIPTION
## Summary

- Add `NSFileProviderNamespacePolicy` for iOS and macOS 27.0.
- Bind the optional `NSFileProviderItem.NamespacePolicy` property and preserve availability metadata on its generated extension accessor.
- Classify the Mac Catalyst enum report as an xtro false positive because the SDK marks the API unavailable, and remove the resolved FileProvider todo files.

## Validation

- `make world`
- Clean xtro classification and sanity: passed
- Clean cecil suite: 112 passed, 4 skipped
- macOS introspection: 32 passed, 2 expected OS-version skips
- Mac Catalyst introspection: 39 passed, 4 expected skips
- iOS/tvOS 27 introspection exercised the rebuilt assemblies; only unrelated existing Beta 3 UIKit/AVKit/AVFoundation failures remain
- Clean AppSize fixture: 16 tests intentionally skipped by the beta-Xcode guard