### PR TITLE
[tests] Upload AppSizeTest expected-file diffs instead of full files

### DIFF
--- a/.github/skills/update-expected-app-size/SKILL.md
+++ b/.github/skills/update-expected-app-size/SKILL.md
@@ -21,11 +21,11 @@ Download updated expected app size files from Azure DevOps artifacts for the cur
 
 The app size tests (`tests/dotnet/UnitTests/AppSizeTest.cs`) compare the built app's size and preserved APIs against expected files stored in `tests/dotnet/UnitTests/expected/`. When the test detects a difference and `WRITE_KNOWN_FAILURES` is not set, it writes the updated expected file to `$(Build.ArtifactStagingDirectory)/updated-expected-sizes/`, and a pipeline step publishes this directory as a build artifact.
 
-The artifact name follows the pattern `{uploadPrefix}updated-expected-sizes-{testPrefix}-{attempt}` (e.g., `updated-expected-sizes-dotnettests_ios-1`). Inside the artifact, files are named after the test variant:
-- `{Platform}-{Variant}-size.txt` — e.g., `iOS-MonoVM-size.txt`, `iOS-MonoVM-interpreter-size.txt`, `iOS-NativeAOT-TrimmableStatic-size.txt`, `MacOSX-CoreCLR-Interpreter-size.txt`
-- `{Platform}-{Variant}-preservedapis.txt` — e.g., `iOS-MonoVM-preservedapis.txt`, `MacCatalyst-MonoVM-interpreter-preservedapis.txt`
+The artifact name follows the pattern `{uploadPrefix}updated-expected-sizes-{testPrefix}-{attempt}` (e.g., `updated-expected-sizes-dotnettests_ios-1`). Because the expected files can be very big, the test uploads a unified **diff** for each changed expected file rather than the whole file. Inside the artifact, files are named after the test variant with a `.diff` suffix:
+- `{Platform}-{Variant}-size.txt.diff` — e.g., `iOS-MonoVM-size.txt.diff`, `iOS-MonoVM-interpreter-size.txt.diff`, `iOS-NativeAOT-TrimmableStatic-size.txt.diff`, `MacOSX-CoreCLR-Interpreter-size.txt.diff`
+- `{Platform}-{Variant}-preservedapis.txt.diff` — e.g., `iOS-MonoVM-preservedapis.txt.diff`, `MacCatalyst-MonoVM-interpreter-preservedapis.txt.diff`
 
-The expected files on disk are at:
+Each diff is a unified diff (relative to the repository root) that can be applied with `git apply -p1` or `patch -p1`. The expected files on disk are at:
 - `tests/dotnet/UnitTests/expected/{Platform}-{Variant}-size.txt`
 - `tests/dotnet/UnitTests/expected/{Platform}-{Variant}-preservedapis.txt`
 
@@ -85,15 +85,17 @@ If `az` is not available or not authenticated, direct the user to download manua
 
 ### 4. Place the files
 
-Extract the downloaded artifact zip and place the files in the expected directory:
+Extract the downloaded artifact zip and apply each diff to the expected directory from the repository root:
 
 ```bash
-EXPECTED_DIR="tests/dotnet/UnitTests/expected"
 unzip -o artifact.zip -d /tmp/updated-sizes/
-cp /tmp/updated-sizes/*/*.txt "$EXPECTED_DIR/"
+# Each '*.txt.diff' is a unified diff relative to the repository root.
+for diff in /tmp/updated-sizes/*/*.txt.diff; do
+  git apply -p1 "$diff"
+done
 ```
 
-The files inside the zip already have the correct names (e.g., `iOS-MonoVM-size.txt`) and can be copied directly.
+The diffs reference `tests/dotnet/UnitTests/expected/<name>.txt` directly, so applying them updates (or creates) the expected files in place. If a diff fails to apply cleanly (e.g., the expected file changed since the CI build), re-run the failing app size test locally with `WRITE_KNOWN_FAILURES=1` to regenerate the file (see the "Run Locally" fallback).
 
 ### 5. Verify and commit
 
@@ -112,7 +114,7 @@ If automated download fails (auth issues, etc.), provide the user with:
 1. The Azure DevOps build URL
 2. Instructions to navigate to the build → Summary → Artifacts section
 3. Look for individual artifacts whose names contain `updated-expected-sizes`
-4. Download the artifact zip, extract it, and copy the `.txt` files (e.g., `iOS-MonoVM-interpreter-size.txt`) into `tests/dotnet/UnitTests/expected/`
+4. Download the artifact zip, extract it, and apply the `.txt.diff` files (e.g., `iOS-MonoVM-interpreter-size.txt.diff`) from the repository root with `git apply -p1 <file>`
 
 ## Fallback: Run Locally
 

--- a/.github/workflows/apply-gist.yml
+++ b/.github/workflows/apply-gist.yml
@@ -145,7 +145,7 @@ jobs:
         mkdir -p "$EXPECTED_DIR"
 
         DIFF_DIR="$(mktemp -d)"
-        export DIFF_DIR
+        export DIFF_DIR EXPECTED_DIR
 
         # Download gist metadata to get file URLs. The Gists API isn't accessible to the GitHub Actions token
         # (a GitHub App installation token), so fetch it unauthenticated.
@@ -154,19 +154,25 @@ jobs:
             exit 1
         fi
 
-        # The gist contains a unified diff ('<name>.txt.diff') for each changed expected file, instead of the
-        # entire (potentially very large) expected file. Download and validate each diff, then apply it below.
+        # Newer builds upload a unified diff ('<name>.txt.diff') for each changed expected file, instead of the
+        # entire (potentially very large) expected file. For backwards compatibility we still accept gists that
+        # contain the full expected files ('<name>.txt'). Download and validate everything, applying diffs and
+        # writing full files below.
         echo "$GIST_JSON" | python3 -c "
         import json, sys, urllib.request, os, re
 
         gist = json.load(sys.stdin)
         diff_dir = os.environ['DIFF_DIR']
+        expected_dir = os.environ['EXPECTED_DIR']
         files = gist['files']
-        # Only allow diffs of known expected-file patterns.
-        allowed_name = re.compile(r'^[A-Za-z0-9]+-[A-Za-z0-9-]+-(size|preservedapis)\.txt\.diff$')
-        downloaded = 0
+        # Allowed expected-file name, and the same name with a '.diff' suffix (a unified diff of that file).
+        allowed_diff = re.compile(r'^[A-Za-z0-9]+-[A-Za-z0-9-]+-(size|preservedapis)\.txt\.diff$')
+        allowed_full = re.compile(r'^[A-Za-z0-9]+-[A-Za-z0-9-]+-(size|preservedapis)\.txt$')
+        applied = 0
         for filename, file_info in files.items():
-            if not allowed_name.match(filename):
+            is_diff = bool(allowed_diff.match(filename))
+            is_full = bool(allowed_full.match(filename))
+            if not is_diff and not is_full:
                 print(f'Skipping file with unexpected name: {filename}')
                 continue
             content = file_info.get('content')
@@ -174,23 +180,30 @@ jobs:
                 # Large files need to be fetched from raw_url
                 raw_url = file_info['raw_url']
                 content = urllib.request.urlopen(raw_url).read().decode('utf-8')
-            # The diff for '<name>.txt.diff' is only allowed to touch 'tests/dotnet/UnitTests/expected/<name>.txt'.
-            expected_target = 'tests/dotnet/UnitTests/expected/' + filename[:-len('.diff')]
-            allowed_targets = ('/dev/null', 'a/' + expected_target, 'b/' + expected_target)
-            for line in content.splitlines():
-                if line.startswith('--- ') or line.startswith('+++ '):
-                    # Strip a trailing tab + timestamp if present, then verify the target path.
-                    target = line[4:].split('\t', 1)[0].strip()
-                    if target not in allowed_targets:
-                        print(f'Rejecting diff {filename}: unexpected target path: {target}')
-                        sys.exit(1)
-            dest = os.path.join(diff_dir, filename)
-            with open(dest, 'w') as f:
-                f.write(content)
-            print(f'Downloaded diff: {filename}')
-            downloaded += 1
-        if downloaded == 0:
-            print('No applicable diffs found in gist.')
+            if is_diff:
+                # The diff for '<name>.txt.diff' is only allowed to touch 'tests/dotnet/UnitTests/expected/<name>.txt'.
+                expected_target = 'tests/dotnet/UnitTests/expected/' + filename[:-len('.diff')]
+                allowed_targets = ('/dev/null', 'a/' + expected_target, 'b/' + expected_target)
+                for line in content.splitlines():
+                    if line.startswith('--- ') or line.startswith('+++ '):
+                        # Strip a trailing tab + timestamp if present, then verify the target path.
+                        target = line[4:].split('\t', 1)[0].strip()
+                        if target not in allowed_targets:
+                            print(f'Rejecting diff {filename}: unexpected target path: {target}')
+                            sys.exit(1)
+                dest = os.path.join(diff_dir, filename)
+                with open(dest, 'w') as f:
+                    f.write(content)
+                print(f'Downloaded diff: {filename}')
+            else:
+                # Full expected file: write it directly into the expected directory.
+                dest = os.path.join(expected_dir, filename)
+                with open(dest, 'w') as f:
+                    f.write(content)
+                print(f'Applied full file: {filename}')
+            applied += 1
+        if applied == 0:
+            print('No applicable files found in gist.')
             sys.exit(1)
         "
 

--- a/.github/workflows/apply-gist.yml
+++ b/.github/workflows/apply-gist.yml
@@ -137,30 +137,36 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         persist-credentials: true
 
-    - name: Download and apply gist files
+    - name: Download and apply gist diffs
       env:
         GIST_ID: ${{ steps.parse.outputs.gist_id }}
       run: |
         EXPECTED_DIR="tests/dotnet/UnitTests/expected"
         mkdir -p "$EXPECTED_DIR"
-        export EXPECTED_DIR
 
-        # Download gist metadata to get file URLs. The Gists API isn't accessible to the
-        # GitHub Actions token (a GitHub App installation token), so fetch it unauthenticated.
+        DIFF_DIR="$(mktemp -d)"
+        export DIFF_DIR
+
+        # Download gist metadata to get file URLs. The Gists API isn't accessible to the GitHub Actions token
+        # (a GitHub App installation token), so fetch it unauthenticated.
         if ! GIST_JSON=$(curl -fSL -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" -H "User-Agent: dotnet-macios-apply-gist" "https://api.github.com/gists/$GIST_ID"); then
             echo "Failed to fetch gist '$GIST_ID' (404/403/rate limit?)." >&2
             exit 1
         fi
+
+        # The gist contains a unified diff ('<name>.txt.diff') for each changed expected file, instead of the
+        # entire (potentially very large) expected file. Download and validate each diff, then apply it below.
         echo "$GIST_JSON" | python3 -c "
         import json, sys, urllib.request, os, re
 
         gist = json.load(sys.stdin)
-        expected_dir = os.environ['EXPECTED_DIR']
+        diff_dir = os.environ['DIFF_DIR']
         files = gist['files']
-        # Only allow known expected-file patterns
-        allowed_pattern = re.compile(r'^[A-Za-z0-9]+-[A-Za-z0-9-]+-(size|preservedapis)\.txt$')
+        # Only allow diffs of known expected-file patterns.
+        allowed_name = re.compile(r'^[A-Za-z0-9]+-[A-Za-z0-9-]+-(size|preservedapis)\.txt\.diff$')
+        downloaded = 0
         for filename, file_info in files.items():
-            if not allowed_pattern.match(filename):
+            if not allowed_name.match(filename):
                 print(f'Skipping file with unexpected name: {filename}')
                 continue
             content = file_info.get('content')
@@ -168,11 +174,32 @@ jobs:
                 # Large files need to be fetched from raw_url
                 raw_url = file_info['raw_url']
                 content = urllib.request.urlopen(raw_url).read().decode('utf-8')
-            dest = os.path.join(expected_dir, filename)
+            # The diff for '<name>.txt.diff' is only allowed to touch 'tests/dotnet/UnitTests/expected/<name>.txt'.
+            expected_target = 'tests/dotnet/UnitTests/expected/' + filename[:-len('.diff')]
+            allowed_targets = ('/dev/null', 'a/' + expected_target, 'b/' + expected_target)
+            for line in content.splitlines():
+                if line.startswith('--- ') or line.startswith('+++ '):
+                    # Strip a trailing tab + timestamp if present, then verify the target path.
+                    target = line[4:].split('\t', 1)[0].strip()
+                    if target not in allowed_targets:
+                        print(f'Rejecting diff {filename}: unexpected target path: {target}')
+                        sys.exit(1)
+            dest = os.path.join(diff_dir, filename)
             with open(dest, 'w') as f:
                 f.write(content)
-            print(f'Applied: {filename}')
+            print(f'Downloaded diff: {filename}')
+            downloaded += 1
+        if downloaded == 0:
+            print('No applicable diffs found in gist.')
+            sys.exit(1)
         "
+
+        # Apply each diff. 'git apply' handles both modifications of existing files and creation of new files.
+        shopt -s nullglob
+        for diff in "$DIFF_DIR"/*.diff; do
+          echo "Applying $(basename "$diff")..."
+          git apply -p1 --verbose "$diff"
+        done
 
     - name: Commit and push
       env:

--- a/tests/dotnet/UnitTests/AppSizeTest.cs
+++ b/tests/dotnet/UnitTests/AppSizeTest.cs
@@ -328,9 +328,47 @@ namespace Xamarin.Tests {
 				outputDir = Path.Combine (Cache.CreateTemporaryDirectory ("AppSizeTest"), "updated-expected-sizes");
 			}
 			Directory.CreateDirectory (outputDir);
-			var outputFile = Path.Combine (outputDir, fileName);
-			File.WriteAllText (outputFile, content);
-			Console.WriteLine ($"    Updated expected file written to: {outputFile}");
+
+			// The expected files can be very big, so instead of uploading the entire updated file, compute a
+			// unified diff between the committed expected file and the new content. The diff is typically much
+			// smaller, and it can be applied later using the '/apply-gist' command. The '.diff' extension makes
+			// it clear that these files are diffs rather than full expected files.
+			var diff = CreateExpectedFileDiff (expectedFilePath, content);
+			var outputFile = Path.Combine (outputDir, fileName + ".diff");
+			File.WriteAllText (outputFile, diff);
+			Console.WriteLine ($"    Updated expected file diff written to: {outputFile}");
+		}
+
+		// Compute a unified diff (applyable from the repository root with 'git apply -p1' or 'patch -p1') between
+		// the committed expected file and the new content. If the expected file doesn't exist yet, the diff
+		// describes the creation of a new file.
+		static string CreateExpectedFileDiff (string expectedFilePath, string content)
+		{
+			// The path the diff refers to, relative to the repository root, using forward slashes.
+			var relativePath = Path.GetRelativePath (Configuration.SourceRoot, expectedFilePath).Replace ('\\', '/');
+
+			var newContentPath = Path.GetTempFileName ();
+			try {
+				File.WriteAllText (newContentPath, content);
+
+				// '/dev/null' represents a non-existing original file (i.e. a brand new expected file).
+				var originalPath = File.Exists (expectedFilePath) ? expectedFilePath : "/dev/null";
+				var arguments = new List<string> {
+					"-u",
+					"--label", $"a/{relativePath}",
+					"--label", $"b/{relativePath}",
+					originalPath,
+					newContentPath,
+				};
+				// 'diff' returns 0 when the files are identical, 1 when they differ, and >1 on error. We only
+				// get here when there are differences, so an exit code of 1 is expected; anything else is an error.
+				var rv = Execution.RunAsync ("diff", arguments, timeout: TimeSpan.FromMinutes (1)).Result;
+				if (rv.ExitCode > 1)
+					throw new Exception ($"Failed to compute diff for '{expectedFilePath}' (exit code {rv.ExitCode}):\n{rv.Output.StandardError}");
+				return rv.Output.StandardOutput;
+			} finally {
+				File.Delete (newContentPath);
+			}
 		}
 
 		static string GetUpdateHint ()

--- a/tests/dotnet/UnitTests/AppSizeTest.cs
+++ b/tests/dotnet/UnitTests/AppSizeTest.cs
@@ -355,8 +355,6 @@ namespace Xamarin.Tests {
 				var originalPath = File.Exists (expectedFilePath) ? expectedFilePath : "/dev/null";
 				var arguments = new List<string> {
 					"-u",
-					"--label", $"a/{relativePath}",
-					"--label", $"b/{relativePath}",
 					originalPath,
 					newContentPath,
 				};
@@ -365,7 +363,27 @@ namespace Xamarin.Tests {
 				var rv = Execution.RunAsync ("diff", arguments, timeout: TimeSpan.FromMinutes (1)).Result;
 				if (rv.ExitCode > 1)
 					throw new Exception ($"Failed to compute diff for '{expectedFilePath}' (exit code {rv.ExitCode}):\n{rv.Output.StandardError}");
-				return rv.Output.StandardOutput;
+
+				// 'diff' puts the input file paths (a temporary file and the committed expected file or '/dev/null')
+				// in the '---'/'+++' header lines. Rewrite them to 'a/<path>' and 'b/<path>' so the patch can be
+				// applied from the repository root with 'git apply -p1'. We rewrite the header ourselves rather than
+				// using 'diff --label', because '--label' is a GNU extension that isn't available in every 'diff'
+				// implementation. Only the first '--- '/'+++ ' lines are the file header; hunk content lines are
+				// prefixed with ' ', '+' or '-', so they never begin with '--- ' or '+++ '.
+				var lines = rv.Output.StandardOutput.Split ('\n');
+				for (var i = 0; i < lines.Length; i++) {
+					if (lines [i].StartsWith ("--- ", StringComparison.Ordinal)) {
+						lines [i] = $"--- a/{relativePath}";
+						break;
+					}
+				}
+				for (var i = 0; i < lines.Length; i++) {
+					if (lines [i].StartsWith ("+++ ", StringComparison.Ordinal)) {
+						lines [i] = $"+++ b/{relativePath}";
+						break;
+					}
+				}
+				return string.Join ('\n', lines);
 			} finally {
 				File.Delete (newContentPath);
 			}

--- a/tools/devops/automation/templates/tests/publish-html.yml
+++ b/tools/devops/automation/templates/tests/publish-html.yml
@@ -114,8 +114,10 @@ steps:
 # module (the 'gh' CLI isn't installed on the test agents, and doesn't have credentials to create gists).
 - pwsh: |
     $updatedDir = Join-Path "$Env:SYSTEM_DEFAULTWORKINGDIRECTORY" "updated-expected-sizes"
+    # The expected files can be very big, so the test uploads a unified diff (a '*.txt.diff' file) for each
+    # changed expected file instead of the entire file. The '/apply-gist' command applies these diffs.
     # A file may be present in more than one artifact (e.g. across job attempts); pick the newest copy per file name.
-    $files = Get-ChildItem -Path $updatedDir -Filter "*.txt" -File -Recurse -ErrorAction SilentlyContinue |
+    $files = Get-ChildItem -Path $updatedDir -Filter "*.diff" -File -Recurse -ErrorAction SilentlyContinue |
       Sort-Object -Property LastWriteTimeUtc -Descending |
       Group-Object -Property Name |
       ForEach-Object { $_.Group[0] } |
@@ -151,7 +153,7 @@ steps:
     $sb.AppendLine("<summary>Updated files</summary>") | Out-Null
     $sb.AppendLine() | Out-Null
     foreach ($file in $files) {
-      $sb.AppendLine("- ``$($file.Name)``") | Out-Null
+      $sb.AppendLine("- ``$($file.Name -replace '\.diff$', '')``") | Out-Null
     }
     $sb.AppendLine() | Out-Null
     $sb.AppendLine("</details>") | Out-Null


### PR DESCRIPTION
The AppSizeTest uploads any new/updated expected app size files as a gist so they can later be applied to the PR by commenting `/apply-gist <url>`. Those expected files can be very large, so upload a compact unified diff for each changed file instead of the entire file.

Changes:

* `AppSizeTest.UploadUpdatedExpectedFile` now writes a `<name>.txt.diff` (a unified diff between the committed expected file and the new content) instead of the whole file. New expected files are diffed against `/dev/null`.
* The DevOps gist-creation step (`publish-html.yml`) collects `*.diff` files and lists the target file names (with `.diff` stripped) in the PR comment.
* `apply-gist.yml` downloads the gist files, validates that each one only touches its expected file under `tests/dotnet/UnitTests/expected/`, and applies them. It accepts both the new `*.txt.diff` diffs (applied with `git apply`, handling modifications and new-file creation) and the legacy full `*.txt` files (written directly), so old gists keep working.
* Updated the `update-expected-app-size` skill accordingly.

🤖 Pull request created by Copilot