### PR TITLE
[CoreSpotlight] Update bindings up to Xcode 27.0 Beta 4

### DIFF
--- a/src/corespotlight.cs
+++ b/src/corespotlight.cs
@@ -342,6 +342,15 @@ namespace CoreSpotlight {
 		[Export ("searchableItemsForIdentifiers:searchableItemsHandler:")]
 		void GetSearchableItems (string [] identifiers, CSSearchableIndexDelegateGetSearchableItemsHandler searchableItemsHandler);
 
+		/// <param name="identifiers">The identifiers of the searchable items to retrieve.</param>
+		/// <param name="protectionClass">The file protection class for the requested items.</param>
+		/// <param name="searchableItemsHandler">The handler to invoke with the matching searchable items.</param>
+		/// <summary>Provides searchable items for the specified identifiers and file protection class.</summary>
+		[NoTV, iOS (27, 0), Mac (27, 0), MacCatalyst (27, 0)]
+		[Export ("searchableItemsForIdentifiers:protectionClass:searchableItemsHandler:")]
+		// FIXME: Strongly type protectionClass as NSFileProtectionType once https://github.com/dotnet/macios/issues/26273 is fixed.
+		void GetSearchableItems (string [] identifiers, NSString protectionClass, CSSearchableIndexDelegateGetSearchableItemsHandler searchableItemsHandler);
+
 		[NoTV]
 		[iOS (18, 4), Mac (15, 4), MacCatalyst (18, 4)]
 		[Export ("searchableItemsDidUpdate:")]

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreSpotlight.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-CoreSpotlight.todo
@@ -1,1 +1,0 @@
-!missing-protocol-member! CSSearchableIndexDelegate::searchableItemsForIdentifiers:protectionClass:searchableItemsHandler: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreSpotlight.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-CoreSpotlight.todo
@@ -1,1 +1,0 @@
-!missing-protocol-member! CSSearchableIndexDelegate::searchableItemsForIdentifiers:protectionClass:searchableItemsHandler: not found

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreSpotlight.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-CoreSpotlight.todo
@@ -1,1 +1,0 @@
-!missing-protocol-member! CSSearchableIndexDelegate::searchableItemsForIdentifiers:protectionClass:searchableItemsHandler: not found


### PR DESCRIPTION
## Summary

- Bind `CSSearchableIndexDelegate.searchableItemsForIdentifiers:protectionClass:searchableItemsHandler:` on iOS 27.0, macOS 27.0, and Mac Catalyst 27.0.
- Reuse the existing searchable-items completion handler and preserve the native non-null contract.
- Remove the resolved iOS, macOS, and Mac Catalyst CoreSpotlight xtro todo files.

## Temporary API shape

The native `NSFileProtectionType` parameter is temporarily exposed as `NSString` because bgen still rejects parameter-level `[BindAs]` inside protocol/model definitions. Issue #26273 tracks changing it to `[BindAs (typeof (NSFileProtectionType))] NSString` before Xcode 27 GA, after #26195 lands.

## Validation

- `make world`
- Clean xtro generation/classification: sanity passed for all platforms
- Clean cecil suite: passed
- iOS 27 introspection: 44 passed, 0 failed
- tvOS 27 introspection: 43 passed, 0 failed
- macOS introspection: 32 passed, 0 failed, 2 host-version-gated
- Mac Catalyst introspection: 39 passed, 0 failed, 4 expected ignores
- Clean filtered `AppSizeTest`: 0 failed; 16 skipped because app-size baselines are disabled for beta Xcode