### PR TITLE
[tests] Add a sandboxed macOS 'dotnet watch' test case. Fixes #25816

### DIFF
--- a/tests/dotnet/UnitTests/DotNetWatchTest.cs
+++ b/tests/dotnet/UnitTests/DotNetWatchTest.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Tests {
 		[TestCase (ApplePlatform.MacCatalyst, true, false)]
 		[TestCase (ApplePlatform.iOS, true, false)]
 		[TestCase (ApplePlatform.MacCatalyst, false, true)]
+		[TestCase (ApplePlatform.MacOSX, false, true)]
 		public void DotNetWatch (ApplePlatform platform, bool useMonoRuntime, bool enableSandbox)
 		{
 			DotNetWatchImpl (platform, useMonoRuntime, enableSandbox, usePhysicalDevice: false);

--- a/tests/dotnet/UnitTests/DotNetWatchTest.cs
+++ b/tests/dotnet/UnitTests/DotNetWatchTest.cs
@@ -171,6 +171,12 @@ namespace Xamarin.Tests {
 				logPath = Path.Combine (containerDir, "output.log");
 			}
 			Log ($"The app will write its output to: {logPath}");
+			// Delete any stale log file from a previous run. The sandboxed log file lives in a
+			// well-known location in the app's container (shared between all sandboxed runs), and
+			// the app opens it without truncating, so stale lines from a previous run could
+			// otherwise satisfy the output checks and make the test pass without validating anything.
+			if (File.Exists (logPath))
+				File.Delete (logPath);
 			var pollThread = new Thread ((v) => {
 				Log ($"Output polling thread started. Polling '{logPath}' for app output.");
 				var reportedLines = 0;


### PR DESCRIPTION
Add a test case to verify that 'dotnet watch' (Hot Reload) works with sandboxed macOS apps.

The fix for sandboxed Mac Catalyst apps (#25738) lives entirely in the shared desktop targets (dotnet/targets/Microsoft.Sdk.Desktop.targets, gated on 'SdkIsDesktop == true'), which apply identically to macOS and Mac Catalyst. The 'IsMacEnabled' guard used by the startup-hook-copy logic is true whenever building on a Mac (both macOS and Mac Catalyst), so the same fix already covers sandboxed macOS apps. This test case adds explicit coverage for that scenario.

Fixes https://github.com/dotnet/macios/issues/25816

🤖 Pull request created by Copilot