### PR TITLE
[src] Move focused static initialization to fields

### DIFF
--- a/src/CoreAnimation/CATransform3D.cs
+++ b/src/CoreAnimation/CATransform3D.cs
@@ -40,15 +40,13 @@ namespace CoreAnimation {
 		public nfloat M43;
 		public nfloat M44;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
-		static public readonly CATransform3D Identity;
-
-		static CATransform3D ()
-		{
-			Identity = new CATransform3D ();
-			Identity.M11 = Identity.M22 = Identity.M33 = Identity.M44 = 1f;
-		}
+		/// <summary>The identity transform.</summary>
+		static public readonly CATransform3D Identity = new CATransform3D {
+			M11 = 1f,
+			M22 = 1f,
+			M33 = 1f,
+			M44 = 1f,
+		};
 
 		[DllImport (Constants.QuartzLibrary)]
 		extern static byte CATransform3DIsIdentity (CATransform3D t);

--- a/src/CoreGraphics/CGFunction.cs
+++ b/src/CoreGraphics/CGFunction.cs
@@ -41,14 +41,11 @@ namespace CoreGraphics {
 	public class CGFunction : NativeObject {
 		CGFunctionEvaluate? evaluate;
 
-		static CGFunctionCallbacks cbacks;
-
-		unsafe static CGFunction ()
-		{
-			cbacks.version = 0;
-			cbacks.evaluate = &EvaluateCallback;
-			cbacks.release = &ReleaseCallback;
-		}
+		unsafe static CGFunctionCallbacks cbacks = new CGFunctionCallbacks {
+			version = 0,
+			evaluate = &EvaluateCallback,
+			release = &ReleaseCallback,
+		};
 
 		[Preserve (Conditional = true)]
 		internal CGFunction (NativeHandle handle, bool owns)

--- a/src/CoreGraphics/CGPattern.cs
+++ b/src/CoreGraphics/CGPattern.cs
@@ -87,18 +87,11 @@ namespace CoreGraphics {
 			/* CGFloat */ nfloat xStep, /* CGFloat */ nfloat yStep, CGPatternTiling tiling, byte isColored,
 			/* const CGPatternCallbacks* */ CGPatternCallbacks* callbacks);
 
-		static CGPatternCallbacks callbacks;
-
-		static CGPattern ()
-		{
-			unsafe {
-				callbacks = new CGPatternCallbacks () {
-					version = 0,
-					draw = &DrawCallback,
-					release = &ReleaseCallback,
-				};
-			}
-		}
+		unsafe static CGPatternCallbacks callbacks = new CGPatternCallbacks {
+			version = 0,
+			draw = &DrawCallback,
+			release = &ReleaseCallback,
+		};
 		GCHandle gch;
 
 		public CGPattern (CGRect bounds, CGAffineTransform matrix, nfloat xStep, nfloat yStep, CGPatternTiling tiling, bool isColored, DrawPattern drawPattern)

--- a/src/CoreVideo/CVPixelFormatDescription.cs
+++ b/src/CoreVideo/CVPixelFormatDescription.cs
@@ -40,238 +40,166 @@ namespace CoreVideo {
 	public partial class CVPixelFormatDescription {
 #if !COREBUILD
 #if !XAMCORE_5_0
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.Name" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.Name' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString NameKey;
+		public static readonly NSString NameKey = CVPixelFormatKeys.Name;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.Constant" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.Constant' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString ConstantKey;
+		public static readonly NSString ConstantKey = CVPixelFormatKeys.Constant;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.CodecType" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.CodecType' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString CodecTypeKey;
+		public static readonly NSString CodecTypeKey = CVPixelFormatKeys.CodecType;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.FourCC" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.FourCCKey' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString FourCCKey;
+		public static readonly NSString FourCCKey = CVPixelFormatKeys.FourCC;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.Planes" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.Planes' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString PlanesKey;
+		public static readonly NSString PlanesKey = CVPixelFormatKeys.Planes;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.BlockWidth" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.BlockWidth' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString BlockWidthKey;
+		public static readonly NSString BlockWidthKey = CVPixelFormatKeys.BlockWidth;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.BlockHeight" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.BlockHeight' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString BlockHeightKey;
+		public static readonly NSString BlockHeightKey = CVPixelFormatKeys.BlockHeight;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.BitsPerBlock" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.BitsPerBlock' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString BitsPerBlockKey;
+		public static readonly NSString BitsPerBlockKey = CVPixelFormatKeys.BitsPerBlock;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.BlockHorizontalAlignment" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.BlockHorizontalAlignment' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString BlockHorizontalAlignmentKey;
+		public static readonly NSString BlockHorizontalAlignmentKey = CVPixelFormatKeys.BlockHorizontalAlignment;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.BlockVerticalAlignment" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.BlockVerticalAlignment' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString BlockVerticalAlignmentKey;
+		public static readonly NSString BlockVerticalAlignmentKey = CVPixelFormatKeys.BlockVerticalAlignment;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.BlackBlock" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.BlackBlock' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString BlackBlockKey;
+		public static readonly NSString BlackBlockKey = CVPixelFormatKeys.BlackBlock;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.HorizontalSubsampling" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.HorizontalSubsampling' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString HorizontalSubsamplingKey;
+		public static readonly NSString HorizontalSubsamplingKey = CVPixelFormatKeys.HorizontalSubsampling;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.VerticalSubsampling" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.VerticalSubsampling' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString VerticalSubsamplingKey;
+		public static readonly NSString VerticalSubsamplingKey = CVPixelFormatKeys.VerticalSubsampling;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.OpenGLFormat" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.OpenGLFormat' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString OpenGLFormatKey;
+		public static readonly NSString OpenGLFormatKey = CVPixelFormatKeys.OpenGLFormat;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.OpenGLType" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.OpenGLType' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString OpenGLTypeKey;
+		public static readonly NSString OpenGLTypeKey = CVPixelFormatKeys.OpenGLType;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.OpenGLInternalFormat" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.OpenGLInternalFormat' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString OpenGLInternalFormatKey;
+		public static readonly NSString OpenGLInternalFormatKey = CVPixelFormatKeys.OpenGLInternalFormat;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.CGBitmapInfo" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.CGBitmapInfo' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString CGBitmapInfoKey;
+		public static readonly NSString CGBitmapInfoKey = CVPixelFormatKeys.CGBitmapInfo;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.QDCompatibility" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.QDCompatibility' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString QDCompatibilityKey;
+		public static readonly NSString QDCompatibilityKey = CVPixelFormatKeys.QDCompatibility;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.CGBitmapContextCompatibility" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.CGBitmapContextCompatibility' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString CGBitmapContextCompatibilityKey;
+		public static readonly NSString CGBitmapContextCompatibilityKey = CVPixelFormatKeys.CGBitmapContextCompatibility;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.CGImageCompatibility" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.CGImageCompatibility' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString CGImageCompatibilityKey;
+		public static readonly NSString CGImageCompatibilityKey = CVPixelFormatKeys.CGImageCompatibility;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.OpenGLCompatibility" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.OpenGLCompatibility' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString OpenGLCompatibilityKey;
+		public static readonly NSString OpenGLCompatibilityKey = CVPixelFormatKeys.OpenGLCompatibility;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.FillExtendedPixelsCallback" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.FillExtendedPixelsCallback' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString FillExtendedPixelsCallbackKey;
+		public static readonly NSString FillExtendedPixelsCallbackKey = CVPixelFormatKeys.FillExtendedPixelsCallback;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.ContainsRgb" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.ContainsRgb' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString ContainsRgb;
+		public static readonly NSString ContainsRgb = CVPixelFormatKeys.ContainsRgb;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.ContainsYCbCr" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.ContainsYCbCr' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString ContainsYCbCr;
+		public static readonly NSString ContainsYCbCr = CVPixelFormatKeys.ContainsYCbCr;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.ComponentRange" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.ComponentRange' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString ComponentRangeKey;
+		public static readonly NSString ComponentRangeKey = CVPixelFormatKeys.ComponentRange;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatComponentRangeKeys.FullRange" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatComponentRangeKeys.FullRange' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString ComponentRangeFullRangeKey;
+		public static readonly NSString ComponentRangeFullRangeKey = CVPixelFormatComponentRangeKeys.FullRange;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatComponentRangeKeys.VideoRange" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatComponentRangeKeys.VideoRange' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString ComponentRangeVideoRangeKey;
+		public static readonly NSString ComponentRangeVideoRangeKey = CVPixelFormatComponentRangeKeys.VideoRange;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatComponentRangeKeys.WideRange" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatComponentRangeKeys.WideRange' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
-		public static readonly NSString ComponentRangeWideRangeKey;
+		public static readonly NSString ComponentRangeWideRangeKey = CVPixelFormatComponentRangeKeys.WideRange;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.ContainsGrayscale" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.ContainsGrayscale' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("tvos")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("maccatalyst")]
-		public static readonly NSString ContainsGrayscaleKey;
+		public static readonly NSString ContainsGrayscaleKey = CVPixelFormatKeys.ContainsGrayscale;
 
+		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.ContainsSenselArray" />.</summary>
 		[Obsolete ("Use 'CVPixelFormatKeys.ContainsSenselArray' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		[SupportedOSPlatform ("ios16.0")]
 		[SupportedOSPlatform ("maccatalyst16.0")]
 		[SupportedOSPlatform ("macos13.0")]
 		[SupportedOSPlatform ("tvos16.0")]
-		public static readonly NSString ContainsSenselArray;
-#endif // !XAMCORE_5_0
-
-#if !XAMCORE_5_0
-		static CVPixelFormatDescription ()
-		{
-			NameKey = CVPixelFormatKeys.Name;
-			ConstantKey = CVPixelFormatKeys.Constant;
-			CodecTypeKey = CVPixelFormatKeys.CodecType;
-			FourCCKey = CVPixelFormatKeys.FourCC;
-			PlanesKey = CVPixelFormatKeys.Planes;
-			BlockWidthKey = CVPixelFormatKeys.BlockWidth;
-			BlockHeightKey = CVPixelFormatKeys.BlockHeight;
-			BitsPerBlockKey = CVPixelFormatKeys.BitsPerBlock;
-			BlockHorizontalAlignmentKey = CVPixelFormatKeys.BlockHorizontalAlignment;
-			BlockVerticalAlignmentKey = CVPixelFormatKeys.BlockVerticalAlignment;
-			BlackBlockKey = CVPixelFormatKeys.BlackBlock;
-			HorizontalSubsamplingKey = CVPixelFormatKeys.HorizontalSubsampling;
-			VerticalSubsamplingKey = CVPixelFormatKeys.VerticalSubsampling;
-			OpenGLFormatKey = CVPixelFormatKeys.OpenGLFormat;
-			OpenGLTypeKey = CVPixelFormatKeys.OpenGLType;
-			OpenGLInternalFormatKey = CVPixelFormatKeys.OpenGLInternalFormat;
-			CGBitmapInfoKey = CVPixelFormatKeys.CGBitmapInfo;
-			QDCompatibilityKey = CVPixelFormatKeys.QDCompatibility;
-			CGBitmapContextCompatibilityKey = CVPixelFormatKeys.CGBitmapContextCompatibility;
-			CGImageCompatibilityKey = CVPixelFormatKeys.CGImageCompatibility;
-			OpenGLCompatibilityKey = CVPixelFormatKeys.OpenGLCompatibility;
-			FillExtendedPixelsCallbackKey = CVPixelFormatKeys.FillExtendedPixelsCallback;
-
-			//iOS8 only
-			ContainsRgb = CVPixelFormatKeys.ContainsRgb;
-			ContainsYCbCr = CVPixelFormatKeys.ContainsYCbCr;
-
-			//iOS9 only
-			ComponentRangeKey = CVPixelFormatKeys.ComponentRange;
-			ComponentRangeFullRangeKey = CVPixelFormatComponentRangeKeys.FullRange;
-			ComponentRangeVideoRangeKey = CVPixelFormatComponentRangeKeys.VideoRange;
-			ComponentRangeWideRangeKey = CVPixelFormatComponentRangeKeys.WideRange;
-
-			// Xcode 10
-			ContainsGrayscaleKey = CVPixelFormatKeys.ContainsGrayscale;
-
-			// Xcode 14
 #pragma warning disable CA1416 // This call site is reachable on: 'ios' 12.2 and later, 'maccatalyst' 12.2 and later, 'macOS/OSX' 12.0 and later, 'tvos' 12.2 and later. 'CVPixelFormatKeys.ContainsSenselArray.get' is only supported on: 'ios' 16.0 and later, 'maccatalyst' 16.0 and later, 'macOS/OSX' 13.0 and later, 'tvos' 16.0 and later.
-			ContainsSenselArray = CVPixelFormatKeys.ContainsSenselArray;
+		public static readonly NSString ContainsSenselArray = CVPixelFormatKeys.ContainsSenselArray;
 #pragma warning restore CA1416
-		}
-#endif
+#endif // !XAMCORE_5_0
 
 		// note: bad documentation, ref: https://bugzilla.xamarin.com/show_bug.cgi?id=13917
 		[DllImport (Constants.CoreVideoLibrary)]

--- a/src/CoreVideo/CVPixelFormatDescription.cs
+++ b/src/CoreVideo/CVPixelFormatDescription.cs
@@ -56,7 +56,7 @@ namespace CoreVideo {
 		public static readonly NSString CodecTypeKey = CVPixelFormatKeys.CodecType;
 
 		/// <summary>Obsolete alias for <see cref="CVPixelFormatKeys.FourCC" />.</summary>
-		[Obsolete ("Use 'CVPixelFormatKeys.FourCCKey' instead.")]
+		[Obsolete ("Use 'CVPixelFormatKeys.FourCC' instead.")]
 		[EditorBrowsable (EditorBrowsableState.Never)]
 		public static readonly NSString FourCCKey = CVPixelFormatKeys.FourCC;
 

--- a/src/UIKit/UIScrollView.cs
+++ b/src/UIKit/UIScrollView.cs
@@ -9,18 +9,10 @@
 
 namespace UIKit {
 	/// <summary>Provides data for the <see cref="UIKit.UIScrollView.DraggingEnded" /> event.</summary>
-	///     <remarks>
-	///     </remarks>
 	public partial class DraggingEventArgs : EventArgs {
-		/// <summary>Decelerating.</summary>
-		public readonly static DraggingEventArgs True;
-		/// <summary>Not decelerating.</summary>
-		public readonly static DraggingEventArgs False;
-
-		static DraggingEventArgs ()
-		{
-			True = new DraggingEventArgs (true);
-			False = new DraggingEventArgs (false);
-		}
+		/// <summary>Shared event data indicating that scrolling continues to decelerate after dragging ends.</summary>
+		public readonly static DraggingEventArgs True = new DraggingEventArgs (true);
+		/// <summary>Shared event data indicating that scrolling stops when dragging ends.</summary>
+		public readonly static DraggingEventArgs False = new DraggingEventArgs (false);
 	}
 }


### PR DESCRIPTION

Convert five assignment-only static constructors to direct field initializers so the compiler can mark their types `beforefieldinit`.

This updates:
- `CoreAnimation.CATransform3D`
- `CoreGraphics.CGFunction`
- `CoreGraphics.CGPattern`
- `CoreVideo.CVPixelFormatDescription`
- `UIKit.DraggingEventArgs`

Public fields modified by the conversion now have useful XML documentation.

Follow-up to https://github.com/dotnet/macios/issues/16672.

🤖 Pull request created by Copilot