### PR TITLE
[msbuild] Strip framework metadata by default. Fixes #15724

### DIFF
--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -1556,6 +1556,13 @@ However, the either of the following works:
 
 Note: this property will always be `false` on macOS and Mac Catalyst.
 
+## StripFrameworkHeaders
+
+A boolean property that specifies whether the `Headers`, `PrivateHeaders`, and
+`Modules` directories are removed from embedded frameworks before code signing.
+
+The default value is `true`. Set it to `false` to preserve these directories.
+
 ## StripPath
 
 The full path to the `strip` command-line tool.

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -1126,6 +1126,18 @@
 	     This target will compute that stamp file location.
 	-->
 	<Target Name="_CreateStampLocationForCopyDirectoriesToBundle">
+		<PropertyGroup>
+			<_CopyDirectoriesToBundleInputFile>$(DeviceSpecificIntermediateOutputPath)CopyDirectoriesToBundleInputs.cache</_CopyDirectoriesToBundleInputFile>
+		</PropertyGroup>
+		<WriteLinesToFile
+			File="$(_CopyDirectoriesToBundleInputFile)"
+			Lines="StripFrameworkHeaders=$(StripFrameworkHeaders)"
+			Overwrite="true"
+			WriteOnlyWhenDifferent="true"
+		/>
+		<ItemGroup>
+			<FileWrites Include="$(_CopyDirectoriesToBundleInputFile)" />
+		</ItemGroup>
 		<ComputeHashForItems
 			Input="@(_DirectoriesToPublish)"
 			InputMetadata="Identity;TargetDirectory"
@@ -1153,7 +1165,7 @@
 
 	<Target Name="_CopyDirectoriesToBundle"
 		DependsOnTargets="_CollectDecompressedPlugins;_ComputeFrameworkFilesToPublish;_CollectDecompressedXpcServices;_CreateStampLocationForCopyDirectoriesToBundle"
-		Inputs="@(_DirectoriesToPublish)"
+		Inputs="@(_DirectoriesToPublish);$(_CopyDirectoriesToBundleInputFile)"
 		Outputs="@(_DirectoriesToPublish -> '%(StampLocation)')"
 		>
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/StripFrameworkHeaders.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/StripFrameworkHeaders.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using Xamarin.Messaging.Build.Client;
+
+#nullable enable
+
+namespace Xamarin.MacDev.Tasks {
+	public class StripFrameworkHeaders : XamarinTask, ITaskCallback {
+		static readonly HashSet<string> directoriesToStrip = new HashSet<string> (StringComparer.Ordinal) {
+			"Headers",
+			"Modules",
+			"PrivateHeaders",
+		};
+
+		[Required]
+		public string AppBundleDir { get; set; } = "";
+
+		public override bool Execute ()
+		{
+			if (ShouldExecuteRemotely ())
+				return ExecuteRemotely ();
+
+			StripFrameworksInDirectory (AppBundleDir);
+
+			return !Log.HasLoggedErrors;
+		}
+
+		void StripFrameworksInDirectory (string directory)
+		{
+			foreach (var subdirectory in Directory.GetDirectories (directory)) {
+				if (IsSymbolicLink (subdirectory))
+					continue;
+
+				if (subdirectory.EndsWith (".framework", StringComparison.OrdinalIgnoreCase))
+					StripFramework (subdirectory);
+
+				StripFrameworksInDirectory (subdirectory);
+			}
+		}
+
+		void StripFramework (string framework)
+		{
+			foreach (var directoryName in directoriesToStrip)
+				RemoveDirectory (Path.Combine (framework, directoryName));
+
+			var versionsDirectory = Path.Combine (framework, "Versions");
+			if (!Directory.Exists (versionsDirectory) || IsSymbolicLink (versionsDirectory))
+				return;
+
+			foreach (var versionDirectory in Directory.GetDirectories (versionsDirectory).Where (directory => !IsSymbolicLink (directory))) {
+				foreach (var directoryName in directoriesToStrip)
+					RemoveDirectory (Path.Combine (versionDirectory, directoryName));
+			}
+		}
+
+		void RemoveDirectory (string directory)
+		{
+			if (!Directory.Exists (directory))
+				return;
+
+			Log.LogMessage (MessageImportance.Low, $"Removing framework directory '{directory}'.");
+			if (IsSymbolicLink (directory))
+				File.Delete (directory);
+			else
+				Directory.Delete (directory, true);
+		}
+
+		static bool IsSymbolicLink (string path)
+		{
+			return (File.GetAttributes (path) & FileAttributes.ReparsePoint) != 0;
+		}
+
+		public IEnumerable<ITaskItem> GetAdditionalItemsToBeCopied ()
+		{
+			return Enumerable.Empty<ITaskItem> ();
+		}
+
+		public bool ShouldCopyToBuildServer (ITaskItem item) => false;
+
+		public bool ShouldCreateOutputFile (ITaskItem item) => false;
+	}
+}

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.props
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.props
@@ -174,6 +174,8 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 		<OptimizePropertyLists Condition="'$(_PlatformName)' == 'macOS' And '$(OptimizePropertyLists)' == ''">false</OptimizePropertyLists>
 		<OptimizePropertyLists Condition="'$(_PlatformName)' != 'macOS' And '$(OptimizePropertyLists)' == ''">true</OptimizePropertyLists>
 
+		<StripFrameworkHeaders Condition="'$(StripFrameworkHeaders)' == ''">true</StripFrameworkHeaders>
+
 		<!-- EnableOnDemandResources: default to true for Xamarin.iOS and false for Xamarin.Mac -->
 		<EnableOnDemandResources Condition="'$(_PlatformName)' == 'macOS' And '$(EnableOnDemandResources)' == ''">false</EnableOnDemandResources>
 		<EnableOnDemandResources Condition="'$(_PlatformName)' != 'macOS' And '$(EnableOnDemandResources)' == ''">true</EnableOnDemandResources>
@@ -299,4 +301,3 @@ Copyright (C) 2020 Microsoft. All rights reserved.
 	<Import Project="$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets"
 			Condition="Exists('$(MSBuildThisFileDirectory)$(MSBuildThisFileName).After.targets')"/>
 </Project>
-

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -96,6 +96,7 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Xamarin.MacDev.Tasks.ScnTool" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Xamarin.MacDev.Tasks.SmartCopy" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Xamarin.MacDev.Tasks.SpotlightIndexer" AssemblyFile="$(_TaskAssemblyName)" />
+	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Xamarin.MacDev.Tasks.StripFrameworkHeaders" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Xamarin.MacDev.Tasks.SymbolStrip" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Xamarin.MacDev.Tasks.TextureAtlas" AssemblyFile="$(_TaskAssemblyName)" />
 	<UsingTask Runtime="$(_TaskRuntime)" TaskName="Xamarin.MacDev.Tasks.UnpackLibraryResources" AssemblyFile="$(_TaskAssemblyName)" />
@@ -2439,12 +2440,20 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 			$(CodesignDependsOn);
 			_CreateAppBundle;
 			BeforeCodeSign;
+			_StripFrameworkHeaders;
 			CoreCodeSign;
 			AfterCodeSign;
 		</CodesignDependsOn>
 	</PropertyGroup>
 
 	<Target Name="BeforeCodesign" />
+	<Target Name="_StripFrameworkHeaders" Condition="'$(StripFrameworkHeaders)' == 'true'">
+		<StripFrameworkHeaders
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			AppBundleDir="$(AppBundleDir)"
+		/>
+	</Target>
 	<Target Name="CoreCodesign" DependsOnTargets="$(CoreCodesignDependsOn)" />
 	<Target Name="AfterCodesign" />
 

--- a/tests/dotnet/UnitTests/BundleStructureTest.cs
+++ b/tests/dotnet/UnitTests/BundleStructureTest.cs
@@ -301,7 +301,7 @@ namespace Xamarin.Tests {
 			AddMultiRidAssembly (platform, expectedFiles, assemblyDirectory, "bindings-framework-test", runtimeIdentifiers, forceSingleRid: platform != ApplePlatform.MacCatalyst || !isReleaseBuild, includeDebugFiles: includeDebugFiles);
 			AddExpectedFrameworkFiles (platform, expectedFiles, "XTest", isSigned);
 
-			AddExpectedFrameworkFiles (platform, expectedFiles, "FrameworkWithLongFileNames", isSigned, longHeader: true);
+			AddExpectedFrameworkFiles (platform, expectedFiles, "FrameworkWithLongFileNames", isSigned, longFile: true);
 
 			// various directories
 			expectedFiles.Add (frameworksDirectory);
@@ -541,11 +541,11 @@ namespace Xamarin.Tests {
 			}
 		}
 
-		static void AddExpectedFrameworkFiles (ApplePlatform platform, List<string> expectedFiles, string frameworkName, CodeSignature signature, string subdirectory = "", bool longHeader = false)
+		static void AddExpectedFrameworkFiles (ApplePlatform platform, List<string> expectedFiles, string frameworkName, CodeSignature signature, string subdirectory = "", bool longFile = false)
 		{
 			var isSigned = signature != CodeSignature.None;
 			var frameworksDirectory = "Frameworks";
-			var headersDirectoryInFramework = "Headers";
+			var longFileInFramework = Path.Combine ("Resources", "full-paths-exceeding-two-hundred-and-sixty-characters", "often-cause-trouble-on-windows", "where-the-maximum-is-by-default-two-hundred-and-sixty-characters", "because-frameworks-and-by-extension-xcframeworks", "very-often-have-paths-longer-than-this-limit", "especially-when-contained-in-other-directories.txt");
 			switch (platform) {
 			case ApplePlatform.iOS:
 			case ApplePlatform.TVOS:
@@ -553,15 +553,11 @@ namespace Xamarin.Tests {
 			case ApplePlatform.MacCatalyst:
 			case ApplePlatform.MacOSX:
 				frameworksDirectory = Path.Combine ("Contents", "Frameworks");
-				headersDirectoryInFramework = Path.Combine ("Versions", "A", "Headers");
+				longFileInFramework = Path.Combine ("Versions", "A", longFileInFramework);
 				break;
 			default:
 				throw new NotImplementedException ($"Unknown platform: {platform}");
 			}
-
-			var headers = new List<string> ();
-			if (longHeader)
-				headers.Add (Path.Combine (headersDirectoryInFramework, "full-paths-exceeding-two-hundred-and-sixty-characters", "often-cause-trouble-on-windows", "where-the-maximum-is-by-default-two-hundred-and-sixty-characters", "because-frameworks-and-by-extension-xcframeworks", "very-often-have-paths-longer-than-this-limit", "especially-when-contained-in-other-directories.h"));
 
 			expectedFiles.Add (Path.Combine (frameworksDirectory, $"{frameworkName}.framework"));
 			expectedFiles.Add (Path.Combine (frameworksDirectory, $"{frameworkName}.framework", frameworkName));
@@ -569,6 +565,8 @@ namespace Xamarin.Tests {
 			case ApplePlatform.iOS:
 			case ApplePlatform.TVOS:
 				expectedFiles.Add (Path.Combine (frameworksDirectory, $"{frameworkName}.framework", "Info.plist"));
+				if (longFile)
+					expectedFiles.Add (Path.Combine (frameworksDirectory, $"{frameworkName}.framework", "Resources"));
 				break;
 			case ApplePlatform.MacCatalyst:
 			case ApplePlatform.MacOSX:
@@ -580,19 +578,17 @@ namespace Xamarin.Tests {
 				expectedFiles.Add (Path.Combine (frameworksDirectory, $"{frameworkName}.framework", "Versions", "A", frameworkName));
 				expectedFiles.Add (Path.Combine (frameworksDirectory, $"{frameworkName}.framework", "Versions", "Current"));
 
-				if (headers.Any ())
-					expectedFiles.Add (Path.Combine (frameworksDirectory, $"{frameworkName}.framework", "Headers"));
 				break;
 			default:
 				throw new NotImplementedException ($"Unknown platform: {platform}");
 			}
 
-			foreach (var header in headers) {
+			if (longFile) {
 				var path = Path.Combine (frameworksDirectory, $"{frameworkName}.framework");
-				var headerComponents = header.Split ('\\', '/');
-				for (var i = 0; i < headerComponents.Length; i++) {
-					path = Path.Combine (path, headerComponents [i]);
-					expectedFiles.Add (path);
+				foreach (var component in longFileInFramework.Split ('\\', '/')) {
+					path = Path.Combine (path, component);
+					if (!expectedFiles.Contains (path))
+						expectedFiles.Add (path);
 				}
 			}
 
@@ -618,6 +614,40 @@ namespace Xamarin.Tests {
 			None,
 			Frameworks,
 			All,
+		}
+
+		[Test]
+		public void PreserveFrameworkHeaders ()
+		{
+			var platform = ApplePlatform.iOS;
+			var runtimeIdentifier = "iossimulator-arm64";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifier);
+
+			var projectPath = GetProjectPath ("BundleStructure", runtimeIdentifiers: runtimeIdentifier, platform: platform, out var appPath);
+			Clean (projectPath);
+
+			var properties = GetDefaultProperties (runtimeIdentifier);
+			properties ["EnableCodeSigning"] = "false";
+			DotNet.AssertBuild (projectPath, properties);
+
+			var header = Path.Combine (appPath, "Frameworks", "FrameworkWithLongFileNames.framework", "Headers", "test.h");
+			Assert.That (header, Does.Not.Exist);
+
+			properties ["StripFrameworkHeaders"] = "false";
+			DotNet.AssertBuild (projectPath, properties);
+
+			Assert.That (header, Does.Exist);
+
+			properties ["StripFrameworkHeaders"] = "true";
+			DotNet.AssertBuild (projectPath, properties);
+
+			Assert.That (header, Does.Not.Exist);
+
+			properties ["StripFrameworkHeaders"] = "false";
+			DotNet.AssertBuild (projectPath, properties);
+
+			Assert.That (header, Does.Exist);
 		}
 
 		[Test]

--- a/tests/dotnet/UnitTests/WindowsTest.cs
+++ b/tests/dotnet/UnitTests/WindowsTest.cs
@@ -105,12 +105,12 @@ namespace Xamarin.Tests {
 			{
 				// 'full-paths-exceeding-two-hundred-and-sixty-characters' is a subdirectory inside the FrameworkWithLongFileNames framework
 				"full-paths-exceeding-two-hundred-and-sixty-characters",
-				// 'especially-when-contained-in-other-directories.h' is a file inside the FrameworkWithLongFileNames framework
-				"especially-when-contained-in-other-directories.h",
+				// 'especially-when-contained-in-other-directories.txt' is a file inside the FrameworkWithLongFileNames framework
+				"especially-when-contained-in-other-directories.txt",
 			};
 			foreach (var ip in invalidPaths) {
 				var withLongFilenames = allFiles.Where (v => v.RelativePath.Contains (ip)).ToArray ();
-				Assert.That (longerThanMax, Is.Empty, $"No paths with '{ip}'");
+				Assert.That (withLongFilenames, Is.Empty, $"No paths with '{ip}'");
 			}
 		}
 

--- a/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/StripFrameworkHeadersTaskTests.cs
+++ b/tests/msbuild/Xamarin.MacDev.Tasks.Tests/TaskTests/StripFrameworkHeadersTaskTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+
+using NUnit.Framework;
+
+using Xamarin.MacDev.Tasks;
+using Xamarin.Utils;
+
+#nullable enable
+
+namespace Xamarin.MacDev.Tasks.Tests {
+	[TestFixture]
+	public class StripFrameworkHeadersTaskTests : TestBase {
+		[Test]
+		public void StripFrameworkDirectories ()
+		{
+			var appBundle = Path.Combine (Cache.CreateTemporaryDirectory (), "Test.app");
+			var flatFramework = Path.Combine (appBundle, "Frameworks", "Flat.framework");
+			var versionedFramework = Path.Combine (appBundle, "Frameworks", "Versioned.framework");
+			var nestedFramework = Path.Combine (appBundle, "PlugIns", "Extension.appex", "Frameworks", "Nested.framework");
+			var unrelatedHeaders = Path.Combine (appBundle, "Headers");
+			var resourceHeaders = Path.Combine (versionedFramework, "Versions", "A", "Resources", "Headers");
+			var symbolicLinks = new [] {
+				Path.Combine (versionedFramework, "Headers"),
+				Path.Combine (versionedFramework, "Modules"),
+				Path.Combine (versionedFramework, "PrivateHeaders"),
+			};
+			var directoriesToStrip = new [] {
+				Path.Combine (flatFramework, "Headers"),
+				Path.Combine (flatFramework, "Modules"),
+				Path.Combine (flatFramework, "PrivateHeaders"),
+				Path.Combine (versionedFramework, "Versions", "A", "Headers"),
+				Path.Combine (versionedFramework, "Versions", "A", "Modules"),
+				Path.Combine (versionedFramework, "Versions", "A", "PrivateHeaders"),
+				Path.Combine (nestedFramework, "Headers"),
+			};
+
+			foreach (var directory in directoriesToStrip) {
+				Directory.CreateDirectory (directory);
+				File.WriteAllText (Path.Combine (directory, "content"), "content");
+			}
+			Directory.CreateDirectory (unrelatedHeaders);
+			Directory.CreateDirectory (resourceHeaders);
+
+			if (!OperatingSystem.IsWindows ()) {
+				foreach (var symbolicLink in symbolicLinks)
+					Directory.CreateSymbolicLink (symbolicLink, Path.Combine ("Versions", "A", Path.GetFileName (symbolicLink)));
+			}
+
+			var task = CreateTask<StripFrameworkHeaders> ();
+			task.AppBundleDir = appBundle;
+			ExecuteTask (task);
+
+			foreach (var directory in directoriesToStrip)
+				Assert.That (directory, Does.Not.Exist);
+			foreach (var symbolicLink in symbolicLinks) {
+				Assert.That (symbolicLink, Does.Not.Exist);
+				Assert.That (new DirectoryInfo (symbolicLink).LinkTarget, Is.Null);
+			}
+			Assert.That (unrelatedHeaders, Does.Exist);
+			Assert.That (resourceHeaders, Does.Exist);
+		}
+	}
+}

--- a/tests/test-libraries/frameworks/Makefile
+++ b/tests/test-libraries/frameworks/Makefile
@@ -46,14 +46,20 @@ iphoneos_HEADERS_INFIX=/Headers
 iphonesimulator_HEADERS_INFIX=/Headers
 tvos_HEADERS_INFIX=/Headers
 tvsimulator_HEADERS_INFIX=/Headers
+iphoneos_RESOURCES_INFIX=/Resources
+iphonesimulator_RESOURCES_INFIX=/Resources
+tvos_RESOURCES_INFIX=/Resources
+tvsimulator_RESOURCES_INFIX=/Resources
 
 mac_SYMLINKS=1
 mac_INFO_PLIST_INFIX=/Versions/A/Resources
 mac_HEADERS_INFIX=/Versions/A/Headers
+mac_RESOURCES_INFIX=/Versions/A/Resources
 mac_BINARY_INFIX=/Versions/A
 maccatalyst_SYMLINKS=1
 maccatalyst_INFO_PLIST_INFIX=/Versions/A/Resources
 maccatalyst_HEADERS_INFIX=/Versions/A/Headers
+maccatalyst_RESOURCES_INFIX=/Versions/A/Resources
 maccatalyst_BINARY_INFIX=/Versions/A
 
 # For XCFrameworks, we have to lipo some of the RID-specific frameworks together (the ones with multiple RIDs below)
@@ -70,14 +76,12 @@ else
 ZIP=zip --symlinks
 endif
 
-LONG_HEADER_NAME=full-paths-exceeding-two-hundred-and-sixty-characters/often-cause-trouble-on-windows/where-the-maximum-is-by-default-two-hundred-and-sixty-characters/because-frameworks-and-by-extension-xcframeworks/very-often-have-paths-longer-than-this-limit/especially-when-contained-in-other-directories.h
+LONG_FILE_NAME=full-paths-exceeding-two-hundred-and-sixty-characters/often-cause-trouble-on-windows/where-the-maximum-is-by-default-two-hundred-and-sixty-characters/because-frameworks-and-by-extension-xcframeworks/very-often-have-paths-longer-than-this-limit/especially-when-contained-in-other-directories.txt
 
 define FrameworkWithHeadersTemplate
-$(3)_$(1)_DIRECTORIES += \
-	.libs/$(3)/$(1).framework/Resources/Headers \
-
 $(1)_$(3)_TARGETS += \
-	.libs/$(3)/$(1).framework$($(2)_HEADERS_INFIX)/$(LONG_HEADER_NAME) \
+	.libs/$(3)/$(1).framework$($(2)_HEADERS_INFIX)/test.h \
+	.libs/$(3)/$(1).framework$($(2)_RESOURCES_INFIX)/$(LONG_FILE_NAME) \
 
 ifeq ($($(2)_SYMLINKS),1)
 $(1)_$(3)_TARGETS += \
@@ -85,9 +89,12 @@ $(1)_$(3)_TARGETS += \
 
 endif
 
-.libs/$(3)/$(1).framework$($(2)_HEADERS_INFIX)/$(LONG_HEADER_NAME): | .libs/$(3)/$(1).framework$($(2)_HEADERS_INFIX)
-	$$(Q) mkdir -p $$(dir $$@)
+.libs/$(3)/$(1).framework$($(2)_HEADERS_INFIX)/test.h: | .libs/$(3)/$(1).framework$($(2)_HEADERS_INFIX)
 	$$(Q) echo "#include <hello/windows.h>" > $$@
+
+.libs/$(3)/$(1).framework$($(2)_RESOURCES_INFIX)/$(LONG_FILE_NAME):
+	$$(Q) mkdir -p $$(dir $$@)
+	$$(Q) echo "A file with a long path" > $$@
 endef
 $(foreach name,$(FRAMEWORKS_WITH_HEADERS),$(foreach platform,$(DOTNET_PLATFORMS),$(foreach rid,$(DOTNET_$(platform)_RUNTIME_IDENTIFIERS),$(eval $(call FrameworkWithHeadersTemplate,$(name),$(DOTNET_$(rid)_SDK_PLATFORM),$(rid))))))
 


### PR DESCRIPTION

Remove Headers, PrivateHeaders, and Modules directories from bundled frameworks before code signing, with `StripFrameworkHeaders=false` as an opt-out.

Invalidate framework copy outputs when the property changes, and preserve Windows remoting long-path coverage by keeping the long fixture in framework resources.

Tests:
- `dotnet test tests/msbuild/Xamarin.MacDev.Tasks.Tests/Xamarin.MacDev.Tasks.Tests.csproj --no-restore --filter FullyQualifiedName~StripFrameworkHeadersTaskTests`
- `dotnet build tests/dotnet/UnitTests/DotNetUnitTests.csproj --no-restore`

Fixes https://github.com/dotnet/macios/issues/15724

🤖 Pull request created by Copilot