### PR TITLE
[tests] Truncate command output in DotNet.ExecuteCommand failure messages

### DIFF
--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -199,12 +199,11 @@ namespace Xamarin.Tests {
 			var rv = Execution.RunAsync (exe, args, env, Console.Out, workingDirectory: Configuration.SourceRoot, timeout: TimeSpan.FromMinutes (10)).Result;
 			var output = rv.Output.MergedOutput;
 			if (rv.ExitCode != 0) {
-				var fullOutput = output.ToString ();
 				// Write the complete output to the console. This ends up in a separate
 				// log file, so it's fine if it's big.
 				Console.WriteLine ($"'{exe}' failed with exit code {rv.ExitCode}");
 				Console.WriteLine ($"Full command: {exe} {StringUtils.FormatArguments (args)}");
-				Console.WriteLine (fullOutput);
+				Console.WriteLine (output);
 
 				// Only include the last few lines of the output in the failure message.
 				// The failure message ends up embedded in the test results (and thus in
@@ -214,25 +213,21 @@ namespace Xamarin.Tests {
 				var msg = new StringBuilder ();
 				msg.AppendLine ($"'{exe}' failed with exit code {rv.ExitCode}");
 				msg.AppendLine ($"Full command: {exe} {StringUtils.FormatArguments (args)}");
-				msg.AppendLine (GetLastLines (fullOutput, 100));
+				msg.AppendLine (GetLastLines (rv.Output.MergedOutputLines, 100));
 				Assert.Fail (msg.ToString ());
 			}
 			return new ExecutionResult (output, output, rv.ExitCode, rv.Duration);
 		}
 
-		// Returns the last 'count' lines of the given text, prefixed with a note if any
+		// Returns the last 'count' lines of the given output, prefixed with a note if any
 		// lines were omitted.
-		static string GetLastLines (string text, int count)
+		static string GetLastLines (IList<string> lines, int count)
 		{
-			if (string.IsNullOrEmpty (text))
-				return text;
+			if (lines.Count <= count)
+				return string.Join ("\n", lines);
 
-			var lines = text.Split ('\n');
-			if (lines.Length <= count)
-				return text;
-
-			var lastLines = lines.Skip (lines.Length - count);
-			return $"[Output truncated to the last {count} lines (of {lines.Length} lines); see the full log for the complete output]{Environment.NewLine}" +
+			var lastLines = lines.Skip (lines.Count - count);
+			return $"[Output truncated to the last {count} lines (of {lines.Count} lines); see the full log for the complete output]{Environment.NewLine}" +
 				string.Join ("\n", lastLines);
 		}
 

--- a/tests/common/DotNet.cs
+++ b/tests/common/DotNet.cs
@@ -199,14 +199,41 @@ namespace Xamarin.Tests {
 			var rv = Execution.RunAsync (exe, args, env, Console.Out, workingDirectory: Configuration.SourceRoot, timeout: TimeSpan.FromMinutes (10)).Result;
 			var output = rv.Output.MergedOutput;
 			if (rv.ExitCode != 0) {
+				var fullOutput = output.ToString ();
+				// Write the complete output to the console. This ends up in a separate
+				// log file, so it's fine if it's big.
+				Console.WriteLine ($"'{exe}' failed with exit code {rv.ExitCode}");
+				Console.WriteLine ($"Full command: {exe} {StringUtils.FormatArguments (args)}");
+				Console.WriteLine (fullOutput);
+
+				// Only include the last few lines of the output in the failure message.
+				// The failure message ends up embedded in the test results (and thus in
+				// the HTML report), so including the entire output can make those files
+				// enormous (hundreds of MBs) when the command was executed with diagnostic
+				// verbosity.
 				var msg = new StringBuilder ();
 				msg.AppendLine ($"'{exe}' failed with exit code {rv.ExitCode}");
 				msg.AppendLine ($"Full command: {exe} {StringUtils.FormatArguments (args)}");
-				msg.AppendLine (output.ToString ());
-				Console.WriteLine (msg);
+				msg.AppendLine (GetLastLines (fullOutput, 100));
 				Assert.Fail (msg.ToString ());
 			}
 			return new ExecutionResult (output, output, rv.ExitCode, rv.Duration);
+		}
+
+		// Returns the last 'count' lines of the given text, prefixed with a note if any
+		// lines were omitted.
+		static string GetLastLines (string text, int count)
+		{
+			if (string.IsNullOrEmpty (text))
+				return text;
+
+			var lines = text.Split ('\n');
+			if (lines.Length <= count)
+				return text;
+
+			var lastLines = lines.Skip (lines.Length - count);
+			return $"[Output truncated to the last {count} lines (of {lines.Length} lines); see the full log for the complete output]{Environment.NewLine}" +
+				string.Join ("\n", lastLines);
 		}
 
 		public static ExecutionResult Execute (string verb, string project, Dictionary<string, string>? properties, bool assert_success = true, string? target = null, bool? msbuildParallelism = null, TimeSpan? timeout = null, params string [] extraArguments)

--- a/tools/common/Execution.cs
+++ b/tools/common/Execution.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -53,6 +54,13 @@ namespace Xamarin.Utils {
 					if (isError)
 						yield return line;
 				}
+			}
+		}
+
+		public IList<string> MergedOutputLines {
+			get {
+				VerifyComplete ();
+				return lines.Select (line => line.Line).ToList ();
 			}
 		}
 


### PR DESCRIPTION
`DotNet.ExecuteCommand` (used by `DotNet.GetProperty`/`GetItems`/`Get`) runs
`dotnet build ... -getItem/-getProperty ... -v:diag` with diagnostic
verbosity. On failure it appended the *entire* merged stdout/stderr of the
build to the `Assert.Fail` message.

That failure message ends up in the NUnit results XML and is rendered
verbatim in the VSDrops HTML report, so a single failing `Get*` test could
dump a full ~388k-line diagnostic build log into the report. A recent report
had 4 such blocks and ballooned to 151 MB / 1.5M lines.

The full output is still written to the console (which ends up in a separate
log file), but the failure message now only includes the last 100 lines via
a new `GetLastLines` helper. This mirrors the sibling `DotNet.Execute` path,
which already limits itself to the first 10 binlog errors.

🤖 Pull request created by Copilot