### PR TITLE
[docs] Improve XML docs for NSLayoutManager and MLMultiArray

### DIFF
--- a/src/CoreML/MLMultiArray.cs
+++ b/src/CoreML/MLMultiArray.cs
@@ -25,59 +25,59 @@ namespace CoreML {
 			return NSArray.NonNullArrayFromHandleDropNullElements<nint> (handle, (v) => (nint) Messaging.IntPtr_objc_msgSend (v, Selector.GetHandle ("integerValue")));
 		}
 
+		/// <summary>Creates a new MLMultiArray with the specified shape and data type.</summary>
 		/// <param name="shape">The shape.</param>
 		/// <param name="dataType">The data type.</param>
 		/// <param name="error">The error.</param>
-		/// <summary>Creates a new MLMultiArray with the specified shape and data type.</summary>
 		public MLMultiArray (nint [] shape, MLMultiArrayDataType dataType, out NSError error)
 			: this (ConvertArray (shape), dataType, out error)
 		{
 		}
 
+		/// <summary>Creates a new MLMultiArray with the specified details.</summary>
 		/// <param name="dataPointer">The data pointer.</param>
 		/// <param name="shape">The shape.</param>
 		/// <param name="dataType">The data type.</param>
 		/// <param name="strides">The strides.</param>
 		/// <param name="deallocator">The deallocator.</param>
 		/// <param name="error">The error.</param>
-		/// <summary>Creates a new MLMultiArray with the specified details.</summary>
 		public MLMultiArray (IntPtr dataPointer, nint [] shape, MLMultiArrayDataType dataType, nint [] strides, Action<IntPtr> deallocator, out NSError error)
 			: this (dataPointer, ConvertArray (shape), dataType, ConvertArray (strides), deallocator, out error)
 		{
 		}
 
-		/// <param name="idx">A numeric identifier for the object to get or set.</param>
 		/// <summary>Retrieves the element at <paramref name="idx" />, as if the array were single-dimensional.</summary>
+		/// <param name="idx">A numeric identifier for the object to get or set.</param>
 		public NSNumber this [nint idx] {
 			get { return GetObject (idx); }
 			set { SetObject (value, idx); }
 		}
 
-		/// <param name="indices">A multidimensional coordinate for the object to get or set.</param>
 		/// <summary>Gets or sets the element at <paramref name="indices" />.</summary>
+		/// <param name="indices">A multidimensional coordinate for the object to get or set.</param>
 		public NSNumber this [params nint [] indices] {
 			get { return GetObject (indices); }
 			set { SetObject (value, indices); }
 		}
 
-		/// <param name="key">A numeric identifier for the object to get or set.</param>
 		/// <summary>Accesses the point in the multi-dimensional array identified by <paramref name="key" />.</summary>
+		/// <param name="key">A numeric identifier for the object to get or set.</param>
 		public NSNumber this [NSNumber [] key] {
 			get { return GetObject (key); }
 			set { SetObject (value, key); }
 		}
 
-		/// <param name="indices">A multidimensional coordinate for the object to get.</param>
 		/// <summary>Retrieves the element at <paramref name="indices" />.</summary>
+		/// <param name="indices">A multidimensional coordinate for the object to get.</param>
 		public NSNumber GetObject (params nint [] indices)
 		{
 			using (var arr = NSArray.FromNSObjects<nint> (NSNumber.FromNInt, indices))
 				return GetObjectInternal (arr.GetHandle ());
 		}
 
+		/// <summary>Sets the element at <paramref name="indices" />.</summary>
 		/// <param name="obj">The new value</param>
 		/// <param name="indices">The multidimensional coordinate of the item to set</param>
-		/// <summary>Sets the element at <paramref name="indices" />.</summary>
 		public void SetObject (NSNumber obj, params nint [] indices)
 		{
 			using (var arr = NSArray.FromNSObjects<nint> (NSNumber.FromNInt, indices))
@@ -92,11 +92,11 @@ namespace CoreML {
 		}
 
 		/// <summary>The number of elements to skip to advance an index value by one in the chosen direction.</summary>
-		///         <remarks>
-		///           <para>
-		///             <see cref="CoreML.MLMultiArray" /> objects can be treated as one-dimensional arrays. The <see cref="CoreML.MLMultiArray.Strides" /> property retrieves the number of elements in a one-dimensional array that are necessary to "skip over" in order to advance by 1 in the desired dimension.</para>
-		///           <example>
-		///             <code lang="csharp lang-csharp"><![CDATA[
+		/// <remarks>
+		///   <para>
+		///     <see cref="CoreML.MLMultiArray" /> objects can be treated as one-dimensional arrays. The <see cref="CoreML.MLMultiArray.Strides" /> property retrieves the number of elements in a one-dimensional array that are necessary to "skip over" in order to advance by 1 in the desired dimension.</para>
+		///   <example>
+		///     <code lang="csharp lang-csharp"><![CDATA[
 		/// NSError err;
 		/// var ma = new CoreML.MLMultiArray(new NSNumber[] { 3, 5, 7, 9 },CoreML.MLMultiArrayDataType.Int32, out err);
 		/// if (err is not null) 
@@ -113,8 +113,8 @@ namespace CoreML {
 		/// */        
 		///
 		///     ]]></code>
-		///           </example>
-		///         </remarks>
+		///   </example>
+		/// </remarks>
 		public nint [] Strides {
 			get {
 				return ConvertArray (_Strides);

--- a/src/CoreML/MLMultiArray.cs
+++ b/src/CoreML/MLMultiArray.cs
@@ -25,24 +25,22 @@ namespace CoreML {
 			return NSArray.NonNullArrayFromHandleDropNullElements<nint> (handle, (v) => (nint) Messaging.IntPtr_objc_msgSend (v, Selector.GetHandle ("integerValue")));
 		}
 
-		/// <param name="shape">To be added.</param>
-		/// <param name="dataType">To be added.</param>
-		/// <param name="error">To be added.</param>
+		/// <param name="shape">The shape.</param>
+		/// <param name="dataType">The data type.</param>
+		/// <param name="error">The error.</param>
 		/// <summary>Creates a new MLMultiArray with the specified shape and data type.</summary>
-		/// <remarks>To be added.</remarks>
 		public MLMultiArray (nint [] shape, MLMultiArrayDataType dataType, out NSError error)
 			: this (ConvertArray (shape), dataType, out error)
 		{
 		}
 
-		/// <param name="dataPointer">To be added.</param>
-		/// <param name="shape">To be added.</param>
-		/// <param name="dataType">To be added.</param>
-		/// <param name="strides">To be added.</param>
-		/// <param name="deallocator">To be added.</param>
-		/// <param name="error">To be added.</param>
+		/// <param name="dataPointer">The data pointer.</param>
+		/// <param name="shape">The shape.</param>
+		/// <param name="dataType">The data type.</param>
+		/// <param name="strides">The strides.</param>
+		/// <param name="deallocator">The deallocator.</param>
+		/// <param name="error">The error.</param>
 		/// <summary>Creates a new MLMultiArray with the specified details.</summary>
-		/// <remarks>To be added.</remarks>
 		public MLMultiArray (IntPtr dataPointer, nint [] shape, MLMultiArrayDataType dataType, nint [] strides, Action<IntPtr> deallocator, out NSError error)
 			: this (dataPointer, ConvertArray (shape), dataType, ConvertArray (strides), deallocator, out error)
 		{
@@ -50,8 +48,6 @@ namespace CoreML {
 
 		/// <param name="idx">A numeric identifier for the object to get or set.</param>
 		/// <summary>Retrieves the element at <paramref name="idx" />, as if the array were single-dimensional.</summary>
-		/// <value>To be added.</value>
-		/// <remarks>To be added.</remarks>
 		public NSNumber this [nint idx] {
 			get { return GetObject (idx); }
 			set { SetObject (value, idx); }
@@ -59,8 +55,6 @@ namespace CoreML {
 
 		/// <param name="indices">A multidimensional coordinate for the object to get or set.</param>
 		/// <summary>Gets or sets the element at <paramref name="indices" />.</summary>
-		/// <value>To be added.</value>
-		/// <remarks>To be added.</remarks>
 		public NSNumber this [params nint [] indices] {
 			get { return GetObject (indices); }
 			set { SetObject (value, indices); }
@@ -68,8 +62,6 @@ namespace CoreML {
 
 		/// <param name="key">A numeric identifier for the object to get or set.</param>
 		/// <summary>Accesses the point in the multi-dimensional array identified by <paramref name="key" />.</summary>
-		/// <value>To be added.</value>
-		/// <remarks>To be added.</remarks>
 		public NSNumber this [NSNumber [] key] {
 			get { return GetObject (key); }
 			set { SetObject (value, key); }
@@ -77,8 +69,6 @@ namespace CoreML {
 
 		/// <param name="indices">A multidimensional coordinate for the object to get.</param>
 		/// <summary>Retrieves the element at <paramref name="indices" />.</summary>
-		/// <returns>To be added.</returns>
-		/// <remarks>To be added.</remarks>
 		public NSNumber GetObject (params nint [] indices)
 		{
 			using (var arr = NSArray.FromNSObjects<nint> (NSNumber.FromNInt, indices))
@@ -88,7 +78,6 @@ namespace CoreML {
 		/// <param name="obj">The new value</param>
 		/// <param name="indices">The multidimensional coordinate of the item to set</param>
 		/// <summary>Sets the element at <paramref name="indices" />.</summary>
-		/// <remarks>To be added.</remarks>
 		public void SetObject (NSNumber obj, params nint [] indices)
 		{
 			using (var arr = NSArray.FromNSObjects<nint> (NSNumber.FromNInt, indices))
@@ -96,8 +85,6 @@ namespace CoreML {
 		}
 
 		/// <summary>The dimensions of the array.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public nint [] Shape {
 			get {
 				return ConvertArray (_Shape);
@@ -105,7 +92,6 @@ namespace CoreML {
 		}
 
 		/// <summary>The number of elements to skip to advance an index value by one in the chosen direction.</summary>
-		///         <value>To be added.</value>
 		///         <remarks>
 		///           <para>
 		///             <see cref="CoreML.MLMultiArray" /> objects can be treated as one-dimensional arrays. The <see cref="CoreML.MLMultiArray.Strides" /> property retrieves the number of elements in a one-dimensional array that are necessary to "skip over" in order to advance by 1 in the desired dimension.</para>

--- a/src/CoreML/MLMultiArray.cs
+++ b/src/CoreML/MLMultiArray.cs
@@ -76,8 +76,8 @@ namespace CoreML {
 		}
 
 		/// <summary>Sets the element at <paramref name="indices" />.</summary>
-		/// <param name="obj">The new value</param>
-		/// <param name="indices">The multidimensional coordinate of the item to set</param>
+		/// <param name="obj">The new value.</param>
+		/// <param name="indices">The multidimensional coordinate of the item to set.</param>
 		public void SetObject (NSNumber obj, params nint [] indices)
 		{
 			using (var arr = NSArray.FromNSObjects<nint> (NSNumber.FromNInt, indices))

--- a/src/UIKit/NSLayoutManager.cs
+++ b/src/UIKit/NSLayoutManager.cs
@@ -24,12 +24,12 @@ namespace AppKit {
 namespace UIKit {
 #endif
 	partial class NSLayoutManager {
+		/// <summary>Fills <paramref name="glyphBuffer" /> with the glyphs in <paramref name="glyphRange" />.</summary>
 		/// <param name="glyphRange">The glyph range.</param>
 		/// <param name="glyphBuffer">The glyph buffer.</param>
 		/// <param name="props">The props.</param>
 		/// <param name="charIndexBuffer">The char index buffer.</param>
 		/// <param name="bidiLevelBuffer">The bidi level buffer.</param>
-		/// <summary>Fills <paramref name="glyphBuffer" /> with the glyphs in <paramref name="glyphRange" />.</summary>
 		/// <returns>The number of glyphs in <paramref name="glyphBuffer" />.</returns>
 		public unsafe nuint GetGlyphs (
 			NSRange glyphRange,
@@ -94,12 +94,12 @@ namespace UIKit {
 			}
 		}
 
+		/// <summary>Fills <paramref name="positions" /> and <paramref name="charIndexes" /> with the positions and indices of the insertion points for a line fragment.</summary>
 		/// <param name="charIndex">The char index.</param>
 		/// <param name="alternatePosition">The alternate position.</param>
 		/// <param name="inDisplayOrder">The in display order.</param>
 		/// <param name="positions">The positions.</param>
 		/// <param name="charIndexes">The char indexes.</param>
-		/// <summary>Fills <paramref name="positions" /> and <paramref name="charIndexes" /> with the positions and indices of the insertion points for a line fragment.</summary>
 		/// <returns>The number of insertion points returned in <paramref name="positions" /> and <paramref name="charIndexes" />.</returns>
 		public unsafe nuint GetLineFragmentInsertionPoints (
 			nuint /* NSUInteger */ charIndex,

--- a/src/UIKit/NSLayoutManager.cs
+++ b/src/UIKit/NSLayoutManager.cs
@@ -25,11 +25,11 @@ namespace UIKit {
 #endif
 	partial class NSLayoutManager {
 		/// <summary>Fills <paramref name="glyphBuffer" /> with the glyphs in <paramref name="glyphRange" />.</summary>
-		/// <param name="glyphRange">The glyph range.</param>
-		/// <param name="glyphBuffer">The glyph buffer.</param>
-		/// <param name="props">The props.</param>
-		/// <param name="charIndexBuffer">The char index buffer.</param>
-		/// <param name="bidiLevelBuffer">The bidi level buffer.</param>
+		/// <param name="glyphRange">The range of glyphs to retrieve.</param>
+		/// <param name="glyphBuffer">An output buffer that receives the glyph identifiers for the specified range.</param>
+		/// <param name="props">An output buffer that receives the glyph properties for each glyph.</param>
+		/// <param name="charIndexBuffer">An output buffer that receives the character index corresponding to each glyph.</param>
+		/// <param name="bidiLevelBuffer">An output buffer that receives the bidirectional embedding level for each glyph.</param>
 		/// <returns>The number of glyphs in <paramref name="glyphBuffer" />.</returns>
 		public unsafe nuint GetGlyphs (
 			NSRange glyphRange,
@@ -95,11 +95,11 @@ namespace UIKit {
 		}
 
 		/// <summary>Fills <paramref name="positions" /> and <paramref name="charIndexes" /> with the positions and indices of the insertion points for a line fragment.</summary>
-		/// <param name="charIndex">The char index.</param>
-		/// <param name="alternatePosition">The alternate position.</param>
-		/// <param name="inDisplayOrder">The in display order.</param>
-		/// <param name="positions">The positions.</param>
-		/// <param name="charIndexes">The char indexes.</param>
+		/// <param name="charIndex">A character index within the line fragment.</param>
+		/// <param name="alternatePosition">Whether to use the alternate insertion point position.</param>
+		/// <param name="inDisplayOrder">Whether to return the insertion points in display order rather than logical order.</param>
+		/// <param name="positions">An output buffer that receives the horizontal positions of each insertion point.</param>
+		/// <param name="charIndexes">An output buffer that receives the character index for each insertion point.</param>
 		/// <returns>The number of insertion points returned in <paramref name="positions" /> and <paramref name="charIndexes" />.</returns>
 		public unsafe nuint GetLineFragmentInsertionPoints (
 			nuint /* NSUInteger */ charIndex,

--- a/src/UIKit/NSLayoutManager.cs
+++ b/src/UIKit/NSLayoutManager.cs
@@ -24,14 +24,13 @@ namespace AppKit {
 namespace UIKit {
 #endif
 	partial class NSLayoutManager {
-		/// <param name="glyphRange">To be added.</param>
-		/// <param name="glyphBuffer">To be added.</param>
-		/// <param name="props">To be added.</param>
-		/// <param name="charIndexBuffer">To be added.</param>
-		/// <param name="bidiLevelBuffer">To be added.</param>
+		/// <param name="glyphRange">The glyph range.</param>
+		/// <param name="glyphBuffer">The glyph buffer.</param>
+		/// <param name="props">The props.</param>
+		/// <param name="charIndexBuffer">The char index buffer.</param>
+		/// <param name="bidiLevelBuffer">The bidi level buffer.</param>
 		/// <summary>Fills <paramref name="glyphBuffer" /> with the glyphs in <paramref name="glyphRange" />.</summary>
 		/// <returns>The number of glyphs in <paramref name="glyphBuffer" />.</returns>
-		/// <remarks>To be added.</remarks>
 		public unsafe nuint GetGlyphs (
 			NSRange glyphRange,
 			short [] /* CGGlyph* = CGFontIndex* = unsigned short* */ glyphBuffer,
@@ -68,13 +67,13 @@ namespace UIKit {
 		}
 
 		/// <summary>Renders <paramref name="glyphs" /> at <paramref name="positions" /> into <paramref name="graphicsContext" />.</summary>
-		/// <param name="glyphs">To be added.</param>
-		/// <param name="positions">To be added.</param>
-		/// <param name="glyphCount">To be added.</param>
-		/// <param name="font">To be added.</param>
-		/// <param name="textMatrix">To be added.</param>
-		/// <param name="attributes">To be added.</param>
-		/// <param name="graphicsContext">To be added.</param>
+		/// <param name="glyphs">The glyphs.</param>
+		/// <param name="positions">The positions.</param>
+		/// <param name="glyphCount">The glyph count.</param>
+		/// <param name="font">The font.</param>
+		/// <param name="textMatrix">The text matrix.</param>
+		/// <param name="attributes">The attributes.</param>
+		/// <param name="graphicsContext">The graphics context.</param>
 		[SupportedOSPlatform ("tvos13.0")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios13.0")]
@@ -95,14 +94,13 @@ namespace UIKit {
 			}
 		}
 
-		/// <param name="charIndex">To be added.</param>
-		/// <param name="alternatePosition">To be added.</param>
-		/// <param name="inDisplayOrder">To be added.</param>
-		/// <param name="positions">To be added.</param>
-		/// <param name="charIndexes">To be added.</param>
+		/// <param name="charIndex">The char index.</param>
+		/// <param name="alternatePosition">The alternate position.</param>
+		/// <param name="inDisplayOrder">The in display order.</param>
+		/// <param name="positions">The positions.</param>
+		/// <param name="charIndexes">The char indexes.</param>
 		/// <summary>Fills <paramref name="positions" /> and <paramref name="charIndexes" /> with the positions and indices of the insertion points for a line fragment.</summary>
 		/// <returns>The number of insertion points returned in <paramref name="positions" /> and <paramref name="charIndexes" />.</returns>
-		/// <remarks>To be added.</remarks>
 		public unsafe nuint GetLineFragmentInsertionPoints (
 			nuint /* NSUInteger */ charIndex,
 			bool /* BOOL */ alternatePosition,


### PR DESCRIPTION
Improve XML documentation for the following types:

- **NSLayoutManager** — Fix tag ordering (summary before param), improve method documentation
- **MLMultiArray** — Fix tag ordering, normalize indentation in Strides remarks, remove placeholder docs

Changes include:
- Reorder XML doc tags (summary before param)
- Normalize indentation (single space after `///`)
- Remove empty/placeholder elements

🤖 Pull request created by Copilot