### PR TITLE
[AVFoundation] Fix AVAudioSession.EndInterruption event unsubscription

### DIFF
--- a/src/AVFoundation/Events.cs
+++ b/src/AVFoundation/Events.cs
@@ -474,7 +474,7 @@ namespace AVFoundation {
 			}
 			remove {
 				if (value is not null)
-					EnsureEventDelegate ().cbBeginInterruption -= value;
+					EnsureEventDelegate ().cbEndInterruption -= value;
 			}
 		}
 


### PR DESCRIPTION
The `remove` accessor for `AVAudioSession.EndInterruption` incorrectly
detached `cbBeginInterruption` instead of `cbEndInterruption`. As a result:

- Handlers subscribed to `EndInterruption` were never actually removed.
- Handlers subscribed to `BeginInterruption` could be removed unexpectedly.

Changed the `remove` accessor to detach `cbEndInterruption`.

I also scanned the entire `src/` tree for any other event where the `add`
and `remove` accessors reference mismatched backing fields, and found no
other occurrences — this was the only one.

🤖 Pull request created by Copilot