### PR TITLE
[docs] Improve XML docs for NSScreen, NSTextField, AudioUnitUtils, and 7 more types

### DIFF
--- a/src/AVFoundation/AVAudioFormat.cs
+++ b/src/AVFoundation/AVAudioFormat.cs
@@ -19,7 +19,6 @@ using System.Runtime.CompilerServices;
 
 namespace AVFoundation {
 	/// <summary>Corresponds to a Core Audio AudioStreamBasicDescription struct.</summary>
-	///     <remarks>To be added.</remarks>
 	/// <related type="externalDocumentation" href="https://developer.apple.com/documentation/avfaudio/avaudioformat">Apple documentation for <c>AVAudioFormat</c></related>
 	public partial class AVAudioFormat {
 		public static bool operator == (AVAudioFormat a, AVAudioFormat b)
@@ -37,8 +36,7 @@ namespace AVFoundation {
 		}
 
 		/// <summary>Gets the audio stream description.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <value>The <see cref="AudioStreamBasicDescription" /> for this audio format.</value>
 		[Export ("StreamDescription")]
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("macos")]

--- a/src/AVFoundation/AudioRendererWasFlushedAutomaticallyEventArgs.cs
+++ b/src/AVFoundation/AudioRendererWasFlushedAutomaticallyEventArgs.cs
@@ -11,9 +11,8 @@ namespace AVFoundation {
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("maccatalyst")]
 	public partial class AudioRendererWasFlushedAutomaticallyEventArgs {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets the time at which the audio renderer was flushed.</summary>
+		/// <value>The presentation time at which the flush occurred.</value>
 		public CMTime AudioRendererFlushTime {
 			get {
 				return _AudioRendererFlushTime.CMTimeValue;

--- a/src/AppKit/NSScreen.cs
+++ b/src/AppKit/NSScreen.cs
@@ -31,9 +31,8 @@ namespace AppKit {
 
 	public partial class NSScreen {
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets the list of window depths supported by this screen.</summary>
+		/// <value>An array of supported window depth values.</value>
 		public NSWindowDepth [] SupportedWindowDepths {
 			get {
 				List<NSWindowDepth> list = new List<NSWindowDepth> ();

--- a/src/AppKit/NSTextField.cs
+++ b/src/AppKit/NSTextField.cs
@@ -9,9 +9,8 @@
 namespace AppKit {
 
 	public partial class NSTextField {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets or sets the text field cell associated with this control.</summary>
+		/// <value>The <see cref="NSTextFieldCell" /> used by this control.</value>
 		public new NSTextFieldCell Cell {
 			get { return (NSTextFieldCell) base.Cell; }
 			set { base.Cell = value; }

--- a/src/AudioUnit/AudioUnitUtils.cs
+++ b/src/AudioUnit/AudioUnitUtils.cs
@@ -35,14 +35,12 @@ using AudioToolbox;
 
 namespace AudioUnit {
 	/// <summary>Utility class to hold miscellaneous functions relating to audio streams, samples, and output categories.</summary>
-	///     <remarks>To be added.</remarks>
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("tvos")]
 	public static class AudioUnitUtils {
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>The number of bits used for the fractional part of a fixed-point audio sample.</summary>
 		public const int SampleFractionBits = 24;
 	}
 }

--- a/src/CoreBluetooth/PeripheralScanningOptions.cs
+++ b/src/CoreBluetooth/PeripheralScanningOptions.cs
@@ -33,9 +33,8 @@ namespace CoreBluetooth {
 
 	public partial class PeripheralScanningOptions {
 #if !COREBUILD
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets or sets whether duplicate peripheral discoveries should be reported.</summary>
+		/// <value><see langword="true" /> to allow duplicates; otherwise, <see langword="false" />.</value>
 		public bool AllowDuplicatesKey {
 			get {
 				var value = GetBoolValue (CBCentralManager.ScanOptionAllowDuplicatesKey);

--- a/src/Foundation/ConnectAttribute.cs
+++ b/src/Foundation/ConnectAttribute.cs
@@ -41,11 +41,9 @@ namespace Foundation {
 		string? name;
 
 		/// <summary>Default constructor, uses the name of the property as the name of the outlet.</summary>
-		///         <remarks>To be added.</remarks>
 		public ConnectAttribute () { }
 		/// <param name="name">The name on the Inteface Builder file.</param>
 		///         <summary>Use this constructor to specify the name of the underlying outlet to map to, instead of defaulting to the name of the property.</summary>
-		///         <remarks>To be added.</remarks>
 		public ConnectAttribute (string name)
 		{
 			this.name = name;
@@ -53,7 +51,6 @@ namespace Foundation {
 
 		/// <summary>The name of the outlet.</summary>
 		///         <value>The name of the outlet if specified, or null if it should default to the property name to which it is applied.</value>
-		///         <remarks>To be added.</remarks>
 		public string? Name {
 			get { return this.name; }
 			set { this.name = value; }

--- a/src/Foundation/ConnectAttribute.cs
+++ b/src/Foundation/ConnectAttribute.cs
@@ -42,8 +42,8 @@ namespace Foundation {
 
 		/// <summary>Default constructor, uses the name of the property as the name of the outlet.</summary>
 		public ConnectAttribute () { }
-		/// <param name="name">The name on the Inteface Builder file.</param>
-		///         <summary>Use this constructor to specify the name of the underlying outlet to map to, instead of defaulting to the name of the property.</summary>
+		/// <summary>Use this constructor to specify the name of the underlying outlet to map to, instead of defaulting to the name of the property.</summary>
+		/// <param name="name">The name in the Interface Builder file.</param>
 		public ConnectAttribute (string name)
 		{
 			this.name = name;

--- a/src/Foundation/NSDimension.cs
+++ b/src/Foundation/NSDimension.cs
@@ -6,9 +6,8 @@ namespace Foundation {
 		// this is something that need to be overridden by subclasses, which is not something we _usually_ do in C#
 		// it is exposed here so we can throw a managed exception if some subclasses (e.g. user code) fails to override
 		// (re-declare with `new`) the static property
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets the base unit of this dimension. Subclasses must override this property.</summary>
+		/// <value>This property always throws; subclasses must provide their own implementation.</value>
 		public static NSDimension BaseUnit {
 
 			get {

--- a/src/Foundation/NSDimension.cs
+++ b/src/Foundation/NSDimension.cs
@@ -6,7 +6,7 @@ namespace Foundation {
 		// this is something that need to be overridden by subclasses, which is not something we _usually_ do in C#
 		// it is exposed here so we can throw a managed exception if some subclasses (e.g. user code) fails to override
 		// (re-declare with `new`) the static property
-		/// <summary>Gets the base unit of this dimension. Subclasses must override this property.</summary>
+		/// <summary>Gets the base unit of this dimension. Subclasses must re-declare this property.</summary>
 		/// <value>This property always throws; subclasses must provide their own implementation.</value>
 		public static NSDimension BaseUnit {
 

--- a/src/Foundation/NSErrorException.cs
+++ b/src/Foundation/NSErrorException.cs
@@ -85,9 +85,8 @@ namespace Foundation {
 			get { return error.UserInfo; }
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets a message that describes the error.</summary>
+		/// <value>The error description from the underlying <see cref="NSError" />.</value>
 		public override string Message {
 			get {
 				return error.Description;

--- a/src/Foundation/NSUuid.cs
+++ b/src/Foundation/NSUuid.cs
@@ -34,9 +34,8 @@ namespace Foundation {
 			}
 		}
 
-		/// <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets the UUID as a 16-byte array.</summary>
+		/// <returns>A 16-byte array containing the UUID value.</returns>
 		public byte [] GetBytes ()
 		{
 			byte [] ret = new byte [16];


### PR DESCRIPTION
Improve XML documentation for:
- `NSScreen` (AppKit)
- `NSTextField` (AppKit)
- `AudioUnitUtils` (AudioUnit)
- `AudioRendererWasFlushedAutomaticallyEventArgs` (AudioToolbox)
- `AVAudioFormat` (AVFoundation)
- `PeripheralScanningOptions` (CoreBluetooth)
- `ConnectAttribute` (Foundation)
- `NSDimension` (Foundation)
- `NSErrorException` (Foundation)
- `NSUuid` (Foundation)

Changes:
- Replace boilerplate 'To be added.' with meaningful descriptions
- Remove empty XML doc nodes
- Fix formatting and indentation

🤖 Pull request created by Copilot