### PR TITLE
[msbuild] Return full paths from FilterStaticFrameworks. Fixes #19602

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1033,25 +1033,6 @@
 			<Output TaskParameter="FrameworkToPublish" ItemName="_FilteredFrameworkToPublish" />
 		</FilterStaticFrameworks>
 
-		<!--
-
-			We need to use the full path to the framework for frameworks that
-			come from app extensions (since any relative paths from the app
-			extension projects won't be correct once loaded into the
-			containing project), so compute that. However, also do this for
-			app projects, so that we can properly deduplicate frameworks that
-			come from both extensions and the main app project.
-
-		 -->
-		<GetFullPaths
-			Condition="'$(IsMacEnabled)' == 'true'"
-			SessionId="$(BuildSessionId)"
-			Items="@(_FilteredFrameworkToPublish)"
-			Metadata="Identity;SourceDirectory"
-		>
-			<Output TaskParameter="Output" ItemName="_FilteredFrameworkToPublishWithFullPath" />
-		</GetFullPaths>
-
 		<!-- If we're an app extension, store the list of all the frameworks to disk (and don't publish any of them to the appex) -->
 		<!-- Note that app extensions may be nested, so we first check if we have any app extensions with frameworks, read those, then store the full list to disk if we're an app extension, so the containing app project sees everything -->
 		<ReadItemsFromFile File="@(_ResolvedAppExtensionReferences->'%(Identity)\..\native-frameworks.items')" Condition="Exists('%(Identity)\..\native-frameworks.items')">
@@ -1060,7 +1041,7 @@
 
 		<WriteItemsToFile
 			Condition="'$(IsAppExtension)' == 'true'"
-			Items="@(_FilteredFrameworkToPublishWithFullPath);@(_FrameworksFromAppExtensions)"
+			Items="@(_FilteredFrameworkToPublish);@(_FrameworksFromAppExtensions)"
 			ItemName="_FrameworksFromAppExtensions"
 			File="$(DeviceSpecificOutputPath)\native-frameworks.items"
 			IncludeMetadata="true"
@@ -1075,7 +1056,7 @@
 
 		<ItemGroup>
 			<_DirectoriesToPublish Include="@(_FrameworksFromAppExtensions)" Condition="'$(IsAppExtension)' != 'true'" />
-			<_DirectoriesToPublish Include="@(_FilteredFrameworkToPublishWithFullPath)" Condition="'$(IsAppExtension)' != 'true'" />
+			<_DirectoriesToPublish Include="@(_FilteredFrameworkToPublish)" Condition="'$(IsAppExtension)' != 'true'" />
 		</ItemGroup>
 	</Target>
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/FilterStaticFrameworks.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/FilterStaticFrameworks.cs
@@ -73,7 +73,15 @@ namespace Xamarin.MacDev.Tasks {
 				var list = FrameworkToPublish.ToList ();
 				for (var i = list.Count - 1; i >= 0; i--) {
 					var item = list [i];
-					var frameworkExecutablePath = PathUtils.ConvertToMacPath (item.ItemSpec);
+					var frameworkPath = Path.GetFullPath (PathUtils.ConvertToMacPath (item.ItemSpec));
+					var outputItem = new TaskItem (frameworkPath);
+					item.CopyMetadataTo (outputItem);
+					var sourceDirectory = item.GetMetadata ("SourceDirectory");
+					if (!string.IsNullOrEmpty (sourceDirectory))
+						outputItem.SetMetadata ("SourceDirectory", Path.GetFullPath (PathUtils.ConvertToMacPath (sourceDirectory)));
+					list [i] = outputItem;
+
+					var frameworkExecutablePath = frameworkPath;
 					try {
 						if (frameworkExecutablePath.EndsWith (".framework", StringComparison.OrdinalIgnoreCase) && Directory.Exists (frameworkExecutablePath)) {
 							frameworkExecutablePath = GetFrameworkExecutablePath (frameworkExecutablePath, Platform, Log);
@@ -100,9 +108,7 @@ namespace Xamarin.MacDev.Tasks {
 					list.RemoveAt (i);
 				}
 
-				// Copy back the list if anything was removed from it
-				if (FrameworkToPublish.Length != list.Count)
-					FrameworkToPublish = list.ToArray ();
+				FrameworkToPublish = list.ToArray ();
 			}
 
 			return !Log.HasLoggedErrors;

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/FilterStaticFrameworksTaskTest.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/FilterStaticFrameworksTaskTest.cs
@@ -173,6 +173,34 @@ namespace Xamarin.MacDev.Tasks.Tests {
 		}
 
 		[Test]
+		public void TestOutputUsesFullPaths ()
+		{
+			var tempDir = Cache.CreateTemporaryDirectory ();
+			var frameworkDir = Path.Combine (tempDir, "TestFramework.framework");
+			Directory.CreateDirectory (frameworkDir);
+			File.WriteAllBytes (Path.Combine (frameworkDir, "TestFramework"), CreateMinimalMachODylib ());
+
+			var relativeFrameworkDir = Path.GetRelativePath (Directory.GetCurrentDirectory (), frameworkDir);
+			var relativeSourceDir = Path.GetDirectoryName (relativeFrameworkDir) ?? "";
+			var framework = new TaskItem (relativeFrameworkDir.Replace ('/', '\\'));
+			framework.SetMetadata ("SourceDirectory", relativeSourceDir.Replace ('/', '\\'));
+			framework.SetMetadata ("CustomMetadata", "CustomValue");
+
+			var task = CreateTask<FilterStaticFrameworks> ();
+			task.TargetFrameworkMoniker = TargetFramework.GetTargetFramework (ApplePlatform.iOS).ToString ();
+			task.FrameworkToPublish = [framework];
+			task.OnlyFilterFrameworks = true;
+
+			ExecuteTask (task);
+
+			var output = task.FrameworkToPublish ?? throw new InvalidOperationException ("The task did not produce any output.");
+			Assert.That (output, Has.Length.EqualTo (1));
+			Assert.That (output [0].ItemSpec, Is.EqualTo (frameworkDir), "Identity");
+			Assert.That (output [0].GetMetadata ("SourceDirectory"), Is.EqualTo (Path.GetFullPath (relativeSourceDir)), "SourceDirectory");
+			Assert.That (output [0].GetMetadata ("CustomMetadata"), Is.EqualTo ("CustomValue"), "CustomMetadata");
+		}
+
+		[Test]
 		[TestCase (ApplePlatform.iOS, "BadFramework.framework")]
 		[TestCase (ApplePlatform.TVOS, "BadFramework.framework")]
 		[TestCase (ApplePlatform.MacOSX, "BadFramework.framework")]


### PR DESCRIPTION
Resolve framework identities and source directories during the existing remote FilterStaticFrameworks task execution.

This removes the redundant GetFullPaths remote round trip from _ComputeFrameworkFilesToPublish.

Fixes https://github.com/dotnet/macios/issues/19602

🤖 Pull request created by Copilot