### PR TITLE
[linker] Remove Foundation member attributes

### DIFF
--- a/src/ILLink.LinkAttributes.xml.in
+++ b/src/ILLink.LinkAttributes.xml.in
@@ -10,6 +10,12 @@
     <type fullname="Foundation.NotImplementedAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>
+    <type fullname="Foundation.OptionalMemberAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
+    <type fullname="Foundation.RequiredMemberAttribute">
+      <attribute internal="RemoveAttributeInstances" />
+    </type>
 
     <!-- double-check when applied -->
     <type fullname="Foundation.PreserveAttribute">

--- a/tests/dotnet/LinkerAttributesTestApp/AppDelegate.cs
+++ b/tests/dotnet/LinkerAttributesTestApp/AppDelegate.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+using Foundation;
+
+namespace LinkerAttributesTestApp {
+	public class LinkAttributesTest {
+		[Foundation.RequiredMember]
+		public void RequiredProtocolMember ()
+		{
+		}
+
+		[Foundation.OptionalMember]
+		public void OptionalProtocolMember ()
+		{
+		}
+
+		public required string RequiredProperty { get; set; }
+	}
+
+	public class Program {
+		static int Main ()
+		{
+			var linkAttributesTest = new LinkAttributesTest {
+				RequiredProperty = "",
+			};
+			linkAttributesTest.RequiredProtocolMember ();
+			linkAttributesTest.OptionalProtocolMember ();
+			GC.KeepAlive (linkAttributesTest);
+			GC.KeepAlive (typeof (NSObject));
+
+			return 0;
+		}
+	}
+}

--- a/tests/dotnet/LinkerAttributesTestApp/LinkerAttributesTestApp.csproj
+++ b/tests/dotnet/LinkerAttributesTestApp/LinkerAttributesTestApp.csproj
@@ -1,0 +1,13 @@
+<!-- Copyright (c) Microsoft Corporation. -->
+<!-- Licensed under the MIT License. -->
+
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)-ios</TargetFramework>
+		<OutputType>Exe</OutputType>
+		<ApplicationTitle>LinkerAttributesTestApp</ApplicationTitle>
+		<ApplicationId>com.xamarin.linkerattributestestapp</ApplicationId>
+	</PropertyGroup>
+
+	<Import Project="../../common/shared-dotnet.csproj" />
+</Project>

--- a/tests/dotnet/UnitTests/PublishTrimmedTest.cs
+++ b/tests/dotnet/UnitTests/PublishTrimmedTest.cs
@@ -1,3 +1,6 @@
+using Cecil.Tests;
+using Mono.Cecil;
+
 namespace Xamarin.Tests {
 	[TestFixture]
 	public class PublishTrimmedTest : TestBaseClass {
@@ -54,6 +57,47 @@ namespace Xamarin.Tests {
 			// on CI.
 			var targets = BinLog.GetAllTargets (rv.BinLogPath);
 			AssertTargetNotExecuted (targets, "ILLink", "The trimmer should not have executed.");
+		}
+
+		[TestCase (ApplePlatform.iOS)]
+		public void RemoveFoundationMemberAttributes (ApplePlatform platform)
+		{
+			var project = "LinkerAttributesTestApp";
+			Configuration.IgnoreIfIgnoredPlatform (platform);
+			var runtimeIdentifiers = GetDefaultRuntimeIdentifier (platform);
+			Configuration.AssertRuntimeIdentifiersAvailable (platform, runtimeIdentifiers);
+
+			var projectPath = GetProjectPath (project, runtimeIdentifiers: runtimeIdentifiers, platform: platform, out var appPath);
+			Clean (projectPath);
+			var properties = GetDefaultProperties (runtimeIdentifiers);
+			properties ["MtouchLink"] = "Full";
+			properties ["ExcludeTouchUnitReference"] = "true";
+			properties ["ExcludeNUnitLiteReference"] = "true";
+
+			var rv = DotNet.AssertBuild (projectPath, properties);
+			AssertThatLinkerExecuted (rv);
+
+			var assemblyDirectory = Path.Combine (appPath, GetRelativeAssemblyDirectory (platform));
+			var platformAssemblyPath = Path.Combine (assemblyDirectory, $"Microsoft.{platform.AsString ()}.dll");
+			using var platformAssembly = AssemblyDefinition.ReadAssembly (platformAssemblyPath, new ReaderParameters { ReadingMode = ReadingMode.Deferred });
+			var platformAttributeNames = GetCustomAttributeNames (platformAssembly);
+			Assert.That (platformAttributeNames, Does.Not.Contain ("Foundation.RequiredMemberAttribute"), platformAssemblyPath);
+			Assert.That (platformAttributeNames, Does.Not.Contain ("Foundation.OptionalMemberAttribute"), platformAssemblyPath);
+
+			var appAssemblyPath = Path.Combine (assemblyDirectory, $"{project}.dll");
+			using var appAssembly = AssemblyDefinition.ReadAssembly (appAssemblyPath, new ReaderParameters { ReadingMode = ReadingMode.Deferred });
+			var appAttributeNames = GetCustomAttributeNames (appAssembly);
+			Assert.That (appAttributeNames, Does.Not.Contain ("Foundation.RequiredMemberAttribute"), appAssemblyPath);
+			Assert.That (appAttributeNames, Does.Not.Contain ("Foundation.OptionalMemberAttribute"), appAssemblyPath);
+			Assert.That (appAttributeNames, Does.Contain ("System.Runtime.CompilerServices.RequiredMemberAttribute"), appAssemblyPath);
+		}
+
+		static string [] GetCustomAttributeNames (AssemblyDefinition assembly)
+		{
+			return assembly.EnumerateAttributeProviders ().
+				SelectMany (v => v.CustomAttributes).
+				Select (v => v.AttributeType.FullName).
+				ToArray ();
 		}
 	}
 }


### PR DESCRIPTION
Remove `Foundation.RequiredMemberAttribute` and `Foundation.OptionalMemberAttribute` instances unconditionally using the platform assembly's embedded ILLink descriptor.

Add linked-output metadata coverage that verifies both Foundation attributes are removed while `System.Runtime.CompilerServices.RequiredMemberAttribute` remains unaffected.

🤖 Pull request created by Copilot