### PR TITLE
[tests] Fix IsLinkAll trimmer dataflow heuristic workaround

### DIFF
--- a/tests/common/TestRuntime.LinkAll.cs
+++ b/tests/common/TestRuntime.LinkAll.cs
@@ -38,7 +38,7 @@ partial class TestRuntime {
 				};
 				link_any = false;
 				foreach (var uncommonType in uncommonTypes) {
-					link_any = typeof (int).Assembly.GetType (uncommonType) is null;
+					link_any = typeof (int).Assembly.GetType (uncommonType + WorkAroundLinkerHeuristics) is null;
 					if (link_any == true)
 						break;
 				}

--- a/tests/common/TestRuntime.LinkAll.cs
+++ b/tests/common/TestRuntime.LinkAll.cs
@@ -14,10 +14,14 @@ partial class TestRuntime {
 	public static bool IsLinkAll {
 		get {
 			if (!link_all.HasValue)
-				link_all = typeof (TestRuntime).Assembly.GetType (typeof (TestRuntime).FullName + "+LinkerSentinel") is null;
+				link_all = typeof (TestRuntime).Assembly.GetType (typeof (TestRuntime).FullName + "+LinkerSentinel" + WorkAroundLinkerHeuristics) is null;
 			return link_all.Value;
 		}
 	}
+	// This is used to work around the trimmer's dataflow analysis, which can otherwise constant-fold the
+	// type name passed to GetType and preserve the LinkerSentinel type (making IsLinkAll incorrectly report
+	// false in link-all builds). This property returns "" at runtime, but the trimmer can't constant-fold it.
+	static string WorkAroundLinkerHeuristics { get { return ""; } }
 	class LinkerSentinel { }
 
 	// Determine if any assemblies were linked by checking if a few uncommon classes in corlib are still here.


### PR DESCRIPTION
Addresses a review comment from #26292.

## Problem

In `tests/common/TestRuntime.LinkAll.cs`, the `IsLinkAll` property resolved the `+LinkerSentinel` type using a compile-time-constant type name:

```csharp
link_all = typeof (TestRuntime).Assembly.GetType (typeof (TestRuntime).FullName + "+LinkerSentinel") is null;
```

The trimmer's dataflow analysis (dotnet/runtime#127319) can resolve that constant string and preserve the `LinkerSentinel` type, which would make `IsLinkAll` incorrectly report `false` even in link-all builds.

## Fix

Introduce a `WorkAroundLinkerHeuristics` property that returns `""` at runtime (but the trimmer can't constant-fold) and append it to the type-name string, so the trimmer can no longer statically resolve `+LinkerSentinel`. This matches the pattern already used in `tests/linker/*` (e.g. `CommonLinkAllTest.cs`, `PreserveTest.cs`).

🤖 Pull request created by Copilot