### PR TITLE
[docs] Improve XML docs for 19 types (NSValue, MessageComposeResult, ABRecord, etc.)

### DIFF
--- a/src/ARKit/ARFaceGeometry.cs
+++ b/src/ARKit/ARFaceGeometry.cs
@@ -18,8 +18,6 @@ namespace ARKit {
 
 		// Going for GetXXX methods so we can keep the same name as the matching obsoleted property 'Vertices'.
 		/// <summary>The array of X,Y,Z coordinates defining the facial geometry.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public unsafe Vector3 [] GetVertices ()
 		{
 			var count = (int) VertexCount;
@@ -32,8 +30,6 @@ namespace ARKit {
 
 		// Going for GetXXX methods so we can keep the same name as the matching obsoleted property 'TextureCoordinates'.
 		/// <summary>The UV texture coordinates for the corresponding vertex in the <see cref="ARKit.ARFaceGeometry.GetVertices" /> array.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public unsafe Vector2 [] GetTextureCoordinates ()
 		{
 			var count = (int) TextureCoordinateCount;
@@ -46,7 +42,6 @@ namespace ARKit {
 
 		// Going for GetXXX methods so we can keep the same name as the matching obsoleted property 'TriangleIndices'.
 		/// <summary>An array of indices into the <see cref="ARKit.ARFaceGeometry.GetVertices" /> and <see cref="ARKit.ARFaceGeometry.GetTextureCoordinates" /> arrays.</summary>
-		///         <returns>To be added.</returns>
 		///         <remarks>
 		///           <para>Every three subsequent values define the indices of a single triangle. </para>
 		///         </remarks>

--- a/src/ARKit/ARPlaneGeometry.cs
+++ b/src/ARKit/ARPlaneGeometry.cs
@@ -18,8 +18,6 @@ namespace ARKit {
 
 		// Using GetXXX methods so it's similar to the ARFaceGeometry methods.
 		/// <summary>The array of X,Y,Z coordinates defining the plane geometry.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public unsafe Vector3 [] GetVertices ()
 		{
 			var count = (int) VertexCount;
@@ -32,8 +30,6 @@ namespace ARKit {
 
 		// Using GetXXX methods so it's similar to the ARFaceGeometry methods.
 		/// <summary>The UV texture coordinates for the corresponding vertex in the <see cref="ARKit.ARPlaneGeometry.GetVertices" /> array.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public unsafe Vector2 [] GetTextureCoordinates ()
 		{
 			var count = (int) TextureCoordinateCount;
@@ -46,8 +42,6 @@ namespace ARKit {
 
 		// Using GetXXX methods so it's similar to the ARFaceGeometry methods.
 		/// <summary>An array of indices into the <see cref="ARKit.ARPlaneGeometry.GetVertices" /> and <see cref="ARKit.ARPlaneGeometry.GetTextureCoordinates" /> arrays.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public unsafe short [] GetTriangleIndices ()
 		{
 			// There are always 3x more 'TriangleIndices' than 'TriangleCount' since 'TriangleIndices' represents Triangles (set of three indices).
@@ -61,8 +55,6 @@ namespace ARKit {
 
 		// Using GetXXX methods so it's similar to the ARFaceGeometry methods.
 		/// <summary>The vertices that lie along the plane's boundary.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public unsafe Vector3 [] GetBoundaryVertices ()
 		{
 			var count = (int) BoundaryVertexCount;

--- a/src/AddressBook/ABRecord.cs
+++ b/src/AddressBook/ABRecord.cs
@@ -85,10 +85,9 @@ namespace AddressBook {
 		{
 		}
 
-		/// <param name="handle">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <param name="handle">The native handle of the address book record.</param>
+		/// <summary>Creates an <see cref="ABRecord" /> from the specified native handle.</summary>
+		/// <returns>An <see cref="ABRecord" /> instance, or <see langword="null" /> if the handle is invalid.</returns>
 		public static ABRecord? FromHandle (IntPtr handle)
 		{
 			return FromHandle (handle, false);

--- a/src/AddressBook/ABRecord.cs
+++ b/src/AddressBook/ABRecord.cs
@@ -85,8 +85,8 @@ namespace AddressBook {
 		{
 		}
 
-		/// <param name="handle">The native handle of the address book record.</param>
 		/// <summary>Creates an <see cref="ABRecord" /> from the specified native handle.</summary>
+		/// <param name="handle">The native handle of the address book record.</param>
 		/// <returns>An <see cref="ABRecord" /> instance, or <see langword="null" /> if the handle is invalid.</returns>
 		public static ABRecord? FromHandle (IntPtr handle)
 		{

--- a/src/CoreGraphics/NSValue.cs
+++ b/src/CoreGraphics/NSValue.cs
@@ -61,10 +61,9 @@ public partial class NSValue : NSObject {
 	extern static IntPtr xamarin_encode_CGAffineTransform ();
 
 	// The `+valueWithCGAffineTransform:` selector comes from UIKit and is not available on macOS
-	/// <param name="tran">To be added.</param>
+	/// <param name="tran">The affine transform to wrap.</param>
 	/// <summary>Creates an NSValue that wraps a CGAffineTransform object.</summary>
-	/// <returns>To be added.</returns>
-	/// <remarks>To be added.</remarks>
+	/// <returns>An <see cref="NSValue" /> containing the specified transform.</returns>
 	public unsafe static NSValue FromCGAffineTransform (CGAffineTransform tran)
 	{
 		return Create ((IntPtr) (void*) &tran, xamarin_encode_CGAffineTransform ());

--- a/src/CoreGraphics/NSValue.cs
+++ b/src/CoreGraphics/NSValue.cs
@@ -61,8 +61,8 @@ public partial class NSValue : NSObject {
 	extern static IntPtr xamarin_encode_CGAffineTransform ();
 
 	// The `+valueWithCGAffineTransform:` selector comes from UIKit and is not available on macOS
-	/// <param name="tran">The affine transform to wrap.</param>
 	/// <summary>Creates an NSValue that wraps a CGAffineTransform object.</summary>
+	/// <param name="tran">The affine transform to wrap.</param>
 	/// <returns>An <see cref="NSValue" /> containing the specified transform.</returns>
 	public unsafe static NSValue FromCGAffineTransform (CGAffineTransform tran)
 	{

--- a/src/CoreMotion/CMDeviceMotion.cs
+++ b/src/CoreMotion/CMDeviceMotion.cs
@@ -9,22 +9,17 @@ namespace CoreMotion {
 
 	// CMDeviceMotion.h
 	/// <summary>Encapsulates the accuracy and field strength of the magnetometer after calibration.</summary>
-	///     <remarks>To be added.</remarks>
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("maccatalyst")]
 	[StructLayout (LayoutKind.Sequential)]
 	public struct CMCalibratedMagneticField {
 		/// <summary>The magnetic field.</summary>
-		///         <remarks>To be added.</remarks>
 		public CMMagneticField Field;
 		/// <summary>The accuracy of the calibration.</summary>
-		///         <remarks>To be added.</remarks>
 		public CMMagneticFieldCalibrationAccuracy Accuracy;
 
 		/// <summary>A string describing the magnetic field.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public override string ToString ()
 		{
 			return String.Format ("({0},{1})", Field, Accuracy);

--- a/src/CoreMotion/CMMagnetometer.cs
+++ b/src/CoreMotion/CMMagnetometer.cs
@@ -13,25 +13,19 @@ namespace CoreMotion {
 
 	// CMMagnetometer.h
 	/// <summary>Represents the 3-axis magnetometer data in microteslas.</summary>
-	///     <remarks>To be added.</remarks>
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("maccatalyst")]
 	[StructLayout (LayoutKind.Sequential)]
 	public struct CMMagneticField {
 		/// <summary>X component of the magnetic field, measured in microteslas.</summary>
-		///         <remarks>To be added.</remarks>
 		public double X;
 		/// <summary>Y component of the magnetic field, measured in microteslas.</summary>
-		///         <remarks>To be added.</remarks>
 		public double Y;
 		/// <summary>Z component of the magnetic field, measured in microteslas.</summary>
-		///         <remarks>To be added.</remarks>
 		public double Z;
 
 		/// <summary>String representation of the magnetometer reading.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public override string ToString ()
 		{
 			return string.Format ("({0},{1},{2})", X, Y, Z);

--- a/src/CoreVideo/CVPixelFormatDescription.cs
+++ b/src/CoreVideo/CVPixelFormatDescription.cs
@@ -36,7 +36,6 @@ using CVFillExtendedPixelsCallBackDataStruct = CoreVideo.CVFillExtendedPixelsCal
 
 namespace CoreVideo {
 	/// <summary>A class that supports the definition of customer pixel formats.</summary>
-	///     <remarks>To be added.</remarks>
 	public partial class CVPixelFormatDescription {
 #if !COREBUILD
 #if !XAMCORE_5_0

--- a/src/CoreVideo/CVPixelFormatDescription.cs
+++ b/src/CoreVideo/CVPixelFormatDescription.cs
@@ -35,7 +35,7 @@ using CVFillExtendedPixelsCallBackDataStruct = CoreVideo.CVFillExtendedPixelsCal
 #nullable enable
 
 namespace CoreVideo {
-	/// <summary>A class that supports the definition of customer pixel formats.</summary>
+	/// <summary>A class that supports the definition of custom pixel formats.</summary>
 	public partial class CVPixelFormatDescription {
 #if !COREBUILD
 #if !XAMCORE_5_0

--- a/src/MapKit/MKFeatureDisplayPriority.cs
+++ b/src/MapKit/MKFeatureDisplayPriority.cs
@@ -3,7 +3,6 @@
 
 namespace MapKit {
 	/// <summary>Enumerates annotation display priorities.</summary>
-	///     <remarks>To be added.</remarks>
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("macos")]
@@ -11,13 +10,10 @@ namespace MapKit {
 	// .net does not allow float-based enumerations
 	public static class MKFeatureDisplayPriority {
 		/// <summary>Indicates that the annotation is required to be displayed.</summary>
-		///         <remarks>To be added.</remarks>
 		public const float Required = 1000f;
 		/// <summary>Indicates that the annotation is a high priority for display.</summary>
-		///         <remarks>To be added.</remarks>
 		public const float DefaultHigh = 750f;
 		/// <summary>Indicates that the annotation is a low priority for display.</summary>
-		///         <remarks>To be added.</remarks>
 		public const float DefaultLow = 250f;
 	}
 }

--- a/src/MapKit/MKPolygon.cs
+++ b/src/MapKit/MKPolygon.cs
@@ -8,7 +8,6 @@ namespace MapKit {
 
 		/// <param name="points">An array of <see cref="MapKit.MKMapPoint" />s that define the polygon.</param>
 		///         <summary>Creates an <see cref="MapKit.MKPolygon" /> from the specified <paramref name="points" />.</summary>
-		///         <returns>To be added.</returns>
 		///         <remarks>
 		///           <para>(More documentation for this node is coming)</para>
 		///           <para tool="threads">This can be used from a background thread.</para>
@@ -28,7 +27,6 @@ namespace MapKit {
 		/// <param name="points">An array of <see cref="MapKit.MKMapPoint" />s that define the polygon.</param>
 		///         <param name="interiorPolygons">An array of <see cref="MapKit.MKPolygon" />s that should be excluded from the polygon's interior.</param>
 		///         <summary>Creates an <see cref="MapKit.MKPolygon" /> from the specified <paramref name="points" />, excluding the specified <paramref name="interiorPolygons" />.</summary>
-		///         <returns>To be added.</returns>
 		///         <remarks>
 		///           <para>(More documentation for this node is coming)</para>
 		///           <para tool="threads">This can be used from a background thread.</para>
@@ -47,7 +45,6 @@ namespace MapKit {
 
 		/// <param name="coords">An array of <see cref="CoreLocation.CLLocationCoordinate2D" />s that define the desired polygon.</param>
 		///         <summary>Creates an <see cref="MapKit.MKPolygon" /> from the specified <paramref name="coords" />.</summary>
-		///         <returns>To be added.</returns>
 		///         <remarks>
 		///           <para>(More documentation for this node is coming)</para>
 		///           <para tool="threads">This can be used from a background thread.</para>
@@ -67,7 +64,6 @@ namespace MapKit {
 		/// <param name="coords">An array of <see cref="CoreLocation.CLLocationCoordinate2D" />s that define the desired polygon.</param>
 		///         <param name="interiorPolygons">An array of <see cref="MapKit.MKPolygon" />s that should be excluded from the polygon's interior.</param>
 		///         <summary>Creates an <see cref="MapKit.MKPolygon" /> from the specified <paramref name="coords" />, excluding the specified <paramref name="interiorPolygons" />.</summary>
-		///         <returns>To be added.</returns>
 		///         <remarks>
 		///           <para>(More documentation for this node is coming)</para>
 		///           <para tool="threads">This can be used from a background thread.</para>

--- a/src/MessageUI/MessageUI.cs
+++ b/src/MessageUI/MessageUI.cs
@@ -35,11 +35,11 @@ namespace MessageUI {
 	/// <summary>An enumeration whose values specify the various results possible from a message being composed.</summary>
 	[Native]
 	public enum MessageComposeResult : long {
-		/// <summary>To be added.</summary>
+		/// <summary>The message composition was cancelled by the user.</summary>
 		Cancelled,
-		/// <summary>To be added.</summary>
+		/// <summary>The message was sent successfully.</summary>
 		Sent,
-		/// <summary>To be added.</summary>
+		/// <summary>The message failed to send.</summary>
 		Failed,
 	}
 }

--- a/src/Metal/MTLArrays.cs
+++ b/src/Metal/MTLArrays.cs
@@ -77,10 +77,9 @@ namespace Metal {
 	}
 
 	public partial class MTLPipelineBufferDescriptorArray {
-		/// <param name="index">To be added.</param>
+		/// <param name="index">The index of the buffer descriptor to get or set.</param>
 		/// <summary>Gets or sets the mutability of the buffer descriptor at the specified index.</summary>
-		/// <value>To be added.</value>
-		/// <remarks>To be added.</remarks>
+		/// <value>The buffer descriptor at the specified index.</value>
 		public MTLPipelineBufferDescriptor this [nuint index] {
 			get {
 				return GetObject (index);

--- a/src/Metal/MTLArrays.cs
+++ b/src/Metal/MTLArrays.cs
@@ -77,9 +77,9 @@ namespace Metal {
 	}
 
 	public partial class MTLPipelineBufferDescriptorArray {
-		/// <param name="index">The index of the buffer descriptor to get or set.</param>
-		/// <summary>Gets or sets the mutability of the buffer descriptor at the specified index.</summary>
+		/// <summary>Gets or sets the pipeline buffer descriptor at the specified index.</summary>
 		/// <value>The buffer descriptor at the specified index.</value>
+		/// <param name="index">The index of the buffer descriptor to get or set.</param>
 		public MTLPipelineBufferDescriptor this [nuint index] {
 			get {
 				return GetObject (index);

--- a/src/Metal/MTLRenderPassDescriptor.cs
+++ b/src/Metal/MTLRenderPassDescriptor.cs
@@ -4,16 +4,16 @@
 
 namespace Metal {
 	public partial class MTLRenderPassDescriptor {
+		/// <summary>Sets the programmable sample positions with data from <paramref name="positions" />.</summary>
 		/// <param name="positions">The positions to set.</param>
-		///         <summary>Sets the programmable sample postions with data from <paramref name="positions" />.</summary>
 		public unsafe void SetSamplePositions (MTLSamplePosition [] positions)
 		{
 			fixed (void* handle = positions)
 				SetSamplePositions ((IntPtr) handle, (nuint) (positions?.Length ?? 0));
 		}
 
+		/// <summary>Fills <paramref name="positions" /> with programmable sample positions.</summary>
 		/// <param name="positions">An array to fill with sample positions.</param>
-		///         <summary>Fills <paramref name="positions" /> with programmable sample positions.</summary>
 		public unsafe nuint GetSamplePositions (MTLSamplePosition [] positions)
 		{
 			fixed (void* handle = positions) {

--- a/src/Metal/MTLRenderPassDescriptor.cs
+++ b/src/Metal/MTLRenderPassDescriptor.cs
@@ -6,7 +6,6 @@ namespace Metal {
 	public partial class MTLRenderPassDescriptor {
 		/// <param name="positions">The positions to set.</param>
 		///         <summary>Sets the programmable sample postions with data from <paramref name="positions" />.</summary>
-		///         <remarks>To be added.</remarks>
 		public unsafe void SetSamplePositions (MTLSamplePosition [] positions)
 		{
 			fixed (void* handle = positions)
@@ -15,8 +14,6 @@ namespace Metal {
 
 		/// <param name="positions">An array to fill with sample positions.</param>
 		///         <summary>Fills <paramref name="positions" /> with programmable sample positions.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public unsafe nuint GetSamplePositions (MTLSamplePosition [] positions)
 		{
 			fixed (void* handle = positions) {

--- a/src/ModelIO/MDLAsset.cs
+++ b/src/ModelIO/MDLAsset.cs
@@ -2,9 +2,9 @@
 
 namespace ModelIO {
 	public partial class MDLAsset {
-		/// <param name="index">The zero-based index of the object to retrieve.</param>
 		/// <summary>Gets the top-level <see cref="ModelIO.MDLObject" /> node in this asset's indexed list of <see cref="ModelIO.MDLObject" /> nodes, at the specified index.</summary>
 		/// <value>The <see cref="MDLObject" /> at the specified index.</value>
+		/// <param name="index">The zero-based index of the object to retrieve.</param>
 		public MDLObject this [nuint index] {
 			get {
 				return GetObject (index);

--- a/src/ModelIO/MDLAsset.cs
+++ b/src/ModelIO/MDLAsset.cs
@@ -2,10 +2,9 @@
 
 namespace ModelIO {
 	public partial class MDLAsset {
-		/// <param name="index">To be added.</param>
+		/// <param name="index">The zero-based index of the object to retrieve.</param>
 		/// <summary>Gets the top-level <see cref="ModelIO.MDLObject" /> node in this asset's indexed list of <see cref="ModelIO.MDLObject" /> nodes, at the specified index.</summary>
-		/// <value>To be added.</value>
-		/// <remarks>To be added.</remarks>
+		/// <value>The <see cref="MDLObject" /> at the specified index.</value>
 		public MDLObject this [nuint index] {
 			get {
 				return GetObject (index);

--- a/src/Photos/PHAssetCreationRequest.cs
+++ b/src/Photos/PHAssetCreationRequest.cs
@@ -11,8 +11,8 @@
 namespace Photos {
 
 	partial class PHAssetCreationRequest {
-		/// <param name="resourceTypes">The resource types to check for support.</param>
 		/// <summary>Whether Photos supports creating an asset that combines the specified <paramref name="resourceTypes" />.</summary>
+		/// <param name="resourceTypes">The resource types to check for support.</param>
 		/// <returns><see langword="true" /> if the combination of resource types is supported; otherwise, <see langword="false" />.</returns>
 		public bool SupportsAssetResourceTypes (params PHAssetResourceType [] resourceTypes)
 		{

--- a/src/Photos/PHAssetCreationRequest.cs
+++ b/src/Photos/PHAssetCreationRequest.cs
@@ -11,10 +11,9 @@
 namespace Photos {
 
 	partial class PHAssetCreationRequest {
-		/// <param name="resourceTypes">To be added.</param>
-		///         <summary>Whether Photos supports creating an asset that combines the specified <paramref name="resourceTypes" />.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <param name="resourceTypes">The resource types to check for support.</param>
+		/// <summary>Whether Photos supports creating an asset that combines the specified <paramref name="resourceTypes" />.</summary>
+		/// <returns><see langword="true" /> if the combination of resource types is supported; otherwise, <see langword="false" />.</returns>
 		public bool SupportsAssetResourceTypes (params PHAssetResourceType [] resourceTypes)
 		{
 			var l = resourceTypes.Length;

--- a/src/SceneKit/SCNPhysicsTest.cs
+++ b/src/SceneKit/SCNPhysicsTest.cs
@@ -11,9 +11,8 @@
 
 namespace SceneKit {
 	public partial class SCNPhysicsTest {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets or sets the search mode for physics shape tests.</summary>
+		/// <value>The physics search mode.</value>
 		public SCNPhysicsSearchMode SearchMode {
 			get {
 				var k = _SearchMode;

--- a/src/SceneKit/SCNRenderingOptions.cs
+++ b/src/SceneKit/SCNRenderingOptions.cs
@@ -4,9 +4,8 @@
 
 namespace SceneKit {
 	public partial class SCNRenderingOptions {
-		/// <summary>To be added.</summary>
-		/// <value>To be added.</value>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Gets the rendering API used for this scene.</summary>
+		/// <value>The rendering API, or <see langword="null" /> if not specified.</value>
 		[UnsupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("macos")]

--- a/src/SceneKit/SCNSceneLoadingOptions.cs
+++ b/src/SceneKit/SCNSceneLoadingOptions.cs
@@ -3,9 +3,8 @@
 
 namespace SceneKit {
 	public partial class SCNSceneLoadingOptions {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets or sets the animation import policy for scene loading.</summary>
+		/// <value>The animation import policy.</value>
 		public SCNAnimationImportPolicy AnimationImportPolicy {
 			get {
 				var k = _AnimationImportPolicyKey;

--- a/src/UIKit/UIFontFeature.cs
+++ b/src/UIKit/UIFontFeature.cs
@@ -22,9 +22,8 @@ namespace UIKit {
 		FontFeatureGroup fontFeature;
 		object? fontFeatureValue;
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets the native handle for this font feature.</summary>
+		/// <value>The native object handle.</value>
 		NativeHandle INativeObject.Handle {
 			get {
 				return dictionary.Handle;

--- a/src/VideoSubscriberAccount/VSAccountMetadataRequest.cs
+++ b/src/VideoSubscriberAccount/VSAccountMetadataRequest.cs
@@ -6,9 +6,8 @@ using System.Threading.Tasks;
 namespace VideoSubscriberAccount {
 
 	public partial class VSAccountMetadataRequest {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets or sets the authentication schemes supported by the account provider.</summary>
+		/// <value>An array of supported authentication schemes.</value>
 		[SupportedOSPlatform ("tvos")]
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("macos")]


### PR DESCRIPTION
Improve XML documentation for 19 types:

- **NSValue.FromCGAffineTransform**: Document param, returns
- **MessageComposeResult**: Remove empty remarks
- **MTLPipelineBufferDescriptorArray**: Remove empty remarks/returns
- **MKFeatureDisplayPriority**: Remove empty remarks
- **ARFaceGeometry**: Remove empty remarks/returns
- **ARPlaneGeometry**: Remove empty remarks/returns
- **CMCalibratedMagneticField**: Remove empty remarks/returns
- **CMMagneticField**: Remove empty remarks/returns
- **MKPolygon**: Remove empty remarks
- **MTLRenderPassDescriptor**: Remove empty remarks/returns
- **MDLAsset**: Remove empty remarks
- **PHAssetCreationRequest**: Remove empty remarks
- **SCNPhysicsTest**: Remove empty remarks
- **SCNRenderingOptions**: Remove empty remarks
- **SCNSceneLoadingOptions**: Remove empty remarks
- **UIFontFeature**: Remove empty remarks
- **VSAccountMetadataRequest**: Remove empty remarks
- **ABRecord**: Document FromHandle method with proper tag ordering

Also fix XML doc tag ordering to follow convention (summary before param).

🤖 Pull request created by Copilot