### PR TITLE
[MediaAccessibility] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/MediaAccessibility/MAEnums.cs
+++ b/src/MediaAccessibility/MAEnums.cs
@@ -20,6 +20,9 @@ namespace MediaAccessibility {
 		Default = 0,
 		/// <summary>To be added.</summary>
 		User = 1,
+		/// <summary>Represents the caption appearance preferences for video conferencing.</summary>
+		[TV (27, 0), Mac (27, 0), iOS (27, 0), MacCatalyst (27, 0)]
+		VideoConferencing = 2,
 	}
 
 	/// <summary>Enumerates values that indicate whether to display captions only for translation, always, or only if an audio track language differs from the system.</summary>

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-MediaAccessibility.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-MediaAccessibility.todo
@@ -1,1 +1,0 @@
-!missing-enum-value! MACaptionAppearanceDomain native value kMACaptionAppearanceDomainVideoConferencing = 2 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-MediaAccessibility.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-MediaAccessibility.todo
@@ -1,1 +1,0 @@
-!missing-enum-value! MACaptionAppearanceDomain native value kMACaptionAppearanceDomainVideoConferencing = 2 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-MediaAccessibility.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-MediaAccessibility.todo
@@ -1,1 +1,0 @@
-!missing-enum-value! MACaptionAppearanceDomain native value kMACaptionAppearanceDomainVideoConferencing = 2 not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-MediaAccessibility.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-MediaAccessibility.todo
@@ -1,1 +1,0 @@
-!missing-enum-value! MACaptionAppearanceDomain native value kMACaptionAppearanceDomainVideoConferencing = 2 not bound


### PR DESCRIPTION
## Summary

- Bind `MACaptionAppearanceDomain.VideoConferencing` with iOS, tvOS, macOS, and Mac Catalyst 27.0 availability.
- Remove the resolved MediaAccessibility xtro todo files for all four platforms.

## Validation

- Fresh baseline and post-change `make world` builds completed successfully.
- Xtro classification and sanity passed.
- Cecil: 116 tests passed.
- MediaAccessibility monotouch tests: 4/4 passed on iOS 27, tvOS 27, macOS, and Mac Catalyst.
- macOS introspection: 32/32 passed. iOS/tvOS full introspection only reported unrelated Xcode 27 beta runtime gaps in UIKit/AVFoundation; Mac Catalyst hit the known unsigned-app TCC constructor crash, while all remaining fixtures passed.
- App-size suite completed with all 16 cases skipped by the repository beta-Xcode policy.