### PR TITLE
[AVFoundation] Fix InputChannelsChanged event to remove handler on unsubscribe

### DIFF
--- a/src/AVFoundation/Events.cs
+++ b/src/AVFoundation/Events.cs
@@ -540,7 +540,7 @@ namespace AVFoundation {
 
 			remove {
 				if (value is not null)
-					EnsureEventDelegate ().cbInputChanged += value;
+					EnsureEventDelegate ().cbInputChanged -= value;
 			}
 		}
 


### PR DESCRIPTION
The `remove` accessor of `AVAudioSession.InputChannelsChanged` incorrectly
added the handler again (`+=`) instead of removing it (`-=`), which could
lead to duplicate callbacks and leaks.

This was found in a review comment on #26311. A search of the whole `src/`
tree confirmed this was the only event accessor with this bug.

🤖 Pull request created by Copilot