### PR TITLE
[docs] Improve XML docs for HMCharacteristicMetadata, HMCharacteristicProperties, INCallRecord, INIntentResolutionResult, MTKTextureLoaderOptions, GKGridGraph, UIDynamicAnimator, UINavigationBar, CGDataConsumer, ModelNotImplementedException, GKEntity, GKPolygonObstacle, SCNRenderer, UIKitThreadAccessException

### DIFF
--- a/src/CoreGraphics/CGDataConsumer.cs
+++ b/src/CoreGraphics/CGDataConsumer.cs
@@ -69,8 +69,8 @@ namespace CoreGraphics {
 			return result;
 		}
 
+		/// <summary>Creates a data sink that saves the data on the specified NSData.</summary>
 		/// <param name="data">The data.</param>
-		///         <summary>Creates a data sink that saves the data on the specified NSData.</summary>
 		public CGDataConsumer (NSMutableData data)
 			: base (Create (data), true)
 		{
@@ -89,8 +89,8 @@ namespace CoreGraphics {
 			return result;
 		}
 
+		/// <summary>Creates a data sink that saves the data on a file specified by the url.</summary>
 		/// <param name="url">The url.</param>
-		///         <summary>Creates a data sink that saves the data on a file specified by the url.</summary>
 		public CGDataConsumer (NSUrl url)
 			: base (Create (url), true)
 		{

--- a/src/CoreGraphics/CGDataConsumer.cs
+++ b/src/CoreGraphics/CGDataConsumer.cs
@@ -33,7 +33,6 @@ using CoreFoundation;
 namespace CoreGraphics {
 	// CGDataConsumer.h
 	/// <summary>Data sink for <see cref="CoreGraphics.CGContextPDF" /> or <see cref="ImageIO.CGImageDestination" /> to store data on.</summary>
-	///     <remarks>To be added.</remarks>
 	public partial class CGDataConsumer : NativeObject {
 		[Preserve (Conditional = true)]
 		internal CGDataConsumer (NativeHandle handle, bool owns)
@@ -70,9 +69,8 @@ namespace CoreGraphics {
 			return result;
 		}
 
-		/// <param name="data">To be added.</param>
+		/// <param name="data">The data.</param>
 		///         <summary>Creates a data sink that saves the data on the specified NSData.</summary>
-		///         <remarks>To be added.</remarks>
 		public CGDataConsumer (NSMutableData data)
 			: base (Create (data), true)
 		{
@@ -91,9 +89,8 @@ namespace CoreGraphics {
 			return result;
 		}
 
-		/// <param name="url">To be added.</param>
+		/// <param name="url">The url.</param>
 		///         <summary>Creates a data sink that saves the data on a file specified by the url.</summary>
-		///         <remarks>To be added.</remarks>
 		public CGDataConsumer (NSUrl url)
 			: base (Create (url), true)
 		{

--- a/src/Foundation/ModelNotImplementedException.cs
+++ b/src/Foundation/ModelNotImplementedException.cs
@@ -23,18 +23,14 @@
 
 namespace Foundation {
 	/// <summary>An convenience exception used in Model method implementations.</summary>
-	///     <remarks>To be added.</remarks>
 	public class ModelNotImplementedException : Exception {
 		/// <summary>Default constructor.</summary>
-		///         <remarks>To be added.</remarks>
 		public ModelNotImplementedException () { }
 	}
 
 	/// <summary>This class exits purely as a warning to future generations.   You called a method using “base”, but this was not required.</summary>
-	///     <remarks>To be added.</remarks>
 	public class You_Should_Not_Call_base_In_This_Method : Exception {
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>You_Should_Not_Call_base_In_This_Method.</summary>
 		public You_Should_Not_Call_base_In_This_Method () { }
 	}
 }

--- a/src/Foundation/ModelNotImplementedException.cs
+++ b/src/Foundation/ModelNotImplementedException.cs
@@ -22,15 +22,15 @@
 //
 
 namespace Foundation {
-	/// <summary>An convenience exception used in Model method implementations.</summary>
+	/// <summary>A convenience exception used in Model method implementations.</summary>
 	public class ModelNotImplementedException : Exception {
-		/// <summary>Default constructor.</summary>
+		/// <summary>Initializes a new instance of the <see cref="ModelNotImplementedException" /> class.</summary>
 		public ModelNotImplementedException () { }
 	}
 
-	/// <summary>This class exits purely as a warning to future generations.   You called a method using “base”, but this was not required.</summary>
+	/// <summary>This class exists purely as a warning to future generations. You called a method using "base", but this was not required.</summary>
 	public class You_Should_Not_Call_base_In_This_Method : Exception {
-		/// <summary>You_Should_Not_Call_base_In_This_Method.</summary>
+		/// <summary>Initializes a new instance of the <see cref="You_Should_Not_Call_base_In_This_Method" /> class.</summary>
 		public You_Should_Not_Call_base_In_This_Method () { }
 	}
 }

--- a/src/GameplayKit/GKEntity.cs
+++ b/src/GameplayKit/GKEntity.cs
@@ -12,18 +12,15 @@
 namespace GameplayKit {
 	public partial class GKEntity {
 
-		/// <param name="componentType">To be added.</param>
+		/// <param name="componentType">The component type.</param>
 		///         <summary>Removes the element in <see cref="GameplayKit.GKEntity.Components" /> of the specified <paramref name="componentType" />.</summary>
-		///         <remarks>To be added.</remarks>
 		public void RemoveComponent (Type componentType)
 		{
 			RemoveComponent (GKState.GetClass (componentType, "componentType"));
 		}
 
-		/// <param name="componentType">To be added.</param>
+		/// <param name="componentType">The component type.</param>
 		///         <summary>Retrieves the element in <see cref="GameplayKit.GKEntity.Components" /> of the specified <paramref name="componentType" />.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public GKComponent? GetComponent (Type componentType)
 		{
 			return GetComponent (GKState.GetClass (componentType, "componentType"));

--- a/src/GameplayKit/GKEntity.cs
+++ b/src/GameplayKit/GKEntity.cs
@@ -12,15 +12,15 @@
 namespace GameplayKit {
 	public partial class GKEntity {
 
+		/// <summary>Removes the element in <see cref="GameplayKit.GKEntity.Components" /> of the specified <paramref name="componentType" />.</summary>
 		/// <param name="componentType">The component type.</param>
-		///         <summary>Removes the element in <see cref="GameplayKit.GKEntity.Components" /> of the specified <paramref name="componentType" />.</summary>
 		public void RemoveComponent (Type componentType)
 		{
 			RemoveComponent (GKState.GetClass (componentType, "componentType"));
 		}
 
+		/// <summary>Retrieves the element in <see cref="GameplayKit.GKEntity.Components" /> of the specified <paramref name="componentType" />.</summary>
 		/// <param name="componentType">The component type.</param>
-		///         <summary>Retrieves the element in <see cref="GameplayKit.GKEntity.Components" /> of the specified <paramref name="componentType" />.</summary>
 		public GKComponent? GetComponent (Type componentType)
 		{
 			return GetComponent (GKState.GetClass (componentType, "componentType"));

--- a/src/GameplayKit/GKGridGraph.cs
+++ b/src/GameplayKit/GKGridGraph.cs
@@ -14,7 +14,7 @@ using Vector2i = global::CoreGraphics.NVector2i;
 namespace GameplayKit {
 	public partial class GKGridGraph {
 		/// <summary>Gets the node at the specified <paramref name="position" />.</summary>
-		/// <typeparam name="NodeType">The type parameter.</typeparam>
+		/// <typeparam name="NodeType">The type of grid graph node to return.</typeparam>
 		/// <param name="position">The position.</param>
 		public NodeType? GetNodeAt<NodeType> (Vector2i position) where NodeType : GKGridGraphNode
 		{

--- a/src/GameplayKit/GKGridGraph.cs
+++ b/src/GameplayKit/GKGridGraph.cs
@@ -13,9 +13,9 @@ using Vector2i = global::CoreGraphics.NVector2i;
 
 namespace GameplayKit {
 	public partial class GKGridGraph {
+		/// <summary>Gets the node at the specified <paramref name="position" />.</summary>
 		/// <typeparam name="NodeType">The type parameter.</typeparam>
 		/// <param name="position">The position.</param>
-		/// <summary>Gets the node at the specified <paramref name="position" />.</summary>
 		public NodeType? GetNodeAt<NodeType> (Vector2i position) where NodeType : GKGridGraphNode
 		{
 			return Runtime.GetNSObject<NodeType> (_GetNodeAt (position));

--- a/src/GameplayKit/GKGridGraph.cs
+++ b/src/GameplayKit/GKGridGraph.cs
@@ -13,11 +13,9 @@ using Vector2i = global::CoreGraphics.NVector2i;
 
 namespace GameplayKit {
 	public partial class GKGridGraph {
-		/// <typeparam name="NodeType">To be added.</typeparam>
-		/// <param name="position">To be added.</param>
+		/// <typeparam name="NodeType">The type parameter.</typeparam>
+		/// <param name="position">The position.</param>
 		/// <summary>Gets the node at the specified <paramref name="position" />.</summary>
-		/// <returns>To be added.</returns>
-		/// <remarks>To be added.</remarks>
 		public NodeType? GetNodeAt<NodeType> (Vector2i position) where NodeType : GKGridGraphNode
 		{
 			return Runtime.GetNSObject<NodeType> (_GetNodeAt (position));

--- a/src/GameplayKit/GKPolygonObstacle.cs
+++ b/src/GameplayKit/GKPolygonObstacle.cs
@@ -14,10 +14,8 @@ using System.Numerics;
 namespace GameplayKit {
 	public partial class GKPolygonObstacle {
 
-		/// <param name="points">To be added.</param>
+		/// <param name="points">The points.</param>
 		/// <summary>Factory method to create a <see cref="GameplayKit.GKPolygonObstacle" /> defined by the <paramref name="points" />.</summary>
-		/// <returns>To be added.</returns>
-		/// <remarks>To be added.</remarks>
 		public static GKPolygonObstacle FromPoints (Vector2 [] points)
 		{
 			if (points is null)
@@ -63,9 +61,8 @@ namespace GameplayKit {
 			return ctor_pointer = buffer;
 		}
 
-		/// <param name="points">To be added.</param>
+		/// <param name="points">The points.</param>
 		/// <summary>Creates a <see cref="GameplayKit.GKPolygonObstacle" /> with a shape defined by the specified <paramref name="points" />.</summary>
-		/// <remarks>To be added.</remarks>
 		public unsafe GKPolygonObstacle (Vector2 [] points)
 			: this (GetPointer (points), (nuint) points.Length)
 		{

--- a/src/GameplayKit/GKPolygonObstacle.cs
+++ b/src/GameplayKit/GKPolygonObstacle.cs
@@ -14,8 +14,8 @@ using System.Numerics;
 namespace GameplayKit {
 	public partial class GKPolygonObstacle {
 
-		/// <param name="points">The points.</param>
 		/// <summary>Factory method to create a <see cref="GameplayKit.GKPolygonObstacle" /> defined by the <paramref name="points" />.</summary>
+		/// <param name="points">The points.</param>
 		public static GKPolygonObstacle FromPoints (Vector2 [] points)
 		{
 			if (points is null)
@@ -61,8 +61,8 @@ namespace GameplayKit {
 			return ctor_pointer = buffer;
 		}
 
-		/// <param name="points">The points.</param>
 		/// <summary>Creates a <see cref="GameplayKit.GKPolygonObstacle" /> with a shape defined by the specified <paramref name="points" />.</summary>
+		/// <param name="points">The points.</param>
 		public unsafe GKPolygonObstacle (Vector2 [] points)
 			: this (GetPointer (points), (nuint) points.Length)
 		{

--- a/src/HomeKit/HMCharacteristicMetadata.cs
+++ b/src/HomeKit/HMCharacteristicMetadata.cs
@@ -4,8 +4,6 @@ namespace HomeKit {
 
 	public partial class HMCharacteristicMetadata {
 		/// <summary>Gets the units in which the characteristic is expressed.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public HMCharacteristicMetadataUnits Units {
 			get {
 				var u = _Units;
@@ -33,8 +31,6 @@ namespace HomeKit {
 		}
 
 		/// <summary>Gets the data format of the characteristic.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public HMCharacteristicMetadataFormat Format {
 			get {
 				var f = _Format;

--- a/src/HomeKit/HMCharacteristicProperties.cs
+++ b/src/HomeKit/HMCharacteristicProperties.cs
@@ -2,35 +2,24 @@
 
 namespace HomeKit {
 	/// <summary>Common capabilities of an <see cref="HomeKit.HMCharacteristic" />, such as whether it's writable or supports events.</summary>
-	///     <remarks>To be added.</remarks>
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("tvos")]
 	public class HMCharacteristicProperties {
 
 		/// <summary>Gets or sets a value that tells whether the property supports numbered changes.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public bool SupportsChangeNumber { get; set; }
 
 		/// <summary>Gets or sets a value that tells whether the property support bonjour notifications.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public bool SupportsBonjourNotification { get; set; }
 
 		/// <summary>Gets or sets a value that tells whether the property supports event notifications.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public bool SupportsEventNotification { get; set; }
 
 		/// <summary>Gets or sets a value that tells whether the property is readable.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public bool Readable { get; set; }
 
 		/// <summary>Gets or sets a value that tells whether the property is writable.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public bool Writable { get; set; }
 	}
 }

--- a/src/HomeKit/HMCharacteristicProperties.cs
+++ b/src/HomeKit/HMCharacteristicProperties.cs
@@ -10,7 +10,7 @@ namespace HomeKit {
 		/// <summary>Gets or sets a value that tells whether the property supports numbered changes.</summary>
 		public bool SupportsChangeNumber { get; set; }
 
-		/// <summary>Gets or sets a value that tells whether the property support bonjour notifications.</summary>
+		/// <summary>Gets or sets a value that tells whether the property supports Bonjour notifications.</summary>
 		public bool SupportsBonjourNotification { get; set; }
 
 		/// <summary>Gets or sets a value that tells whether the property supports event notifications.</summary>

--- a/src/Intents/INCallRecord.cs
+++ b/src/Intents/INCallRecord.cs
@@ -15,15 +15,11 @@ namespace Intents {
 	public partial class INCallRecord {
 
 		/// <summary>Gets the length of the call, in seconds.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public double? CallDuration {
 			get { return WeakCallDuration?.DoubleValue; }
 		}
 
 		/// <summary>Gets a Boolean value that tells whether the call record has been viewed by the user.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public bool? Unseen {
 			get { return WeakUnseen?.BoolValue; }
 		}

--- a/src/Intents/INIntentResolutionResult.cs
+++ b/src/Intents/INIntentResolutionResult.cs
@@ -26,8 +26,6 @@ namespace Intents {
 	public partial class INIntentResolutionResult {
 
 		/// <summary>Factory method to create an <see cref="Intents.INIntentResolutionResult" /> object indicating that a value is required for the parameter.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public static INIntentResolutionResult NeedsValue {
 			get {
 				throw new NotImplementedException ("All subclasses of INIntentResolutionResult must re-implement this property");
@@ -35,8 +33,6 @@ namespace Intents {
 		}
 
 		/// <summary>Factory method to create an <see cref="Intents.INIntentResolutionResult" /> object indicating that a value is not required for the parameter.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public static INIntentResolutionResult NotRequired {
 			get {
 				throw new NotImplementedException ("All subclasses of INIntentResolutionResult must re-implement this property");
@@ -44,8 +40,6 @@ namespace Intents {
 		}
 
 		/// <summary>Factory method to create an <see cref="Intents.INIntentResolutionResult" /> object indicating that the developer's app does not support the parameter.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public static INIntentResolutionResult Unsupported {
 			get {
 				throw new NotImplementedException ("All subclasses of INIntentResolutionResult must re-implement this property");

--- a/src/Intents/INIntentResolutionResult.cs
+++ b/src/Intents/INIntentResolutionResult.cs
@@ -25,21 +25,21 @@ namespace Intents {
 
 	public partial class INIntentResolutionResult {
 
-		/// <summary>Factory method to create an <see cref="Intents.INIntentResolutionResult" /> object indicating that a value is required for the parameter.</summary>
+		/// <summary>Gets a resolution result indicating that a value is required for the parameter.</summary>
 		public static INIntentResolutionResult NeedsValue {
 			get {
 				throw new NotImplementedException ("All subclasses of INIntentResolutionResult must re-implement this property");
 			}
 		}
 
-		/// <summary>Factory method to create an <see cref="Intents.INIntentResolutionResult" /> object indicating that a value is not required for the parameter.</summary>
+		/// <summary>Gets a resolution result indicating that a value is not required for the parameter.</summary>
 		public static INIntentResolutionResult NotRequired {
 			get {
 				throw new NotImplementedException ("All subclasses of INIntentResolutionResult must re-implement this property");
 			}
 		}
 
-		/// <summary>Factory method to create an <see cref="Intents.INIntentResolutionResult" /> object indicating that the developer's app does not support the parameter.</summary>
+		/// <summary>Gets a resolution result indicating that the developer's app does not support the parameter.</summary>
 		public static INIntentResolutionResult Unsupported {
 			get {
 				throw new NotImplementedException ("All subclasses of INIntentResolutionResult must re-implement this property");

--- a/src/MetalKit/MTKTextureLoaderOptions.cs
+++ b/src/MetalKit/MTKTextureLoaderOptions.cs
@@ -19,7 +19,7 @@ namespace MetalKit {
 	[SupportedOSPlatform ("tvos")]
 	public partial class MTKTextureLoaderOptions : DictionaryContainer {
 
-		/// <summary>Gets an orable flag value that describes for which of the following the texture will be used: for blitting; as a render target; as a shader read source or write target; as a pixel format view; or for an unknown use.</summary>
+		/// <summary>Gets a flag value that describes for which of the following the texture will be used: for blitting; as a render target; as a shader read source or write target; as a pixel format view; or for an unknown use.</summary>
 		public MTLTextureUsage? TextureUsage {
 			get {
 				var val = GetNUIntValue (MTKTextureLoaderKeys.TextureUsageKey);

--- a/src/MetalKit/MTKTextureLoaderOptions.cs
+++ b/src/MetalKit/MTKTextureLoaderOptions.cs
@@ -20,8 +20,6 @@ namespace MetalKit {
 	public partial class MTKTextureLoaderOptions : DictionaryContainer {
 
 		/// <summary>Gets an orable flag value that describes for which of the following the texture will be used: for blitting; as a render target; as a shader read source or write target; as a pixel format view; or for an unknown use.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public MTLTextureUsage? TextureUsage {
 			get {
 				var val = GetNUIntValue (MTKTextureLoaderKeys.TextureUsageKey);
@@ -38,8 +36,6 @@ namespace MetalKit {
 		}
 
 		/// <summary>Gets a value that describes whether read-write operations will be optimized, or be performed in the (non-optimized) order in which they are specified.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public MTLCpuCacheMode? TextureCpuCacheMode {
 			get {
 				var val = GetNUIntValue (MTKTextureLoaderKeys.TextureCpuCacheModeKey);
@@ -56,8 +52,6 @@ namespace MetalKit {
 		}
 
 		/// <summary>Gets or sets the texture storage mode of the new texture.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("maccatalyst")]
@@ -78,8 +72,6 @@ namespace MetalKit {
 		}
 
 		/// <summary>Gets or sets a value that indicates the orientation of cube map texture data.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("maccatalyst")]
@@ -100,8 +92,6 @@ namespace MetalKit {
 		}
 
 		/// <summary>Gets or sets a value that controls when to flip the texture.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("maccatalyst")]

--- a/src/SceneKit/SCNRenderer.cs
+++ b/src/SceneKit/SCNRenderer.cs
@@ -18,11 +18,9 @@ namespace SceneKit {
 
 #if !__MACCATALYST__
 
-		/// <param name="context">To be added.</param>
-		/// <param name="options">To be added.</param>
-		/// <summary>To be added.</summary>
-		/// <returns>To be added.</returns>
-		/// <remarks>To be added.</remarks>
+		/// <param name="context">The context.</param>
+		/// <param name="options">The options.</param>
+		/// <summary>FromContext.</summary>
 		[UnsupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("macos")]

--- a/src/SceneKit/SCNRenderer.cs
+++ b/src/SceneKit/SCNRenderer.cs
@@ -18,9 +18,9 @@ namespace SceneKit {
 
 #if !__MACCATALYST__
 
+		/// <summary>Creates an <see cref="SCNRenderer" /> from the specified OpenGL context.</summary>
 		/// <param name="context">The context.</param>
 		/// <param name="options">The options.</param>
-		/// <summary>FromContext.</summary>
 		[UnsupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("macos")]

--- a/src/UIKit/UIApplication.cs
+++ b/src/UIKit/UIApplication.cs
@@ -18,8 +18,7 @@ using CoreFoundation;
 namespace UIKit {
 	/// <include file="../../docs/api/UIKit/UIKitThreadAccessException.xml" path="/Documentation/Docs[@DocId='T:UIKit.UIKitThreadAccessException']/*" />
 	public class UIKitThreadAccessException : Exception {
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>UIKitThreadAccessException.</summary>
 		public UIKitThreadAccessException () : base ("UIKit Consistency error: you are calling a UIKit method that can only be invoked from the UI thread.")
 		{
 		}
@@ -47,7 +46,6 @@ namespace UIKit {
 		///         </remarks>
 		public static bool CheckForIllegalCrossThreadCalls = true;
 		/// <summary>If <see langword="true" />, the system will try to diagnose potential mistakes where events and delegate-object overrides are in conflict.</summary>
-		///         <remarks>To be added.</remarks>
 		public static bool CheckForEventAndDelegateMismatches = true;
 
 		// We link with __Internal here so that this function is interposable from third-party native libraries.
@@ -150,12 +148,8 @@ namespace UIKit {
 	}
 
 	/// <summary>Provides data for the  event.</summary>
-	///     <remarks>
-	///     </remarks>
 	public partial class UIContentSizeCategoryChangedEventArgs {
 		/// <summary>The new size of the content, e.g., the new font size, in points.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public UIContentSizeCategory NewValue {
 			get {
 				return UIContentSizeCategoryExtensions.GetValue (WeakNewValue);

--- a/src/UIKit/UIApplication.cs
+++ b/src/UIKit/UIApplication.cs
@@ -18,7 +18,7 @@ using CoreFoundation;
 namespace UIKit {
 	/// <include file="../../docs/api/UIKit/UIKitThreadAccessException.xml" path="/Documentation/Docs[@DocId='T:UIKit.UIKitThreadAccessException']/*" />
 	public class UIKitThreadAccessException : Exception {
-		/// <summary>UIKitThreadAccessException.</summary>
+		/// <summary>Initializes a new instance of the <see cref="UIKitThreadAccessException" /> class.</summary>
 		public UIKitThreadAccessException () : base ("UIKit Consistency error: you are calling a UIKit method that can only be invoked from the UI thread.")
 		{
 		}
@@ -147,7 +147,7 @@ namespace UIKit {
 		}
 	}
 
-	/// <summary>Provides data for the  event.</summary>
+	/// <summary>Provides data for the <see cref="UIContentSizeCategory" /> changed event.</summary>
 	public partial class UIContentSizeCategoryChangedEventArgs {
 		/// <summary>The new size of the content, e.g., the new font size, in points.</summary>
 		public UIContentSizeCategory NewValue {

--- a/src/UIKit/UIDynamicAnimator.cs
+++ b/src/UIKit/UIDynamicAnimator.cs
@@ -46,17 +46,14 @@ namespace UIKit {
 
 		/// <param name="behaviors">Array of behaviors to be removed from the animator.</param>
 		///         <summary>Removes the listed behaviors from the animator.</summary>
-		///         <remarks>
-		///         </remarks>
 		public void RemoveBehaviors (params UIDynamicBehavior [] behaviors)
 		{
 			foreach (var behavior in behaviors)
 				RemoveBehavior (behavior);
 		}
 
-		/// <param name="behavior">To be added.</param>
+		/// <param name="behavior">The behavior.</param>
 		///         <summary>Adds the specified behavior.</summary>
-		///         <remarks>To be added.</remarks>
 		public void Add (UIDynamicBehavior behavior)
 		{
 			AddBehavior (behavior);
@@ -70,8 +67,6 @@ namespace UIKit {
 		}
 
 		/// <summary>Retrieves the behaviors via an enumerator.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		IEnumerator IEnumerable.GetEnumerator ()
 		{
 			foreach (var behavior in Behaviors)

--- a/src/UIKit/UIDynamicAnimator.cs
+++ b/src/UIKit/UIDynamicAnimator.cs
@@ -13,12 +13,12 @@ using System.Collections.Generic;
 namespace UIKit {
 	public partial class UIDynamicAnimator :
 	IEnumerable<UIDynamicBehavior> {
+		/// <summary>Adds the array of specified behaviors.</summary>
 		/// <param name="behaviors">Behaviors that you want to add to the animator</param>
-		///         <summary>Adds the array of specified behaviors.</summary>
-		///         <remarks>
-		///           <para>The following example shows how you can add a couple of behaviors to an animator:</para>
-		///           <example>
-		///             <code lang="csharp lang-csharp"><![CDATA[
+		/// <remarks>
+		///   <para>The following example shows how you can add a couple of behaviors to an animator:</para>
+		///   <example>
+		///     <code lang="csharp lang-csharp"><![CDATA[
 		/// public override void ViewDidLoad ()
 		/// {
 		/// 	base.ViewDidLoad ();
@@ -36,24 +36,24 @@ namespace UIKit {
 		/// 	animator.AddBehaviors (gravityBehavior, collisionBehavior);
 		/// }
 		/// 	    ]]></code>
-		///           </example>
-		///         </remarks>
+		///   </example>
+		/// </remarks>
 		public void AddBehaviors (params UIDynamicBehavior [] behaviors)
 		{
 			foreach (var behavior in behaviors)
 				AddBehavior (behavior);
 		}
 
+		/// <summary>Removes the listed behaviors from the animator.</summary>
 		/// <param name="behaviors">Array of behaviors to be removed from the animator.</param>
-		///         <summary>Removes the listed behaviors from the animator.</summary>
 		public void RemoveBehaviors (params UIDynamicBehavior [] behaviors)
 		{
 			foreach (var behavior in behaviors)
 				RemoveBehavior (behavior);
 		}
 
+		/// <summary>Adds the specified behavior.</summary>
 		/// <param name="behavior">The behavior.</param>
-		///         <summary>Adds the specified behavior.</summary>
 		public void Add (UIDynamicBehavior behavior)
 		{
 			AddBehavior (behavior);

--- a/src/UIKit/UINavigationBar.cs
+++ b/src/UIKit/UINavigationBar.cs
@@ -17,16 +17,13 @@ namespace UIKit {
 	public partial class UINavigationBar {
 		public partial class UINavigationBarAppearance {
 			/// <summary>Display attributes for the bar's title.</summary>
-			///         <returns>To be added.</returns>
-			///         <remarks>To be added.</remarks>
 			public virtual UITextAttributes GetTitleTextAttributes ()
 			{
 				return new UITextAttributes (_TitleTextAttributes);
 			}
 
-			/// <param name="attributes">To be added.</param>
+			/// <param name="attributes">The attributes.</param>
 			///         <summary>Sets the text attributes used by the title text.</summary>
-			///         <remarks>To be added.</remarks>
 			public virtual void SetTitleTextAttributes (UITextAttributes attributes)
 			{
 				if (attributes is null)

--- a/src/UIKit/UINavigationBar.cs
+++ b/src/UIKit/UINavigationBar.cs
@@ -22,8 +22,8 @@ namespace UIKit {
 				return new UITextAttributes (_TitleTextAttributes);
 			}
 
+			/// <summary>Sets the text attributes used by the title text.</summary>
 			/// <param name="attributes">The attributes.</param>
-			///         <summary>Sets the text attributes used by the title text.</summary>
 			public virtual void SetTitleTextAttributes (UITextAttributes attributes)
 			{
 				if (attributes is null)


### PR DESCRIPTION
Improves XML documentation for 14 types:

- HMCharacteristicMetadata
- HMCharacteristicProperties
- INCallRecord
- INIntentResolutionResult
- MTKTextureLoaderOptions
- GKGridGraph
- UIDynamicAnimator
- UINavigationBar
- CGDataConsumer
- ModelNotImplementedException
- GKEntity
- GKPolygonObstacle
- SCNRenderer
- UIKitThreadAccessException

Changes:
- Replaces placeholder 'To be added.' docs with meaningful descriptions
- Removes empty `<remarks>` and `<returns>` nodes
- Fixes XML doc tag ordering (summary before param)
- Normalizes XML doc indentation

🤖 Pull request created by Copilot