### PR TITLE
[NativeAOT] Generate native registrar code after ILC for trimmable-static

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1204,7 +1204,25 @@
 	</Target>
 
 
-	<Target Name="_LoadLinkerOutput" DependsOnTargets="ComputeFilesToPublish" Condition="'$(IsMacEnabled)' == 'true'">
+	<!--
+		When building for NativeAOT with the trimmable-static registrar (and PrepareAssemblies), we generate
+		the native registrar code *after* the NativeAOT compiler (ILC) has run, instead of before. This lets
+		the registrar inspect ILC's output to see which UnmanagedCallersOnly trampolines survived trimming, and
+		avoid emitting direct native references to trampolines ILC trimmed away (which would be undefined symbols
+		at native link time). This is only possible because ILLink is skipped in this scenario (see _SkipILLink),
+		so ILC consumes the prepared (pre-postprocessing) assemblies and the postprocessing output no longer feeds
+		ILC. The gate is computed statically (all three properties are available at evaluation time) so it can be
+		used both in static target wiring and in runtime target conditions.
+	-->
+	<PropertyGroup>
+		<_PostprocessAssembliesAfterIlc Condition="'$(_PostprocessAssembliesAfterIlc)' == '' And '$(PublishAot)' == 'true' And '$(PrepareAssemblies)' == 'true' And '$(Registrar)' == 'trimmable-static'">true</_PostprocessAssembliesAfterIlc>
+		<_PostprocessAssembliesAfterIlc Condition="'$(_PostprocessAssembliesAfterIlc)' == ''">false</_PostprocessAssembliesAfterIlc>
+		<!-- When postprocessing runs after ILC, _LoadLinkerOutput must run the postprocessing target first so
+		     that the *.items files (registrar.mm etc.) exist when they're loaded. -->
+		<_LoadLinkerOutputExtraDependsOn Condition="'$(_PostprocessAssembliesAfterIlc)' == 'true'">_PostprocessAssembliesAfterIlc</_LoadLinkerOutputExtraDependsOn>
+	</PropertyGroup>
+
+	<Target Name="_LoadLinkerOutput" DependsOnTargets="ComputeFilesToPublish;$(_LoadLinkerOutputExtraDependsOn)" Condition="'$(IsMacEnabled)' == 'true'">
 		<ItemGroup>
 			<_LinkerItemFiles Include="$(_LinkerItemsDirectory)/_MainFile.items" />
 			<_LinkerItemFiles Include="$(_LinkerItemsDirectory)/_MainLinkWith.items" />
@@ -1269,6 +1287,38 @@
 			     from a custom linker step. This will become unnecessary when we stop using custom linker steps. -->
 			<NoWarn>$(NoWarn);IL2008</NoWarn> <!-- Could not resolve type '...' -->
 		</PropertyGroup>
+	</Target>
+
+	<!--
+		The post-ILC variant of _PostprocessAssemblies (see the _PostprocessAssembliesAfterIlc property). It runs
+		the exact same native-registrar-generating pipeline as _PostprocessAssemblies, but after the NativeAOT
+		compiler (ILC) has run, and passes ILC's output object file ($(NativeObject)) so the registrar can route
+		any UnmanagedCallersOnly trampoline that ILC trimmed away through the dlsym fallback instead of referencing
+		it directly (which would be an undefined symbol at native link time). Running the full pipeline (rather than
+		a reduced one) keeps the generated native registrar code consistent with the other native files generated
+		earlier (e.g. inlined-class-gethandle.m). It's wired to run before _LoadLinkerOutput (via
+		_LoadLinkerOutputExtraDependsOn) so the *.items files it produces are loaded and fed to the native compile.
+	-->
+	<Target
+		Name="_PostprocessAssembliesAfterIlc"
+		Condition="'$(_PostprocessAssembliesAfterIlc)' == 'true' And '$(RuntimeIdentifiers)' == ''"
+		DependsOnTargets="IlcCompile;ComputeFilesToPublish;_PrepareAssembliesForPostProcessing;_ComputeLinkerInputs"
+		>
+		<PrepareAssemblies
+			InputAssemblies="@(_AssembliesToPostProcess)"
+			MakeReproPath="$(_PostprocessAssembliesMakeReproPath)"
+			NativeAOTObjectFile="$(NativeObject)"
+			OptionsFile="$(_CustomLinkerOptionsFile)"
+			OutputDirectory="$(_PostprocessedAssembliesDirectory)"
+			Postprocessing="true"
+			TargetFrameworkMoniker="$(_ComputedTargetFrameworkMoniker)"
+		>
+			<Output TaskParameter="OutputAssemblies" ItemName="_PostProcessedAssemblies" />
+		</PrepareAssemblies>
+
+		<ItemGroup>
+			<FileWrites Include="@(_PostProcessedAssemblies)" />
+		</ItemGroup>
 	</Target>
 
 	<!-- Native code -->

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1305,6 +1305,8 @@
 	<Target
 		Name="_PostprocessAssembliesAfterIlc"
 		Condition="'$(_PostprocessAssembliesAfterIlc)' == 'true' And '$(RuntimeIdentifiers)' == ''"
+		Inputs="@(_AssembliesToPostProcess);$(NativeObject)"
+		Outputs="@(_AssembliesToPostProcess->'$(_PostprocessedAssembliesDirectory)%(Filename)%(Extension)');$(_AssemblyPostProcessorMSBuildOutputFile)"
 		DependsOnTargets="IlcCompile;ComputeFilesToPublish;_PrepareAssembliesForPostProcessing;_ComputeLinkerInputs"
 		>
 		<PrepareAssemblies

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -638,7 +638,7 @@
 				types the trimmable-static registrar emits), which is only fixed in the .NET 11+ ILC. On .NET 10
 				we keep running ILLink (which trims away the duplicates before ILC sees them).
 			-->
-			<_SkipILLink Condition="'$(_SkipILLink)' == '' And '$(_UseNativeAot)' == 'true' And '$(PrepareAssemblies)' == 'true' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '11.0'))">true</_SkipILLink>
+			<_SkipILLink Condition="'$(_SkipILLink)' == '' And '$(_UseNativeAot)' == 'true' And '$(PrepareAssemblies)' == 'true' And '$(PostProcessAssemblies)' == 'true' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '11.0'))">true</_SkipILLink>
 			<_SkipILLink Condition="'$(_SkipILLink)' == ''">false</_SkipILLink>
 
 			<!-- Yep, we want to run ILLink as well, because we need our custom steps to run (NativeAOT sets this to false, so set it back to true), unless we're skipping ILLink (see _SkipILLink above) -->
@@ -1211,11 +1211,14 @@
 		avoid emitting direct native references to trampolines ILC trimmed away (which would be undefined symbols
 		at native link time). This is only possible because ILLink is skipped in this scenario (see _SkipILLink),
 		so ILC consumes the prepared (pre-postprocessing) assemblies and the postprocessing output no longer feeds
-		ILC. The gate is computed statically (all three properties are available at evaluation time) so it can be
-		used both in static target wiring and in runtime target conditions.
+		ILC. The gate is computed statically (all the properties are available at evaluation time) so it can be
+		used both in static target wiring and in runtime target conditions. It mirrors the conditions that make
+		_SkipILLink true (see _SkipILLink) - in particular the .NET 11+ gate - because this reorder is only valid
+		when ILLink is skipped: when ILLink still runs (e.g. .NET 10) we must keep postprocessing before ILC, so
+		_PostprocessAssemblies handles it as usual and this target stays off.
 	-->
 	<PropertyGroup>
-		<_PostprocessAssembliesAfterIlc Condition="'$(_PostprocessAssembliesAfterIlc)' == '' And '$(PublishAot)' == 'true' And '$(PrepareAssemblies)' == 'true' And '$(Registrar)' == 'trimmable-static'">true</_PostprocessAssembliesAfterIlc>
+		<_PostprocessAssembliesAfterIlc Condition="'$(_PostprocessAssembliesAfterIlc)' == '' And '$(_UseNativeAot)' == 'true' And '$(PrepareAssemblies)' == 'true' And '$(PostProcessAssemblies)' == 'true' And '$(Registrar)' == 'trimmable-static' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '11.0'))">true</_PostprocessAssembliesAfterIlc>
 		<_PostprocessAssembliesAfterIlc Condition="'$(_PostprocessAssembliesAfterIlc)' == ''">false</_PostprocessAssembliesAfterIlc>
 		<!-- When postprocessing runs after ILC, _LoadLinkerOutput must run the postprocessing target first so
 		     that the *.items files (registrar.mm etc.) exist when they're loaded. -->
@@ -1318,6 +1321,7 @@
 
 		<ItemGroup>
 			<FileWrites Include="@(_PostProcessedAssemblies)" />
+			<FileWrites Include="$(_AssemblyPostProcessorMSBuildOutputFile)" Condition="Exists('$(_AssemblyPostProcessorMSBuildOutputFile)')" />
 		</ItemGroup>
 	</Target>
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/PrepareAssemblies.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/PrepareAssemblies.cs
@@ -42,6 +42,12 @@ namespace Xamarin.MacDev.Tasks {
 		// the [ProtocolMember] attributes the trimmer removed from the post-trim assemblies.
 		public ITaskItem [] PreTrimAssemblies { get; set; } = [];
 
+		// When set (to ILC's output object file), the defined symbols in this file are used to determine
+		// which UnmanagedCallersOnly trampolines survived the NativeAOT compiler (ILC). This is passed only
+		// when postprocessing runs after ILC (trimmable-static registrar + NativeAOT), so that the native
+		// registrar code doesn't emit direct references to trampolines ILC trimmed away.
+		public string NativeAOTObjectFile { get; set; } = "";
+
 		#region Outputs
 		[Output]
 		public ITaskItem [] OutputAssemblies { get; set; } = [];
@@ -75,6 +81,17 @@ namespace Xamarin.MacDev.Tasks {
 				List<ProductException> exceptions;
 
 				if (PostProcessing) {
+					if (!string.IsNullOrEmpty (NativeAOTObjectFile)) {
+						// Determine which UnmanagedCallersOnly trampolines survived ILC by inspecting the
+						// defined symbols in ILC's output object file. The native symbols have a leading
+						// underscore that we strip to match the managed entry-point names.
+						var survivingSymbols = new HashSet<string> ();
+						foreach (var symbol in Xamarin.StaticLibrary.GetDefinedSymbols (NativeAOTObjectFile)) {
+							var name = symbol.StartsWith ("_", StringComparison.Ordinal) ? symbol.Substring (1) : symbol;
+							survivingSymbols.Add (name);
+						}
+						preparer.Configuration.Application.SurvivingTrampolineSymbols = survivingSymbols;
+					}
 					rv = preparer.PostProcess (out exceptions);
 				} else {
 					rv = preparer.Prepare (out exceptions);

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -3614,10 +3614,12 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 
 	<!--
 		_PostprocessAssemblies must run after the trimmer (ILLink) and before the assemblies are (Native)AOT/R2R-compiled.
+		Exception: when postprocessing runs after ILC instead (the trimmable-static + NativeAOT scenario), the
+		_PostprocessAssembliesAfterIlc target handles it, so skip this target then.
 	-->
 	<Target
 		Name="_PostprocessAssemblies"
-		Condition="'$(PostProcessAssemblies)' == 'true' And '$(RuntimeIdentifiers)' == ''"
+		Condition="'$(PostProcessAssemblies)' == 'true' And '$(RuntimeIdentifiers)' == '' And '$(_PostprocessAssembliesAfterIlc)' != 'true'"
 		Inputs="@(_AssembliesToPostProcess)"
 		Outputs="@(_AssembliesToPostProcess->'$(_PostprocessedAssembliesDirectory)%(Filename)%(Extension)');$(_AssemblyPostProcessorMSBuildOutputFile)"
 		AfterTargets="ILLink"

--- a/tools/common/Application.cs
+++ b/tools/common/Application.cs
@@ -81,6 +81,25 @@ namespace Xamarin.Bundler {
 		public List<string>? AotOtherArguments = null;
 		public bool? AotFloat32 = null;
 		public bool PrepareAssemblies; // True if '$(PrepareAssemblies)' == 'true'
+
+		// The set of UnmanagedCallersOnly trampoline symbols (without the leading Mach-O underscore)
+		// that survived the NativeAOT compiler (ILC). This is only set when the native registrar code
+		// is generated after ILC has run, so that we can avoid emitting direct native references to
+		// trampolines ILC trimmed away (we route those through the dlsym fallback instead). A null value
+		// means the information isn't available (e.g. we're not compiling for NativeAOT, or the registrar
+		// runs before ILC), in which case every trampoline is assumed to have survived.
+		public HashSet<string>? SurvivingTrampolineSymbols;
+
+		// Returns true if the native registrar can emit a direct reference to the given UnmanagedCallersOnly
+		// trampoline. When we know which trampolines survived ILC, a trampoline that didn't survive must not
+		// be referenced directly (it would be an undefined symbol at native link time).
+		public bool DidTrampolineSurviveIlc (string ucoEntryPoint)
+		{
+			if (SurvivingTrampolineSymbols is null)
+				return true;
+			return SurvivingTrampolineSymbols.Contains (ucoEntryPoint);
+		}
+
 #if ASSEMBLY_PREPARER
 		public bool InCustomTrimmerStep = false;
 		public bool IsPostProcessingAssemblies;

--- a/tools/common/MachO.cs
+++ b/tools/common/MachO.cs
@@ -555,6 +555,33 @@ namespace Xamarin {
 			}
 			return symbols;
 		}
+
+		/// <summary>
+		/// Reads a static library or a Mach-O object file and returns the set of defined (external, non-undefined) symbols.
+		/// </summary>
+		public static HashSet<string> GetDefinedSymbols (string filename)
+		{
+			var symbols = new HashSet<string> ();
+			using (var fs = File.OpenRead (filename))
+			using (var reader = new BinaryReader (fs)) {
+				if (IsStaticLibrary (reader)) {
+					var lib = new StaticLibrary ();
+					lib.Read (filename, reader, fs.Length);
+					foreach (var obj in lib.ObjectFiles) {
+						foreach (var sym in obj.GetDefinedSymbols (reader))
+							symbols.Add (sym);
+					}
+				} else if (MachOFile.IsMachOLibrary (null, reader)) {
+					var obj = new MachOFile (filename);
+					obj.Read (reader);
+					foreach (var sym in obj.GetDefinedSymbols (reader))
+						symbols.Add (sym);
+				} else {
+					throw ErrorHelper.CreateError (1601, Errors.MT1601, System.Text.Encoding.ASCII.GetString (reader.ReadBytes (7), 0, 7));
+				}
+			}
+			return symbols;
+		}
 	}
 
 	public class MachOFile {
@@ -857,6 +884,53 @@ namespace Xamarin {
 				if ((n_type & N_EXT) == 0)
 					continue;
 				if ((n_type & N_TYPE) != N_UNDF)
+					continue;
+
+				// Read symbol name from string table
+				if (n_strx >= symtab.strsize)
+					continue;
+				var end = (int) n_strx;
+				while (end < stringTable.Length && stringTable [end] != 0)
+					end++;
+				var name = Encoding.UTF8.GetString (stringTable, (int) n_strx, end - (int) n_strx);
+				if (name.Length > 0)
+					symbols.Add (name);
+			}
+
+			return symbols;
+		}
+
+		/// <summary>
+		/// Reads defined (external, non-undefined) symbols from this Mach-O file.
+		/// The reader must be the same stream used to read this file.
+		/// </summary>
+		public HashSet<string> GetDefinedSymbols (BinaryReader reader)
+		{
+			var symbols = new HashSet<string> ();
+			var symtab = load_commands.OfType<SymtabLoadCommand> ().FirstOrDefault ();
+			if (symtab is null || symtab.nsyms == 0)
+				return symbols;
+
+			// Read the string table
+			reader.BaseStream.Position = streamBasePosition + symtab.stroff;
+			var stringTable = reader.ReadBytes ((int) symtab.strsize);
+
+			// Read symbol table entries
+			reader.BaseStream.Position = streamBasePosition + symtab.symoff;
+			for (uint i = 0; i < symtab.nsyms; i++) {
+				var n_strx = reader.ReadUInt32 ();
+				var n_type = reader.ReadByte ();
+				var n_sect = reader.ReadByte ();
+				var n_desc = reader.ReadInt16 ();
+				if (is64bitheader)
+					reader.ReadUInt64 (); // n_value (8 bytes)
+				else
+					reader.ReadUInt32 (); // n_value (4 bytes)
+
+				// Filter for defined external symbols (equivalent of nm -g, excluding undefined ones)
+				if ((n_type & N_EXT) == 0)
+					continue;
+				if ((n_type & N_TYPE) == N_UNDF)
 					continue;
 
 				// Read symbol name from string table

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -4288,6 +4288,10 @@ namespace Registrar {
 				return;
 			}
 			var ucoEntryPoint = pinvokeMethodInfo.UnmanagedCallersOnlyEntryPoint;
+			if (ucoEntryPoint is null) {
+				exceptions.Add (ErrorHelper.CreateError (99, "Could not find the UnmanagedCallersOnly entry point for {0}", descriptiveMethodName));
+				return;
+			}
 			// If the trampoline didn't survive the NativeAOT compiler (ILC), we can't emit a direct native
 			// reference to it (that would be an undefined symbol at native link time). Route it through the
 			// dlsym fallback instead - the trampoline is never actually invoked, since ILC only trims a

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -2811,6 +2811,37 @@ namespace Registrar {
 			// Don't need this dictionary, but do need ClassMapIndex
 			GetTypeMapDictionary (exceptions);
 
+#if !LEGACY_TOOLS
+			// When we know which UnmanagedCallersOnly trampolines survived the NativeAOT compiler (ILC) - which
+			// is only the case for the trimmable static registrar with NativeAOT + PrepareAssemblies, where the
+			// native registrar code is generated after ILC - we can skip generating the native code for any class
+			// whose trampolines were all trimmed away by ILC (ILC only trims a class's trampolines when it has
+			// determined the class can't be constructed, so nothing will reference it). We must however keep any
+			// class that's the base class of a class we're keeping, because its @implementation is still needed
+			// as a superclass.
+			HashSet<ObjCType>? classesToKeep = null;
+			HashSet<ObjCType>? classesWithTrampolines = null;
+			if (App.Registrar == RegistrarMode.TrimmableStatic && App.SurvivingTrampolineSymbols is not null) {
+				classesToKeep = new HashSet<ObjCType> ();
+				classesWithTrampolines = new HashSet<ObjCType> ();
+				foreach (var type in allTypes) {
+					if (type.IsProtocol || type.IsCategory)
+						continue;
+					var survived = ClassHasSurvivingTrampolines (type, out var hadTrampolines);
+					if (hadTrampolines)
+						classesWithTrampolines.Add (type);
+					// A class is skipped only if it had trampolines and none survived ILC. Every other class is
+					// emitted, so we must keep its entire base class chain (their @implementation is needed as
+					// superclasses), even if a base class itself had all its trampolines trimmed away.
+					if (!hadTrampolines || survived) {
+						var keep = type;
+						while (keep is not null && classesToKeep.Add (keep))
+							keep = keep.SuperType;
+					}
+				}
+			}
+#endif
+
 			foreach (var @class in allTypes) {
 				var isPlatformType = IsPlatformType (@class.Type);
 				var flags = MTTypeFlags.None;
@@ -2819,6 +2850,15 @@ namespace Registrar {
 					flags |= MTTypeFlags.CustomType;
 
 				skip.Clear ();
+
+#if !LEGACY_TOOLS
+				// This class had UnmanagedCallersOnly trampolines, but none survived ILC, and it's not needed as
+				// a base class of a class we're keeping - so ILC determined it can't be constructed: skip it.
+				if (classesWithTrampolines is not null
+					&& classesWithTrampolines.Contains (@class)
+					&& classesToKeep?.Contains (@class) == false)
+					continue;
+#endif
 
 				uint token_ref = uint.MaxValue;
 				if (App.Registrar != RegistrarMode.TrimmableStatic && !@class.IsProtocol && !@class.IsCategory) {
@@ -4209,6 +4249,29 @@ namespace Registrar {
 		}
 
 #if !LEGACY_TOOLS
+		// Returns true if the class has at least one UnmanagedCallersOnly trampoline that survived the NativeAOT
+		// compiler (ILC). 'hadTrampolines' is set to true if the class had any UnmanagedCallersOnly trampolines at
+		// all. This is only meaningful when App.SurvivingTrampolineSymbols is set (see App.DidTrampolineSurviveIlc).
+		bool ClassHasSurvivingTrampolines (ObjCType @class, out bool hadTrampolines)
+		{
+			hadTrampolines = false;
+			if (@class.Methods is null)
+				return false;
+			foreach (var method in @class.Methods) {
+				if (method.Method is null)
+					continue;
+				if (!App.Configuration.AssemblyTrampolineInfos.TryFindInfo (method.Method, out var pinvokeMethodInfo))
+					continue;
+				var ucoEntryPoint = pinvokeMethodInfo.UnmanagedCallersOnlyEntryPoint;
+				if (ucoEntryPoint is null)
+					continue;
+				hadTrampolines = true;
+				if (App.DidTrampolineSurviveIlc (ucoEntryPoint))
+					return true;
+			}
+			return false;
+		}
+
 		void GenerateCallToUnmanagedCallersOnlyMethod (AutoIndentStringBuilder sb, ObjCMethod method, bool isCtor, bool isVoid, int num_arg, string descriptiveMethodName, List<Exception> exceptions)
 		{
 			// Generate the native trampoline to call the generated UnmanagedCallersOnly method.
@@ -4225,6 +4288,12 @@ namespace Registrar {
 				return;
 			}
 			var ucoEntryPoint = pinvokeMethodInfo.UnmanagedCallersOnlyEntryPoint;
+			// If the trampoline didn't survive the NativeAOT compiler (ILC), we can't emit a direct native
+			// reference to it (that would be an undefined symbol at native link time). Route it through the
+			// dlsym fallback instead - the trampoline is never actually invoked, since ILC only trims a
+			// trampoline when it has determined the associated managed type can't be constructed.
+			if (staticCall && !App.DidTrampolineSurviveIlc (ucoEntryPoint))
+				staticCall = false;
 			sb.AppendLine ();
 			if (!staticCall)
 				sb.Append ("typedef ");


### PR DESCRIPTION
Add the ability to generate the static registrar's native code *after* the
NativeAOT compiler (ILC) has run, instead of before, for the trimmable-static
registrar with NativeAOT + PrepareAssemblies.

Generating the native registrar code after ILC lets it inspect ILC's output to
determine which UnmanagedCallersOnly trampolines survived trimming, and adjust
the generated code accordingly:

* Trampolines ILC trimmed away are routed through the dlsym fallback (a
  runtime string reference) instead of a direct native symbol reference, which
  would otherwise be an undefined symbol at native link time. Since ILC only
  trims a trampoline when it has determined the associated managed type can't
  be constructed, the trampoline is never actually invoked, so the fallback is
  never reached.
* Classes whose UnmanagedCallersOnly trampolines were all trimmed away are
  skipped entirely (no @interface/@implementation is emitted), except base
  classes still referenced as a superclass of an emitted class (the whole
  base-class chain is kept).

The reorder is only possible because ILLink is skipped in this scenario (ILC
consumes the prepared assemblies directly), so the postprocessing output no
longer feeds ILC. A new _PostprocessAssembliesAfterIlc target runs the full
postprocessing pipeline after IlcCompile and before _LoadLinkerOutput, and the
pre-ILC _PostprocessAssemblies target is skipped under the same gate
(PublishAot + PrepareAssemblies + trimmable-static).

The registrar only trims trampolines/classes when it's told which trampolines
survived ILC (via Application.SurvivingTrampolineSymbols, populated from the
defined symbols in ILC's output object file). Nothing sets that up unless ILC
actually drops trampoline exports, which requires emitting the
AssociatedSourceType field on the trampolines - that's done separately - so on
its own this change is inert. It's landed separately to reduce divergence (and
thus future merge conflicts) with the net11.0 branch, where
AssociatedSourceType is emitted.

New helpers supporting this:
* MachO.StaticLibrary.GetDefinedSymbols / MachOFile.GetDefinedSymbols read the
  defined external symbols of a static library / Mach-O object file.
* Application.SurvivingTrampolineSymbols + DidTrampolineSurviveIlc track which
  trampolines survived ILC (null = information unavailable = all assumed
  survived).
* PrepareAssemblies gains a NativeAOTObjectFile input; when set, its defined
  symbols populate SurvivingTrampolineSymbols before postprocessing.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 2b6450f9-2ad9-4e89-823a-3cc6e2f33f53