### PR TITLE
[monotouch-test] Fix TOCTOU race in SecProtocolMetadataTest.TlsDefaults. Fixes #25877.

### DIFF
--- a/tests/monotouch-test/Security/SecProtocolMetadataTest.cs
+++ b/tests/monotouch-test/Security/SecProtocolMetadataTest.cs
@@ -81,9 +81,10 @@ namespace MonoTouchFixtures.Security {
 							Assert.That (s.NegotiatedTlsProtocolVersion, Is.EqualTo (TlsProtocolVersion.Tls12).Or.EqualTo (TlsProtocolVersion.Tls13), "NegotiatedTlsProtocolVersion");
 							// we want to test the binding/API - not the exact value which can vary depending on the negotiation between the client (OS) and server...
 							Assert.That (s.NegotiatedTlsCipherSuite, Is.Not.EqualTo (0), "NegotiatedTlsCipherSuite");
-							if (s.ServerName is null)
+							var serverName = s.ServerName;
+							if (serverName is null)
 								TestRuntime.IgnoreInCI ("ServerName is null - likely network proxy interference");
-							Assert.That (s.ServerName, Is.EqualTo ("www.microsoft.com"), "ServerName");
+							Assert.That (serverName, Is.EqualTo ("www.microsoft.com"), "ServerName");
 							// we don't have a TLS-PSK enabled server to test this
 							Assert.That (s.AccessPreSharedKeys ((psk, pskId) => { }), Is.False, "AccessPreSharedKeys");
 						}


### PR DESCRIPTION
The mitigation for the flaky `ServerName` check read the live native
`s.ServerName` property twice: once for the null-check that triggers
`IgnoreInCI`, and again in the `Assert.That` equality check. The two
native reads could disagree (e.g. transient network proxy interference),
so the first read returning non-null would skip the `IgnoreInCI` while
the second returned null and hard-failed the assertion.

Cache the value once and use it for both the null-check and the
assertion, closing the race.

Fixes https://github.com/dotnet/macios/issues/25877

🤖 Pull request created by Copilot