### PR TITLE
[CI] Make 'Clean for remote tests' able to delete read-only directories

### DIFF
--- a/tools/devops/automation/scripts/clean-for-remote-tests.sh
+++ b/tools/devops/automation/scripts/clean-for-remote-tests.sh
@@ -10,8 +10,12 @@
 # to gain access (unlike GNU rm), so it fails with "Permission denied" and
 # leaves the tree behind. That would make this cleanup step fail on every
 # subsequent build. So make sure everything is writable before deleting.
+#
+# Use 'u+wX' (capital X) so that directories also get the execute bit they
+# need to be traversable and deletable, without setting execute on regular
+# files that don't already have it.
 safe_rm () {
-	chmod -R u+w "$@" || true
+	chmod -R u+wX "$@" || true
 	rm -rf "$@"
 }
 

--- a/tools/devops/automation/scripts/clean-for-remote-tests.sh
+++ b/tools/devops/automation/scripts/clean-for-remote-tests.sh
@@ -1,18 +1,33 @@
 #!/bin/bash -eux
 
+# Delete a directory tree, even if it contains read-only directories.
+#
+# Some builds copy read-only directories into their output (by mistake,
+# they're PR builds after all - for instance the readonly macOS timezone
+# database at /var/db/timezone, which is mode 0555, could be copied around if
+# MSBuild globs are incorrect). BSD/macOS 'rm -rf' won't remove entries inside
+# a directory that lacks the write bit, and it doesn't chmod such directories
+# to gain access (unlike GNU rm), so it fails with "Permission denied" and
+# leaves the tree behind. That would make this cleanup step fail on every
+# subsequent build. So make sure everything is writable before deleting.
+safe_rm () {
+	chmod -R u+w "$@" || true
+	rm -rf "$@"
+}
+
 # I've seen machines with more than 1gb of Xamarin.Messaging logs, so clean that up.
 if du -hs ~/Library/Logs/Xamarin.Messaging*; then
-	rm -rf ~/Library/Logs/Xamarin.Messaging*
+	safe_rm ~/Library/Logs/Xamarin.Messaging*
 fi
 
 # Make sure we don't have any old stuff installed
 if du -hs ~/Library/Caches/Xamarin; then
-	rm -rf ~/Library/Caches/Xamarin
+	safe_rm ~/Library/Caches/Xamarin
 fi
 
 # Make sure we don't have any old stuff installed
 if du -hs ~/Library/Caches/maui; then
-	rm -rf ~/Library/Caches/maui
+	safe_rm ~/Library/Caches/maui
 fi
 
 # Clean up temporary logs


### PR DESCRIPTION
The 'Clean for remote tests' step runs 'rm -rf ~/Library/Caches/maui', which persistently failed on bot VSM-XAM-03.Tahoe.arm64 with:

    rm: .../bin/Debug/net10.0-ios/iossimulator-arm64/private/var/db/timezone/zoneinfo: Permission denied

A remote iossimulator-arm64 build of tests/dotnet/IncrementalTestApp (the `CodeChangeSkipsTargetsOnRemoteWindows` test) unintentionally copied macOS timezone database (/var/db/timezone, mode 0555) into the app bundle output, preserving the read-only permissions. BSD/macOS 'rm -rf' won't remove entries inside a directory that lacks the write bit, and (unlike GNU rm) doesn't chmod such directories to gain access, so it fails and leaves the tree behind. Since the build-input hash directory is reused every build, the leftover then made this cleanup step fail on every subsequent build, which is why the bot stayed broken for over a week.

Add a 'safe_rm' helper that runs 'chmod -R u+w' before 'rm -rf' so the cleanup is self-healing.

Fixes https://github.com/dotnet/macios/issues/26190

🤖 Pull request created by Copilot