### PR TITLE
[tests] Fix LinkedAwayGenericTypeAsOptionalMemberInProtocol keeping NSSet<T> alive

### DIFF
--- a/tests/linker/link all/LinkAllTest.cs
+++ b/tests/linker/link all/LinkAllTest.cs
@@ -509,7 +509,10 @@ namespace LinkAll {
 				Assert.Ignore ("This test only applies to the trimmable static registrar.");
 
 			// https://github.com/dotnet/macios/issues/3523
-			Assert.That (typeof (NSObject).Assembly.GetType (NamespacePrefix + "Foundation.NSSet`1"), Is.Null, "NSSet<T> must be linked away, otherwise this test is useless");
+			// Don't use constants here, because the linker can see what we're trying to do and keeps the type we're verifying has been removed.
+			string prefix = NamespacePrefix;
+			string suffix = AssemblyName;
+			Assert.That (Helper.GetType (prefix + "Foundation.NSSet`1, " + suffix), Is.Null, "NSSet<T> must be linked away, otherwise this test is useless");
 		}
 
 		[Protocol (Name = "ProtocolWithGenericsInOptionalMember", WrapperType = typeof (ProtocolWithGenericsInOptionalMemberWrapper))]


### PR DESCRIPTION
The `LinkedAwayGenericTypeAsOptionalMemberInProtocol` test verifies that a generic
type referenced only from an optional protocol member (`Foundation.NSSet<T>`) is
trimmed away when using the trimmable static registrar. It did so with:

    typeof (NSObject).Assembly.GetType (NamespacePrefix + "Foundation.NSSet`1")

Since `NamespacePrefix` is a `const string = ""`, the argument is a compile-time
constant, so ILLink's intrinsic handling of `Assembly.GetType(string)` resolves it
and marks `Foundation.NSSet\`1` as kept — the test's own assertion was the sole reason
the type survived (confirmed via `--dump-dependencies`). The result was the assertion
failing with "NSSet<T> must be linked away, otherwise this test is useless".

Fix it the same way the sibling `RemovedAttributes` test already does: copy the name
pieces into non-const locals and go through `Helper.GetType`, so ILLink can't
statically resolve the type name and keep it. With this change `NSSet<T>` is trimmed
and the test passes.

🤖 Pull request created by Copilot
