### PR TITLE
[tests] Only force complete NativeAOT metadata when NUnit is referenced

### DIFF
--- a/tests/common/shared-dotnet.csproj
+++ b/tests/common/shared-dotnet.csproj
@@ -82,9 +82,12 @@
 		<IlcTreatWarningsAsErrors>false</IlcTreatWarningsAsErrors>
 		<!-- NUnit 4.x's EquatablesComparer calls Type.GetInterfaceMap() which requires complete type metadata.
 		     Without this, any Assert.That(x, Is.EqualTo(y)) where x implements IEquatable<T> will throw
-		     NotSupportedException on NativeAOT. See https://github.com/nunit/nunit/issues/3970 -->
-		<IlcGenerateCompleteTypeMetadata>true</IlcGenerateCompleteTypeMetadata>
-		<IlcTrimMetadata>false</IlcTrimMetadata>
+		     NotSupportedException on NativeAOT. See https://github.com/nunit/nunit/issues/3970
+		     Only enable this when NUnit is actually referenced: it makes every reflectable type keep
+		     complete metadata (and every method reflectable), which significantly increases the app size
+		     of any app that uses NUnit. We must not impose that cost on apps that don't reference NUnit. -->
+		<IlcGenerateCompleteTypeMetadata Condition="'$(ExcludeNUnitLiteReference)' != 'true'">true</IlcGenerateCompleteTypeMetadata>
+		<IlcTrimMetadata Condition="'$(ExcludeNUnitLiteReference)' != 'true'">false</IlcTrimMetadata>
 	</PropertyGroup>
 
 	<!-- Trimmer options -->
@@ -148,9 +151,12 @@
 		<IlcTreatWarningsAsErrors>false</IlcTreatWarningsAsErrors>
 		<!-- NUnit 4.x's EquatablesComparer calls Type.GetInterfaceMap() which requires complete type metadata.
 		     Without this, any Assert.That(x, Is.EqualTo(y)) where x implements IEquatable<T> will throw
-		     NotSupportedException on NativeAOT. See https://github.com/nunit/nunit/issues/3970 -->
-		<IlcGenerateCompleteTypeMetadata>true</IlcGenerateCompleteTypeMetadata>
-		<IlcTrimMetadata>false</IlcTrimMetadata>
+		     NotSupportedException on NativeAOT. See https://github.com/nunit/nunit/issues/3970
+		     Only enable this when NUnit is actually referenced: it makes every reflectable type keep
+		     complete metadata (and every method reflectable), which significantly increases the app size
+		     of any app that uses NUnit. We must not impose that cost on apps that don't reference NUnit. -->
+		<IlcGenerateCompleteTypeMetadata Condition="'$(ExcludeNUnitLiteReference)' != 'true'">true</IlcGenerateCompleteTypeMetadata>
+		<IlcTrimMetadata Condition="'$(ExcludeNUnitLiteReference)' != 'true'">false</IlcTrimMetadata>
 	</PropertyGroup>
 
 	<!--

--- a/tests/dotnet/UnitTests/expected/MacCatalyst-NativeAOT-TrimmableStatic-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacCatalyst-NativeAOT-TrimmableStatic-size.txt
@@ -1,9 +1,9 @@
-AppBundleSize: 13,866,447 bytes (13,541.5 KB = 13.2 MB)
+AppBundleSize: 8,788,638 bytes (8,582.7 KB = 8.4 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    1,079 bytes (1.1 KB = 0.0 MB)
+    1,062 bytes (1.0 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
-    13,863,464 bytes (13,538.5 KB = 13.2 MB)
+    8,785,672 bytes (8,579.8 KB = 8.4 MB)
 Contents/MonoBundle/runtimeconfig.bin:
     1,896 bytes (1.9 KB = 0.0 MB)
 Contents/PkgInfo:

--- a/tests/dotnet/UnitTests/expected/MacCatalyst-NativeAOT-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacCatalyst-NativeAOT-size.txt
@@ -1,9 +1,9 @@
-AppBundleSize: 6,094,471 bytes (5,951.6 KB = 5.8 MB)
+AppBundleSize: 2,742,214 bytes (2,677.9 KB = 2.6 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    1,079 bytes (1.1 KB = 0.0 MB)
+    1,062 bytes (1.0 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
-    6,091,576 bytes (5,948.8 KB = 5.8 MB)
+    2,739,336 bytes (2,675.1 KB = 2.6 MB)
 Contents/MonoBundle/runtimeconfig.bin:
     1,808 bytes (1.8 KB = 0.0 MB)
 Contents/PkgInfo:

--- a/tests/dotnet/UnitTests/expected/MacOSX-NativeAOT-TrimmableStatic-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacOSX-NativeAOT-TrimmableStatic-size.txt
@@ -1,9 +1,9 @@
-AppBundleSize: 32,523,405 bytes (31,761.1 KB = 31.0 MB)
+AppBundleSize: 21,463,772 bytes (20,960.7 KB = 20.5 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    757 bytes (0.7 KB = 0.0 MB)
+    740 bytes (0.7 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
-    29,434,088 bytes (28,744.2 KB = 28.1 MB)
+    18,374,472 bytes (17,943.8 KB = 17.5 MB)
 Contents/MonoBundle/libSystem.Globalization.Native.dylib:
     267,872 bytes (261.6 KB = 0.3 MB)
 Contents/MonoBundle/libSystem.IO.Compression.Native.dylib:

--- a/tests/dotnet/UnitTests/expected/MacOSX-NativeAOT-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacOSX-NativeAOT-size.txt
@@ -1,9 +1,9 @@
-AppBundleSize: 15,769,451 bytes (15,399.9 KB = 15.0 MB)
+AppBundleSize: 8,779,418 bytes (8,573.7 KB = 8.4 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    757 bytes (0.7 KB = 0.0 MB)
+    740 bytes (0.7 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
-    12,680,216 bytes (12,383.0 KB = 12.1 MB)
+    5,690,200 bytes (5,556.8 KB = 5.4 MB)
 Contents/MonoBundle/libSystem.Globalization.Native.dylib:
     267,872 bytes (261.6 KB = 0.3 MB)
 Contents/MonoBundle/libSystem.IO.Compression.Native.dylib:

--- a/tests/dotnet/UnitTests/expected/TVOS-NativeAOT-TrimmableStatic-size.txt
+++ b/tests/dotnet/UnitTests/expected/TVOS-NativeAOT-TrimmableStatic-size.txt
@@ -1,10 +1,10 @@
-AppBundleSize: 12,481,322 bytes (12,188.8 KB = 11.9 MB)
+AppBundleSize: 7,804,745 bytes (7,621.8 KB = 7.4 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Info.plist:
-    1,145 bytes (1.1 KB = 0.0 MB)
+    1,128 bytes (1.1 KB = 0.0 MB)
 PkgInfo:
     8 bytes (0.0 KB = 0.0 MB)
 runtimeconfig.bin:
     1,889 bytes (1.8 KB = 0.0 MB)
 SizeTestApp:
-    12,478,280 bytes (12,185.8 KB = 11.9 MB)
+    7,801,720 bytes (7,618.9 KB = 7.4 MB)

--- a/tests/dotnet/UnitTests/expected/TVOS-NativeAOT-size.txt
+++ b/tests/dotnet/UnitTests/expected/TVOS-NativeAOT-size.txt
@@ -1,10 +1,10 @@
-AppBundleSize: 5,999,201 bytes (5,858.6 KB = 5.7 MB)
+AppBundleSize: 2,705,640 bytes (2,642.2 KB = 2.6 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Info.plist:
-    1,145 bytes (1.1 KB = 0.0 MB)
+    1,128 bytes (1.1 KB = 0.0 MB)
 PkgInfo:
     8 bytes (0.0 KB = 0.0 MB)
 runtimeconfig.bin:
     1,808 bytes (1.8 KB = 0.0 MB)
 SizeTestApp:
-    5,996,240 bytes (5,855.7 KB = 5.7 MB)
+    2,702,696 bytes (2,639.4 KB = 2.6 MB)

--- a/tests/dotnet/UnitTests/expected/iOS-NativeAOT-TrimmableStatic-size.txt
+++ b/tests/dotnet/UnitTests/expected/iOS-NativeAOT-TrimmableStatic-size.txt
@@ -1,10 +1,10 @@
-AppBundleSize: 14,086,169 bytes (13,756.0 KB = 13.4 MB)
+AppBundleSize: 8,998,312 bytes (8,787.4 KB = 8.6 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Info.plist:
-    1,169 bytes (1.1 KB = 0.0 MB)
+    1,152 bytes (1.1 KB = 0.0 MB)
 PkgInfo:
     8 bytes (0.0 KB = 0.0 MB)
 runtimeconfig.bin:
     1,888 bytes (1.8 KB = 0.0 MB)
 SizeTestApp:
-    14,083,104 bytes (13,753.0 KB = 13.4 MB)
+    8,995,264 bytes (8,784.4 KB = 8.6 MB)

--- a/tests/dotnet/UnitTests/expected/iOS-NativeAOT-size.txt
+++ b/tests/dotnet/UnitTests/expected/iOS-NativeAOT-size.txt
@@ -1,10 +1,10 @@
-AppBundleSize: 6,015,929 bytes (5,874.9 KB = 5.7 MB)
+AppBundleSize: 2,706,000 bytes (2,642.6 KB = 2.6 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Info.plist:
-    1,169 bytes (1.1 KB = 0.0 MB)
+    1,152 bytes (1.1 KB = 0.0 MB)
 PkgInfo:
     8 bytes (0.0 KB = 0.0 MB)
 runtimeconfig.bin:
     1,808 bytes (1.8 KB = 0.0 MB)
 SizeTestApp:
-    6,012,944 bytes (5,872.0 KB = 5.7 MB)
+    2,703,032 bytes (2,639.7 KB = 2.6 MB)


### PR DESCRIPTION
The test infrastructure (tests/common/shared-dotnet.csproj) unconditionally set the following ILC properties for every NativeAOT publish:

    IlcGenerateCompleteTypeMetadata=true   (--completetypemetadata)
    IlcTrimMetadata=false                   (--reflectiondata:all)

These were added as a workaround for NUnit 4.x, whose EquatablesComparer calls Type.GetInterfaceMap(), which requires complete type metadata (see https://github.com/nunit/nunit/issues/3970).

However, they were applied to *all* NativeAOT test apps, including apps that don't reference NUnit at all (e.g. SizeTestApp). Together these flags make every reflectable type keep complete metadata and every compiled method reflectable, which defeats trimming and dramatically inflates app size - for the trimmable-static registrar in particular they were the dominant driver of the complete-metadata cascade through the registered NSObject binding surface.

This change gates both flags on `'$(ExcludeNUnitLiteReference)' != 'true'`, the exact same condition that already governs whether NUnitLite is referenced and whether nunit.framework.targets is imported. Apps that reference NUnit keep the workaround; apps that don't no longer pay the size cost.

The expected app-size files are regenerated accordingly - NativeAOT sizes (and especially the trimmable-static variants) drop substantially.

🤖 Pull request created by Copilot
