### PR TITLE
[rgen] Scope UI namespace cache per-compilation to fix generator flakiness. Fixes #26184.

### DIFF
--- a/src/rgen/Microsoft.Macios.Generator/Extensions/CompilationExtensions.cs
+++ b/src/rgen/Microsoft.Macios.Generator/Extensions/CompilationExtensions.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Threading;
+using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -73,8 +73,7 @@ static class CompilationExtensions {
 		"MapKit"
 	};
 
-	readonly static Lock uiNamespaceLock = new Lock ();
-	static HashSet<string>? uiNamespacesCache = null;
+	readonly static ConditionalWeakTable<Compilation, IReadOnlySet<string>> uiNamespacesCache = new ();
 
 	/// <summary>
 	/// Calculates the UI namespaces for the current compilation.
@@ -84,20 +83,23 @@ static class CompilationExtensions {
 	/// <returns>The currently configured UI namespaces.</returns>
 	public static IReadOnlySet<string> GetUINamespaces (this Compilation self, bool force = false)
 	{
-		lock (uiNamespaceLock) {
-			if (force || uiNamespacesCache is null) {
-				uiNamespacesCache = new ();
-				// build the hash set based on the current definitions used in the compilation
-				var preprocessorSymbols = self.GetPreprocessorSymbols ();
-				foreach (var ns in uiNamespaces) {
-					var define = $"HAS_{ns.ToUpper ()}";
-					if (preprocessorSymbols.Contains (define)) {
-						uiNamespacesCache.Add (ns);
-					}
+		// The cache is keyed on the compilation, so that concurrent compilations targeting different
+		// platforms (e.g. an iOS and a macOS compilation running in parallel) do not race and overwrite
+		// each other's results.
+		if (force)
+			uiNamespacesCache.Remove (self);
+
+		return uiNamespacesCache.GetValue (self, static compilation => {
+			var result = new HashSet<string> ();
+			// build the hash set based on the current definitions used in the compilation
+			var preprocessorSymbols = compilation.GetPreprocessorSymbols ();
+			foreach (var ns in uiNamespaces) {
+				var define = $"HAS_{ns.ToUpper ()}";
+				if (preprocessorSymbols.Contains (define)) {
+					result.Add (ns);
 				}
 			}
-
-			return uiNamespacesCache;
-		}
+			return result;
+		});
 	}
 }

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/BaseGeneratorTestClass.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/BaseGeneratorTestClass.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Macios.Generator.Extensions;
@@ -92,46 +91,40 @@ public class BaseGeneratorTestClass {
 		return new (CSharpCompilation.Create (name, trees, references, options), trees);
 	}
 
-	readonly static Lock uiNamespaceLock = new ();
 	protected void CompareGeneratedCode (GenerationTestData testData)
 	{
-		lock (uiNamespaceLock) {
-			var driver = CSharpGeneratorDriver.Create (new BindingSourceGeneratorGenerator ());
-			// We need to create a compilation with the required source code.
-			var (compilation, _) = CreateCompilation (testData.Platform, sources: testData.InputText);
-			// for the refresh of the namespaces, this is needed to make sure that the generator does not get confused
-			// when several compilations are running
-			compilation.GetUINamespaces (force: true);
+		var driver = CSharpGeneratorDriver.Create (new BindingSourceGeneratorGenerator ());
+		// We need to create a compilation with the required source code.
+		var (compilation, _) = CreateCompilation (testData.Platform, sources: testData.InputText);
 
-			// Run generators and retrieve all results.
-			var runResult = RunGenerators (driver, compilation);
+		// Run generators and retrieve all results.
+		var runResult = RunGenerators (driver, compilation);
 
-			// All generated files can be found in 'RunResults.GeneratedTrees'.
-			var generatedFileSyntax = runResult.GeneratedTrees.Where (t => t.FilePath.EndsWith ($"{testData.ClassName}.g.cs")).ToArray ();
-			Assert.Single (generatedFileSyntax);
+		// All generated files can be found in 'RunResults.GeneratedTrees'.
+		var generatedFileSyntax = runResult.GeneratedTrees.Where (t => t.FilePath.EndsWith ($"{testData.ClassName}.g.cs")).ToArray ();
+		Assert.Single (generatedFileSyntax);
 
-			// Complex generators should be tested using text comparison.
-			Assert.Equal (testData.ExpectedOutputText, generatedFileSyntax [0].GetText ().ToString (),
-				ignoreLineEndingDifferences: true);
+		// Complex generators should be tested using text comparison.
+		Assert.Equal (testData.ExpectedOutputText, generatedFileSyntax [0].GetText ().ToString (),
+			ignoreLineEndingDifferences: true);
 
-			if (testData.ExpectedLibraryText is not null) {
-				// validate that Library.g.cs was created by the LibraryEmitter and matches the expectation
-				var generatedLibSyntax = runResult.GeneratedTrees.Single (t => t.FilePath.EndsWith ("Libraries.g.cs"));
-				Assert.Equal (testData.ExpectedLibraryText, generatedLibSyntax.GetText ().ToString ());
-			}
+		if (testData.ExpectedLibraryText is not null) {
+			// validate that Library.g.cs was created by the LibraryEmitter and matches the expectation
+			var generatedLibSyntax = runResult.GeneratedTrees.Single (t => t.FilePath.EndsWith ("Libraries.g.cs"));
+			Assert.Equal (testData.ExpectedLibraryText, generatedLibSyntax.GetText ().ToString ());
+		}
 
-			if (testData.ExpectedTrampolineText is not null) {
-				// validate that Library.g.cs was created by the LibraryEmitter and matches the expectation
-				var generatedLibSyntax = runResult.GeneratedTrees.Single (t => t.FilePath.EndsWith ("ObjCRuntime/Trampolines.g.cs"));
-				Assert.Equal (testData.ExpectedTrampolineText, generatedLibSyntax.GetText ().ToString ());
-			}
+		if (testData.ExpectedTrampolineText is not null) {
+			// validate that Library.g.cs was created by the LibraryEmitter and matches the expectation
+			var generatedLibSyntax = runResult.GeneratedTrees.Single (t => t.FilePath.EndsWith ("ObjCRuntime/Trampolines.g.cs"));
+			Assert.Equal (testData.ExpectedTrampolineText, generatedLibSyntax.GetText ().ToString ());
+		}
 
-			if (testData.ExtraFiles is not null) {
-				// validate that we have the expected extra files and that their values are the correct ones
-				foreach (var (filePath, fileContent) in testData.ExtraFiles) {
-					var generatedFile = runResult.GeneratedTrees.Single (t => t.FilePath.EndsWith (filePath));
-					Assert.Equal (fileContent, generatedFile.GetText ().ToString ());
-				}
+		if (testData.ExtraFiles is not null) {
+			// validate that we have the expected extra files and that their values are the correct ones
+			foreach (var (filePath, fileContent) in testData.ExtraFiles) {
+				var generatedFile = runResult.GeneratedTrees.Single (t => t.FilePath.EndsWith (filePath));
+				Assert.Equal (fileContent, generatedFile.GetText ().ToString ());
 			}
 		}
 

--- a/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/CompilationExtensionsTest.cs
+++ b/tests/rgen/Microsoft.Macios.Generator.Tests/Extensions/CompilationExtensionsTest.cs
@@ -106,4 +106,35 @@ public class DummyClass {}
 		var (compilation, _) = CreateCompilation (platform, sources: dummyClass);
 		Assert.True (collectionComparer.Equals (expectedNamespaces, compilation.GetUINamespaces (force: true)));
 	}
+
+	[Fact]
+	public void GetUINamespacesIsCompilationSpecific ()
+	{
+		// Regression test for https://github.com/dotnet/macios/issues/26184
+		// The UI namespaces are cached per-compilation, so interleaving compilations that target
+		// different platforms must not race and overwrite each other's cached result. Before the fix
+		// a process-global cache could return e.g. the macOS namespaces (which don't contain UIKit)
+		// while querying an iOS compilation.
+		if (!Configuration.IsEnabled (ApplePlatform.iOS) || !Configuration.IsEnabled (ApplePlatform.MacOSX))
+			return;
+
+		const string dummyClass = @"
+using System;
+
+public class DummyClass {}
+";
+		var (iosCompilation, _) = CreateCompilation (ApplePlatform.iOS, sources: dummyClass);
+		var (macCompilation, _) = CreateCompilation (ApplePlatform.MacOSX, sources: dummyClass);
+
+		// prime and then interleave the queries; the results must remain stable regardless of order.
+		for (var i = 0; i < 10; i++) {
+			var iosNamespaces = iosCompilation.GetUINamespaces ();
+			var macNamespaces = macCompilation.GetUINamespaces ();
+
+			Assert.Contains ("UIKit", iosNamespaces);
+			Assert.DoesNotContain ("UIKit", macNamespaces);
+			Assert.Contains ("AppKit", macNamespaces);
+			Assert.DoesNotContain ("AppKit", iosNamespaces);
+		}
+	}
 }


### PR DESCRIPTION
`CompilationExtensions.GetUINamespaces` used a process-global static cache
guarded by a `Lock`. Because xUnit runs test classes in parallel, a macOS
compilation (which has no UIKit) could replace the cache while an iOS
generator test was reading it. That made `BindingContext.NeedsThreadChecks`
false and dropped the `UIKit.UIApplication.EnsureUIThread ();` line from the
generated code, producing the observed flaky failure.

Replace the global cache with a `ConditionalWeakTable` keyed on the
`Compilation` so each compilation caches its own result and concurrent
compilations targeting different platforms cannot race.

Since the cache is now compilation-scoped, remove the serialization
workaround (static lock + force refresh) from `BaseGeneratorTestClass`, and
add an interleaved iOS/macOS regression test.

Fixes https://github.com/dotnet/macios/issues/26184

🤖 Pull request created by Copilot