### PR TITLE
[docs] Improve XML docs for NSFontCollectionAction, AppKitFramework, SKReceiptRefreshRequest, NSBrowser, NSLevelIndicator, NSPopUpButton

### DIFF
--- a/src/AppKit/EventArgs.cs
+++ b/src/AppKit/EventArgs.cs
@@ -32,25 +32,22 @@
 #nullable enable
 
 namespace AppKit {
-	/// <summary>To be added.</summary>
-	///     <remarks>To be added.</remarks>
+	/// <summary>Specifies the action that occurred on a font collection.</summary>
 	public enum NSFontCollectionAction {
-		/// <summary>To be added.</summary>
+		/// <summary>An unknown action.</summary>
 		Unknown,
-		/// <summary>To be added.</summary>
+		/// <summary>The font collection was shown.</summary>
 		Shown,
-		/// <summary>To be added.</summary>
+		/// <summary>The font collection was hidden.</summary>
 		Hidden,
-		/// <summary>To be added.</summary>
+		/// <summary>The font collection was renamed.</summary>
 		Renamed,
 	}
 
-	/// <summary>To be added.</summary>
-	///     <remarks>To be added.</remarks>
+	/// <summary>Provides data for the font collection changed notification.</summary>
 	public partial class NSFontCollectionChangedEventArgs {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets the action that triggered the font collection change.</summary>
+		/// <value>The action that occurred on the font collection.</value>
 		public NSFontCollectionAction Action {
 			get {
 				if (_Action == NSFontCollection.ActionWasShown) {
@@ -65,9 +62,8 @@ namespace AppKit {
 			}
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets the visibility of the font collection after the change.</summary>
+		/// <value>The visibility level of the font collection.</value>
 		public NSFontCollectionVisibility Visibility {
 			get { return (NSFontCollectionVisibility) (int) _Visibility; }
 		}

--- a/src/AppKit/EventArgs.cs
+++ b/src/AppKit/EventArgs.cs
@@ -63,7 +63,7 @@ namespace AppKit {
 		}
 
 		/// <summary>Gets the visibility of the font collection after the change.</summary>
-		/// <value>The visibility level of the font collection.</value>
+		/// <value>The visibility scope flags for the font collection.</value>
 		public NSFontCollectionVisibility Visibility {
 			get { return (NSFontCollectionVisibility) (int) _Visibility; }
 		}

--- a/src/AppKit/Functions.cs
+++ b/src/AppKit/Functions.cs
@@ -31,12 +31,10 @@ namespace AppKit {
 
 #if MONOMAC
 	// Class to access C functions
-	/// <summary>To be added.</summary>
-	///     <remarks>To be added.</remarks>
+	/// <summary>Provides access to AppKit framework C functions.</summary>
 	public partial class AppKitFramework {
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Plays the system alert sound.</summary>
 		[DllImport (Constants.AppKitLibrary)]
 		public static extern void NSBeep ();
 	}

--- a/src/AppKit/NSBrowser.cs
+++ b/src/AppKit/NSBrowser.cs
@@ -30,9 +30,8 @@ namespace AppKit {
 	public partial class NSBrowser {
 
 		// note: if needed override the protected Get|Set methods
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets or sets the browser's current path.</summary>
+		/// <value>The browser's current path string.</value>
 		public string Path {
 			get { return GetPath (); }
 			// ignore return value (bool)

--- a/src/AppKit/NSLevelIndicator.cs
+++ b/src/AppKit/NSLevelIndicator.cs
@@ -12,9 +12,8 @@
 namespace AppKit {
 
 	public partial class NSLevelIndicator {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets or sets the level indicator cell associated with this control.</summary>
+		/// <value>The <see cref="NSLevelIndicatorCell" /> used by this control.</value>
 		public new NSLevelIndicatorCell Cell {
 			get { return (NSLevelIndicatorCell) base.Cell; }
 			set { base.Cell = value; }

--- a/src/AppKit/NSPopUpButton.cs
+++ b/src/AppKit/NSPopUpButton.cs
@@ -33,9 +33,8 @@
 namespace AppKit {
 
 	public partial class NSPopUpButton {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets or sets the pop-up button cell associated with this control.</summary>
+		/// <value>The <see cref="NSPopUpButtonCell" /> used by this control.</value>
 		public new NSPopUpButtonCell Cell {
 			get { return (NSPopUpButtonCell) base.Cell; }
 			set { base.Cell = value; }

--- a/src/StoreKit/NativeMethods.cs
+++ b/src/StoreKit/NativeMethods.cs
@@ -3,8 +3,7 @@
 namespace StoreKit {
 
 	partial class SKReceiptRefreshRequest {
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Terminates the application if the receipt is invalid.</summary>
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("maccatalyst")]


### PR DESCRIPTION
Improve XML documentation for:
- `NSFontCollectionAction` and `NSFontCollectionChangedEventArgs` (AppKit)
- `AppKitFramework` constants (AppKit)
- `SKReceiptRefreshRequest` (StoreKit)
- `NSBrowser` (AppKit)
- `NSLevelIndicator` (AppKit)
- `NSPopUpButton` (AppKit)

Changes:
- Replace boilerplate 'To be added.' with meaningful descriptions
- Remove empty XML doc nodes
- Fix formatting and indentation

🤖 Pull request created by Copilot