### PR TITLE
[ImageIO] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/ImageIO/CGImageSource.cs
+++ b/src/ImageIO/CGImageSource.cs
@@ -70,6 +70,15 @@ namespace ImageIO {
 		/// https://developer.apple.com/library/mac/#documentation/FileManagement/Conceptual/understanding_utis/understand_utis_intro/understand_utis_intro.html</remarks>
 		public string? BestGuessTypeIdentifier { get; set; }
 
+		/// <summary>Gets or sets the uniform type identifiers that restrict the image formats this source may decode.</summary>
+		/// <value><see langword="null" /> omits the per-source restriction, while an empty array disables image parsing.</value>
+		/// <remarks>Unknown identifiers are ignored. If process-wide restrictions were configured with <see cref="CGImageSource.SetAllowableTypes" />, only identifiers allowed by both lists are permitted.</remarks>
+		[SupportedOSPlatform ("ios27.0")]
+		[SupportedOSPlatform ("tvos27.0")]
+		[SupportedOSPlatform ("macos27.0")]
+		[SupportedOSPlatform ("maccatalyst27.0")]
+		public string []? AllowableTypes { get; set; }
+
 		/// <summary>Determines whether the loaded image should be cached.</summary>
 		///         <value />
 		///         <remarks>To be added.</remarks>
@@ -95,6 +104,12 @@ namespace ImageIO {
 
 			if (BestGuessTypeIdentifier is not null)
 				dict.LowlevelSetObject (BestGuessTypeIdentifier, kTypeIdentifierHint);
+#pragma warning disable CA1416 // The key is only used when available on the current OS.
+			if (kAllowableTypes != IntPtr.Zero && AllowableTypes is not null) {
+				using (var allowableTypes = NSArray.FromStrings (AllowableTypes))
+					dict.LowlevelSetObject (allowableTypes, kAllowableTypes);
+			}
+#pragma warning restore CA1416
 			if (!ShouldCache)
 				dict.LowlevelSetObject (CFBoolean.FalseHandle, kShouldCache);
 			if (ShouldAllowFloat)

--- a/src/imageio.cs
+++ b/src/imageio.cs
@@ -4031,6 +4031,11 @@ namespace ImageIO {
 		[Field ("kCGImageSourceTypeIdentifierHint")]
 		IntPtr kTypeIdentifierHint { get; }
 
+		[iOS (27, 0), TV (27, 0), Mac (27, 0), MacCatalyst (27, 0)]
+		[Internal]
+		[Field ("kCGImageSourceAllowableTypes")]
+		IntPtr kAllowableTypes { get; }
+
 		[Internal]
 		[Field ("kCGImageSourceShouldCache")]
 		IntPtr kShouldCache { get; }

--- a/tests/monotouch-test/ImageIO/CGImageSourceTest.cs
+++ b/tests/monotouch-test/ImageIO/CGImageSourceTest.cs
@@ -28,6 +28,27 @@ namespace MonoTouchFixtures.ImageIO {
 		}
 
 		[Test]
+		public void AllowableTypes ()
+		{
+			TestRuntime.AssertXcodeVersion (27, 0);
+			TestRuntime.AssertSystemVersion (TestRuntime.CurrentPlatform, 27, 0);
+
+			bool CanDecode (string [] allowableTypes)
+			{
+				using (var source = CGImageSource.FromUrl (fileUrl, new CGImageOptions { AllowableTypes = allowableTypes })) {
+					if (source is null)
+						return false;
+					using (var image = source.CreateImage (0, null))
+						return image is not null;
+				}
+			}
+
+			Assert.That (CanDecode (new [] { "public.png" }), Is.True, "Allowed");
+			Assert.That (CanDecode (new [] { "public.jpeg" }), Is.False, "Disallowed");
+			Assert.That (CanDecode ([]), Is.False, "Empty");
+		}
+
+		[Test]
 		public void FromDataProviderTest ()
 		{
 			var file = NSBundle.MainBundle.PathForResource ("xamarin2", "png");

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-ImageIO.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-ImageIO.todo
@@ -1,1 +1,0 @@
-!missing-field! kCGImageSourceAllowableTypes not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-ImageIO.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-ImageIO.todo
@@ -1,1 +1,0 @@
-!missing-field! kCGImageSourceAllowableTypes not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-ImageIO.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-ImageIO.todo
@@ -1,1 +1,0 @@
-!missing-field! kCGImageSourceAllowableTypes not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-ImageIO.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-ImageIO.todo
@@ -1,1 +1,0 @@
-!missing-field! kCGImageSourceAllowableTypes not bound


### PR DESCRIPTION
## Summary

- Bind the Xcode 27 `kCGImageSourceAllowableTypes` creation option as `CGImageOptions.AllowableTypes` on iOS, tvOS, macOS, and Mac Catalyst.
- Preserve the native null-versus-empty semantics and safely omit the key on older runtimes.
- Add behavioral coverage for allowed, rejected, and empty image-format allowlists.
- Remove the four resolved ImageIO xtro todo files.

## Validation

- `make world` on the current `xcode27.0` tip
- Clean xtro classification: sanity passed
- Clean cecil suite: passed
- iOS 27 ImageIO test: 1/1 passed
- tvOS 27 ImageIO test: 1/1 passed
- iOS 27 introspection: 44/44 passed
- tvOS 27 introspection: 43/43 passed
- macOS introspection: 32/32 passed, 2 host-version-gated
- Mac Catalyst build passed; local `run-bare` is blocked by the known unsigned-app TCC privacy abort on the macOS 26.5 host
- App-size suite: 0 failed; all 16 cases intentionally skipped on beta Xcode
