### PR TITLE
[docs] Improve XML docs for NSCell, CTBaselineClass, MTProfessionalVideoWorkflow, NEVpnManager, INSetCarLockStatusIntent, CMCustomBlockAllocator

### DIFF
--- a/src/AppKit/NSCell.cs
+++ b/src/AppKit/NSCell.cs
@@ -39,15 +39,15 @@ namespace AppKit {
 			IntPtr /* NSImage* */ startCap, IntPtr /* NSImage* */ centerFill, IntPtr /* NSImage* */ endCap,
 			byte vertial, nint op, nfloat alphaFraction, byte flipped);
 
-		/// <param name="frame">The frame.</param>
-		/// <param name="startCap">The start cap.</param>
-		/// <param name="centerFill">The center fill.</param>
-		/// <param name="endCap">The end cap.</param>
-		/// <param name="vertical">The vertical.</param>
-		/// <param name="op">The op.</param>
-		/// <param name="alphaFraction">The alpha fraction.</param>
-		/// <param name="flipped">The flipped.</param>
-		/// <summary>DrawThreePartImage.</summary>
+		/// <summary>Draws a three-part image in the specified frame.</summary>
+		/// <param name="frame">The frame rectangle in which to draw.</param>
+		/// <param name="startCap">The image for the start cap.</param>
+		/// <param name="centerFill">The image for the center fill region.</param>
+		/// <param name="endCap">The image for the end cap.</param>
+		/// <param name="vertical">Whether to draw the image vertically.</param>
+		/// <param name="op">The compositing operation to use.</param>
+		/// <param name="alphaFraction">The alpha fraction for the drawing operation.</param>
+		/// <param name="flipped">Whether to draw with a flipped coordinate system.</param>
 		public void DrawThreePartImage (CGRect frame,
 			NSImage startCap, NSImage centerFill, NSImage endCap,
 			bool vertical, NSCompositingOperation op, nfloat alphaFraction, bool flipped)
@@ -72,20 +72,20 @@ namespace AppKit {
 			IntPtr /* NSImage* */ bottomLeftCorner, IntPtr /* NSImage* */ bottomEdgeFill, IntPtr /* NSImage* */ bottomRightCnint,
 			nint op, nfloat alphaFraction, byte flipped);
 
-		/// <param name="frame">The frame.</param>
-		/// <param name="topLeftCorner">The top left corner.</param>
-		/// <param name="topEdgeFill">The top edge fill.</param>
-		/// <param name="topRightCorner">The top right corner.</param>
-		/// <param name="leftEdgeFill">The left edge fill.</param>
-		/// <param name="centerFill">The center fill.</param>
-		/// <param name="rightEdgeFill">The right edge fill.</param>
-		/// <param name="bottomLeftCorner">The bottom left corner.</param>
-		/// <param name="bottomEdgeFill">The bottom edge fill.</param>
-		/// <param name="bottomRightCorner">The bottom right corner.</param>
-		/// <param name="op">The op.</param>
-		/// <param name="alphaFraction">The alpha fraction.</param>
-		/// <param name="flipped">The flipped.</param>
-		/// <summary>DrawNinePartImage.</summary>
+		/// <summary>Draws a nine-part image in the specified frame.</summary>
+		/// <param name="frame">The frame rectangle in which to draw.</param>
+		/// <param name="topLeftCorner">The image for the top-left corner.</param>
+		/// <param name="topEdgeFill">The image for the top edge fill.</param>
+		/// <param name="topRightCorner">The image for the top-right corner.</param>
+		/// <param name="leftEdgeFill">The image for the left edge fill.</param>
+		/// <param name="centerFill">The image for the center fill region.</param>
+		/// <param name="rightEdgeFill">The image for the right edge fill.</param>
+		/// <param name="bottomLeftCorner">The image for the bottom-left corner.</param>
+		/// <param name="bottomEdgeFill">The image for the bottom edge fill.</param>
+		/// <param name="bottomRightCorner">The image for the bottom-right corner.</param>
+		/// <param name="op">The compositing operation to use.</param>
+		/// <param name="alphaFraction">The alpha fraction for the drawing operation.</param>
+		/// <param name="flipped">Whether to draw with a flipped coordinate system.</param>
 		public void DrawNinePartImage (CGRect frame,
 			NSImage topLeftCorner, NSImage topEdgeFill, NSImage topRightCorner,
 			NSImage leftEdgeFill, NSImage centerFill, NSImage rightEdgeFill,

--- a/src/AppKit/NSCell.cs
+++ b/src/AppKit/NSCell.cs
@@ -39,16 +39,15 @@ namespace AppKit {
 			IntPtr /* NSImage* */ startCap, IntPtr /* NSImage* */ centerFill, IntPtr /* NSImage* */ endCap,
 			byte vertial, nint op, nfloat alphaFraction, byte flipped);
 
-		/// <param name="frame">To be added.</param>
-		/// <param name="startCap">To be added.</param>
-		/// <param name="centerFill">To be added.</param>
-		/// <param name="endCap">To be added.</param>
-		/// <param name="vertical">To be added.</param>
-		/// <param name="op">To be added.</param>
-		/// <param name="alphaFraction">To be added.</param>
-		/// <param name="flipped">To be added.</param>
-		/// <summary>To be added.</summary>
-		/// <remarks>To be added.</remarks>
+		/// <param name="frame">The frame.</param>
+		/// <param name="startCap">The start cap.</param>
+		/// <param name="centerFill">The center fill.</param>
+		/// <param name="endCap">The end cap.</param>
+		/// <param name="vertical">The vertical.</param>
+		/// <param name="op">The op.</param>
+		/// <param name="alphaFraction">The alpha fraction.</param>
+		/// <param name="flipped">The flipped.</param>
+		/// <summary>DrawThreePartImage.</summary>
 		public void DrawThreePartImage (CGRect frame,
 			NSImage startCap, NSImage centerFill, NSImage endCap,
 			bool vertical, NSCompositingOperation op, nfloat alphaFraction, bool flipped)
@@ -73,21 +72,20 @@ namespace AppKit {
 			IntPtr /* NSImage* */ bottomLeftCorner, IntPtr /* NSImage* */ bottomEdgeFill, IntPtr /* NSImage* */ bottomRightCnint,
 			nint op, nfloat alphaFraction, byte flipped);
 
-		/// <param name="frame">To be added.</param>
-		/// <param name="topLeftCorner">To be added.</param>
-		/// <param name="topEdgeFill">To be added.</param>
-		/// <param name="topRightCorner">To be added.</param>
-		/// <param name="leftEdgeFill">To be added.</param>
-		/// <param name="centerFill">To be added.</param>
-		/// <param name="rightEdgeFill">To be added.</param>
-		/// <param name="bottomLeftCorner">To be added.</param>
-		/// <param name="bottomEdgeFill">To be added.</param>
-		/// <param name="bottomRightCorner">To be added.</param>
-		/// <param name="op">To be added.</param>
-		/// <param name="alphaFraction">To be added.</param>
-		/// <param name="flipped">To be added.</param>
-		/// <summary>To be added.</summary>
-		/// <remarks>To be added.</remarks>
+		/// <param name="frame">The frame.</param>
+		/// <param name="topLeftCorner">The top left corner.</param>
+		/// <param name="topEdgeFill">The top edge fill.</param>
+		/// <param name="topRightCorner">The top right corner.</param>
+		/// <param name="leftEdgeFill">The left edge fill.</param>
+		/// <param name="centerFill">The center fill.</param>
+		/// <param name="rightEdgeFill">The right edge fill.</param>
+		/// <param name="bottomLeftCorner">The bottom left corner.</param>
+		/// <param name="bottomEdgeFill">The bottom edge fill.</param>
+		/// <param name="bottomRightCorner">The bottom right corner.</param>
+		/// <param name="op">The op.</param>
+		/// <param name="alphaFraction">The alpha fraction.</param>
+		/// <param name="flipped">The flipped.</param>
+		/// <summary>DrawNinePartImage.</summary>
 		public void DrawNinePartImage (CGRect frame,
 			NSImage topLeftCorner, NSImage topEdgeFill, NSImage topRightCorner,
 			NSImage leftEdgeFill, NSImage centerFill, NSImage rightEdgeFill,

--- a/src/CoreMedia/CMCustomBlockAllocator.cs
+++ b/src/CoreMedia/CMCustomBlockAllocator.cs
@@ -13,8 +13,7 @@ using CoreFoundation;
 
 namespace CoreMedia {
 
-	/// <summary>To be added.</summary>
-	///     <remarks>To be added.</remarks>
+	/// <summary>Provides custom memory allocation for Core Media block buffers.</summary>
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("macos")]
@@ -23,8 +22,7 @@ namespace CoreMedia {
 
 		GCHandle gch;
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Initializes a new instance of the <see cref="CMCustomBlockAllocator" /> class.</summary>
 		public CMCustomBlockAllocator ()
 		{
 			gch = GCHandle.Alloc (this);
@@ -84,10 +82,13 @@ namespace CoreMedia {
 		}
 
 		/// <summary>Releases the resources used by the CMCustomBlockAllocator object.</summary>
-		///         <remarks>
-		///           <para>The Dispose method releases the resources used by the CMCustomBlockAllocator class.</para>
-		///           <para>Calling the Dispose method when the application is finished using the CMCustomBlockAllocator ensures that all external resources used by this managed object are released as soon as possible.  Once developers have invoked the Dispose method, the object is no longer useful and developers should no longer make any calls to it.  For more information on releasing resources see ``Cleaning up Unmananaged Resources'' at https://msdn.microsoft.com/en-us/library/498928w2.aspx</para>
-		///         </remarks>
+		/// <remarks>
+		///   <para>The Dispose method releases the resources used by the CMCustomBlockAllocator class.</para>
+		///   <para>Calling the Dispose method when the application is finished using the CMCustomBlockAllocator ensures
+		///   that all external resources used by this managed object are released as soon as possible. Once developers
+		///   have invoked the Dispose method, the object is no longer useful and developers should no longer make any
+		///   calls to it.</para>
+		/// </remarks>
 		public void Dispose ()
 		{
 			Dispose (true);

--- a/src/CoreText/CTBaselineClass.cs
+++ b/src/CoreText/CTBaselineClass.cs
@@ -76,7 +76,7 @@ namespace CoreText {
 	}
 
 	// Convenience enum for string values in ObjC.
-	/// <summary>An enumeration whose values specify the whether the baseline font is from the original font or a reference font.</summary>
+	/// <summary>An enumeration whose values specify whether the baseline font is from the original font or a reference font.</summary>
 	public enum CTBaselineFont {
 		/// <summary>The reference font baseline.</summary>
 		Reference,

--- a/src/CoreText/CTBaselineClass.cs
+++ b/src/CoreText/CTBaselineClass.cs
@@ -32,7 +32,6 @@ namespace CoreText {
 
 	// Convenience enum for string values in ObjC.
 	/// <summary>The kind of baselines supported when typesetting text.</summary>
-	///     <remarks>To be added.</remarks>
 	public enum CTBaselineClass {
 		/// <summary>Used to offset a roman baseline.</summary>
 		Roman,
@@ -78,11 +77,10 @@ namespace CoreText {
 
 	// Convenience enum for string values in ObjC.
 	/// <summary>An enumeration whose values specify the whether the baseline font is from the original font or a reference font.</summary>
-	///     <remarks>To be added.</remarks>
 	public enum CTBaselineFont {
-		/// <summary>To be added.</summary>
+		/// <summary>The reference font baseline.</summary>
 		Reference,
-		/// <summary>To be added.</summary>
+		/// <summary>The original font baseline.</summary>
 		Original,
 	}
 

--- a/src/Intents/INSetCarLockStatusIntent.cs
+++ b/src/Intents/INSetCarLockStatusIntent.cs
@@ -15,10 +15,9 @@ namespace Intents {
 
 	public partial class INSetCarLockStatusIntent {
 
-		/// <param name="locked">To be added.</param>
-		///         <param name="carName">To be added.</param>
-		///         <summary>Creates a new set car lock status intent for the specified lock state and car name.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Creates a new set car lock status intent for the specified lock state and car name.</summary>
+		/// <param name="locked">Whether the car should be locked.</param>
+		/// <param name="carName">The name of the car.</param>
 		public INSetCarLockStatusIntent (bool? locked, INSpeakableString carName) :
 			this (locked.HasValue ? new NSNumber (locked.Value) : null, carName)
 		{

--- a/src/MediaToolbox/MTProfessionalVideoWorkflow.cs
+++ b/src/MediaToolbox/MTProfessionalVideoWorkflow.cs
@@ -3,13 +3,11 @@
 #if MONOMAC
 
 namespace MediaToolbox {
-	/// <summary>To be added.</summary>
-	///     <remarks>To be added.</remarks>
+	/// <summary>Provides methods for registering professional video workflow format readers.</summary>
 	[SupportedOSPlatform ("macos")]
 	static public class MTProfessionalVideoWorkflow {
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Registers professional video workflow format readers with the system.</summary>
 		[SupportedOSPlatform ("macos")]
 		[DllImport (Constants.MediaToolboxLibrary, EntryPoint = "MTRegisterProfessionalVideoWorkflowFormatReaders")]
 		public static extern void RegisterFormatReaders ();

--- a/src/NetworkExtension/NEVpnManager.cs
+++ b/src/NetworkExtension/NEVpnManager.cs
@@ -14,12 +14,10 @@ using Security;
 
 namespace NetworkExtension {
 	/// <summary>Manages and controls VPN configurations and connections.</summary>
-	///     <remarks>To be added.</remarks>
-	///     <related type="externalDocumentation" href="https://developer.apple.com/library/ios/documentation/NetworkExtension/Reference/NEVPNManagerClassRef/index.html">Apple documentation for <c>NEVPNManager</c></related>
+	/// <related type="externalDocumentation" href="https://developer.apple.com/library/ios/documentation/NetworkExtension/Reference/NEVPNManagerClassRef/index.html">Apple documentation for <c>NEVPNManager</c></related>
 	public partial class NEVpnManager {
-		/// <param name="authorization">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Sets the authorization for this VPN manager.</summary>
+		/// <param name="authorization">The authorization object to set.</param>
 		[SupportedOSPlatform ("macos")]
 		[UnsupportedOSPlatform ("ios")]
 		[UnsupportedOSPlatform ("maccatalyst")]


### PR DESCRIPTION
Improve XML documentation for 6 types:

| Type | Changes |
|------|---------|
| NSCell | Fix tag ordering, replace placeholder descriptions with meaningful docs |
| CTBaselineClass | Remove empty remarks, add summaries for CTBaselineFont members |
| MTProfessionalVideoWorkflow | Replace placeholder docs with meaningful summaries |
| NEVpnManager | Fix tag ordering, replace placeholders, fix indentation |
| INSetCarLockStatusIntent | Fix tag ordering, replace placeholder param descriptions |
| CMCustomBlockAllocator | Replace placeholders, fix indentation, clean up remarks |

🤖 Pull request created by Copilot