### PR TITLE
[docs] Clarify EnableOnDemandResources and EmbedOnDemandResources properties

### DIFF
--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -502,7 +502,22 @@ build warns) when those conditions aren't met.
 
 ## EmbedOnDemandResources
 
-If on-demand resources should be embedded in the app bundle.
+Controls where on-demand resource asset packs are placed when packaging an app
+for distribution. This property does **not** enable on-demand resources (use
+[EnableOnDemandResources](#enableondemandresources) for that) — it only affects
+how already-tagged asset packs are packaged.
+
+This is the property set by the "Embed on-demand resources in the app bundle"
+option in the IDE.
+
+* `true`: the asset packs are embedded in the `.app` bundle inside the IPA and
+  served locally by the app.
+* `false`: the asset packs are packaged separately (outside the app bundle) so
+  they can be streamed/hosted (for example on a web server or by the App Store).
+
+This property is only consulted when packaging an IPA for distribution (when
+`BuildIpa` is `true` and the distribution type is `AppStore` or `AdHoc`); it has
+no effect on a simulator or device debug build.
 
 Default: true
 
@@ -519,6 +534,26 @@ See [CodesignEntitlements](#codesignentitlements).
 ## EnableOnDemandResources
 
 If on-demand resources are enabled.
+
+When enabled, bundle resources that are tagged with `ResourceTags` metadata are
+placed into on-demand resource asset packs instead of being copied directly into
+the app bundle. A resource is tagged like this:
+
+```xml
+<ItemGroup>
+  <BundleResource Update="Resources\MyResource.dat" ResourceTags="MyTag" />
+</ItemGroup>
+```
+
+Use `Update` (not `Include`) when the file is already part of the project's
+default resources (for example anything under the `Resources` folder on iOS,
+which is automatically included as a `BundleResource`), otherwise the resource
+would be added twice and the untagged copy would win. In a .NET MAUI project the
+same `ResourceTags` metadata can be set on the corresponding `MauiAsset` item.
+
+This property only enables on-demand resources; it does not control how the asset
+packs are packaged for distribution — see
+[EmbedOnDemandResources](#embedondemandresources) for that.
 
 Default: false for macOS, true for all other platforms.
 

--- a/docs/building-apps/build-properties.md
+++ b/docs/building-apps/build-properties.md
@@ -508,12 +508,15 @@ for distribution. This property does **not** enable on-demand resources (use
 how already-tagged asset packs are packaged.
 
 This is the property set by the "Embed on-demand resources in the app bundle"
-option in the IDE.
+option in the IDE. It only takes effect for `AdHoc` distribution:
 
 * `true`: the asset packs are embedded in the `.app` bundle inside the IPA and
   served locally by the app.
 * `false`: the asset packs are packaged separately (outside the app bundle) so
-  they can be streamed/hosted (for example on a web server or by the App Store).
+  they can be streamed/hosted (for example on a web server).
+
+For `AppStore` distribution the asset packs are always placed outside the `.app`
+bundle (to be hosted by the App Store), regardless of this property.
 
 This property is only consulted when packaging an IPA for distribution (when
 `BuildIpa` is `true` and the distribution type is `AppStore` or `AdHoc`); it has


### PR DESCRIPTION
Expand the documentation for the two on-demand-resources (ODR) build
properties. The difference between them caused customer confusion in
issue #26218, where a user thought on-demand resources were disabled by
default (they aren't on iOS) and that the "Embed on-demand resources in the
app bundle" option was what turned the feature on (it doesn't).

* `EnableOnDemandResources`: explain that this is what turns ODR on, and show
  how to tag a resource with `ResourceTags` metadata — using `Update` rather
  than `Include` for resources that are already part of the project's default
  resources, and mentioning the `MauiAsset` equivalent for .NET MAUI projects.
* `EmbedOnDemandResources`: clarify that it does NOT enable ODR, and only
  controls where asset packs are placed when packaging an IPA for
  distribution.

The two entries now cross-reference each other.

This is a documentation-only change; it does not change any build behavior and
does not by itself fix #26218 (which was a user project-metadata problem).

🤖 Pull request created by Copilot