### PR TITLE
[tools] Strip resources from linked assemblies in Hot Reload + PrepareAssemblies builds.

### DIFF
--- a/tests/assembly-preparer/BaseClass.cs
+++ b/tests/assembly-preparer/BaseClass.cs
@@ -54,7 +54,7 @@ public abstract class BaseClass {
 
 	// Builds the provided code into a Test.dll and returns an AssemblyPreparer configured for it, without
 	// running any preparation steps. Use this when a test needs to run a custom set of steps.
-	public AssemblyPreparer CreatePreparer (ApplePlatform platform, bool isCoreCLR, Action<AssemblyPreparer>? configure, string code, out AssemblyPreparerInfo testInfo, string extraCsproj = "", string extraConfig = "", IEnumerable<(string FileName, byte [] Content)>? extraFiles = null)
+	public AssemblyPreparer CreatePreparer (ApplePlatform platform, bool isCoreCLR, Action<AssemblyPreparer>? configure, string code, out AssemblyPreparerInfo testInfo, string extraCsproj = "", string extraConfig = "", IEnumerable<(string FileName, byte [] Content)>? extraFiles = null, string testTrimMode = "link")
 	{
 		Configuration.IgnoreIfIgnoredPlatform (platform);
 
@@ -101,7 +101,7 @@ public abstract class BaseClass {
 
 		var assemblies = Configuration.GetImplementationAssemblies (platform, isCoreCLR);
 		assemblies.Add (Path.Combine (assemblyDir, "Test.dll"));
-		var infos = assemblies.Select (v => new AssemblyPreparerInfo (v, Path.Combine (assemblyDir, "out", Path.GetFileName (v)), true, "link")).ToArray ();
+		var infos = assemblies.Select (v => new AssemblyPreparerInfo (v, Path.Combine (assemblyDir, "out", Path.GetFileName (v)), true, Path.GetFileNameWithoutExtension (v) == "Test" ? testTrimMode : "link")).ToArray ();
 		var logger = new TestLogger () { Platform = platform };
 		var preparer = new AssemblyPreparer (logger, infos, configpath);
 		if (configure is not null)

--- a/tests/assembly-preparer/RemoveUserResourcesSubStepTests.cs
+++ b/tests/assembly-preparer/RemoveUserResourcesSubStepTests.cs
@@ -26,8 +26,9 @@ public class RemoveUserResourcesSubStepTests : BaseClass {
 
 	// Builds a user assembly with an embedded MonoTouch/XamMac content resource, then runs the
 	// RemoveUserResourcesSubStep with the provided value of HotReloadCompatibleBuild and returns the
-	// resource names still present in the (in-memory) assembly after the step ran.
-	List<string> GetResourcesAfterStep (ApplePlatform platform, bool isCoreCLR, bool hotReloadCompatibleBuild)
+	// resource names still present in the (in-memory) assembly after the step ran. The 'trimMode'
+	// controls whether the Test assembly is linked ("link") or copied ("copy", i.e. reloadable).
+	List<string> GetResourcesAfterStep (ApplePlatform platform, bool isCoreCLR, bool hotReloadCompatibleBuild, string trimMode = "link")
 	{
 		var prefix = GetContentPrefix (platform);
 		var resourceName = prefix + "TestResource.bin";
@@ -47,7 +48,7 @@ public class RemoveUserResourcesSubStepTests : BaseClass {
 
 		var extraConfig = $"HotReloadCompatibleBuild={(hotReloadCompatibleBuild ? "true" : "false")}";
 
-		using var preparer = CreatePreparer (platform, isCoreCLR, p => p.Registrar = RegistrarMode.Dynamic, code, out var testInfo, extraCsproj: extraCsproj, extraConfig: extraConfig, extraFiles: new [] { ("TestResource.bin", content) });
+		using var preparer = CreatePreparer (platform, isCoreCLR, p => p.Registrar = RegistrarMode.Dynamic, code, out var testInfo, extraCsproj: extraCsproj, extraConfig: extraConfig, extraFiles: new [] { ("TestResource.bin", content) }, testTrimMode: trimMode);
 
 		var context = preparer.Configuration.DerivedLinkContext;
 		new LoadAssembliesStep ().Process (context);
@@ -78,10 +79,25 @@ public class RemoveUserResourcesSubStepTests : BaseClass {
 	{
 		var prefix = GetContentPrefix (platform);
 		var resourceName = prefix + "TestResource.bin";
-		var resources = GetResourcesAfterStep (platform, isCoreCLR, hotReloadCompatibleBuild: true);
+		// A reloadable (non-linked, i.e. copied) assembly must be left untouched: the step must not
+		// remove the resource (which would upgrade the assembly to AssemblyAction.Save and break Hot Reload).
+		var resources = GetResourcesAfterStep (platform, isCoreCLR, hotReloadCompatibleBuild: true, trimMode: "copy");
 
-		// The resource must be left untouched: the step must not remove it (and thus not upgrade the
-		// user assembly to AssemblyAction.Save, which is what would break Hot Reload).
-		Assert.That (resources, Has.Some.EqualTo (resourceName), "The user resource must be kept when HotReloadCompatibleBuild is enabled.");
+		Assert.That (resources, Has.Some.EqualTo (resourceName), "The user resource must be kept for a reloadable assembly when HotReloadCompatibleBuild is enabled.");
+	}
+
+	[Test]
+	[TestCase (ApplePlatform.iOS, false)]
+	[TestCase (ApplePlatform.TVOS, false)]
+	[TestCase (ApplePlatform.MacCatalyst, false)]
+	[TestCase (ApplePlatform.MacOSX, true)]
+	public void ResourceRemovedForLinkedAssemblyInHotReload (ApplePlatform platform, bool isCoreCLR)
+	{
+		var prefix = GetContentPrefix (platform);
+		// A linked assembly is re-serialized regardless (it's not reloadable), so its resources must be
+		// stripped even in a Hot Reload compatible build.
+		var resources = GetResourcesAfterStep (platform, isCoreCLR, hotReloadCompatibleBuild: true, trimMode: "link");
+
+		Assert.That (resources, Has.None.StartsWith (prefix), "The user resource should be stripped from a linked assembly even when HotReloadCompatibleBuild is enabled.");
 	}
 }

--- a/tools/linker/RemoveUserResourcesSubStep.cs
+++ b/tools/linker/RemoveUserResourcesSubStep.cs
@@ -97,9 +97,10 @@ namespace Xamarin.Linker {
 				return false;
 
 #if ASSEMBLY_PREPARER
-			// In the assembly-preparer any modification re-serializes (saves) the assembly, which breaks Hot
-			// Reload. So skip resource stripping entirely for Hot Reload compatible builds.
-			if (Configuration.HotReloadCompatibleBuild)
+			// In Hot Reload compatible builds, don't strip resources from reloadable (non-linked) assemblies,
+			// because modifying them re-serializes (saves) the assembly, breaking Hot Reload. Linked assemblies
+			// are re-serialized regardless, so stripping them is fine.
+			if (Configuration.HotReloadCompatibleBuild && Annotations.GetAction (assembly) != AssemblyAction.Link)
 				return false;
 #endif
 


### PR DESCRIPTION
The assembly-preparer's RemoveUserResourcesSubStep unconditionally skipped
resource stripping for every assembly in Hot Reload compatible builds. This
was too broad: linked (trimmed) assemblies are re-serialized regardless, so
stripping them doesn't break Hot Reload - only reloadable (non-linked, copied)
assemblies must be left untouched.

This matches the non-preparer (ILLink) code path, which only skips assemblies
whose action isn't 'Link'. Without this fix, the
'prepare-assemblies|trimmable-static-registrar' variation of the
'link all' MacCatalyst test failed because embedded resources were left in the
linked BundledResources assembly.

Updated the unit tests to cover both the reloadable (kept) and linked (stripped)
cases in a Hot Reload build.

🤖 Pull request created by Copilot
