### PR TITLE
[docs] Improve XML docs for AVPlayerItem, AVPlayerItemVideoOutput, CKRecord, CABasicAnimation, CAKeyFrameAnimation

### DIFF
--- a/src/AVFoundation/AVPlayerItem.cs
+++ b/src/AVFoundation/AVPlayerItem.cs
@@ -2,9 +2,8 @@
 
 namespace AVFoundation {
 	public partial class AVPlayerItem {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets or sets the video aperture mode for the player item.</summary>
+		/// <value>The video aperture mode.</value>
 		[SupportedOSPlatform ("tvos")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]

--- a/src/AVFoundation/AVPlayerItemVideoOutput.cs
+++ b/src/AVFoundation/AVPlayerItemVideoOutput.cs
@@ -25,10 +25,10 @@ namespace AVFoundation {
 			}
 		}
 
+		/// <summary>Initializes a new instance with the specified pixel buffer attributes.</summary>
 		/// <param name="pixelBufferAttributes">
 		///   <para tool="nullallowed">This parameter can be <see langword="null" />.</para>
 		/// </param>
-		/// <summary>Initializes a new instance with the specified pixel buffer attributes.</summary>
 		[DesignatedInitializer]
 		[Advice ("Please use the constructor that uses one of the available StrongDictionaries. This constructor expects PixelBuffer attributes.")]
 		protected AVPlayerItemVideoOutput (NSDictionary pixelBufferAttributes) : this (pixelBufferAttributes, InitMode.PixelAttributes) { }

--- a/src/AVFoundation/AVPlayerItemVideoOutput.cs
+++ b/src/AVFoundation/AVPlayerItemVideoOutput.cs
@@ -26,11 +26,9 @@ namespace AVFoundation {
 		}
 
 		/// <param name="pixelBufferAttributes">
-		///           <para>To be added.</para>
-		///           <para tool="nullallowed">This parameter can be <see langword="null" />.</para>
-		///         </param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		///   <para tool="nullallowed">This parameter can be <see langword="null" />.</para>
+		/// </param>
+		/// <summary>Initializes a new instance with the specified pixel buffer attributes.</summary>
 		[DesignatedInitializer]
 		[Advice ("Please use the constructor that uses one of the available StrongDictionaries. This constructor expects PixelBuffer attributes.")]
 		protected AVPlayerItemVideoOutput (NSDictionary pixelBufferAttributes) : this (pixelBufferAttributes, InitMode.PixelAttributes) { }

--- a/src/CloudKit/CKRecord.cs
+++ b/src/CloudKit/CKRecord.cs
@@ -5,10 +5,9 @@ using System.Collections.Generic;
 
 namespace CloudKit {
 	public partial class CKRecord {
-		/// <param name="key">To be added.</param>
+		/// <param name="key">The key identifying the record field.</param>
 		/// <summary>Gets or sets the <see cref="Foundation.NSObject" /> value of the field specified by <paramref name="key" />.</summary>
-		/// <value>To be added.</value>
-		/// <remarks>To be added.</remarks>
+		/// <value>The value of the field, or <see langword="null" /> if the field does not exist.</value>
 		public NSObject? this [string key] {
 			get { return _ObjectForKey (key); }
 			set { _SetObject (value.GetHandle (), key); GC.KeepAlive (value); }

--- a/src/CloudKit/CKRecord.cs
+++ b/src/CloudKit/CKRecord.cs
@@ -5,9 +5,9 @@ using System.Collections.Generic;
 
 namespace CloudKit {
 	public partial class CKRecord {
-		/// <param name="key">The key identifying the record field.</param>
 		/// <summary>Gets or sets the <see cref="Foundation.NSObject" /> value of the field specified by <paramref name="key" />.</summary>
 		/// <value>The value of the field, or <see langword="null" /> if the field does not exist.</value>
+		/// <param name="key">The key identifying the record field.</param>
 		public NSObject? this [string key] {
 			get { return _ObjectForKey (key); }
 			set { _SetObject (value.GetHandle (), key); GC.KeepAlive (value); }

--- a/src/CoreAnimation/CABasicAnimation.cs
+++ b/src/CoreAnimation/CABasicAnimation.cs
@@ -8,88 +8,51 @@ using CoreGraphics;
 
 namespace CoreAnimation {
 	public partial class CABasicAnimation {
-		/// <typeparam name="T">To be added.</typeparam>
-		///         <summary>Returns the initial value for the property to animate, returned as an object of the specified type.</summary>
-		///         <returns>
-		///           <para>
-		///           </para>
-		///         </returns>
-		///         <remarks>
-		///           <para>
-		///           </para>
-		///         </remarks>
+		/// <typeparam name="T">The type to return the value as.</typeparam>
+		/// <summary>Returns the initial value for the property to animate, returned as an object of the specified type.</summary>
 		public T GetFromAs<T> () where T : class, INativeObject
 		{
 			return Runtime.GetINativeObject<T> (_From, false)!;
 		}
 
 		/// <param name="value">
-		///           <para>Initial value that the property will have.</para>
-		///           <para>If you want to set the value to null, use the From property.</para>
-		///           <para>
-		///           </para>
-		///         </param>
-		///         <summary>Sets the value for the initial value of the property to animate, by using a non-NSObject type.</summary>
-		///         <remarks>
-		///           <para>
-		///           </para>
-		///         </remarks>
+		///   <para>Initial value that the property will have.</para>
+		///   <para>If you want to set the value to null, use the From property.</para>
+		/// </param>
+		/// <summary>Sets the value for the initial value of the property to animate, by using a non-NSObject type.</summary>
 		public void SetFrom (INativeObject value)
 		{
 			_From = value.Handle;
 			GC.KeepAlive (value);
 		}
 
-		/// <typeparam name="T">To be added.</typeparam>
-		///         <summary>Returns the destination value for the property to animate, returned as an object of the specified type.</summary>
-		///         <returns>
-		///           <para>
-		///           </para>
-		///         </returns>
-		///         <remarks>
-		///           <para>
-		///           </para>
-		///         </remarks>
+		/// <typeparam name="T">The type to return the value as.</typeparam>
+		/// <summary>Returns the destination value for the property to animate, returned as an object of the specified type.</summary>
 		public T GetToAs<T> () where T : class, INativeObject
 		{
 			return Runtime.GetINativeObject<T> (_To, false)!;
 		}
 
 		/// <param name="value">
-		///           <para>Final value that the property will have.</para>
-		///           <para tool="nullallowed">If you want to set the value to null, use the property To.</para>
-		///           <para>
-		///           </para>
-		///         </param>
-		///         <summary>Destination value for the property to animate (using INativeObject).</summary>
-		///         <remarks>
-		///         </remarks>
+		///   <para>Final value that the property will have.</para>
+		///   <para tool="nullallowed">If you want to set the value to null, use the property To.</para>
+		/// </param>
+		/// <summary>Destination value for the property to animate (using INativeObject).</summary>
 		public void SetTo (INativeObject value)
 		{
 			_To = value.Handle;
 			GC.KeepAlive (value);
 		}
 
-		/// <typeparam name="T">To be added.</typeparam>
-		///         <summary>Returns the value to increment by, returned as an object of the specified type.</summary>
-		///         <returns>
-		///           <para />
-		///         </returns>
-		///         <remarks>
-		///           <para />
-		///         </remarks>
+		/// <typeparam name="T">The type to return the value as.</typeparam>
+		/// <summary>Returns the value to increment by, returned as an object of the specified type.</summary>
 		public T GetByAs<T> () where T : class, INativeObject
 		{
 			return Runtime.GetINativeObject<T> (_By, false)!;
 		}
 
-		/// <param name="value">
-		///           <para />
-		///         </param>
-		///         <summary>Sets the value to increment by, by using a non-NSObject type.</summary>
-		///         <remarks>
-		///           <para />
-		///         </remarks>
+		/// <param name="value">The value to increment by.</param>
+		/// <summary>Sets the value to increment by, by using a non-NSObject type.</summary>
 		public void SetBy (INativeObject value)
 		{
 			_By = value.Handle;

--- a/src/CoreAnimation/CABasicAnimation.cs
+++ b/src/CoreAnimation/CABasicAnimation.cs
@@ -8,51 +8,51 @@ using CoreGraphics;
 
 namespace CoreAnimation {
 	public partial class CABasicAnimation {
-		/// <typeparam name="T">The type to return the value as.</typeparam>
 		/// <summary>Returns the initial value for the property to animate, returned as an object of the specified type.</summary>
+		/// <typeparam name="T">The type to return the value as.</typeparam>
 		public T GetFromAs<T> () where T : class, INativeObject
 		{
 			return Runtime.GetINativeObject<T> (_From, false)!;
 		}
 
+		/// <summary>Sets the value for the initial value of the property to animate, by using a non-NSObject type.</summary>
 		/// <param name="value">
 		///   <para>Initial value that the property will have.</para>
 		///   <para>If you want to set the value to null, use the From property.</para>
 		/// </param>
-		/// <summary>Sets the value for the initial value of the property to animate, by using a non-NSObject type.</summary>
 		public void SetFrom (INativeObject value)
 		{
 			_From = value.Handle;
 			GC.KeepAlive (value);
 		}
 
-		/// <typeparam name="T">The type to return the value as.</typeparam>
 		/// <summary>Returns the destination value for the property to animate, returned as an object of the specified type.</summary>
+		/// <typeparam name="T">The type to return the value as.</typeparam>
 		public T GetToAs<T> () where T : class, INativeObject
 		{
 			return Runtime.GetINativeObject<T> (_To, false)!;
 		}
 
+		/// <summary>Destination value for the property to animate (using INativeObject).</summary>
 		/// <param name="value">
 		///   <para>Final value that the property will have.</para>
 		///   <para tool="nullallowed">If you want to set the value to null, use the property To.</para>
 		/// </param>
-		/// <summary>Destination value for the property to animate (using INativeObject).</summary>
 		public void SetTo (INativeObject value)
 		{
 			_To = value.Handle;
 			GC.KeepAlive (value);
 		}
 
-		/// <typeparam name="T">The type to return the value as.</typeparam>
 		/// <summary>Returns the value to increment by, returned as an object of the specified type.</summary>
+		/// <typeparam name="T">The type to return the value as.</typeparam>
 		public T GetByAs<T> () where T : class, INativeObject
 		{
 			return Runtime.GetINativeObject<T> (_By, false)!;
 		}
 
-		/// <param name="value">The value to increment by.</param>
 		/// <summary>Sets the value to increment by, by using a non-NSObject type.</summary>
+		/// <param name="value">The value to increment by.</param>
 		public void SetBy (INativeObject value)
 		{
 			_By = value.Handle;

--- a/src/CoreAnimation/CAKeyFrameAnimation.cs
+++ b/src/CoreAnimation/CAKeyFrameAnimation.cs
@@ -32,9 +32,8 @@ namespace CoreAnimation {
 		// or some other trickery. Our NSString -> C# string -> NSString conversions
 		// were breaking this on the Mac. We look up the equivilant NSString and pass that
 		// along to "fix" this
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets or sets the calculation mode used to interpolate key frame values.</summary>
+		/// <value>The calculation mode string.</value>
 		public virtual string CalculationMode {
 			get {
 				return _CalculationMode;


### PR DESCRIPTION
Improve XML documentation for 5 types:

- **AVPlayerItem**: Document VideoApertureMode property
- **AVPlayerItemVideoOutput**: Document constructor with pixel buffer attributes  
- **CKRecord**: Document indexer property
- **CABasicAnimation**: Document GetFromAs/SetFrom/GetToAs/SetTo/GetByAs/SetBy methods, remove empty remarks/returns
- **CAKeyFrameAnimation**: Document CalculationMode property

Also fix XML doc tag ordering to follow convention (summary before param/typeparam).

🤖 Pull request created by Copilot