### PR TITLE
[msbuild] Show a helpful error when codesign fails with errSecInternalComponent. Fixes #26183.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1701,4 +1701,8 @@
     <data name="E0192" xml:space="preserve">
         <value>The PrepareAssemblies task failed without reporting a specific error. Please rebuild with increased verbosity for more details.</value>
     </data>
+    <data name="E7184" xml:space="preserve">
+        <value>Codesign failed with 'errSecInternalComponent'. This usually means the keychain is locked, which is common when building over SSH. Unlock the keychain first, for example by running 'security unlock-keychain ~/Library/Keychains/login.keychain-db'.</value>
+        <comment>Shown when codesign fails with the 'errSecInternalComponent' error, which typically indicates a locked keychain.</comment>
+    </data>
 </root>

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Codesign.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Codesign.cs
@@ -22,6 +22,9 @@ namespace Xamarin.MacDev.Tasks {
 		const string CodeSignatureDirName = "_CodeSignature";
 		string? toolExe;
 
+		// Set to 1 (using Interlocked) the first time we log the errSecInternalComponent hint, so we only log it once per task invocation.
+		int loggedInternalComponentHint;
+
 		#region Inputs
 
 		// Whether we'll check for and show an error if the app bundle we're trying to sign contains a 'Resources' subdirectory.
@@ -375,7 +378,7 @@ namespace Xamarin.MacDev.Tasks {
 					Log.LogError (MSBStrings.E0004, item.ItemSpec, errors);
 				else
 					Log.LogError (MSBStrings.E0005, item.ItemSpec);
-				if (errors.Contains ("errSecInternalComponent"))
+				if (errors.IndexOf ("errSecInternalComponent", StringComparison.Ordinal) >= 0 && System.Threading.Interlocked.CompareExchange (ref loggedInternalComponentHint, 1, 0) == 0)
 					Log.LogError (MSBStrings.E7184 /* Codesign failed with 'errSecInternalComponent'. This usually means the keychain is locked, which is common when building over SSH. Unlock the keychain first, for example by running 'security unlock-keychain ~/Library/Keychains/login.keychain-db'. */);
 			} else {
 				var stampFile = GetCodesignStampFile (item);

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Codesign.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Codesign.cs
@@ -375,6 +375,8 @@ namespace Xamarin.MacDev.Tasks {
 					Log.LogError (MSBStrings.E0004, item.ItemSpec, errors);
 				else
 					Log.LogError (MSBStrings.E0005, item.ItemSpec);
+				if (errors.Contains ("errSecInternalComponent"))
+					Log.LogError (MSBStrings.E7184);
 			} else {
 				var stampFile = GetCodesignStampFile (item);
 				if (string.IsNullOrEmpty (stampFile)) {

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/Codesign.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/Codesign.cs
@@ -376,7 +376,7 @@ namespace Xamarin.MacDev.Tasks {
 				else
 					Log.LogError (MSBStrings.E0005, item.ItemSpec);
 				if (errors.Contains ("errSecInternalComponent"))
-					Log.LogError (MSBStrings.E7184);
+					Log.LogError (MSBStrings.E7184 /* Codesign failed with 'errSecInternalComponent'. This usually means the keychain is locked, which is common when building over SSH. Unlock the keychain first, for example by running 'security unlock-keychain ~/Library/Keychains/login.keychain-db'. */);
 			} else {
 				var stampFile = GetCodesignStampFile (item);
 				if (string.IsNullOrEmpty (stampFile)) {


### PR DESCRIPTION
When you build/deploy an app over SSH, the login keychain is typically locked (there's no GUI login session to unlock it). In that state codesign can't access the signing identity's private key and fails with the cryptic Security-framework error `errSecInternalComponent`, with no hint about what's actually wrong.

This detects that specific error in the `Codesign` MSBuild task and emits an additional, actionable error telling the user the keychain is likely locked and how to unlock it:

> Codesign failed with 'errSecInternalComponent'. This usually means the keychain is locked, which is common when building over SSH. Unlock the keychain first, for example by running 'security unlock-keychain ~/Library/Keychains/login.keychain-db'.

The original codesign error is still shown as well, since `errSecInternalComponent` isn't *always* caused by a locked keychain.

Fixes https://github.com/dotnet/macios/issues/26183

🤖 Pull request created by Copilot