### PR TITLE
[msbuild] Use GetFileSystemEntries for remote-safe XCFramework dSYM discovery

### DIFF
--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/GetFileSystemEntries.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/GetFileSystemEntries.cs
@@ -55,6 +55,12 @@ namespace Xamarin.MacDev.Tasks {
 			var entries = new List<ITaskItem> ();
 			foreach (var item in DirectoryPath) {
 				var path = item.ItemSpec.TrimEnd ('\\', '/');
+
+				if (!Directory.Exists (path)) {
+					Log.LogMessage (MessageImportance.Low, $"Skipping {path} because the directory does not exist.");
+					continue;
+				}
+
 				var entriesFullPath = IncludeDirectories ?
 					Directory.EnumerateFileSystemEntries (path, Pattern, searchOption) :
 					Directory.EnumerateFiles (path, Pattern, searchOption);

--- a/msbuild/Xamarin.Shared/Xamarin.Shared.targets
+++ b/msbuild/Xamarin.Shared/Xamarin.Shared.targets
@@ -3296,21 +3296,35 @@ Copyright (C) 2018 Microsoft. All rights reserved.
 		>
 
 		<ItemGroup>
-			<!-- Compute the potential dSYM path for each framework in the post-processing items.
+			<!-- Compute the potential dSYMs directory for each framework in the post-processing items.
 			     For a framework at path/to/xcframework/ios-arm64/MyFramework.framework/MyFramework,
-			     the dSYM would be at path/to/xcframework/ios-arm64/dSYMs/MyFramework.framework.dSYM
-			     Note: this target only runs on macOS, so forward slashes are fine. -->
+			     the dSYMs directory would be at path/to/xcframework/ios-arm64/dSYMs -->
 			<_XCFrameworkDSymCandidate
 				Include="@(_GenerateDSymItems)"
 				Condition="'%(_GenerateDSymItems.ItemSourcePath)' != ''"
 			>
 				<DSymSourceDir>$([System.IO.Path]::GetDirectoryName($([System.IO.Path]::GetDirectoryName('%(_GenerateDSymItems.ItemSourcePath)'))))/dSYMs</DSymSourceDir>
 			</_XCFrameworkDSymCandidate>
-			<_XCFrameworkDSymToCopy
-				Include="@(_XCFrameworkDSymCandidate->'%(DSymSourceDir)/%(DSymName)')"
-				Condition="Exists('%(DSymSourceDir)/%(DSymName)')"
+		</ItemGroup>
+
+		<!-- Find which dSYMs actually exist using a task instead of the MSBuild Exists() function.
+		     Exists() evaluates on the build host (Windows for remote builds), but the dSYMs live on
+		     the Mac, so we have to use the remote-capable GetFileSystemEntries task to look for them. -->
+		<GetFileSystemEntries
+			SessionId="$(BuildSessionId)"
+			Condition="'$(IsMacEnabled)' == 'true'"
+			DirectoryPath="@(_XCFrameworkDSymCandidate->'%(DSymSourceDir)')"
+			Pattern="*.dSYM"
+			Recursive="false"
+			IncludeDirectories="true"
 			>
-				<DSymName>%(DSymName)</DSymName>
+			<Output TaskParameter="Entries" ItemName="_XCFrameworkDSymToCopy" />
+		</GetFileSystemEntries>
+
+		<ItemGroup>
+			<!-- The dSYM directory is named the same as the DSymName metadata used for the copy destination. -->
+			<_XCFrameworkDSymToCopy>
+				<DSymName>%(Filename)%(Extension)</DSymName>
 			</_XCFrameworkDSymToCopy>
 		</ItemGroup>
 	</Target>


### PR DESCRIPTION
Addresses a code review comment from #26292.

## Problem

The `_ComputeXCFrameworkDSyms` target in `msbuild/Xamarin.Shared/Xamarin.Shared.targets` filtered xcframework dSYM candidates using the MSBuild `Exists(...)` function:

```xml
<_XCFrameworkDSymToCopy
    Include="@(_XCFrameworkDSymCandidate->'%(DSymSourceDir)/%(DSymName)')"
    Condition="Exists('%(DSymSourceDir)/%(DSymName)')">
    <DSymName>%(DSymName)</DSymName>
</_XCFrameworkDSymToCopy>
```

`Exists(...)` evaluates on the MSBuild host using host path semantics. For remote builds (Windows → macOS, e.g. Hot Restart / remote Mac builds) this is wrong: the files live on the Mac, not the Windows host, so the check never finds them and the xcframework dSYMs are not copied into the archive. The old comment even claimed the target "only runs on macOS", which is misleading.

## Fix

Use the existing remote-capable `GetFileSystemEntries` task (already used elsewhere in the same file) to discover which `*.dSYM` directories actually exist under the computed `dSYMs` directory on the build machine (the Mac), and copy only those — instead of relying on the host-side `Exists(...)` function.

- The discovered directory name equals the `DSymName` metadata used for the copy destination, so the `_XCFrameworkDSymToCopy` item shape (Identity = source dSYM path, `DSymName` metadata) is preserved and `_CopyXCFrameworkDSyms` keeps working unchanged.
- `GetFileSystemEntries` now skips non-existent directories, since a framework's `dSYMs` directory may not exist.
- Updated the misleading "only runs on macOS" comment.

🤖 Pull request created by Copilot