### PR TITLE
[MediaPlayer] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/mediaplayer.cs
+++ b/src/mediaplayer.cs
@@ -2607,6 +2607,10 @@ namespace MediaPlayer {
 		[MacCatalyst (26, 0), TV (26, 0), Mac (26, 0), iOS (26, 0)]
 		[Field ("MPNowPlayingInfoProperty3x4AnimatedArtwork")]
 		NSString Property3x4AnimatedArtwork { get; }
+
+		[MacCatalyst (27, 0), TV (27, 0), Mac (27, 0), iOS (27, 0)]
+		[Field ("MPNowPlayingInfoPropertyAppEntityIdentifiers")]
+		NSString PropertyAppEntityIdentifiers { get; }
 	}
 
 	/// <summary>User-meaningful information about an <see cref="MediaPlayer.MPMediaItem" />.</summary>

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-MediaPlayer.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-MediaPlayer.todo
@@ -1,1 +1,0 @@
-!missing-field! MPNowPlayingInfoPropertyAppEntityIdentifiers not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-MediaPlayer.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-MediaPlayer.todo
@@ -1,1 +1,0 @@
-!missing-field! MPNowPlayingInfoPropertyAppEntityIdentifiers not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-MediaPlayer.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-MediaPlayer.todo
@@ -1,1 +1,0 @@
-!missing-field! MPNowPlayingInfoPropertyAppEntityIdentifiers not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-MediaPlayer.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-MediaPlayer.todo
@@ -1,1 +1,0 @@
-!missing-field! MPNowPlayingInfoPropertyAppEntityIdentifiers not bound


### PR DESCRIPTION
## Summary
- Bind `MPNowPlayingInfoPropertyAppEntityIdentifiers` as `MPNowPlayingInfoCenter.PropertyAppEntityIdentifiers`.
- Apply Xcode 27.0 availability for iOS, tvOS, macOS, and Mac Catalyst.
- Remove the resolved MediaPlayer xtro todo files for all four platforms.

## Validation
- `make world`
- Clean xtro regeneration/classification: sanity passed
- Clean cecil test run: passed
- iOS 27.0 Beta 3 introspection: 44/44 passed
- tvOS 27.0 Beta 3 introspection: 43/43 passed
- macOS introspection: 32/32 passed (2 expected host-version ignores)
- Mac Catalyst introspection: 39/39 passed (4 expected host-version/simulator ignores)
- Clean AppSizeTest run: 16/16 skipped as expected while Xcode is beta