### PR TITLE
[docs] Improve XML docs for PreserveAttribute, CLEnums, MKLocalSearch, and 12 more types

### DIFF
--- a/src/AVFoundation/AVCaptureDeviceInput.cs
+++ b/src/AVFoundation/AVCaptureDeviceInput.cs
@@ -34,10 +34,9 @@
 
 namespace AVFoundation {
 	public partial class AVCaptureDeviceInput {
-		/// <param name="device">To be added.</param>
-		///         <summary>Factory method to create an <see cref="AVFoundation.AVCaptureDeviceInput" /> for the <paramref name="device" />.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <param name="device">The capture device to create an input for.</param>
+		/// <summary>Factory method to create an <see cref="AVFoundation.AVCaptureDeviceInput" /> for the <paramref name="device" />.</summary>
+		/// <returns>A new <see cref="AVCaptureDeviceInput" /> for the specified device, or <see langword="null" /> on failure.</returns>
 		static public AVCaptureDeviceInput? FromDevice (AVCaptureDevice device)
 		{
 			return FromDevice (device, out var error);

--- a/src/AVFoundation/AVCaptureDeviceInput.cs
+++ b/src/AVFoundation/AVCaptureDeviceInput.cs
@@ -34,8 +34,8 @@
 
 namespace AVFoundation {
 	public partial class AVCaptureDeviceInput {
-		/// <param name="device">The capture device to create an input for.</param>
 		/// <summary>Factory method to create an <see cref="AVFoundation.AVCaptureDeviceInput" /> for the <paramref name="device" />.</summary>
+		/// <param name="device">The capture device to create an input for.</param>
 		/// <returns>A new <see cref="AVCaptureDeviceInput" /> for the specified device, or <see langword="null" /> on failure.</returns>
 		static public AVCaptureDeviceInput? FromDevice (AVCaptureDevice device)
 		{

--- a/src/AVFoundation/AVCaptureMetadataOutput.cs
+++ b/src/AVFoundation/AVCaptureMetadataOutput.cs
@@ -34,13 +34,13 @@ namespace AVFoundation {
 
 	public partial class AVCaptureMetadataOutput {
 
-		/// <summary>Keys for the metadata types produced by the active <see cref="AVFoundation.AVCaptureInputPort" />.</summary>
+		/// <summary>Gets the metadata object types produced by the active <see cref="AVFoundation.AVCaptureInputPort" />.</summary>
 		/// <value>The available metadata object types.</value>
 		public AVMetadataObjectType AvailableMetadataObjectTypes {
 			get { return AVMetadataObjectTypeExtensions.ToFlags (WeakAvailableMetadataObjectTypes); }
 		}
 
-		/// <summary>A filter of metadata keys. Only metadata whose keys are in this array will be forwarded to the <see cref="AVFoundation.AVCaptureMetadataOutput.Delegate" /></summary>
+		/// <summary>Gets or sets the metadata object types to filter. Only metadata matching these types will be forwarded to the <see cref="AVFoundation.AVCaptureMetadataOutput.Delegate" />.</summary>
 		/// <value>
 		///   <para tool="nullallowed">This value can be <see langword="null" />.</para>
 		/// </value>

--- a/src/AVFoundation/AVCaptureMetadataOutput.cs
+++ b/src/AVFoundation/AVCaptureMetadataOutput.cs
@@ -35,18 +35,15 @@ namespace AVFoundation {
 	public partial class AVCaptureMetadataOutput {
 
 		/// <summary>Keys for the metadata types produced by the active <see cref="AVFoundation.AVCaptureInputPort" />.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <value>The available metadata object types.</value>
 		public AVMetadataObjectType AvailableMetadataObjectTypes {
 			get { return AVMetadataObjectTypeExtensions.ToFlags (WeakAvailableMetadataObjectTypes); }
 		}
 
 		/// <summary>A filter of metadata keys. Only metadata whose keys are in this array will be forwarded to the <see cref="AVFoundation.AVCaptureMetadataOutput.Delegate" /></summary>
-		///         <value>
-		///           <para>(More documentation for this node is coming)</para>
-		///           <para tool="nullallowed">This value can be <see langword="null" />.</para>
-		///         </value>
-		///         <remarks>To be added.</remarks>
+		/// <value>
+		///   <para tool="nullallowed">This value can be <see langword="null" />.</para>
+		/// </value>
 		public AVMetadataObjectType MetadataObjectTypes {
 			get { return AVMetadataObjectTypeExtensions.ToFlags (WeakMetadataObjectTypes); }
 			set { WeakMetadataObjectTypes = value.ToArray (); }

--- a/src/AppKit/NSSound.cs
+++ b/src/AppKit/NSSound.cs
@@ -30,9 +30,8 @@ namespace AppKit {
 	public partial class NSSound {
 
 		// note: if needed override the protected Get|Set methods
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets or sets the name of the sound.</summary>
+		/// <value>The name identifying this sound.</value>
 		public string Name {
 			get { return GetName (); }
 			// ignore return value (bool)

--- a/src/AppKit/NSSpeechSynthesizer.cs
+++ b/src/AppKit/NSSpeechSynthesizer.cs
@@ -30,9 +30,8 @@ namespace AppKit {
 	public partial class NSSpeechSynthesizer {
 
 		// note: if needed override the protected Get|Set methods
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets or sets the voice used by the speech synthesizer.</summary>
+		/// <value>The identifier of the voice.</value>
 		public string Voice {
 			get { return GetVoice (); }
 			// ignore return value (bool)

--- a/src/AppKit/NSSpellChecker.cs
+++ b/src/AppKit/NSSpellChecker.cs
@@ -30,9 +30,8 @@ namespace AppKit {
 	public partial class NSSpellChecker {
 
 		// note: if needed override the protected Get|Set methods
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets or sets the language used for spell checking.</summary>
+		/// <value>The language identifier.</value>
 		public string Language {
 			get { return GetLanguage (); }
 			// ignore return value (bool)

--- a/src/CoreLocation/CLEnums.cs
+++ b/src/CoreLocation/CLEnums.cs
@@ -124,9 +124,9 @@ namespace CoreLocation {
 		[Deprecated (PlatformName.iOS, 8, 0, message: "Use 'AuthorizedAlways' instead.")]
 		[Deprecated (PlatformName.MacCatalyst, 13, 1, message: "Use 'AuthorizedAlways' instead.")]
 		Authorized,
-		/// <summary>To be added.</summary>
+		/// <summary>The user has authorized the app to access location services at any time.</summary>
 		AuthorizedAlways = Authorized,
-		/// <summary>To be added.</summary>
+		/// <summary>The user has authorized the app to access location services only while the app is in use.</summary>
 		[Deprecated (PlatformName.MacOSX, 13, 0)]
 		AuthorizedWhenInUse,
 	}
@@ -146,7 +146,7 @@ namespace CoreLocation {
 		Fitness,
 		/// <summary>Indicates that the app is involved in navigation, but not in a car. This value should be used for tracking motion in, e.g., trains, planes, and boats.</summary>
 		OtherNavigation,
-		/// <summary>To be added.</summary>
+		/// <summary>Indicates that the app is involved in airborne activities.</summary>
 		[MacCatalyst (13, 1)]
 		Airborne,
 	}

--- a/src/CoreMotion/CMSensorDataList.cs
+++ b/src/CoreMotion/CMSensorDataList.cs
@@ -18,7 +18,6 @@ namespace CoreMotion {
 		#region IEnumerable implementation
 		/// <summary>Gets an enumerator for iterating over accelerometer data.</summary>
 		///         <returns>An enumerator for iterating over accelerometer data.</returns>
-		///         <remarks>To be added.</remarks>
 		public IEnumerator<CMAccelerometerData> GetEnumerator ()
 		{
 			return new NSFastEnumerator<CMAccelerometerData> (this);
@@ -27,8 +26,6 @@ namespace CoreMotion {
 
 		#region IEnumerable implementation
 		/// <summary>For internal use only.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator ()
 		{
 			return GetEnumerator ();

--- a/src/CoreSpotlight/CSSearchableIndex.cs
+++ b/src/CoreSpotlight/CSSearchableIndex.cs
@@ -16,9 +16,9 @@ namespace CoreSpotlight {
 	public partial class CSSearchableIndex {
 
 		// Strongly typed version of initWithName:protectionClass:
+		/// <summary>Creates a new <see cref="CoreSpotlight.CSSearchableIndex" /> with the specified <paramref name="name" /> and protection options.</summary>
 		/// <param name="name">The name of the searchable index.</param>
 		/// <param name="protectionOption">The file protection level for the index.</param>
-		/// <summary>Creates a new <see cref="CoreSpotlight.CSSearchableIndex" /> with the specified <paramref name="name" /> and protection options.</summary>
 		public CSSearchableIndex (string name, CSFileProtection protectionOption = CSFileProtection.None) : this (name, Translate (protectionOption))
 		{ }
 

--- a/src/CoreSpotlight/CSSearchableIndex.cs
+++ b/src/CoreSpotlight/CSSearchableIndex.cs
@@ -16,10 +16,9 @@ namespace CoreSpotlight {
 	public partial class CSSearchableIndex {
 
 		// Strongly typed version of initWithName:protectionClass:
-		/// <param name="name">To be added.</param>
-		///         <param name="protectionOption">To be added.</param>
-		///         <summary>Creates a new <see cref="CoreSpotlight.CSSearchableIndex" /> with the specified <paramref name="name" /> and protection options.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <param name="name">The name of the searchable index.</param>
+		/// <param name="protectionOption">The file protection level for the index.</param>
+		/// <summary>Creates a new <see cref="CoreSpotlight.CSSearchableIndex" /> with the specified <paramref name="name" /> and protection options.</summary>
 		public CSSearchableIndex (string name, CSFileProtection protectionOption = CSFileProtection.None) : this (name, Translate (protectionOption))
 		{ }
 

--- a/src/CoreText/CTFontCollection.cs
+++ b/src/CoreText/CTFontCollection.cs
@@ -103,7 +103,6 @@ namespace CoreText {
 	}
 
 	/// <summary>Font collections are the standard mechanism used to enumerate fonts descriptors.</summary>
-	///     <remarks>To be added.</remarks>
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("macos")]
@@ -145,10 +144,8 @@ namespace CoreText {
 			return result;
 		}
 		/// <param name="queryDescriptors">An array of font descriptors, can be null.</param>
-		///         <param name="options">To be added.</param>
-		///         <summary>Creates a CTFontCollection from the specified set of queryDescriptors.</summary>
-		///         <remarks>
-		///         </remarks>
+		/// <param name="options">The options for matching font descriptors.</param>
+		/// <summary>Creates a CTFontCollection from the specified set of queryDescriptors.</summary>
 		public CTFontCollection (CTFontDescriptor []? queryDescriptors, CTFontCollectionOptions? options)
 			: base (Create (queryDescriptors, options), true, true)
 		{
@@ -200,7 +197,6 @@ namespace CoreText {
 		/// <param name="options">The options to match.</param>
 		///         <summary>Returns an array of font descriptors that have the specified options.</summary>
 		///         <returns>An array of font descriptors that have the specified options.</returns>
-		///         <remarks>To be added.</remarks>
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("tvos")]
 		[SupportedOSPlatform ("maccatalyst")]

--- a/src/CoreText/CTFontCollection.cs
+++ b/src/CoreText/CTFontCollection.cs
@@ -143,9 +143,9 @@ namespace CoreText {
 			GC.KeepAlive (options);
 			return result;
 		}
+		/// <summary>Creates a CTFontCollection from the specified set of queryDescriptors.</summary>
 		/// <param name="queryDescriptors">An array of font descriptors, can be null.</param>
 		/// <param name="options">The options for matching font descriptors.</param>
-		/// <summary>Creates a CTFontCollection from the specified set of queryDescriptors.</summary>
 		public CTFontCollection (CTFontDescriptor []? queryDescriptors, CTFontCollectionOptions? options)
 			: base (Create (queryDescriptors, options), true, true)
 		{

--- a/src/CoreVideo/CVPixelBufferAttributes.cs
+++ b/src/CoreVideo/CVPixelBufferAttributes.cs
@@ -47,8 +47,8 @@ namespace CoreVideo {
 		{
 		}
 
-		/// <param name="dictionary">The dictionary containing pixel buffer attributes.</param>
 		/// <summary>Initializes the strongly typed <see cref="CoreVideo.CVPixelBufferAttributes" /> from the provided dictionary.</summary>
+		/// <param name="dictionary">The dictionary containing pixel buffer attributes.</param>
 		public CVPixelBufferAttributes (NSDictionary dictionary)
 			: base (dictionary)
 		{

--- a/src/CoreVideo/CVPixelBufferAttributes.cs
+++ b/src/CoreVideo/CVPixelBufferAttributes.cs
@@ -42,15 +42,13 @@ namespace CoreVideo {
 	public class CVPixelBufferAttributes : DictionaryContainer {
 #if !COREBUILD
 		/// <summary>Creates an empty set of attributes.</summary>
-		///         <remarks>To be added.</remarks>
 		public CVPixelBufferAttributes ()
 			: base (new NSMutableDictionary ())
 		{
 		}
 
-		/// <param name="dictionary">To be added.</param>
-		///         <summary>Initializes the strongly typed <see cref="CoreVideo.CVPixelBufferAttributes" /> from the provided dictionary.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <param name="dictionary">The dictionary containing pixel buffer attributes.</param>
+		/// <summary>Initializes the strongly typed <see cref="CoreVideo.CVPixelBufferAttributes" /> from the provided dictionary.</summary>
 		public CVPixelBufferAttributes (NSDictionary dictionary)
 			: base (dictionary)
 		{

--- a/src/Foundation/PreserveAttribute.cs
+++ b/src/Foundation/PreserveAttribute.cs
@@ -66,9 +66,8 @@ namespace Foundation {
 		{
 		}
 
-		/// <param name="type">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <param name="type">The type to preserve.</param>
+		/// <summary>Initializes a new instance of the <see cref="PreserveAttribute" /> class with the specified type.</summary>
 		public PreserveAttribute (Type type)
 		{
 		}

--- a/src/Foundation/PreserveAttribute.cs
+++ b/src/Foundation/PreserveAttribute.cs
@@ -66,8 +66,8 @@ namespace Foundation {
 		{
 		}
 
-		/// <param name="type">The type to preserve.</param>
 		/// <summary>Initializes a new instance of the <see cref="PreserveAttribute" /> class with the specified type.</summary>
+		/// <param name="type">The type to preserve.</param>
 		public PreserveAttribute (Type type)
 		{
 		}

--- a/src/GameplayKit/GKGameModel.cs
+++ b/src/GameplayKit/GKGameModel.cs
@@ -3,14 +3,11 @@
 namespace GameplayKit {
 
 	/// <summary>Describes gameplay in a way that can be optimized with a <see cref="GameplayKit.GKMinMaxStrategist" />.</summary>
-	///     <remarks>To be added.</remarks>
 	public partial class GKGameModel {
 
 		/// <summary>The maximum allowable score.</summary>
-		///         <remarks>To be added.</remarks>
 		public const int MaxScore = (1 << 24);
 		/// <summary>The minimum allowable score.</summary>
-		///         <remarks>To be added.</remarks>
 		public const int MinScore = (-(1 << 24));
 	}
 }

--- a/src/HomeKit/HMHome.cs
+++ b/src/HomeKit/HMHome.cs
@@ -6,8 +6,8 @@ using System.Threading.Tasks;
 namespace HomeKit {
 
 	public partial class HMHome {
-		/// <param name="serviceTypes">The service types to filter by.</param>
 		/// <summary>Returns services that accessories in the home provide that are of type <paramref name="serviceTypes" />.</summary>
+		/// <param name="serviceTypes">The service types to filter by.</param>
 		/// <returns>An array of services matching the specified types, or <see langword="null" /> if none are found.</returns>
 		public HMService []? GetServices (HMServiceType serviceTypes)
 		{

--- a/src/HomeKit/HMHome.cs
+++ b/src/HomeKit/HMHome.cs
@@ -6,10 +6,9 @@ using System.Threading.Tasks;
 namespace HomeKit {
 
 	public partial class HMHome {
-		/// <param name="serviceTypes">To be added.</param>
-		///         <summary>Returns services that accessories in the home provide that are of type <paramref name="serviceTypes" />. </summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <param name="serviceTypes">The service types to filter by.</param>
+		/// <summary>Returns services that accessories in the home provide that are of type <paramref name="serviceTypes" />.</summary>
+		/// <returns>An array of services matching the specified types, or <see langword="null" /> if none are found.</returns>
 		public HMService []? GetServices (HMServiceType serviceTypes)
 		{
 			return GetServices (serviceTypes.ToArray ());

--- a/src/LocalAuthentication/LAEnums.cs
+++ b/src/LocalAuthentication/LAEnums.cs
@@ -68,9 +68,9 @@ namespace LocalAuthentication {
 		SystemCancel = -4,
 		/// <summary>Authentication could not start, because passcode is not set on the device.</summary>
 		PasscodeNotSet = -5,
-		/// <summary>To be added.</summary>
+		/// <summary>Authentication was canceled by the application.</summary>
 		AppCancel = -9,
-		/// <summary>To be added.</summary>
+		/// <summary>The authentication context was invalidated.</summary>
 		InvalidContext = -10,
 		[Deprecated (PlatformName.MacOSX, 15, 0, message: "Use 'CompanionNotAvailable' instead.")]
 		[NoiOS, NoMacCatalyst]
@@ -90,7 +90,7 @@ namespace LocalAuthentication {
 		/// <summary>Indicates that biometric authentication has failed too many times, and the user is now locked out.</summary>
 		[MacCatalyst (13, 1)]
 		BiometryLockout = -8,
-		/// <summary>To be added.</summary>
+		/// <summary>Authentication failed because the user interface was not allowed to be presented.</summary>
 		NotInteractive = -1004,
 		CompanionNotAvailable = -11,
 	}

--- a/src/MapKit/MKLocalSearch.cs
+++ b/src/MapKit/MKLocalSearch.cs
@@ -33,8 +33,8 @@ using System.Threading;
 namespace MapKit {
 	public partial class MKLocalSearch {
 
-		/// <param name="token">A cancellation token that can be used to cancel the search.</param>
 		/// <summary>Asynchronously starts the local search.</summary>
+		/// <param name="token">A cancellation token that can be used to cancel the search.</param>
 		/// <returns>A task that represents the asynchronous search operation, containing the search response.</returns>
 		/// <remarks>
 		///   <para tool="threads">This can be used from a background thread.</para>

--- a/src/MapKit/MKLocalSearch.cs
+++ b/src/MapKit/MKLocalSearch.cs
@@ -35,7 +35,7 @@ namespace MapKit {
 
 		/// <summary>Asynchronously starts the local search.</summary>
 		/// <param name="token">A cancellation token that can be used to cancel the search.</param>
-		/// <returns>A task that represents the asynchronous search operation, containing the search response.</returns>
+		/// <returns>A task that represents the asynchronous search operation. The result may be <see langword="null" /> if the search was cancelled.</returns>
 		/// <remarks>
 		///   <para tool="threads">This can be used from a background thread.</para>
 		/// </remarks>

--- a/src/MapKit/MKLocalSearch.cs
+++ b/src/MapKit/MKLocalSearch.cs
@@ -33,13 +33,13 @@ using System.Threading;
 namespace MapKit {
 	public partial class MKLocalSearch {
 
-				/// <param name="token">A cancellation token that can be used to cancel the search.</param>
-				/// <summary>Asynchronously starts the local search.</summary>
-				/// <returns>A task that represents the asynchronous search operation, containing the search response.</returns>
-				/// <remarks>
-				///   <para tool="threads">This can be used from a background thread.</para>
-				/// </remarks>
-				public virtual Task<MKLocalSearchResponse?> StartAsync (CancellationToken token)
+		/// <param name="token">A cancellation token that can be used to cancel the search.</param>
+		/// <summary>Asynchronously starts the local search.</summary>
+		/// <returns>A task that represents the asynchronous search operation, containing the search response.</returns>
+		/// <remarks>
+		///   <para tool="threads">This can be used from a background thread.</para>
+		/// </remarks>
+		public virtual Task<MKLocalSearchResponse?> StartAsync (CancellationToken token)
 		{
 			var tcs = new TaskCompletionSource<MKLocalSearchResponse?> ();
 

--- a/src/MapKit/MKLocalSearch.cs
+++ b/src/MapKit/MKLocalSearch.cs
@@ -33,14 +33,13 @@ using System.Threading;
 namespace MapKit {
 	public partial class MKLocalSearch {
 
-		/// <param name="token">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>
-		///           <para>(More documentation for this node is coming)</para>
-		///           <para tool="threads">This can be used from a background thread.</para>
-		///         </remarks>
-		public virtual Task<MKLocalSearchResponse?> StartAsync (CancellationToken token)
+				/// <param name="token">A cancellation token that can be used to cancel the search.</param>
+				/// <summary>Asynchronously starts the local search.</summary>
+				/// <returns>A task that represents the asynchronous search operation, containing the search response.</returns>
+				/// <remarks>
+				///   <para tool="threads">This can be used from a background thread.</para>
+				/// </remarks>
+				public virtual Task<MKLocalSearchResponse?> StartAsync (CancellationToken token)
 		{
 			var tcs = new TaskCompletionSource<MKLocalSearchResponse?> ();
 


### PR DESCRIPTION
Improve XML documentation for:
- `PreserveAttribute` (Foundation)
- `CMSensorDataList` (CoreMotion)
- `CSSearchableIndex` (CoreSpotlight)
- `CLAuthorizationStatus` and `CLActivityType` (CoreLocation)
- `CTFontCollection` (CoreText)
- `GKGameModel` (GameplayKit)
- `HMHome` (HomeKit)
- `LAStatus` (LocalAuthentication)
- `MKLocalSearch` (MapKit)
- `CVPixelBufferAttributes` (CoreVideo)
- `NSSound` (AppKit)
- `NSSpeechSynthesizer` (AppKit)
- `NSSpellChecker` (AppKit)
- `AVCaptureDeviceInput` (AVFoundation)
- `AVCaptureMetadataOutput` (AVFoundation)

Changes:
- Replace boilerplate 'To be added.' with meaningful descriptions
- Remove empty XML doc nodes
- Fix tag ordering (summary before param)
- Fix indentation

🤖 Pull request created by Copilot