### PR TITLE
[Messages] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/messages.cs
+++ b/src/messages.cs
@@ -511,5 +511,35 @@ namespace Messages {
 		[Export ("alternateLayout")]
 		MSMessageTemplateLayout AlternateLayout { get; }
 	}
+
+	/// <summary>Represents a request for Unified Payments Interface (UPI) device validation.</summary>
+	/// <remarks>Using this API requires the <c>com.apple.developer.upi-device-validation</c> managed entitlement. It works only on devices with SMS capability and with recipients who cannot receive iMessages.</remarks>
+	[NoTV, NoMac, iOS (27, 0), MacCatalyst (27, 0)]
+	[BaseType (typeof (NSObject), Name = "MSUPIRequest")]
+	[DisableDefaultCtor]
+	interface MSUpiRequest {
+		/// <summary>Gets the validation token to send.</summary>
+		[Export ("validationToken")]
+		string ValidationToken { get; }
+
+		/// <summary>Gets the SMS recipients who will receive the UPI validation message.</summary>
+		[Export ("recipients", ArgumentSemantic.Copy)]
+		string [] Recipients { get; }
+
+		/// <param name="validationToken">The validation token to send.</param>
+		/// <param name="recipients">The SMS recipients who will receive the UPI validation message.</param>
+		/// <summary>Creates a UPI request with the specified validation token and recipients.</summary>
+		[Export ("initWithValidationToken:recipients:")]
+		NativeHandle Constructor (string validationToken, string [] recipients);
+
+		/// <param name="completionHandler">The handler to invoke when sending completes. Its argument is <see langword="true" /> if the message was sent; otherwise, <see langword="false" />.</param>
+		/// <summary>Sends this UPI request.</summary>
+		[Async (XmlDocs = """
+			<summary>Sends this UPI request asynchronously.</summary>
+			<returns>A task whose result is <see langword="true" /> if the message was sent; otherwise, <see langword="false" />.</returns>
+			""")]
+		[Export ("sendWithCompletionHandler:")]
+		void Send (Action<bool> completionHandler);
+	}
 }
 #endif // !MONOMAC

--- a/tests/introspection/ApiTypoTest.cs
+++ b/tests/introspection/ApiTypoTest.cs
@@ -783,7 +783,7 @@ namespace Introspection {
 			{ "Unsynced", ApplePlatform.MacOSX | ApplePlatform.iOS }, // sync state adjective
 			{ "Untrash", ApplePlatform.iOS }, // mail/files verb
 			{ "Upce", All }, // UPC-E barcode
-			{ "Upi", ApplePlatform.iOS }, // Unified Payments Interface
+			{ "Upi", ApplePlatform.iOS | ApplePlatform.MacCatalyst }, // Unified Payments Interface
 			{ "Uri", ApplePlatform.MacOSX | ApplePlatform.MacCatalyst }, // Uniform Resource Identifier
 			{ "Usac", All }, // Unified Speech and Audio Coding
 			{ "Usd", All }, // Universal Scene Description

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-Messages.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-Messages.todo
@@ -1,5 +1,0 @@
-!missing-selector! MSUPIRequest::initWithValidationToken:recipients: not bound
-!missing-selector! MSUPIRequest::recipients not bound
-!missing-selector! MSUPIRequest::sendWithCompletionHandler: not bound
-!missing-selector! MSUPIRequest::validationToken not bound
-!missing-type! MSUPIRequest not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-Messages.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-Messages.todo
@@ -1,5 +1,0 @@
-!missing-selector! MSUPIRequest::initWithValidationToken:recipients: not bound
-!missing-selector! MSUPIRequest::recipients not bound
-!missing-selector! MSUPIRequest::sendWithCompletionHandler: not bound
-!missing-selector! MSUPIRequest::validationToken not bound
-!missing-type! MSUPIRequest not bound


### PR DESCRIPTION
## Summary

- Bind `MSUPIRequest` as `MSUpiRequest` for iOS and Mac Catalyst 27.0.
- Add its validation token, recipient list, initializer, callback-based send API, and generated `SendAsync` wrapper.
- Disable the default constructor because the iOS 27 runtime reports `init()` as unimplemented.
- Document the new public API, extend the `Upi` typo allowlist to Mac Catalyst, and remove the resolved Messages xtro todo files.

## Validation

- Repeated full `make world` builds, including a final pass on current `xcode27.0`.
- Clean xtro classification: sanity passed.
- Clean Cecil suite: 112 passed, 4 skipped, 0 failed.
- iOS 27: Messages constructor, selector, signature, naming, and availability checks passed; the full suite retained unrelated Xcode 27 beta failures in UIKit, AVKit, and AVFoundation.
- tvOS 27: Messages exclusion validated; the full suite retained the same unrelated beta failures.
- macOS introspection: 32 passed, 0 failed, 2 host-version-gated.
- Mac Catalyst introspection: 39 passed, 0 failed, 4 host-version-gated.
- Clean app-size suite: all 16 cases intentionally skipped on beta Xcode by the test itself.