### PR TITLE
[docs] Improve XML docs for NSCollectionViewLayout, NSPasteboard, NSSharingService, ARPointCloud, CAMediaTimingFunction, CFType, CGPattern, AVAssetDownloadTask, AVOutputSettingsAssistant, CFMachPortContext, GKComponentSystem, HMCharacteristic

### DIFF
--- a/src/ARKit/ARPointCloud.cs
+++ b/src/ARKit/ARPointCloud.cs
@@ -15,8 +15,7 @@ namespace ARKit {
 	public partial class ARPointCloud {
 
 		/// <summary>A set of positions in the world coordinate system. Image-processing tentatively believes that the position is a point on a real-world surface.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <value>An array of 3D points in world coordinates.</value>
 		public unsafe Vector3 [] Points {
 			get {
 				var count = (int) Count;
@@ -29,8 +28,7 @@ namespace ARKit {
 		}
 
 		/// <summary>Gets an array of identifiers that correspond, index by index, to each point in <see cref="ARKit.ARPointCloud.Points" />.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <value>An array of unique identifiers for each point.</value>
 		public unsafe ulong [] Identifiers {
 			get {
 				var count = (int) Count;

--- a/src/AVFoundation/AVAssetDownloadTask.cs
+++ b/src/AVFoundation/AVAssetDownloadTask.cs
@@ -14,21 +14,21 @@ namespace AVFoundation {
 	public partial class AVAssetDownloadTask : NSUrlSessionTask {
 
 		// NSURLRequest and NSURLResponse objects are not available for AVAssetDownloadTask
-		/// <summary>Gets the original URL request object that was passed to the task when the task was initialized.</summary>
+		/// <summary>Not supported. Always throws <see cref="NotSupportedException" />.</summary>
 		public override NSUrlRequest OriginalRequest {
 			get {
 				throw new NotSupportedException ("OriginalRequest not available for AVAssetDownloadTask");
 			}
 		}
 
-		/// <summary>Gets the URL request object that the task is currently handling.</summary>
+		/// <summary>Not supported. Always throws <see cref="NotSupportedException" />.</summary>
 		public override NSUrlRequest CurrentRequest {
 			get {
 				throw new NotSupportedException ("CurrentRequest not available for AVAssetDownloadTask");
 			}
 		}
 
-		/// <summary>Gets the HTTP response for the current request.</summary>
+		/// <summary>Not supported. Always throws <see cref="NotSupportedException" />.</summary>
 		public override NSUrlResponse Response {
 			get {
 				throw new NotSupportedException ("Response not available for AVAssetDownloadTask");

--- a/src/AVFoundation/AVAssetDownloadTask.cs
+++ b/src/AVFoundation/AVAssetDownloadTask.cs
@@ -15,8 +15,6 @@ namespace AVFoundation {
 
 		// NSURLRequest and NSURLResponse objects are not available for AVAssetDownloadTask
 		/// <summary>Gets the original URL request object that was passed to the task when the task was initialized.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public override NSUrlRequest OriginalRequest {
 			get {
 				throw new NotSupportedException ("OriginalRequest not available for AVAssetDownloadTask");
@@ -24,8 +22,6 @@ namespace AVFoundation {
 		}
 
 		/// <summary>Gets the URL request object that the task is currently handling.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public override NSUrlRequest CurrentRequest {
 			get {
 				throw new NotSupportedException ("CurrentRequest not available for AVAssetDownloadTask");
@@ -33,8 +29,6 @@ namespace AVFoundation {
 		}
 
 		/// <summary>Gets the HTTP response for the current request.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public override NSUrlResponse Response {
 			get {
 				throw new NotSupportedException ("Response not available for AVAssetDownloadTask");

--- a/src/AVFoundation/AVOutputSettingsAssistant.cs
+++ b/src/AVFoundation/AVOutputSettingsAssistant.cs
@@ -13,8 +13,6 @@ namespace AVFoundation {
 
 	public unsafe partial class AVOutputSettingsAssistant : NSObject {
 		/// <summary>Preset for 640x480 output.</summary>
-		///         <value>
-		///         </value>
 		public AVOutputSettingsAssistant? Preset640x480 {
 			get {
 				return FromPreset (_Preset640x480);
@@ -22,8 +20,6 @@ namespace AVFoundation {
 		}
 
 		/// <summary>Preset for 960x540 output.</summary>
-		///         <value>
-		///         </value>
 		public AVOutputSettingsAssistant? Preset960x540 {
 			get {
 				return FromPreset (_Preset960x540);
@@ -31,8 +27,6 @@ namespace AVFoundation {
 		}
 
 		/// <summary>Preset for 1280x720 output.</summary>
-		///         <value>
-		///         </value>
 		public AVOutputSettingsAssistant? Preset1280x720 {
 			get {
 				return FromPreset (_Preset1280x720);
@@ -40,8 +34,6 @@ namespace AVFoundation {
 		}
 
 		/// <summary>Preset for 1920x1080 output.</summary>
-		///         <value>
-		///         </value>
 		public AVOutputSettingsAssistant? Preset1920x1080 {
 			get {
 				return FromPreset (_Preset1920x1080);
@@ -55,14 +47,14 @@ namespace AVFoundation {
 			}
 		}
 
-		/// <summary>Preset for HVEC 1920x1080 output.</summary>
+		/// <summary>Preset for HEVC 1920x1080 output.</summary>
 		public AVOutputSettingsAssistant? PresetHevc1920x1080 {
 			get {
 				return FromPreset (_PresetHevc1920x1080);
 			}
 		}
 
-		/// <summary>Preset for HVEC 3840x2160 output</summary>
+		/// <summary>Preset for HEVC 3840x2160 output.</summary>
 		public AVOutputSettingsAssistant? PresetHevc3840x2160 {
 			get {
 				return FromPreset (_PresetHevc3840x2160);

--- a/src/AVFoundation/AVOutputSettingsAssistant.cs
+++ b/src/AVFoundation/AVOutputSettingsAssistant.cs
@@ -15,8 +15,6 @@ namespace AVFoundation {
 		/// <summary>Preset for 640x480 output.</summary>
 		///         <value>
 		///         </value>
-		///         <remarks>
-		///         </remarks>
 		public AVOutputSettingsAssistant? Preset640x480 {
 			get {
 				return FromPreset (_Preset640x480);
@@ -26,8 +24,6 @@ namespace AVFoundation {
 		/// <summary>Preset for 960x540 output.</summary>
 		///         <value>
 		///         </value>
-		///         <remarks>
-		///         </remarks>
 		public AVOutputSettingsAssistant? Preset960x540 {
 			get {
 				return FromPreset (_Preset960x540);
@@ -37,8 +33,6 @@ namespace AVFoundation {
 		/// <summary>Preset for 1280x720 output.</summary>
 		///         <value>
 		///         </value>
-		///         <remarks>
-		///         </remarks>
 		public AVOutputSettingsAssistant? Preset1280x720 {
 			get {
 				return FromPreset (_Preset1280x720);
@@ -48,8 +42,6 @@ namespace AVFoundation {
 		/// <summary>Preset for 1920x1080 output.</summary>
 		///         <value>
 		///         </value>
-		///         <remarks>
-		///         </remarks>
 		public AVOutputSettingsAssistant? Preset1920x1080 {
 			get {
 				return FromPreset (_Preset1920x1080);
@@ -57,8 +49,6 @@ namespace AVFoundation {
 		}
 
 		/// <summary>Preset for 3840x2160 output.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public AVOutputSettingsAssistant? Preset3840x2160 {
 			get {
 				return FromPreset (_Preset3840x2160);
@@ -66,8 +56,6 @@ namespace AVFoundation {
 		}
 
 		/// <summary>Preset for HVEC 1920x1080 output.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public AVOutputSettingsAssistant? PresetHevc1920x1080 {
 			get {
 				return FromPreset (_PresetHevc1920x1080);
@@ -75,8 +63,6 @@ namespace AVFoundation {
 		}
 
 		/// <summary>Preset for HVEC 3840x2160 output</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public AVOutputSettingsAssistant? PresetHevc3840x2160 {
 			get {
 				return FromPreset (_PresetHevc3840x2160);

--- a/src/AppKit/NSCollectionViewLayout.cs
+++ b/src/AppKit/NSCollectionViewLayout.cs
@@ -5,9 +5,9 @@
 namespace AppKit {
 
 	public partial class NSCollectionViewLayout {
+		/// <summary>Registers a class for use in creating decoration views.</summary>
 		/// <param name="itemClass">The class to register for the decoration view.</param>
 		/// <param name="elementKind">The element kind identifier for the decoration view.</param>
-		/// <summary>Registers a class for use in creating decoration views.</summary>
 		public void RegisterClassForDecorationView (Type itemClass, NSString elementKind)
 		{
 			_RegisterClassForDecorationView (Class.GetHandle (itemClass), elementKind);

--- a/src/AppKit/NSCollectionViewLayout.cs
+++ b/src/AppKit/NSCollectionViewLayout.cs
@@ -5,10 +5,9 @@
 namespace AppKit {
 
 	public partial class NSCollectionViewLayout {
-		/// <param name="itemClass">To be added.</param>
-		///         <param name="elementKind">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <param name="itemClass">The class to register for the decoration view.</param>
+		/// <param name="elementKind">The element kind identifier for the decoration view.</param>
+		/// <summary>Registers a class for use in creating decoration views.</summary>
 		public void RegisterClassForDecorationView (Type itemClass, NSString elementKind)
 		{
 			_RegisterClassForDecorationView (Class.GetHandle (itemClass), elementKind);

--- a/src/AppKit/NSPasteboard.cs
+++ b/src/AppKit/NSPasteboard.cs
@@ -6,8 +6,8 @@ using CoreGraphics;
 
 namespace AppKit {
 	public partial class NSPasteboard {
-		/// <param name="objects">The objects to write to the pasteboard.</param>
 		/// <summary>Writes the specified objects to the pasteboard.</summary>
+		/// <param name="objects">The objects to write to the pasteboard.</param>
 		/// <returns><see langword="true" /> if the objects were written successfully; otherwise, <see langword="false" />.</returns>
 		public bool WriteObjects (INSPasteboardWriting [] objects)
 		{

--- a/src/AppKit/NSPasteboard.cs
+++ b/src/AppKit/NSPasteboard.cs
@@ -6,10 +6,9 @@ using CoreGraphics;
 
 namespace AppKit {
 	public partial class NSPasteboard {
-		/// <param name="objects">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <param name="objects">The objects to write to the pasteboard.</param>
+		/// <summary>Writes the specified objects to the pasteboard.</summary>
+		/// <returns><see langword="true" /> if the objects were written successfully; otherwise, <see langword="false" />.</returns>
 		public bool WriteObjects (INSPasteboardWriting [] objects)
 		{
 			var nsa_pasteboardReading = NSArray.FromNSObjects (objects);

--- a/src/AppKit/NSSharingService.cs
+++ b/src/AppKit/NSSharingService.cs
@@ -4,10 +4,9 @@
 
 namespace AppKit {
 	public partial class NSSharingService {
-		/// <param name="service">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <param name="service">The sharing service to retrieve.</param>
+		/// <summary>Returns the sharing service for the specified service name.</summary>
+		/// <returns>The sharing service, or <see langword="null" /> if the service is not available.</returns>
 		public static NSSharingService? GetSharingService (NSSharingServiceName service)
 		{
 			var constant = service.GetConstant ();

--- a/src/AppKit/NSSharingService.cs
+++ b/src/AppKit/NSSharingService.cs
@@ -4,8 +4,8 @@
 
 namespace AppKit {
 	public partial class NSSharingService {
-		/// <param name="service">The sharing service to retrieve.</param>
 		/// <summary>Returns the sharing service for the specified service name.</summary>
+		/// <param name="service">The sharing service to retrieve.</param>
 		/// <returns>The sharing service, or <see langword="null" /> if the service is not available.</returns>
 		public static NSSharingService? GetSharingService (NSSharingServiceName service)
 		{

--- a/src/CoreAnimation/CAMediaTimingFunction.cs
+++ b/src/CoreAnimation/CAMediaTimingFunction.cs
@@ -32,10 +32,9 @@ using CoreGraphics;
 
 namespace CoreAnimation {
 	public unsafe partial class CAMediaTimingFunction {
-		/// <param name="index">To be added.</param>
-		/// <summary>To be added.</summary>
-		/// <returns>To be added.</returns>
-		/// <remarks>To be added.</remarks>
+		/// <param name="index">The index of the control point (0-3).</param>
+		/// <summary>Gets the control point at the specified index.</summary>
+		/// <returns>The control point at the specified index.</returns>
 		public CGPoint GetControlPoint (nint index)
 		{
 			if ((index < 0) || (index > 3))

--- a/src/CoreAnimation/CAMediaTimingFunction.cs
+++ b/src/CoreAnimation/CAMediaTimingFunction.cs
@@ -32,8 +32,8 @@ using CoreGraphics;
 
 namespace CoreAnimation {
 	public unsafe partial class CAMediaTimingFunction {
-		/// <param name="index">The index of the control point (0-3).</param>
 		/// <summary>Gets the control point at the specified index.</summary>
+		/// <param name="index">The index of the control point (0-3).</param>
 		/// <returns>The control point at the specified index.</returns>
 		public CGPoint GetControlPoint (nint index)
 		{

--- a/src/CoreFoundation/CFMachPort.cs
+++ b/src/CoreFoundation/CFMachPort.cs
@@ -52,8 +52,6 @@ namespace CoreFoundation {
 		extern static IntPtr CFMachPortGetPort (IntPtr handle);
 
 		/// <summary>Gets the pointer to the wrapped Mach port instance.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public IntPtr MachPort {
 			get {
 				return CFMachPortGetPort (Handle);
@@ -64,7 +62,6 @@ namespace CoreFoundation {
 		extern static void CFMachPortInvalidate (IntPtr handle);
 
 		/// <summary>Stops the Mach port from sending or receiving messages, but does not destroy it.</summary>
-		///         <remarks>To be added.</remarks>
 		public void Invalidate ()
 		{
 			CFMachPortInvalidate (Handle);
@@ -73,8 +70,6 @@ namespace CoreFoundation {
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static byte CFMachPortIsValid (IntPtr handle);
 		/// <summary>Gets a value that tells whether the port can send and receive messages.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public bool IsValid {
 			get {
 				return CFMachPortIsValid (Handle) != 0;
@@ -85,8 +80,6 @@ namespace CoreFoundation {
 		extern static IntPtr CFMachPortCreateRunLoopSource (IntPtr allocator, IntPtr port, IntPtr order);
 
 		/// <summary>Creates the run loop source for the Mach port.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public CFRunLoopSource CreateRunLoopSource ()
 		{
 			// order is currently ignored, we must pass 0

--- a/src/CoreFoundation/CFType.cs
+++ b/src/CoreFoundation/CFType.cs
@@ -27,8 +27,7 @@ namespace CoreFoundation {
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static IntPtr CFCopyDescription (IntPtr ptr);
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Initializes a new instance of the <see cref="CFType" /> class.</summary>
 		internal CFType ()
 		{
 		}
@@ -56,12 +55,10 @@ namespace CoreFoundation {
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static byte CFEqual (/*CFTypeRef*/ IntPtr cf1, /*CFTypeRef*/ IntPtr cf2);
 
-		/// <param name="cf1">To be added.</param>
-		///         <param name="cf2">To be added.</param>
-		///         <summary>Compares two handles of native objects for equality.</summary>
-		///         <returns>true if the types are the same.</returns>
-		///         <remarks>
-		///         </remarks>
+		/// <param name="cf1">The first CoreFoundation object handle.</param>
+		/// <param name="cf2">The second CoreFoundation object handle.</param>
+		/// <summary>Compares two handles of native objects for equality.</summary>
+		/// <returns>true if the types are the same.</returns>
 		public static bool Equal (IntPtr cf1, IntPtr cf2)
 		{
 			// CFEqual is not happy (but crashy) when it receive null

--- a/src/CoreFoundation/CFType.cs
+++ b/src/CoreFoundation/CFType.cs
@@ -8,19 +8,13 @@ using CoreFoundation;
 
 namespace CoreFoundation {
 	/// <summary>Base type for some Core Foundation classes, such as <see cref="CoreFoundation.CFSocket" /> and <see cref="CoreFoundation.CFStream" />.</summary>
-	///     <remarks>
-	///     </remarks>
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("tvos")]
 	public class CFType : NativeObject, ICFType {
+		/// <summary>Returns the CoreFoundation type for the specified object.</summary>
 		/// <param name="typeRef">Handle to a CoreFoundation object.</param>
-		///         <summary>Returns the CoreFoundation type for the specified object.</summary>
-		///         <returns>
-		///         </returns>
-		///         <remarks>
-		///         </remarks>
 		[DllImport (Constants.CoreFoundationLibrary, EntryPoint = "CFGetTypeID")]
 		public static extern nint GetTypeID (IntPtr typeRef);
 
@@ -38,12 +32,8 @@ namespace CoreFoundation {
 		{
 		}
 
+		/// <summary>Returns a textual representation of the specified object.</summary>
 		/// <param name="handle">Handle to the native CoreFoundation object.</param>
-		///         <summary>Returns a textual representation of the specified object.</summary>
-		///         <returns>
-		///         </returns>
-		///         <remarks>
-		///         </remarks>
 		public string? GetDescription (IntPtr handle)
 		{
 			if (handle == IntPtr.Zero)
@@ -55,9 +45,9 @@ namespace CoreFoundation {
 		[DllImport (Constants.CoreFoundationLibrary)]
 		extern static byte CFEqual (/*CFTypeRef*/ IntPtr cf1, /*CFTypeRef*/ IntPtr cf2);
 
+		/// <summary>Compares two handles of native objects for equality.</summary>
 		/// <param name="cf1">The first CoreFoundation object handle.</param>
 		/// <param name="cf2">The second CoreFoundation object handle.</param>
-		/// <summary>Compares two handles of native objects for equality.</summary>
 		/// <returns>true if the types are the same.</returns>
 		public static bool Equal (IntPtr cf1, IntPtr cf2)
 		{

--- a/src/CoreFoundation/CFType.cs
+++ b/src/CoreFoundation/CFType.cs
@@ -13,7 +13,7 @@ namespace CoreFoundation {
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("tvos")]
 	public class CFType : NativeObject, ICFType {
-		/// <summary>Returns the CoreFoundation type for the specified object.</summary>
+		/// <summary>Returns the CoreFoundation type identifier for the specified object.</summary>
 		/// <param name="typeRef">Handle to a CoreFoundation object.</param>
 		[DllImport (Constants.CoreFoundationLibrary, EntryPoint = "CFGetTypeID")]
 		public static extern nint GetTypeID (IntPtr typeRef);
@@ -48,7 +48,7 @@ namespace CoreFoundation {
 		/// <summary>Compares two handles of native objects for equality.</summary>
 		/// <param name="cf1">The first CoreFoundation object handle.</param>
 		/// <param name="cf2">The second CoreFoundation object handle.</param>
-		/// <returns>true if the types are the same.</returns>
+		/// <returns><see langword="true" /> if the two objects are equal; otherwise, <see langword="false" />.</returns>
 		public static bool Equal (IntPtr cf1, IntPtr cf2)
 		{
 			// CFEqual is not happy (but crashy) when it receive null

--- a/src/CoreGraphics/CGPattern.cs
+++ b/src/CoreGraphics/CGPattern.cs
@@ -33,7 +33,7 @@ using CoreFoundation;
 namespace CoreGraphics {
 
 	// untyped enum -> CGPattern.h
-	/// <summary>Pattern styling style.</summary>
+	/// <summary>Specifies the tiling mode for a pattern.</summary>
 	public enum CGPatternTiling {
 		/// <summary>No distortion.</summary>
 		NoDistortion,

--- a/src/CoreGraphics/CGPattern.cs
+++ b/src/CoreGraphics/CGPattern.cs
@@ -34,13 +34,12 @@ namespace CoreGraphics {
 
 	// untyped enum -> CGPattern.h
 	/// <summary>Pattern styling style.</summary>
-	///     <remarks>To be added.</remarks>
 	public enum CGPatternTiling {
 		/// <summary>No distortion.</summary>
 		NoDistortion,
-		/// <summary>To be added.</summary>
+		/// <summary>Constant spacing with minimal distortion.</summary>
 		ConstantSpacingMinimalDistortion,
-		/// <summary>To be added.</summary>
+		/// <summary>Constant spacing.</summary>
 		ConstantSpacing,
 	}
 
@@ -57,9 +56,8 @@ namespace CoreGraphics {
 
 
 	/// <summary>A pattern to draw in a CGContext.</summary>
-	///     <remarks>To be added.</remarks>
-	///     <related type="sample" href="https://github.com/xamarin/ios-samples/tree/master/Drawing/">Example_Drawing</related>
-	///     <related type="sample" href="https://github.com/xamarin/ios-samples/tree/master/QuartzSample/">QuartzSample</related>
+	/// <related type="sample" href="https://github.com/xamarin/ios-samples/tree/master/Drawing/">Example_Drawing</related>
+	/// <related type="sample" href="https://github.com/xamarin/ios-samples/tree/master/QuartzSample/">QuartzSample</related>
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("macos")]

--- a/src/GameplayKit/GKComponentSystem.cs
+++ b/src/GameplayKit/GKComponentSystem.cs
@@ -23,8 +23,8 @@ namespace GameplayKit {
 			get { return Class.Lookup (ComponentClass); }
 		}
 
-		/// <param name="index">The 0-based index of the component to get.</param>
 		/// <summary>Gets the component at the specified index from the array of components that are contained in the component system.</summary>
+		/// <param name="index">The 0-based index of the component to get.</param>
 		public TComponent this [nuint index] {
 			get { return ObjectAtIndexedSubscript (index); }
 		}

--- a/src/GameplayKit/GKComponentSystem.cs
+++ b/src/GameplayKit/GKComponentSystem.cs
@@ -13,23 +13,18 @@ namespace GameplayKit {
 	public partial class GKComponentSystem<TComponent> {
 
 		/// <summary>Creates a new component system object with default values.</summary>
-		///         <remarks>To be added.</remarks>
 		public GKComponentSystem ()
 			: this (GKState.GetClass (typeof (TComponent), "componentType"))
 		{
 		}
 
 		/// <summary>Gets the System.Type that represents the component class of the components that can be contained in this component system.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public Type? ComponentType {
 			get { return Class.Lookup (ComponentClass); }
 		}
 
 		/// <param name="index">The 0-based index of the component to get.</param>
 		/// <summary>Gets the component at the specified index from the array of components that are contained in the component system.</summary>
-		/// <value>To be added.</value>
-		/// <remarks>To be added.</remarks>
 		public TComponent this [nuint index] {
 			get { return ObjectAtIndexedSubscript (index); }
 		}

--- a/src/HomeKit/HMCharacteristic.cs
+++ b/src/HomeKit/HMCharacteristic.cs
@@ -4,8 +4,6 @@ namespace HomeKit {
 
 	partial class HMCharacteristic {
 		/// <summary>Gets a value that tells whether the characteristic supports event notifications.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public bool SupportsEventNotification {
 			get {
 				foreach (var p in Properties) {
@@ -17,8 +15,6 @@ namespace HomeKit {
 		}
 
 		/// <summary>Gets a value that tells whether the characteristic value is readable.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public bool Readable {
 			get {
 				foreach (var p in Properties) {
@@ -30,8 +26,6 @@ namespace HomeKit {
 		}
 
 		/// <summary>Gets a value that tells whether the characteristic is writeable.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public bool Writable {
 			get {
 				foreach (var p in Properties) {
@@ -43,8 +37,6 @@ namespace HomeKit {
 		}
 
 		/// <summary>If <see langword="true" />, the property should not be displayed to the user.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("tvos")]
 		[SupportedOSPlatform ("maccatalyst")]

--- a/src/HomeKit/HMCharacteristic.cs
+++ b/src/HomeKit/HMCharacteristic.cs
@@ -25,7 +25,7 @@ namespace HomeKit {
 			}
 		}
 
-		/// <summary>Gets a value that tells whether the characteristic is writeable.</summary>
+		/// <summary>Gets a value that tells whether the characteristic is writable.</summary>
 		public bool Writable {
 			get {
 				foreach (var p in Properties) {


### PR DESCRIPTION
Improves XML documentation for 12 types:

- NSCollectionViewLayout
- NSPasteboard
- NSSharingService
- ARPointCloud
- CAMediaTimingFunction
- CFType
- CGPattern / CGPatternTiling
- AVAssetDownloadTask
- AVOutputSettingsAssistant
- CFMachPortContext
- GKComponentSystem
- HMCharacteristic

Changes:
- Replaces placeholder 'To be added.' docs with meaningful descriptions
- Removes empty `<remarks>` and `<returns>` nodes
- Fixes XML doc tag ordering (summary before param)

🤖 Pull request created by Copilot