### PR TITLE
[SensitiveContentAnalysis] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/sensitivecontentanalysis.cs
+++ b/src/sensitivecontentanalysis.cs
@@ -1,15 +1,34 @@
+using System.Collections.Generic;
+
 using AVFoundation;
 using CoreGraphics;
 using CoreVideo;
 using VideoToolbox;
 
 namespace SensitiveContentAnalysis {
+	[NoTV, iOS (27, 0), Mac (27, 0), MacCatalyst (27, 0)]
+	public enum SCSensitiveContentType {
+		[Field ("SCSensitiveContentTypeSexuallyExplicit")]
+		SexuallyExplicit,
+
+		[Field ("SCSensitiveContentTypeGoreOrViolence")]
+		GoreOrViolence,
+	}
+
 	[NoTV, iOS (17, 0), MacCatalyst (17, 0)]
 	[BaseType (typeof (NSObject))]
 	[DisableDefaultCtor]
 	interface SCSensitivityAnalysis {
 		[Export ("sensitive")]
 		bool Sensitive { [Bind ("isSensitive")] get; }
+
+		[NoTV, iOS (27, 0), Mac (27, 0), MacCatalyst (27, 0)]
+		[Export ("detectedTypes", ArgumentSemantic.Copy)]
+		NSSet<NSString> WeakDetectedTypes { get; }
+
+		[NoTV, iOS (27, 0), Mac (27, 0), MacCatalyst (27, 0)]
+		[Wrap ("WeakDetectedTypes.ToHashSet (v => SCSensitiveContentTypeExtensions.GetValue (v))")]
+		HashSet<SCSensitiveContentType> DetectedTypes { get; }
 
 		// From the VideoStreamAnalysis (SCSensitiveAnalysis) category
 		[NoTV, NoMacCatalyst, NoMac, iOS (26, 0)]

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -6494,6 +6494,8 @@ F:Security.TlsProtocolVersion.Tls10
 F:Security.TlsProtocolVersion.Tls11
 F:Security.TlsProtocolVersion.Tls12
 F:Security.TlsProtocolVersion.Tls13
+F:SensitiveContentAnalysis.SCSensitiveContentType.GoreOrViolence
+F:SensitiveContentAnalysis.SCSensitiveContentType.SexuallyExplicit
 F:SensitiveContentAnalysis.SCSensitivityAnalysisPolicy.DescriptiveInterventions
 F:SensitiveContentAnalysis.SCSensitivityAnalysisPolicy.Disabled
 F:SensitiveContentAnalysis.SCSensitivityAnalysisPolicy.SimpleInterventions
@@ -50079,10 +50081,12 @@ P:SecurityUI.SFCertificatePresentation.HelpUrl
 P:SecurityUI.SFCertificatePresentation.Message
 P:SecurityUI.SFCertificatePresentation.Title
 P:SecurityUI.SFCertificatePresentation.Trust
+P:SensitiveContentAnalysis.SCSensitivityAnalysis.DetectedTypes
 P:SensitiveContentAnalysis.SCSensitivityAnalysis.Sensitive
 P:SensitiveContentAnalysis.SCSensitivityAnalysis.ShouldIndicateSensitivity
 P:SensitiveContentAnalysis.SCSensitivityAnalysis.ShouldInterruptVideo
 P:SensitiveContentAnalysis.SCSensitivityAnalysis.ShouldMuteAudio
+P:SensitiveContentAnalysis.SCSensitivityAnalysis.WeakDetectedTypes
 P:SensitiveContentAnalysis.SCSensitivityAnalyzer.AnalysisPolicy
 P:SensitiveContentAnalysis.SCVideoStreamAnalyzer.Analysis
 P:SensitiveContentAnalysis.SCVideoStreamAnalyzer.AnalysisChangedHandler
@@ -61843,6 +61847,7 @@ T:Security.TlsCipherSuite
 T:Security.TlsCipherSuiteGroup
 T:Security.TlsProtocolVersion
 T:SecurityUI.SFCertificatePresentation
+T:SensitiveContentAnalysis.SCSensitiveContentType
 T:SensitiveContentAnalysis.SCSensitivityAnalysis
 T:SensitiveContentAnalysis.SCSensitivityAnalysisPolicy
 T:SensitiveContentAnalysis.SCSensitivityAnalyzer

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-SensitiveContentAnalysis.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-SensitiveContentAnalysis.todo
@@ -1,3 +1,0 @@
-!missing-field! SCSensitiveContentTypeGoreOrViolence not bound
-!missing-field! SCSensitiveContentTypeSexuallyExplicit not bound
-!missing-selector! SCSensitivityAnalysis::detectedTypes not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-SensitiveContentAnalysis.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-SensitiveContentAnalysis.todo
@@ -1,3 +1,0 @@
-!missing-field! SCSensitiveContentTypeGoreOrViolence not bound
-!missing-field! SCSensitiveContentTypeSexuallyExplicit not bound
-!missing-selector! SCSensitivityAnalysis::detectedTypes not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-SensitiveContentAnalysis.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-SensitiveContentAnalysis.todo
@@ -1,3 +1,0 @@
-!missing-field! SCSensitiveContentTypeGoreOrViolence not bound
-!missing-field! SCSensitiveContentTypeSexuallyExplicit not bound
-!missing-selector! SCSensitivityAnalysis::detectedTypes not bound


### PR DESCRIPTION
## Summary

- Bind `SCSensitiveContentType` as a strongly typed NSString-backed enum with the sexually explicit and gore/violence classifications.
- Expose `SCSensitivityAnalysis.WeakDetectedTypes` and the strongly typed `DetectedTypes` set on iOS, macOS, and Mac Catalyst 27.0.
- Remove the resolved SensitiveContentAnalysis xtro todo files and update the existing cecil documentation baseline.

## Validation

- `make world` before implementation and again after the binding changes.
- Final clean xtro generation/classification: sanity passed.
- Final clean cecil suite: passed.
- iOS 27 introspection: 44/44 passed.
- tvOS 27 introspection: 43/43 passed, validating the tvOS exclusions.
- macOS introspection: 32/32 passed with two expected latest-OS-only ignores.
- Mac Catalyst field, selector, signature, and weak-property fixtures passed; the unrelated full constructor fixture remains blocked by the documented headless `CLLocationButton` TCC crash.
- Final clean filtered app-size suite completed with 16 expected skips because the selected Xcode is a beta.
