### PR TITLE
[Network] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/Network/NWEnums.cs
+++ b/src/Network/NWEnums.cs
@@ -337,7 +337,11 @@ namespace Network {
 	}
 
 	[NativeName ("nw_link_quality_t")]
+#if XAMCORE_5_0
+	public enum NWLinkQuality : byte {
+#else
 	public enum NWLinkQuality : uint {
+#endif
 		Unknown = 0,
 		Minimal = 10,
 		Moderate = 20,

--- a/src/Network/NWPath.cs
+++ b/src/Network/NWPath.cs
@@ -266,13 +266,13 @@ namespace Network {
 		[SupportedOSPlatform ("ios26.0")]
 		[SupportedOSPlatform ("maccatalyst26.0")]
 		[DllImport (Constants.NetworkLibrary)]
-		static extern NWLinkQuality nw_path_get_link_quality (IntPtr path);
+		static extern byte nw_path_get_link_quality (IntPtr path);
 
 		[SupportedOSPlatform ("tvos26.0")]
 		[SupportedOSPlatform ("macos26.0")]
 		[SupportedOSPlatform ("ios26.0")]
 		[SupportedOSPlatform ("maccatalyst26.0")]
-		public NWLinkQuality LinkQuality => nw_path_get_link_quality (GetCheckedHandle ());
+		public NWLinkQuality LinkQuality => (NWLinkQuality) nw_path_get_link_quality (GetCheckedHandle ());
 
 	}
 }

--- a/src/Network/NWTcpMetadata.cs
+++ b/src/Network/NWTcpMetadata.cs
@@ -24,5 +24,26 @@ namespace Network {
 		public uint AvailableReceiveBuffer => nw_tcp_get_available_receive_buffer (GetCheckedHandle ());
 
 		public uint AvailableSendBuffer => nw_tcp_get_available_send_buffer (GetCheckedHandle ());
+
+		[SupportedOSPlatform ("tvos27.0")]
+		[SupportedOSPlatform ("macos27.0")]
+		[SupportedOSPlatform ("ios27.0")]
+		[SupportedOSPlatform ("maccatalyst27.0")]
+		[DllImport (Constants.NetworkLibrary)]
+		static extern int nw_tcp_set_max_pacing_rate (IntPtr metadata, ulong maximumPacingRate);
+
+		/// <summary>Sets the maximum pacing rate for TCP transmissions.</summary>
+		/// <param name="maximumPacingRate">The maximum pacing rate, in bytes per second.</param>
+		/// <returns>Zero on success; otherwise, a POSIX error code.</returns>
+		/// <remarks>
+		/// A value of 0 or <c>ulong.MaxValue</c> disables pacing. Values between 1 and 12,499 are clamped to 12,500.
+		/// Each call replaces the previous pacing rate.
+		/// </remarks>
+		[SupportedOSPlatform ("tvos27.0")]
+		[SupportedOSPlatform ("macos27.0")]
+		[SupportedOSPlatform ("ios27.0")]
+		[SupportedOSPlatform ("maccatalyst27.0")]
+		public int SetMaximumPacingRate (ulong maximumPacingRate)
+			=> nw_tcp_set_max_pacing_rate (GetCheckedHandle (), maximumPacingRate);
 	}
 }

--- a/tests/monotouch-test/Network/NWTcpMetadataTest.cs
+++ b/tests/monotouch-test/Network/NWTcpMetadataTest.cs
@@ -1,0 +1,77 @@
+#nullable enable
+
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+using CoreFoundation;
+using Network;
+
+namespace MonoTouchFixtures.Network {
+
+	[TestFixture]
+	[Preserve (AllMembers = true)]
+	public class NWTcpMetadataTest {
+
+		[Test]
+		public void SetMaximumPacingRate ()
+		{
+			TestRuntime.AssertXcodeVersion (27, 0);
+
+			var readyCompletion = new TaskCompletionSource<string?> (TaskCreationOptions.RunContinuationsAsynchronously);
+			var cancelledCompletion = new TaskCompletionSource<bool> (TaskCreationOptions.RunContinuationsAsynchronously);
+			using var listener = new TcpListener (IPAddress.Loopback, 0);
+			listener.Start ();
+
+			var port = ((IPEndPoint) listener.LocalEndpoint).Port;
+			using var endpoint = NWEndpoint.Create ("127.0.0.1", port.ToString (CultureInfo.InvariantCulture));
+			using var parameters = NWParameters.CreateTcp ();
+			using var connection = new NWConnection (endpoint, parameters);
+
+			connection.SetQueue (DispatchQueue.DefaultGlobalQueue);
+			connection.SetStateChangeHandler ((state, error) => {
+				switch (state) {
+				case NWConnectionState.Ready:
+					readyCompletion.TrySetResult (null);
+					break;
+				case NWConnectionState.Invalid:
+				case NWConnectionState.Failed:
+					readyCompletion.TrySetResult (error?.ToString () ?? $"Connection entered the {state} state.");
+					break;
+				case NWConnectionState.Cancelled:
+					cancelledCompletion.TrySetResult (true);
+					break;
+				}
+			});
+
+			TcpClient? acceptedClient = null;
+			connection.Start ();
+			try {
+				Assert.That (readyCompletion.Task.Wait (TimeSpan.FromSeconds (10)), Is.True, "Connection did not become ready.");
+				var failureMessage = readyCompletion.Task.Result;
+				if (failureMessage is not null)
+					Assert.Fail (failureMessage);
+
+				acceptedClient = listener.AcceptTcpClient ();
+
+				using var definition = NWProtocolDefinition.CreateTcpDefinition ();
+				using var metadata = connection.GetProtocolMetadata<NWTcpMetadata> (definition);
+				Assert.That (metadata, Is.Not.Null, "TCP metadata");
+				if (metadata is not null) {
+					Assert.That (metadata.SetMaximumPacingRate (12_500), Is.Zero, "Set pacing rate");
+					Assert.That (metadata.SetMaximumPacingRate (ulong.MaxValue), Is.Zero, "Disable pacing");
+				}
+			} finally {
+				acceptedClient?.Dispose ();
+				connection.Cancel ();
+				var cancelled = cancelledCompletion.Task.Wait (TimeSpan.FromSeconds (5));
+				if (!cancelled) {
+					connection.ForceCancel ();
+					cancelled = cancelledCompletion.Task.Wait (TimeSpan.FromSeconds (5));
+				}
+				Assert.That (cancelled, Is.True, "Connection did not cancel.");
+			}
+		}
+	}
+}

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-Network.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-Network.todo
@@ -1,2 +1,0 @@
-!missing-pinvoke! nw_tcp_set_max_pacing_rate is not bound
-!wrong-enum-size! nw_link_quality_t managed 4 vs native 1

--- a/tests/xtro-sharpie/api-annotations-dotnet/common-Network.ignore
+++ b/tests/xtro-sharpie/api-annotations-dotnet/common-Network.ignore
@@ -76,3 +76,6 @@
 !missing-enum! nw_ws_opcode_t not bound
 !missing-enum! nw_ws_response_status_t not bound
 !missing-enum! nw_ws_version_t not bound
+
+## nw_link_quality_t - changing the backing type from uint to byte is a breaking change; fixed in XAMCORE_5_0
+!wrong-enum-size! nw_link_quality_t managed 4 vs native 1

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-Network.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-Network.todo
@@ -1,2 +1,0 @@
-!missing-pinvoke! nw_tcp_set_max_pacing_rate is not bound
-!wrong-enum-size! nw_link_quality_t managed 4 vs native 1

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-Network.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-Network.todo
@@ -1,2 +1,0 @@
-!missing-pinvoke! nw_tcp_set_max_pacing_rate is not bound
-!wrong-enum-size! nw_link_quality_t managed 4 vs native 1

--- a/tests/xtro-sharpie/api-annotations-dotnet/tvOS-Network.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/tvOS-Network.todo
@@ -1,2 +1,0 @@
-!missing-pinvoke! nw_tcp_set_max_pacing_rate is not bound
-!wrong-enum-size! nw_link_quality_t managed 4 vs native 1


### PR DESCRIPTION
## Summary

- bind `nw_tcp_set_max_pacing_rate` as `NWTcpMetadata.SetMaximumPacingRate`
- preserve the shipped `NWLinkQuality : uint` ABI while queuing the native `byte` backing type for `XAMCORE_5_0`
- marshal `nw_path_get_link_quality` through `byte` in current builds and move the unavoidable enum-size mismatch to the shared xtro ignore
- add deterministic loopback coverage for setting and disabling the TCP pacing rate
- remove the resolved Network todo files for iOS, tvOS, macOS, and Mac Catalyst

## Validation

- `make world`
- clean all-platform xtro classification and sanity
- clean Cecil tests: 112 passed, 4 skipped
- iOS/tvOS 27.0 introspection: Network P/Invoke checks passed; unrelated Beta 3 runtime gaps remain in other frameworks
- macOS introspection: 32 passed; Mac Catalyst introspection: 39 passed
- `NWTcpMetadataTest` passed on iOS 27.0 and tvOS 27.0 and was correctly gated on the macOS 26.5 desktop host
- full monotouch suites completed on all four platforms; their only non-Network failure was the existing external-network timeout in `CreateResponseAuth`
- clean app-size fixture: 0 failed, 16 skipped by the beta-Xcode policy
