### PR TITLE
[registrar] Omit CoreCLR callback entry points. Fixes #21732

### DIFF
--- a/tests/assembly-preparer/ManagedRegistrarStepTests.cs
+++ b/tests/assembly-preparer/ManagedRegistrarStepTests.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace AssemblyPreparerTests;
+
+public class ManagedRegistrarStepTests : BaseClass {
+	[TestCase (XamarinRuntime.CoreCLR, false)]
+	[TestCase (XamarinRuntime.MonoVM, true)]
+	public void UnmanagedCallersOnlyEntryPoint (XamarinRuntime runtime, bool expectedEntryPoint)
+	{
+		var code = @"
+		using Foundation;
+		using ObjCRuntime;
+
+		class MyClass : NSObject {
+			[Export (""myMethod"")]
+			public void MyMethod ()
+			{
+			}
+		}
+		";
+
+		// The runtime is configured independently of the reference assembly set used to compile the test code.
+		AssertPrepare (ApplePlatform.iOS, false, RegistrarMode.ManagedStatic, code, out var assemblyDefinition, $"XamarinRuntime={runtime}");
+
+		var type = assemblyDefinition.MainModule.Types.Single (v => v.Name == "MyClass");
+		var callbackType = type.NestedTypes.Single (v => v.Name == "__Registrar_Callbacks__");
+		var callback = callbackType.Methods.Single (v => v.Name.EndsWith ("_MyMethod", StringComparison.Ordinal));
+		var attribute = callback.CustomAttributes.Single (v => v.AttributeType.FullName == "System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute");
+		var entryPointFields = attribute.Fields.Where (v => v.Name == "EntryPoint").ToArray ();
+
+		if (expectedEntryPoint) {
+			Assert.That (entryPointFields, Has.Exactly (1).Items, "EntryPoint fields");
+			Assert.That (entryPointFields [0].Argument.Value, Is.EqualTo (callback.Name), "EntryPoint");
+		} else {
+			Assert.That (entryPointFields, Is.Empty, "EntryPoint fields");
+		}
+	}
+}

--- a/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-TrimmableStatic-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-TrimmableStatic-size.txt
@@ -1,9 +1,9 @@
-AppBundleSize: 258,070,329 bytes (252,021.8 KB = 246.1 MB)
+AppBundleSize: 257,596,211 bytes (251,558.8 KB = 245.7 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    756 bytes (0.7 KB = 0.0 MB)
+    718 bytes (0.7 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
-    7,387,720 bytes (7,214.6 KB = 7.0 MB)
+    7,386,728 bytes (7,213.6 KB = 7.0 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/_Microsoft.macOS.TypeMap.dll:
     4,847,616 bytes (4,734.0 KB = 4.6 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/_SizeTestApp.TypeMap.dll:
@@ -11,7 +11,7 @@ Contents/MonoBundle/.xamarin/osx-arm64/_SizeTestApp.TypeMap.dll:
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.CSharp.dll:
     892,712 bytes (871.8 KB = 0.9 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.macOS.dll:
-    37,449,728 bytes (36,572.0 KB = 35.7 MB)
+    37,213,184 bytes (36,341.0 KB = 35.5 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.Core.dll:
     1,334,568 bytes (1,303.3 KB = 1.3 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.dll:
@@ -363,7 +363,7 @@ Contents/MonoBundle/.xamarin/osx-x64/_SizeTestApp.TypeMap.dll:
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.CSharp.dll:
     795,944 bytes (777.3 KB = 0.8 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.macOS.dll:
-    37,449,728 bytes (36,572.0 KB = 35.7 MB)
+    37,213,184 bytes (36,341.0 KB = 35.5 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.Core.dll:
     1,166,120 bytes (1,138.8 KB = 1.1 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.dll:

--- a/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-size.txt
@@ -1,13 +1,13 @@
-AppBundleSize: 248,449,511 bytes (242,626.5 KB = 236.9 MB)
+AppBundleSize: 247,975,409 bytes (242,163.5 KB = 236.5 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    756 bytes (0.7 KB = 0.0 MB)
+    718 bytes (0.7 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
-    8,029,512 bytes (7,841.3 KB = 7.7 MB)
+    8,028,536 bytes (7,840.4 KB = 7.7 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.CSharp.dll:
     892,712 bytes (871.8 KB = 0.9 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.macOS.dll:
-    37,168,640 bytes (36,297.5 KB = 35.4 MB)
+    36,932,096 bytes (36,066.5 KB = 35.2 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.Core.dll:
     1,334,568 bytes (1,303.3 KB = 1.3 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.dll:
@@ -355,7 +355,7 @@ Contents/MonoBundle/.xamarin/osx-arm64/WindowsBase.dll:
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.CSharp.dll:
     795,944 bytes (777.3 KB = 0.8 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.macOS.dll:
-    37,168,640 bytes (36,297.5 KB = 35.4 MB)
+    36,932,096 bytes (36,066.5 KB = 35.2 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.Core.dll:
     1,166,120 bytes (1,138.8 KB = 1.1 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.dll:

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -1246,7 +1246,8 @@ namespace Xamarin.Linker {
 		CustomAttribute CreateUnmanagedCallersAttribute (string entryPoint)
 		{
 			var unmanagedCallersAttribute = new CustomAttribute (abr.UnmanagedCallersOnlyAttribute_Constructor);
-			unmanagedCallersAttribute.Fields.Add (new CustomAttributeNamedArgument ("EntryPoint", new CustomAttributeArgument (abr.System_String, entryPoint)));
+			if (App.XamarinRuntime != XamarinRuntime.CoreCLR)
+				unmanagedCallersAttribute.Fields.Add (new CustomAttributeNamedArgument ("EntryPoint", new CustomAttributeArgument (abr.System_String, entryPoint)));
 			return unmanagedCallersAttribute;
 		}
 


### PR DESCRIPTION

Generated managed registrar callbacks targeting CoreCLR still receive `UnmanagedCallersOnlyAttribute`, but no longer include its unused `EntryPoint` named field.

MonoVM and NativeAOT configurations continue to include `EntryPoint`, preserving direct-symbol lookup behavior.

Added focused assembly-preparer tests covering both CoreCLR and MonoVM.

Fixes https://github.com/dotnet/macios/issues/21732

🤖 Pull request created by Copilot
