### PR TITLE
[SharedWithYou] Update bindings up to Xcode 27.0 Beta 3

### DIFF
--- a/src/sharedwithyou.cs
+++ b/src/sharedwithyou.cs
@@ -133,6 +133,11 @@ namespace SharedWithYou {
 		[Field ("SWCollaborationMetadataTypeIdentifier")]
 		NSString MetadataTypeIdentifier { get; }
 
+		/// <summary>Gets the type identifier that signals the system to use the app's local document version for a copy representation.</summary>
+		[NoTV, iOS (27, 0), Mac (27, 0), MacCatalyst (27, 0)]
+		[Field ("SWCopyRepresentationTypeIdentifier", "SharedWithYouCore")]
+		NSString CopyRepresentationTypeIdentifier { get; }
+
 		[Export ("identifier", ArgumentSemantic.Copy)]
 		NSObject/*<NSSecureCoding, NSCopying>*/ Identifier { get; }
 
@@ -267,6 +272,11 @@ namespace SharedWithYou {
 
 		[Export ("activeParticipantCount")]
 		nuint ActiveParticipantCount { get; set; }
+
+		/// <summary>Gets or sets the number of pending access requests.</summary>
+		[iOS (27, 0), Mac (27, 0), MacCatalyst (27, 0)]
+		[Export ("pendingAccessRequestsCount")]
+		nuint PendingAccessRequestsCount { get; set; }
 
 		[Wrap ("WeakDelegate")]
 		[NullAllowed]

--- a/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-SharedWithYou.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/MacCatalyst-SharedWithYou.todo
@@ -1,3 +1,0 @@
-!missing-field! SWCopyRepresentationTypeIdentifier not bound
-!missing-selector! SWCollaborationView::pendingAccessRequestsCount not bound
-!missing-selector! SWCollaborationView::setPendingAccessRequestsCount: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/iOS-SharedWithYou.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/iOS-SharedWithYou.todo
@@ -1,3 +1,0 @@
-!missing-field! SWCopyRepresentationTypeIdentifier not bound
-!missing-selector! SWCollaborationView::pendingAccessRequestsCount not bound
-!missing-selector! SWCollaborationView::setPendingAccessRequestsCount: not bound

--- a/tests/xtro-sharpie/api-annotations-dotnet/macOS-SharedWithYou.todo
+++ b/tests/xtro-sharpie/api-annotations-dotnet/macOS-SharedWithYou.todo
@@ -1,3 +1,0 @@
-!missing-field! SWCopyRepresentationTypeIdentifier not bound
-!missing-selector! SWCollaborationView::pendingAccessRequestsCount not bound
-!missing-selector! SWCollaborationView::setPendingAccessRequestsCount: not bound


### PR DESCRIPTION
## Summary

- Bind `SWCopyRepresentationTypeIdentifier` as `SWHighlight.CopyRepresentationTypeIdentifier` using the exporting `SharedWithYouCore` framework.
- Bind `SWCollaborationView.PendingAccessRequestsCount` on iOS, macOS, and Mac Catalyst 27.0.
- Document the new APIs and remove the resolved SharedWithYou xtro todo files.

## Validation

- `make world` before and after the binding update
- Clean xtro generation/classification: sanity passed
- Clean Cecil tests: 112 passed, 4 skipped
- iOS 27 introspection: 44 passed
- tvOS 27 introspection: 43 passed
- macOS introspection: 32 passed, 2 OS-gated
- Mac Catalyst: all non-constructor introspection fixtures passed; the full constructor run hit the known unsigned `CLLocationButton` TCC crash
- Clean app size tests: 16 skipped because beta Xcode disables the suite