### PR TITLE
[docs] Improve XML docs for UISegmentedControl, VNUtils, CGVector, CIFilter, NSSecureCoding, MDLVertexFormatExtensions, UIBarItem, CNInstantMessageAddress, CNSocialProfile, NSPrintInfo

### DIFF
--- a/src/AppKit/NSPrintInfo.cs
+++ b/src/AppKit/NSPrintInfo.cs
@@ -5,21 +5,21 @@ using PrintCore;
 
 namespace AppKit {
 	public partial class NSPrintInfo {
-		/// <summary>GetPrintSession.</summary>
+		/// <summary>Returns the print session associated with this print info.</summary>
 		public PMPrintSession GetPrintSession ()
 		{
 			var ptr = GetPMPrintSession ();
 			return new PMPrintSession (ptr, false);
 		}
 
-		/// <summary>GetPageFormat.</summary>
+		/// <summary>Returns the page format associated with this print info.</summary>
 		public PMPageFormat GetPageFormat ()
 		{
 			var ptr = GetPMPageFormat ();
 			return new PMPageFormat (ptr, false);
 		}
 
-		/// <summary>GetPrintSettings.</summary>
+		/// <summary>Returns the print settings associated with this print info.</summary>
 		public PMPrintSettings GetPrintSettings ()
 		{
 			var ptr = GetPMPrintSettings ();

--- a/src/AppKit/NSPrintInfo.cs
+++ b/src/AppKit/NSPrintInfo.cs
@@ -5,27 +5,21 @@ using PrintCore;
 
 namespace AppKit {
 	public partial class NSPrintInfo {
-		/// <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>GetPrintSession.</summary>
 		public PMPrintSession GetPrintSession ()
 		{
 			var ptr = GetPMPrintSession ();
 			return new PMPrintSession (ptr, false);
 		}
 
-		/// <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>GetPageFormat.</summary>
 		public PMPageFormat GetPageFormat ()
 		{
 			var ptr = GetPMPageFormat ();
 			return new PMPageFormat (ptr, false);
 		}
 
-		/// <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>GetPrintSettings.</summary>
 		public PMPrintSettings GetPrintSettings ()
 		{
 			var ptr = GetPMPrintSettings ();

--- a/src/Contacts/CNInstantMessageAddress.cs
+++ b/src/Contacts/CNInstantMessageAddress.cs
@@ -12,7 +12,6 @@
 namespace Contacts {
 	// Strong typed Keys to enum
 	/// <summary>Enumeration of values used by all instant-message services.</summary>
-	///     <remarks>To be added.</remarks>
 	public enum CNInstantMessageAddressOption {
 		/// <summary>Associated with the <see cref="Contacts.CNInstantMessageAddress.Username" /> property..</summary>
 		Username,
@@ -22,7 +21,6 @@ namespace Contacts {
 
 	// Strong typed Keys to enum
 	/// <summary>Enumerates common providers of instant messaging.</summary>
-	///     <remarks>To be added.</remarks>
 	public enum CNInstantMessageServiceOption {
 		/// <summary>AOL Instant Messenger.</summary>
 		Aim,
@@ -48,10 +46,8 @@ namespace Contacts {
 
 	public partial class CNInstantMessageAddress {
 
-		/// <param name="property">To be added.</param>
+		/// <param name="property">The property.</param>
 		///         <summary>Returns the localized property name for <paramref name="property" />.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public static string LocalizeProperty (CNInstantMessageAddressOption property)
 		{
 			switch (property) {
@@ -64,10 +60,8 @@ namespace Contacts {
 			}
 		}
 
-		/// <param name="serviceOption">To be added.</param>
+		/// <param name="serviceOption">The service option.</param>
 		///         <summary>Returns the localized string for the specified <paramref name="serviceOption" />.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public static string LocalizeService (CNInstantMessageServiceOption serviceOption)
 		{
 			var srvc = ServiceOptionsToNSString (serviceOption);

--- a/src/Contacts/CNInstantMessageAddress.cs
+++ b/src/Contacts/CNInstantMessageAddress.cs
@@ -46,8 +46,8 @@ namespace Contacts {
 
 	public partial class CNInstantMessageAddress {
 
+		/// <summary>Returns the localized property name for <paramref name="property" />.</summary>
 		/// <param name="property">The property.</param>
-		///         <summary>Returns the localized property name for <paramref name="property" />.</summary>
 		public static string LocalizeProperty (CNInstantMessageAddressOption property)
 		{
 			switch (property) {
@@ -60,8 +60,8 @@ namespace Contacts {
 			}
 		}
 
+		/// <summary>Returns the localized string for the specified <paramref name="serviceOption" />.</summary>
 		/// <param name="serviceOption">The service option.</param>
-		///         <summary>Returns the localized string for the specified <paramref name="serviceOption" />.</summary>
 		public static string LocalizeService (CNInstantMessageServiceOption serviceOption)
 		{
 			var srvc = ServiceOptionsToNSString (serviceOption);

--- a/src/Contacts/CNInstantMessageAddress.cs
+++ b/src/Contacts/CNInstantMessageAddress.cs
@@ -13,9 +13,9 @@ namespace Contacts {
 	// Strong typed Keys to enum
 	/// <summary>Enumeration of values used by all instant-message services.</summary>
 	public enum CNInstantMessageAddressOption {
-		/// <summary>Associated with the <see cref="Contacts.CNInstantMessageAddress.Username" /> property..</summary>
+		/// <summary>Associated with the <see cref="Contacts.CNInstantMessageAddress.Username" /> property.</summary>
 		Username,
-		/// <summary>Associated with the <see cref="Contacts.CNInstantMessageAddress.Service" /> property..</summary>
+		/// <summary>Associated with the <see cref="Contacts.CNInstantMessageAddress.Service" /> property.</summary>
 		Service,
 	}
 

--- a/src/Contacts/CNSocialProfile.cs
+++ b/src/Contacts/CNSocialProfile.cs
@@ -48,8 +48,8 @@ namespace Contacts {
 
 	public partial class CNSocialProfile {
 
+		/// <summary>Returns the localized string representing the <paramref name="option" />.</summary>
 		/// <param name="option">The option.</param>
-		///         <summary>Returns the localized string representing the <paramref name="option" />.</summary>
 		public static string LocalizeProperty (CNSocialProfileOption option)
 		{
 			switch (option) {
@@ -66,8 +66,8 @@ namespace Contacts {
 			}
 		}
 
+		/// <summary>Returns the localized string representing the <paramref name="serviceOption" />.</summary>
 		/// <param name="serviceOption">The service option.</param>
-		///         <summary>Returns the localized string representing the <paramref name="serviceOption" />.</summary>
 		public static string LocalizeService (CNSocialProfileServiceOption serviceOption)
 		{
 			var srvc = ServiceOptionsToNSString (serviceOption);

--- a/src/Contacts/CNSocialProfile.cs
+++ b/src/Contacts/CNSocialProfile.cs
@@ -12,7 +12,6 @@
 namespace Contacts {
 	// Strong typed Keys to enum
 	/// <summary>Enumerates properties of social services that are always fetched.</summary>
-	///     <remarks>To be added.</remarks>
 	public enum CNSocialProfileOption {
 		/// <summary>Associated with the <see cref="Contacts.CNSocialProfileKey.UrlString" /> property.</summary>
 		UrlString,
@@ -26,7 +25,6 @@ namespace Contacts {
 
 	// Strong typed Keys to enum
 	/// <summary>Enumerates known social services.</summary>
-	///     <remarks>To be added.</remarks>
 	public enum CNSocialProfileServiceOption {
 		/// <summary>Facebook.</summary>
 		Facebook,
@@ -50,10 +48,8 @@ namespace Contacts {
 
 	public partial class CNSocialProfile {
 
-		/// <param name="option">To be added.</param>
+		/// <param name="option">The option.</param>
 		///         <summary>Returns the localized string representing the <paramref name="option" />.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public static string LocalizeProperty (CNSocialProfileOption option)
 		{
 			switch (option) {
@@ -70,10 +66,8 @@ namespace Contacts {
 			}
 		}
 
-		/// <param name="serviceOption">To be added.</param>
+		/// <param name="serviceOption">The service option.</param>
 		///         <summary>Returns the localized string representing the <paramref name="serviceOption" />.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public static string LocalizeService (CNSocialProfileServiceOption serviceOption)
 		{
 			var srvc = ServiceOptionsToNSString (serviceOption);

--- a/src/CoreGraphics/CGVector.cs
+++ b/src/CoreGraphics/CGVector.cs
@@ -64,14 +64,14 @@ namespace CoreGraphics {
 			return left.dx != right.dx || left.dy != right.dy;
 		}
 
-		/// <summary />
+		/// <summary>Returns the hash code for this vector.</summary>
 		public override int GetHashCode ()
 		{
 			return HashCode.Combine (dx, dy);
 		}
 
-		/// <param name="other">The other.</param>
-		///         <summary />
+		/// <summary>Determines whether this vector is equal to the specified object.</summary>
+		/// <param name="other">The object to compare with.</param>
 		public override bool Equals (object? other)
 		{
 			if (other is CGVector vector)
@@ -88,13 +88,7 @@ namespace CoreGraphics {
 		[DllImport (Constants.UIKitLibrary)]
 		extern static IntPtr NSStringFromCGVector (CGVector vector);
 
-		/// <summary>String representation of the vector, suitable to be passed later to <see cref="CoreGraphics.CGVector.FromString(System.String)" /> method.</summary>
-		///         <returns>
-		///           <para />
-		///         </returns>
-		///         <remarks>
-		///           <para />
-		///         </remarks>
+		/// <summary>String representation of the vector, suitable to be passed later to <see cref="CoreGraphics.CGVector.FromString(System.String)" /> method.</summary>
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]
@@ -111,12 +105,9 @@ namespace CoreGraphics {
 		[DllImport (Constants.UIKitLibrary)]
 		extern static CGVector CGVectorFromString (IntPtr str);
 
-		/// <param name="s">String representation, created previously with either the <see cref="CoreGraphics.CGVector.ToString" /> method or serialized in the CGVector format.</param>
-		///         <summary>Creates a CGVector from a stringified representation of the vector.</summary>
-		///         <returns>The CGVector represented by the string representation.</returns>
-		///         <remarks>
-		///           <para />
-		///         </remarks>
+		/// <summary>Creates a CGVector from a stringified representation of the vector.</summary>
+		/// <param name="s">String representation, created previously with either the <see cref="CoreGraphics.CGVector.ToString" /> method or serialized in the CGVector format.</param>
+		/// <returns>The CGVector represented by the string representation.</returns>
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("tvos")]

--- a/src/CoreGraphics/CGVector.cs
+++ b/src/CoreGraphics/CGVector.cs
@@ -44,10 +44,8 @@ namespace CoreGraphics {
 	// CGGeometry.h
 	public struct CGVector {
 		/// <summary>X component of the vector</summary>
-		///         <remarks>To be added.</remarks>
 		public /* CGFloat */ nfloat dx;
 		/// <summary>Y component of the vector</summary>
-		///         <remarks>To be added.</remarks>
 		public /* CGFloat */ nfloat dy;
 
 		public CGVector (nfloat dx, nfloat dy)
@@ -67,17 +65,13 @@ namespace CoreGraphics {
 		}
 
 		/// <summary />
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public override int GetHashCode ()
 		{
 			return HashCode.Combine (dx, dy);
 		}
 
-		/// <param name="other">To be added.</param>
+		/// <param name="other">The other.</param>
 		///         <summary />
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public override bool Equals (object? other)
 		{
 			if (other is CGVector vector)

--- a/src/CoreImage/CIFilter.cs
+++ b/src/CoreImage/CIFilter.cs
@@ -118,7 +118,6 @@ using UIKit;
 namespace CoreImage {
 	public partial class CIFilter {
 		/// <summary>Creates a new CIFilter with default values.</summary>
-		///         <remarks>To be added.</remarks>
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
@@ -132,19 +131,15 @@ namespace CoreImage {
 		{
 		}
 
-		/// <param name="categories">To be added.</param>
+		/// <param name="categories">The categories.</param>
 		///         <summary>Returns an array of strings that specifies the filters that the system provides for the specified <paramref name="categories" />.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public static string [] FilterNamesInCategories (params string []? categories)
 		{
 			return _FilterNamesInCategories (categories);
 		}
 
-		/// <param name="key">To be added.</param>
+		/// <param name="key">The key.</param>
 		/// <summary>Gets the value that is identified by <paramref name="key" />.</summary>
-		/// <value>To be added.</value>
-		/// <remarks>To be added.</remarks>
 		public NSObject? this [NSString key] {
 			get {
 				NSObject? result = ValueForKey (key.GetHandle ());

--- a/src/CoreImage/CIFilter.cs
+++ b/src/CoreImage/CIFilter.cs
@@ -131,15 +131,15 @@ namespace CoreImage {
 		{
 		}
 
+		/// <summary>Returns an array of strings that specifies the filters that the system provides for the specified <paramref name="categories" />.</summary>
 		/// <param name="categories">The categories.</param>
-		///         <summary>Returns an array of strings that specifies the filters that the system provides for the specified <paramref name="categories" />.</summary>
 		public static string [] FilterNamesInCategories (params string []? categories)
 		{
 			return _FilterNamesInCategories (categories);
 		}
 
-		/// <param name="key">The key.</param>
 		/// <summary>Gets the value that is identified by <paramref name="key" />.</summary>
+		/// <param name="key">The key.</param>
 		public NSObject? this [NSString key] {
 			get {
 				NSObject? result = ValueForKey (key.GetHandle ());

--- a/src/Foundation/NSSecureCoding.cs
+++ b/src/Foundation/NSSecureCoding.cs
@@ -4,7 +4,6 @@
 
 namespace Foundation {
 	/// <summary>Implementors handle encoding and decoding in a manner robust against object-substitution attacks.</summary>
-	///     <remarks>To be added.</remarks>
 	///     <!-- 2015-01-05: Our NSCoding doesn't bind decodeObjectOfClass:forKey:, which is needed for NSSecureCoding. -->
 	public static partial class NSSecureCoding {
 		const string selConformsToProtocol = "conformsToProtocol:";
@@ -14,10 +13,8 @@ namespace Foundation {
 		static IntPtr selSupportsSecureCodingHandle = Selector.GetHandle (selSupportsSecureCoding);
 #endif
 
-		/// <param name="type">To be added.</param>
+		/// <param name="type">The type.</param>
 		///         <summary>Whether the class supports secure coding and decoding.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public static bool SupportsSecureCoding (Type type)
 		{
 			if (type is null)
@@ -37,10 +34,8 @@ namespace Foundation {
 #endif
 		}
 
-		/// <param name="klass">To be added.</param>
+		/// <param name="klass">The klass.</param>
 		///         <summary>Whether the class supports secure coding and decoding.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public static bool SupportsSecureCoding (Class klass)
 		{
 			if (klass is null)

--- a/src/Foundation/NSSecureCoding.cs
+++ b/src/Foundation/NSSecureCoding.cs
@@ -13,8 +13,8 @@ namespace Foundation {
 		static IntPtr selSupportsSecureCodingHandle = Selector.GetHandle (selSupportsSecureCoding);
 #endif
 
+		/// <summary>Whether the class supports secure coding and decoding.</summary>
 		/// <param name="type">The type.</param>
-		///         <summary>Whether the class supports secure coding and decoding.</summary>
 		public static bool SupportsSecureCoding (Type type)
 		{
 			if (type is null)
@@ -34,8 +34,8 @@ namespace Foundation {
 #endif
 		}
 
+		/// <summary>Whether the class supports secure coding and decoding.</summary>
 		/// <param name="klass">The klass.</param>
-		///         <summary>Whether the class supports secure coding and decoding.</summary>
 		public static bool SupportsSecureCoding (Class klass)
 		{
 			if (klass is null)

--- a/src/ModelIO/MDLStructs.cs
+++ b/src/ModelIO/MDLStructs.cs
@@ -32,8 +32,8 @@ namespace ModelIO {
 		[DllImport (Constants.MetalKitLibrary)]
 		static extern /* MTLVertexFormat */ nuint MTKMetalVertexFormatFromModelIO (/* MTLVertexFormat */ nuint vertexFormat);
 
+		/// <summary>Converts the current vertex format into the specified <paramref name="vertexFormat" />.</summary>
 		/// <param name="vertexFormat">The vertex format.</param>
-		///         <summary>Converts the current vertex format into the specified <paramref name="vertexFormat" />.</summary>
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("maccatalyst")]

--- a/src/ModelIO/MDLStructs.cs
+++ b/src/ModelIO/MDLStructs.cs
@@ -20,7 +20,6 @@ namespace ModelIO {
 
 #if !COREBUILD
 	/// <summary>Extension methods for <see cref="ModelIO.MDLVertexFormat" />.</summary>
-	///     <remarks>To be added.</remarks>
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("macos")]
@@ -33,10 +32,8 @@ namespace ModelIO {
 		[DllImport (Constants.MetalKitLibrary)]
 		static extern /* MTLVertexFormat */ nuint MTKMetalVertexFormatFromModelIO (/* MTLVertexFormat */ nuint vertexFormat);
 
-		/// <param name="vertexFormat">To be added.</param>
+		/// <param name="vertexFormat">The vertex format.</param>
 		///         <summary>Converts the current vertex format into the specified <paramref name="vertexFormat" />.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("maccatalyst")]
@@ -50,7 +47,6 @@ namespace ModelIO {
 #endif
 
 	/// <summary>A bounding box whose axes are aligned with its coordinate system.</summary>
-	///     <remarks>To be added.</remarks>
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("macos")]
@@ -58,10 +54,8 @@ namespace ModelIO {
 	[StructLayout (LayoutKind.Sequential)]
 	public struct MDLAxisAlignedBoundingBox {
 		/// <summary>Gets the maximum bounds.</summary>
-		///         <remarks>To be added.</remarks>
 		public Vector3 MaxBounds;
 		/// <summary>Gets the minimum bounds.</summary>
-		///         <remarks>To be added.</remarks>
 		public Vector3 MinBounds;
 
 		public MDLAxisAlignedBoundingBox (Vector3 maxBounds, Vector3 minBounds)

--- a/src/UIKit/UIBarItem.cs
+++ b/src/UIKit/UIBarItem.cs
@@ -12,17 +12,17 @@ using TextAttributes = UIKit.UIStringAttributes;
 namespace UIKit {
 	public partial class UIBarItem {
 
+		/// <summary>Specifies the text attributes of the title of the UIBarItem.</summary>
 		/// <param name="attributes">Specified title text attributes.</param>
 		/// <param name="state">Specified <see cref="UIKit.UIControlState" />.</param>
-		/// <summary>Specifies the text attributes of the title of the UIBarItem.</summary>
 		public void SetTitleTextAttributes (TextAttributes attributes, UIControlState state)
 		{
 			var dict = attributes?.Dictionary;
 			_SetTitleTextAttributes (dict, state);
 		}
 
-		/// <param name="state">The state for which text attributes are to be set for the title.</param>
 		/// <summary>The text attributes of the title of the UIBarItem.</summary>
+		/// <param name="state">The state for which text attributes are to be set for the title.</param>
 		/// <returns>The <see cref="UIKit.UIStringAttributes" /></returns>
 		public TextAttributes GetTitleTextAttributes (UIControlState state)
 		{
@@ -32,9 +32,9 @@ namespace UIKit {
 		}
 
 		public partial class UIBarItemAppearance {
+			/// <summary>Sets the attributes applied to the title text of the UIBarItem.</summary>
 			/// <param name="attributes">The attributes.</param>
 			/// <param name="state">The state.</param>
-			/// <summary>Sets the attributes applied to the title text of the UIBarItem.</summary>
 			public virtual void SetTitleTextAttributes (TextAttributes attributes, UIControlState state)
 			{
 				if (attributes is null)
@@ -43,8 +43,8 @@ namespace UIKit {
 				_SetTitleTextAttributes (dict, state);
 			}
 
+			/// <summary>The attributes applied to the title text of the UIBarItem.</summary>
 			/// <param name="state">The state.</param>
-			///         <summary>The attributes applies to the title text of the UIBarItem.</summary>
 			public virtual TextAttributes GetTitleTextAttributes (UIControlState state)
 			{
 				using (var d = _GetTitleTextAttributes (state)) {

--- a/src/UIKit/UIBarItem.cs
+++ b/src/UIKit/UIBarItem.cs
@@ -15,7 +15,6 @@ namespace UIKit {
 		/// <param name="attributes">Specified title text attributes.</param>
 		/// <param name="state">Specified <see cref="UIKit.UIControlState" />.</param>
 		/// <summary>Specifies the text attributes of the title of the UIBarItem.</summary>
-		/// <remarks>To be added.</remarks>
 		public void SetTitleTextAttributes (TextAttributes attributes, UIControlState state)
 		{
 			var dict = attributes?.Dictionary;
@@ -33,10 +32,9 @@ namespace UIKit {
 		}
 
 		public partial class UIBarItemAppearance {
-			/// <param name="attributes">To be added.</param>
-			/// <param name="state">To be added.</param>
+			/// <param name="attributes">The attributes.</param>
+			/// <param name="state">The state.</param>
 			/// <summary>Sets the attributes applied to the title text of the UIBarItem.</summary>
-			/// <remarks>To be added.</remarks>
 			public virtual void SetTitleTextAttributes (TextAttributes attributes, UIControlState state)
 			{
 				if (attributes is null)
@@ -45,10 +43,8 @@ namespace UIKit {
 				_SetTitleTextAttributes (dict, state);
 			}
 
-			/// <param name="state">To be added.</param>
+			/// <param name="state">The state.</param>
 			///         <summary>The attributes applies to the title text of the UIBarItem.</summary>
-			///         <returns>To be added.</returns>
-			///         <remarks>To be added.</remarks>
 			public virtual TextAttributes GetTitleTextAttributes (UIControlState state)
 			{
 				using (var d = _GetTitleTextAttributes (state)) {

--- a/src/UIKit/UISegmentedControl.cs
+++ b/src/UIKit/UISegmentedControl.cs
@@ -16,8 +16,8 @@ using UIKit;
 
 namespace UIKit {
 	public partial class UISegmentedControl {
+		/// <summary>Creates a UISegmentedControl by passing an array containing strings or <see cref="UIKit.UIImage" /> objects.</summary>
 		/// <param name="args">Array of strings or UIImage objects to use in the control.</param>
-		///         <summary>Creates a UISegmentedControl by passing an array containing strings or <see cref="UIKit.UIImage" /> objects.</summary>
 		public UISegmentedControl (params object [] args) : this (FromObjects (args))
 		{
 		}
@@ -55,14 +55,14 @@ namespace UIKit {
 			return NSArray.FromNSObjects (nsargs);
 		}
 
+		/// <summary>Creates a new segmented control with the images in the provided array.</summary>
 		/// <param name="images">The images.</param>
-		///         <summary>Creates a new segmented control with the images in the provided array.</summary>
 		public UISegmentedControl (params UIImage [] images) : this (FromNSObjects (images))
 		{
 		}
 
+		/// <summary>Creates a new segmented control with the titles in the provided array.</summary>
 		/// <param name="strings">The strings.</param>
-		///         <summary>Creates a new segmented control with the titles in the provided array.</summary>
 		public UISegmentedControl (params NSString [] strings) : this (FromNSObjects (strings))
 		{
 		}
@@ -77,8 +77,8 @@ namespace UIKit {
 			return NSArray.FromNSObjects (items);
 		}
 
+		/// <summary>Creates a new segmented control with the titles in the provided array.</summary>
 		/// <param name="strings">The strings.</param>
-		///         <summary>Creates a new segmented control with the titles in the provided array.</summary>
 		public UISegmentedControl (params string [] strings) : this (FromStrings (strings))
 		{
 		}

--- a/src/UIKit/UISegmentedControl.cs
+++ b/src/UIKit/UISegmentedControl.cs
@@ -18,8 +18,6 @@ namespace UIKit {
 	public partial class UISegmentedControl {
 		/// <param name="args">Array of strings or UIImage objects to use in the control.</param>
 		///         <summary>Creates a UISegmentedControl by passing an array containing strings or <see cref="UIKit.UIImage" /> objects.</summary>
-		///         <remarks>
-		///         </remarks>
 		public UISegmentedControl (params object [] args) : this (FromObjects (args))
 		{
 		}
@@ -57,16 +55,14 @@ namespace UIKit {
 			return NSArray.FromNSObjects (nsargs);
 		}
 
-		/// <param name="images">To be added.</param>
+		/// <param name="images">The images.</param>
 		///         <summary>Creates a new segmented control with the images in the provided array.</summary>
-		///         <remarks>To be added.</remarks>
 		public UISegmentedControl (params UIImage [] images) : this (FromNSObjects (images))
 		{
 		}
 
-		/// <param name="strings">To be added.</param>
+		/// <param name="strings">The strings.</param>
 		///         <summary>Creates a new segmented control with the titles in the provided array.</summary>
-		///         <remarks>To be added.</remarks>
 		public UISegmentedControl (params NSString [] strings) : this (FromNSObjects (strings))
 		{
 		}
@@ -81,9 +77,8 @@ namespace UIKit {
 			return NSArray.FromNSObjects (items);
 		}
 
-		/// <param name="strings">To be added.</param>
+		/// <param name="strings">The strings.</param>
 		///         <summary>Creates a new segmented control with the titles in the provided array.</summary>
-		///         <remarks>To be added.</remarks>
 		public UISegmentedControl (params string [] strings) : this (FromStrings (strings))
 		{
 		}

--- a/src/Vision/VNUtils.cs
+++ b/src/Vision/VNUtils.cs
@@ -28,8 +28,8 @@ namespace Vision {
 		[DllImport (Constants.VisionLibrary, EntryPoint = "VNNormalizedRectIsIdentityRect")]
 		static extern byte _IsIdentityRect (CGRect rect);
 
+		/// <summary>Returns <see langword="true" /> if the <paramref name="rect" /> is [0, 0, 1, 1].</summary>
 		/// <param name="rect">The rect.</param>
-		///         <summary>Returns <see langword="true" /> if the <paramref name="rect" /> is [0, 0, 1, 1].</summary>
 		public static bool IsIdentityRect (CGRect rect)
 		{
 			return _IsIdentityRect (rect) != 0;

--- a/src/Vision/VNUtils.cs
+++ b/src/Vision/VNUtils.cs
@@ -14,7 +14,6 @@ using CoreGraphics;
 
 namespace Vision {
 	/// <summary>A set of utility functions for working with images.</summary>
-	///     <remarks>To be added.</remarks>
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
@@ -23,18 +22,14 @@ namespace Vision {
 
 		// initialized only once (see tests/cecil-tests/)
 		/// <summary>Gets the normalized identity <see cref="CoreGraphics.CGRect" /> [0, 0, 1, 1].</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		[Field ("VNNormalizedIdentityRect", Constants.VisionLibrary)]
 		public static CGRect NormalizedIdentityRect { get; } = Dlfcn.GetCGRect (Libraries.Vision.Handle, "VNNormalizedIdentityRect");
 
 		[DllImport (Constants.VisionLibrary, EntryPoint = "VNNormalizedRectIsIdentityRect")]
 		static extern byte _IsIdentityRect (CGRect rect);
 
-		/// <param name="rect">To be added.</param>
+		/// <param name="rect">The rect.</param>
 		///         <summary>Returns <see langword="true" /> if the <paramref name="rect" /> is [0, 0, 1, 1].</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public static bool IsIdentityRect (CGRect rect)
 		{
 			return _IsIdentityRect (rect) != 0;


### PR DESCRIPTION
Improve XML documentation for 10 types:

- UISegmentedControl
- VNUtils
- CGVector
- CIFilter
- NSSecureCoding
- MDLVertexFormatExtensions
- UIBarItem
- CNInstantMessageAddressOption / CNInstantMessageAddress
- CNSocialProfileOption / CNSocialProfile
- NSPrintInfo

Changes include adding missing summaries, fixing tag ordering (summary before param), removing empty elements, and normalizing indentation.

🤖 Pull request created by Copilot