### PR TITLE
[tests] Don't crash macOS test runner on late log output

### DIFF
--- a/scripts/run-packaged-macos-tests/run-packaged-macos-tests.cs
+++ b/scripts/run-packaged-macos-tests/run-packaged-macos-tests.cs
@@ -123,6 +123,7 @@ if (!string.IsNullOrEmpty (testOutputDir))
 Process? logStreamProcess = null;
 string? logStreamFile = null;
 StreamWriter? logStreamWriter = null;
+var logStreamWriterClosed = false;
 if (!string.IsNullOrEmpty (crashReportsDir)) {
 	Directory.CreateDirectory (crashReportsDir);
 	logStreamFile = Path.Combine (crashReportsDir, "system.log");
@@ -138,13 +139,17 @@ if (!string.IsNullOrEmpty (crashReportsDir)) {
 	var writer = logStreamWriter;
 	logStreamProcess.OutputDataReceived += (_, e) => {
 		if (e.Data is not null)
-			lock (writer)
-				writer.WriteLine (e.Data);
+			lock (writer) {
+				if (!logStreamWriterClosed)
+					writer.WriteLine (e.Data);
+			}
 	};
 	logStreamProcess.ErrorDataReceived += (_, e) => {
 		if (e.Data is not null)
-			lock (writer)
-				writer.WriteLine (e.Data);
+			lock (writer) {
+				if (!logStreamWriterClosed)
+					writer.WriteLine (e.Data);
+			}
 	};
 	logStreamProcess.Start ();
 	logStreamProcess.BeginOutputReadLine ();
@@ -287,13 +292,47 @@ if (!string.IsNullOrEmpty (htmlReportPath)) {
 if (logStreamProcess is not null && logStreamFile is not null) {
 	try {
 		NativeMethods.kill (logStreamProcess.Id, 2 /* SIGINT */);
-		logStreamProcess.WaitForExit (10_000);
+		// WaitForExit (int) returns as soon as the process exits, but it doesn't wait
+		// for the asynchronous output handlers to finish processing buffered output,
+		// so the tail of the log stream would be lost (this is the same reason
+		// ExecuteWithTimeout calls the parameterless overload below).
+		//
+		// The parameterless overload can block indefinitely if anything else still
+		// holds the redirected pipes, so drain on a background thread and give up
+		// after a while rather than risk hanging the job for hours.
+		if (logStreamProcess.WaitForExit (10_000)) {
+			var drain = new Thread (() => {
+				try {
+					logStreamProcess.WaitForExit ();
+				} catch {
+					// Nothing useful to do if draining fails
+				}
+			}) { IsBackground = true };
+			drain.Start ();
+			drain.Join (30_000);
+		}
 	} catch {
 		// Process may have already exited
 	}
 
-	// Flush and close the log writer
-	logStreamWriter?.Dispose ();
+	// Stop delivering output, so no further callbacks are queued.
+	try {
+		logStreamProcess.CancelOutputRead ();
+		logStreamProcess.CancelErrorRead ();
+	} catch {
+		// The asynchronous reads may already have completed
+	}
+
+	// Flush and close the log writer. The flag is what actually makes a late
+	// callback harmless: without it a queued line could still be delivered here
+	// and throw ObjectDisposedException on a thread pool thread, which would
+	// crash this process even though every test passed.
+	if (logStreamWriter is not null) {
+		lock (logStreamWriter) {
+			logStreamWriterClosed = true;
+			logStreamWriter.Dispose ();
+		}
+	}
 
 	try {
 		Console.WriteLine ($"Wrote {new FileInfo (logStreamFile).Length} bytes to {logStreamFile}");

--- a/scripts/run-packaged-macos-tests/run-packaged-macos-tests.cs
+++ b/scripts/run-packaged-macos-tests/run-packaged-macos-tests.cs
@@ -300,19 +300,39 @@ if (logStreamProcess is not null && logStreamFile is not null) {
 		// The parameterless overload can block indefinitely if anything else still
 		// holds the redirected pipes, so drain on a background thread and give up
 		// after a while rather than risk hanging the job for hours.
-		if (logStreamProcess.WaitForExit (10_000)) {
+		var exited = logStreamProcess.WaitForExit (10_000);
+		if (!exited) {
+			Console.Error.WriteLine ("Warning: 'log stream' did not exit after SIGINT; terminating it.");
+			try {
+				logStreamProcess.Kill ();
+				exited = logStreamProcess.WaitForExit (10_000);
+			} catch (InvalidOperationException) {
+				// The process exited before Kill could terminate it.
+				exited = true;
+			} catch (Exception e) {
+				Console.Error.WriteLine ($"Warning: Failed to terminate 'log stream': {e.Message}");
+			}
+		}
+		if (exited) {
+			Exception? drainException = null;
 			var drain = new Thread (() => {
 				try {
 					logStreamProcess.WaitForExit ();
-				} catch {
-					// Nothing useful to do if draining fails
+				} catch (Exception e) {
+					drainException = e;
 				}
 			}) { IsBackground = true };
 			drain.Start ();
-			drain.Join (30_000);
+			if (!drain.Join (30_000)) {
+				Console.Error.WriteLine ("Warning: Timed out draining buffered 'log stream' output; system.log may be incomplete.");
+			} else if (drainException is not null) {
+				Console.Error.WriteLine ($"Warning: Failed to drain buffered 'log stream' output; system.log may be incomplete: {drainException.Message}");
+			}
+		} else {
+			Console.Error.WriteLine ("Warning: 'log stream' did not terminate; system.log may be incomplete.");
 		}
-	} catch {
-		// Process may have already exited
+	} catch (Exception e) {
+		Console.Error.WriteLine ($"Warning: Failed to stop 'log stream': {e.Message}");
 	}
 
 	// Stop delivering output, so no further callbacks are queued.
@@ -328,9 +348,13 @@ if (logStreamProcess is not null && logStreamFile is not null) {
 	// and throw ObjectDisposedException on a thread pool thread, which would
 	// crash this process even though every test passed.
 	if (logStreamWriter is not null) {
-		lock (logStreamWriter) {
-			logStreamWriterClosed = true;
-			logStreamWriter.Dispose ();
+		try {
+			lock (logStreamWriter) {
+				logStreamWriterClosed = true;
+				logStreamWriter.Dispose ();
+			}
+		} catch (Exception e) {
+			Console.Error.WriteLine ($"Warning: Failed to flush and close {logStreamFile}: {e.Message}");
 		}
 	}
 
@@ -347,7 +371,11 @@ if (logStreamProcess is not null && logStreamFile is not null) {
 		Console.Error.WriteLine ($"Warning: Failed to save log stream output: {ex.Message}");
 	}
 
-	logStreamProcess.Dispose ();
+	try {
+		logStreamProcess.Dispose ();
+	} catch (Exception e) {
+		Console.Error.WriteLine ($"Warning: Failed to dispose 'log stream': {e.Message}");
+	}
 }
 
 return failedSuites > 0 ? 1 : 0;


### PR DESCRIPTION
## Summary

- prevent late asynchronous `log stream` callbacks from writing after the diagnostic `StreamWriter` is closed
- bound SIGINT, force-termination, and output-drain waits so cleanup cannot hang test jobs
- report drain, flush, and disposal failures without failing an otherwise successful test run

## Root cause

The macOS 27 test leg twice completed all suites successfully, then failed while shutting down diagnostic logging:

```
5 suites passed, 0 suites failed.
Unhandled exception. System.ObjectDisposedException: Cannot write to a closed TextWriter.
```

`WaitForExit (10_000)` waited for the process but not the asynchronous output handlers, so buffered `DataReceived` callbacks could arrive after writer disposal.

This was split from #26280 at reviewer request so the infrastructure fix can flow through `main` independently.

## Validation

- built `scripts/run-packaged-macos-tests/run-packaged-macos-tests.csproj` with 0 warnings and 0 errors
- independent GPT-5.6 Sol and Claude Opus 4.8 max-reasoning concurrency reviews