### PR TITLE
[MediaExtension] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/mediaextension.cs
+++ b/src/mediaextension.cs
@@ -95,6 +95,10 @@ namespace MediaExtension {
 		[Mac (26, 0)]
 		[Export ("sidecarFileName"), NullAllowed]
 		string SidecarFileName { get; set; }
+
+		[Mac (27, 0)]
+		[Export ("constituentFileNames", ArgumentSemantic.Copy)]
+		string [] ConstituentFileNames { get; set; }
 	}
 
 	delegate void METrackReaderLoadTrackInfoCallback ([NullAllowed] METrackInfo trackInfo, [NullAllowed] NSError error);

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -45882,6 +45882,7 @@ P:MediaExtension.MEDecodeFrameOptions.RealTimePlayback
 P:MediaExtension.MEEstimatedSampleLocation.ByteSource
 P:MediaExtension.MEEstimatedSampleLocation.EstimatedSampleLocation
 P:MediaExtension.MEEstimatedSampleLocation.RefinementDataLocation
+P:MediaExtension.MEFileInfo.ConstituentFileNames
 P:MediaExtension.MEFileInfo.Duration
 P:MediaExtension.MEFileInfo.FragmentsStatus
 P:MediaExtension.MEFileInfo.SidecarFileName

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-MediaExtension.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-MediaExtension.todo
@@ -1,2 +1,0 @@
-!missing-selector! MEFileInfo::constituentFileNames not bound
-!missing-selector! MEFileInfo::setConstituentFileNames: not bound


### PR DESCRIPTION
## Summary
- Bind `MEFileInfo.ConstituentFileNames` with copy semantics and macOS 27.0 availability.
- Remove the resolved MediaExtension xtro todo.
- Update the cecil documentation baseline for the new property.

## Validation
- Fresh pre-change and post-change `make world` runs completed successfully.
- Clean xtro generation/classification passed with `Sanity check passed`.
- Clean cecil suite passed.
- macOS introspection: 32 passed, 0 failed (the macOS 27 selector is host-gated on macOS 26.5).
- Mac Catalyst introspection: 39 passed, 0 failed.
- iOS/tvOS 27 introspection ran; MediaExtension is unavailable there, and the remaining UIKit/AVFoundation beta-runtime failures are unrelated to this change.
- Clean `AppSizeTest` run: 16 skipped by the existing beta-Xcode policy, 0 failed.