### PR TITLE
[MultipeerConnectivity] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/multipeerconnectivity.cs
+++ b/src/multipeerconnectivity.cs
@@ -23,6 +23,10 @@ namespace MultipeerConnectivity {
 	///     </remarks>
 	///     <related type="externalDocumentation" href="https://developer.apple.com/library/ios/documentation/MultipeerConnectivity/Reference/MCPeerID_class/index.html">Apple documentation for <c>MCPeerID</c></related>
 	[MacCatalyst (13, 1)]
+	[Deprecated (PlatformName.iOS, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.TvOS, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use Network Framework instead")]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: -[MCPeerID init]: unrecognized selector sent to instance 0x7d721090
 	partial interface MCPeerID : NSCopying, NSSecureCoding {
@@ -46,6 +50,10 @@ namespace MultipeerConnectivity {
 
 	/// <include file="../docs/api/MultipeerConnectivity/MCSession.xml" path="/Documentation/Docs[@DocId='T:MultipeerConnectivity.MCSession']/*" />
 	[MacCatalyst (13, 1)]
+	[Deprecated (PlatformName.iOS, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.TvOS, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use Network Framework instead")]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // crash when calling `description` selector
 	partial interface MCSession {
@@ -323,6 +331,10 @@ namespace MultipeerConnectivity {
 	///     
 	///     <related type="externalDocumentation" href="https://developer.apple.com/library/ios/documentation/MultipeerConnectivity/Reference/MCNearbyServiceAdvertiserClassRef/index.html">Apple documentation for <c>MCNearbyServiceAdvertiser</c></related>
 	[MacCatalyst (13, 1)]
+	[Deprecated (PlatformName.iOS, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.TvOS, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use Network Framework instead")]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException -[MCNearbyServiceAdvertiser init]: unrecognized selector sent to instance 0x19195e50
 	partial interface MCNearbyServiceAdvertiser {
@@ -427,6 +439,10 @@ namespace MultipeerConnectivity {
 	///     
 	///     <related type="externalDocumentation" href="https://developer.apple.com/library/ios/documentation/MultipeerConnectivity/Reference/MCNearbyServiceBrowserClassRef/index.html">Apple documentation for <c>MCNearbyServiceBrowser</c></related>
 	[MacCatalyst (13, 1)]
+	[Deprecated (PlatformName.iOS, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.TvOS, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use Network Framework instead")]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException -[MCNearbyServiceBrowser init]: unrecognized selector sent to instance 0x15519a70
 	partial interface MCNearbyServiceBrowser {
@@ -540,6 +556,10 @@ namespace MultipeerConnectivity {
 
 	/// <include file="../docs/api/MultipeerConnectivity/MCBrowserViewController.xml" path="/Documentation/Docs[@DocId='T:MultipeerConnectivity.MCBrowserViewController']/*" />
 	[MacCatalyst (13, 1)]
+	[Deprecated (PlatformName.iOS, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.TvOS, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use Network Framework instead")]
 	[BaseType (typeof (UIViewController))]
 	[DisableDefaultCtor] // NSInvalidArgumentException -[MCPeerPickerViewController initWithNibName:bundle:]: unrecognized selector sent to instance 0x15517b90
 	partial interface MCBrowserViewController : MCNearbyServiceBrowserDelegate {
@@ -672,6 +692,10 @@ namespace MultipeerConnectivity {
 	///     
 	///     <related type="externalDocumentation" href="https://developer.apple.com/library/ios/documentation/MultipeerConnectivity/Reference/MCAdvertiserAssistant_class/index.html">Apple documentation for <c>MCAdvertiserAssistant</c></related>
 	[MacCatalyst (13, 1)]
+	[Deprecated (PlatformName.iOS, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.TvOS, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use Network Framework instead")]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: -[MCAdvertiserAssistant init]: unrecognized selector sent to instance 0x7ea7fa40
 	interface MCAdvertiserAssistant {

--- a/src/multipeerconnectivity.cs
+++ b/src/multipeerconnectivity.cs
@@ -23,10 +23,10 @@ namespace MultipeerConnectivity {
 	///     </remarks>
 	///     <related type="externalDocumentation" href="https://developer.apple.com/library/ios/documentation/MultipeerConnectivity/Reference/MCPeerID_class/index.html">Apple documentation for <c>MCPeerID</c></related>
 	[MacCatalyst (13, 1)]
-	[Deprecated (PlatformName.iOS, 27, 0, message: "Use Network Framework instead")]
-	[Deprecated (PlatformName.TvOS, 27, 0, message: "Use Network Framework instead")]
-	[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use Network Framework instead")]
-	[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.iOS, 27, 0, message: "Use Network Framework instead.")]
+	[Deprecated (PlatformName.TvOS, 27, 0, message: "Use Network Framework instead.")]
+	[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use Network Framework instead.")]
+	[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use Network Framework instead.")]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: -[MCPeerID init]: unrecognized selector sent to instance 0x7d721090
 	partial interface MCPeerID : NSCopying, NSSecureCoding {
@@ -50,10 +50,10 @@ namespace MultipeerConnectivity {
 
 	/// <include file="../docs/api/MultipeerConnectivity/MCSession.xml" path="/Documentation/Docs[@DocId='T:MultipeerConnectivity.MCSession']/*" />
 	[MacCatalyst (13, 1)]
-	[Deprecated (PlatformName.iOS, 27, 0, message: "Use Network Framework instead")]
-	[Deprecated (PlatformName.TvOS, 27, 0, message: "Use Network Framework instead")]
-	[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use Network Framework instead")]
-	[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.iOS, 27, 0, message: "Use Network Framework instead.")]
+	[Deprecated (PlatformName.TvOS, 27, 0, message: "Use Network Framework instead.")]
+	[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use Network Framework instead.")]
+	[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use Network Framework instead.")]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // crash when calling `description` selector
 	partial interface MCSession {
@@ -331,10 +331,10 @@ namespace MultipeerConnectivity {
 	///     
 	///     <related type="externalDocumentation" href="https://developer.apple.com/library/ios/documentation/MultipeerConnectivity/Reference/MCNearbyServiceAdvertiserClassRef/index.html">Apple documentation for <c>MCNearbyServiceAdvertiser</c></related>
 	[MacCatalyst (13, 1)]
-	[Deprecated (PlatformName.iOS, 27, 0, message: "Use Network Framework instead")]
-	[Deprecated (PlatformName.TvOS, 27, 0, message: "Use Network Framework instead")]
-	[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use Network Framework instead")]
-	[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.iOS, 27, 0, message: "Use Network Framework instead.")]
+	[Deprecated (PlatformName.TvOS, 27, 0, message: "Use Network Framework instead.")]
+	[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use Network Framework instead.")]
+	[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use Network Framework instead.")]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException -[MCNearbyServiceAdvertiser init]: unrecognized selector sent to instance 0x19195e50
 	partial interface MCNearbyServiceAdvertiser {
@@ -439,10 +439,10 @@ namespace MultipeerConnectivity {
 	///     
 	///     <related type="externalDocumentation" href="https://developer.apple.com/library/ios/documentation/MultipeerConnectivity/Reference/MCNearbyServiceBrowserClassRef/index.html">Apple documentation for <c>MCNearbyServiceBrowser</c></related>
 	[MacCatalyst (13, 1)]
-	[Deprecated (PlatformName.iOS, 27, 0, message: "Use Network Framework instead")]
-	[Deprecated (PlatformName.TvOS, 27, 0, message: "Use Network Framework instead")]
-	[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use Network Framework instead")]
-	[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.iOS, 27, 0, message: "Use Network Framework instead.")]
+	[Deprecated (PlatformName.TvOS, 27, 0, message: "Use Network Framework instead.")]
+	[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use Network Framework instead.")]
+	[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use Network Framework instead.")]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException -[MCNearbyServiceBrowser init]: unrecognized selector sent to instance 0x15519a70
 	partial interface MCNearbyServiceBrowser {
@@ -556,10 +556,10 @@ namespace MultipeerConnectivity {
 
 	/// <include file="../docs/api/MultipeerConnectivity/MCBrowserViewController.xml" path="/Documentation/Docs[@DocId='T:MultipeerConnectivity.MCBrowserViewController']/*" />
 	[MacCatalyst (13, 1)]
-	[Deprecated (PlatformName.iOS, 27, 0, message: "Use Network Framework instead")]
-	[Deprecated (PlatformName.TvOS, 27, 0, message: "Use Network Framework instead")]
-	[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use Network Framework instead")]
-	[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.iOS, 27, 0, message: "Use Network Framework instead.")]
+	[Deprecated (PlatformName.TvOS, 27, 0, message: "Use Network Framework instead.")]
+	[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use Network Framework instead.")]
+	[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use Network Framework instead.")]
 	[BaseType (typeof (UIViewController))]
 	[DisableDefaultCtor] // NSInvalidArgumentException -[MCPeerPickerViewController initWithNibName:bundle:]: unrecognized selector sent to instance 0x15517b90
 	partial interface MCBrowserViewController : MCNearbyServiceBrowserDelegate {
@@ -692,10 +692,10 @@ namespace MultipeerConnectivity {
 	///     
 	///     <related type="externalDocumentation" href="https://developer.apple.com/library/ios/documentation/MultipeerConnectivity/Reference/MCAdvertiserAssistant_class/index.html">Apple documentation for <c>MCAdvertiserAssistant</c></related>
 	[MacCatalyst (13, 1)]
-	[Deprecated (PlatformName.iOS, 27, 0, message: "Use Network Framework instead")]
-	[Deprecated (PlatformName.TvOS, 27, 0, message: "Use Network Framework instead")]
-	[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use Network Framework instead")]
-	[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use Network Framework instead")]
+	[Deprecated (PlatformName.iOS, 27, 0, message: "Use Network Framework instead.")]
+	[Deprecated (PlatformName.TvOS, 27, 0, message: "Use Network Framework instead.")]
+	[Deprecated (PlatformName.MacOSX, 27, 0, message: "Use Network Framework instead.")]
+	[Deprecated (PlatformName.MacCatalyst, 27, 0, message: "Use Network Framework instead.")]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor] // NSInvalidArgumentException Reason: -[MCAdvertiserAssistant init]: unrecognized selector sent to instance 0x7ea7fa40
 	interface MCAdvertiserAssistant {

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-MultipeerConnectivity.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-MultipeerConnectivity.todo
@@ -1,6 +1,0 @@
-!deprecated-attribute-missing! MCAdvertiserAssistant missing a [Deprecated] attribute
-!deprecated-attribute-missing! MCBrowserViewController missing a [Deprecated] attribute
-!deprecated-attribute-missing! MCNearbyServiceAdvertiser missing a [Deprecated] attribute
-!deprecated-attribute-missing! MCNearbyServiceBrowser missing a [Deprecated] attribute
-!deprecated-attribute-missing! MCPeerID missing a [Deprecated] attribute
-!deprecated-attribute-missing! MCSession missing a [Deprecated] attribute

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-MultipeerConnectivity.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-MultipeerConnectivity.todo
@@ -1,6 +1,0 @@
-!deprecated-attribute-missing! MCAdvertiserAssistant missing a [Deprecated] attribute
-!deprecated-attribute-missing! MCBrowserViewController missing a [Deprecated] attribute
-!deprecated-attribute-missing! MCNearbyServiceAdvertiser missing a [Deprecated] attribute
-!deprecated-attribute-missing! MCNearbyServiceBrowser missing a [Deprecated] attribute
-!deprecated-attribute-missing! MCPeerID missing a [Deprecated] attribute
-!deprecated-attribute-missing! MCSession missing a [Deprecated] attribute

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-MultipeerConnectivity.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-MultipeerConnectivity.todo
@@ -1,6 +1,0 @@
-!deprecated-attribute-missing! MCAdvertiserAssistant missing a [Deprecated] attribute
-!deprecated-attribute-missing! MCBrowserViewController missing a [Deprecated] attribute
-!deprecated-attribute-missing! MCNearbyServiceAdvertiser missing a [Deprecated] attribute
-!deprecated-attribute-missing! MCNearbyServiceBrowser missing a [Deprecated] attribute
-!deprecated-attribute-missing! MCPeerID missing a [Deprecated] attribute
-!deprecated-attribute-missing! MCSession missing a [Deprecated] attribute

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-MultipeerConnectivity.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-MultipeerConnectivity.todo
@@ -1,6 +1,0 @@
-!deprecated-attribute-missing! MCAdvertiserAssistant missing a [Deprecated] attribute
-!deprecated-attribute-missing! MCBrowserViewController missing a [Deprecated] attribute
-!deprecated-attribute-missing! MCNearbyServiceAdvertiser missing a [Deprecated] attribute
-!deprecated-attribute-missing! MCNearbyServiceBrowser missing a [Deprecated] attribute
-!deprecated-attribute-missing! MCPeerID missing a [Deprecated] attribute
-!deprecated-attribute-missing! MCSession missing a [Deprecated] attribute


### PR DESCRIPTION
### Summary

- mark `MCPeerID`, `MCSession`, `MCNearbyServiceAdvertiser`, `MCNearbyServiceBrowser`, `MCBrowserViewController`, and `MCAdvertiserAssistant` deprecated in Xcode 27.0 across iOS, tvOS, macOS, and Mac Catalyst
- use Apple’s migration guidance to the Network framework
- remove the resolved MultipeerConnectivity xtro todo files for all four platforms

### Validation

- fresh `make world` before changes and full `make world` after binding changes
- clean xtro regeneration/classification: sanity passed
- clean cecil run: 112 passed, 4 skipped, 0 failed
- macOS introspection: 32 passed, 0 failed; Mac Catalyst introspection: 39 passed, 0 failed
- iOS/tvOS introspection completed with unrelated Xcode 27 beta-runtime gaps in LinkSecurity, UIKit, AVFoundation, Metal, CarPlay, and AVKit; no MultipeerConnectivity failure was reported
- clean app-size run: 16 expected skips because Xcode 27 is beta, 0 failed