### PR TITLE
[UIKit] Give priority to the UIMenuIdentifier overload of UIMenu.Create. Fixes #26267.

### DIFF
--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -54,6 +54,7 @@ using NSToolbarItem = Foundation.NSObject;
 #endif
 
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 #nullable enable
 

--- a/src/uikit.cs
+++ b/src/uikit.cs
@@ -11417,6 +11417,7 @@ namespace UIKit {
 		UIMenu Create (string title, [NullAllowed] UIImage image, UIMenuIdentifier identifier, UIMenuOptions options, UIMenuElement [] children);
 
 		[Static]
+		[OverloadResolutionPriority (-1)]
 		[Export ("menuWithTitle:image:identifier:options:children:")]
 		UIMenu Create (string title, [NullAllowed] UIImage image, [NullAllowed] NSString identifier, UIMenuOptions options, UIMenuElement [] children);
 


### PR DESCRIPTION
## Description

The .NET 11 iOS bindings added a new `UIMenu.Create` overload taking an `NSString? identifier` alongside the pre-existing overload taking a `UIMenuIdentifier identifier` enum:

```csharp
UIMenu Create (string title, UIImage? image, UIMenuIdentifier identifier, UIMenuOptions options, UIMenuElement[] children);
UIMenu Create (string title, UIImage? image, NSString? identifier, UIMenuOptions options, UIMenuElement[] children);
```

This is source-breaking: existing code that passes `identifier: default` (a common pattern, since the identifier is optional in UIKit) now fails to compile with **CS0121** (ambiguous call), because `default` converts to both `UIMenuIdentifier` (enum default) and `NSString?` (null).

## Fix

Add `[OverloadResolutionPriority (-1)]` to the newer `NSString` overload so the pre-existing `UIMenuIdentifier`-enum overload wins overload resolution. This keeps `identifier: default` unambiguous and preserves source compatibility, while still allowing callers to reach the `NSString` overload by passing an explicit `NSString` argument.

Also added the missing `using System.Runtime.CompilerServices;` to `src/uikit.cs`, which is required for the attribute to compile in the ApiDefinition project.

## Testing

Verified with a clean managed build (`make all && make install`) for iOS. Confirmed the generated `UIMenu.g.cs` now emits the `[OverloadResolutionPriority (-1)]` attribute on the `NSString` overload.

Fixes https://github.com/dotnet/macios/issues/26267

🤖 Pull request created by Copilot