### PR TITLE
[dotnet-linker] Work around a crossgen2 crash compiling the trimmable-static type maps

### DIFF
--- a/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-TrimmableStatic-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-TrimmableStatic-size.txt
@@ -1,9 +1,9 @@
-AppBundleSize: 257,730,173 bytes (251,689.6 KB = 245.8 MB)
+AppBundleSize: 257,724,211 bytes (251,683.8 KB = 245.8 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    744 bytes (0.7 KB = 0.0 MB)
+    718 bytes (0.7 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
-    7,387,544 bytes (7,214.4 KB = 7.0 MB)
+    7,386,728 bytes (7,213.6 KB = 7.0 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/_Microsoft.macOS.TypeMap.dll:
     4,911,616 bytes (4,796.5 KB = 4.7 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/_SizeTestApp.TypeMap.dll:
@@ -11,7 +11,7 @@ Contents/MonoBundle/.xamarin/osx-arm64/_SizeTestApp.TypeMap.dll:
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.CSharp.dll:
     892,712 bytes (871.8 KB = 0.9 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.macOS.dll:
-    37,215,744 bytes (36,343.5 KB = 35.5 MB)
+    37,213,184 bytes (36,341.0 KB = 35.5 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.Core.dll:
     1,334,568 bytes (1,303.3 KB = 1.3 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.dll:
@@ -363,7 +363,7 @@ Contents/MonoBundle/.xamarin/osx-x64/_SizeTestApp.TypeMap.dll:
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.CSharp.dll:
     795,944 bytes (777.3 KB = 0.8 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.macOS.dll:
-    37,215,744 bytes (36,343.5 KB = 35.5 MB)
+    37,213,184 bytes (36,341.0 KB = 35.5 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.Core.dll:
     1,166,120 bytes (1,138.8 KB = 1.1 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.dll:

--- a/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-TrimmableStatic-size.txt
+++ b/tests/dotnet/UnitTests/expected/MacOSX-CoreCLR-Interpreter-TrimmableStatic-size.txt
@@ -1,17 +1,17 @@
-AppBundleSize: 257,596,211 bytes (251,558.8 KB = 245.7 MB)
+AppBundleSize: 257,730,173 bytes (251,689.6 KB = 245.8 MB)
 # The following list of files and their sizes is just informational / for review, and isn't used in the test:
 Contents/Info.plist:
-    718 bytes (0.7 KB = 0.0 MB)
+    744 bytes (0.7 KB = 0.0 MB)
 Contents/MacOS/SizeTestApp:
-    7,386,728 bytes (7,213.6 KB = 7.0 MB)
+    7,387,544 bytes (7,214.4 KB = 7.0 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/_Microsoft.macOS.TypeMap.dll:
-    4,847,616 bytes (4,734.0 KB = 4.6 MB)
+    4,911,616 bytes (4,796.5 KB = 4.7 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/_SizeTestApp.TypeMap.dll:
     3,072 bytes (3.0 KB = 0.0 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.CSharp.dll:
     892,712 bytes (871.8 KB = 0.9 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.macOS.dll:
-    37,213,184 bytes (36,341.0 KB = 35.5 MB)
+    37,215,744 bytes (36,343.5 KB = 35.5 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.Core.dll:
     1,334,568 bytes (1,303.3 KB = 1.3 MB)
 Contents/MonoBundle/.xamarin/osx-arm64/Microsoft.VisualBasic.dll:
@@ -357,13 +357,13 @@ Contents/MonoBundle/.xamarin/osx-arm64/System.Xml.XPath.XDocument.dll:
 Contents/MonoBundle/.xamarin/osx-arm64/WindowsBase.dll:
     16,208 bytes (15.8 KB = 0.0 MB)
 Contents/MonoBundle/.xamarin/osx-x64/_Microsoft.macOS.TypeMap.dll:
-    4,847,616 bytes (4,734.0 KB = 4.6 MB)
+    4,911,616 bytes (4,796.5 KB = 4.7 MB)
 Contents/MonoBundle/.xamarin/osx-x64/_SizeTestApp.TypeMap.dll:
     3,072 bytes (3.0 KB = 0.0 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.CSharp.dll:
     795,944 bytes (777.3 KB = 0.8 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.macOS.dll:
-    37,213,184 bytes (36,341.0 KB = 35.5 MB)
+    37,215,744 bytes (36,343.5 KB = 35.5 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.Core.dll:
     1,166,120 bytes (1,138.8 KB = 1.1 MB)
 Contents/MonoBundle/.xamarin/osx-x64/Microsoft.VisualBasic.dll:

--- a/tools/dotnet-linker/Steps/TrimmableRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/TrimmableRegistrarStep.cs
@@ -195,7 +195,8 @@ namespace Xamarin.Linker {
 					// Types defined in the type map assembly itself already have a TypeDef row.
 					if (type.Scope == module)
 						continue;
-					if (seen.Add (type.FullName))
+					// Deduplicate on the scope too: two different assemblies can have types with the same full name.
+					if (seen.Add (type.Scope?.Name + "!" + type.FullName))
 						externalTypes.Add (type);
 				}
 			}

--- a/tools/dotnet-linker/Steps/TrimmableRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/TrimmableRegistrarStep.cs
@@ -160,6 +160,62 @@ namespace Xamarin.Linker {
 			il.Append (il.Create (OpCodes.Throw));
 		}
 
+		// The types named by our type-map entries are only mentioned in the custom attribute blobs (as
+		// assembly-qualified names), which means the type map assembly ends up without a TypeRef row for them.
+		// That's valid metadata: ECMA-335 II.23.3 only requires the type to be stored as a SerString with its
+		// canonical name, and neither the CustomAttribute (II.22.10) nor the TypeRef (II.22.38) validity rules
+		// require a corresponding TypeRef row. The runtime agrees: it resolves these types by parsing the string,
+		// not by looking at the TypeRef table (and the type map design explicitly says the assembly name in
+		// TypeMapAssemblyTargetAttribute doesn't need a matching AssemblyRef row either).
+		//
+		// crossgen2 nonetheless assumes such a TypeRef row exists: it can't resolve the type back to a module
+		// token, and crashes with a NotImplementedException (in ModuleTokenResolver.GetModuleTokenForType) when it
+		// ReadyToRun-compiles the type map assembly. See https://github.com/dotnet/runtime/issues/131527.
+		//
+		// Work around that by emitting an unused method that loads the token of every externally defined type we
+		// name, which makes Cecil emit the corresponding TypeRef rows. The method is never called, so it's trimmed
+		// away again by ILLink.
+		void EmitTypeReferencesForTypeMaps (AssemblyDefinition typeMapAssembly)
+		{
+			// Only crossgen2 needs this, and the added metadata isn't free, so don't do it for the other runtimes.
+			// We don't narrow this down to ReadyToRun builds, because that would mean different behavior between
+			// .NET versions (ReadyToRun is a .NET 11+ feature), and the cost for the interpreted CoreCLR
+			// configurations is small (~64 KB per runtime identifier in the platform type map assembly).
+			if (App.XamarinRuntime != XamarinRuntime.CoreCLR)
+				return;
+
+			var module = typeMapAssembly.MainModule;
+			var externalTypes = new List<TypeReference> ();
+			var seen = new HashSet<string> (StringComparer.Ordinal);
+
+			foreach (var attribute in typeMapAssembly.CustomAttributes) {
+				foreach (var argument in attribute.ConstructorArguments) {
+					if (argument.Value is not TypeReference type)
+						continue;
+					// Types defined in the type map assembly itself already have a TypeDef row.
+					if (type.Scope == module)
+						continue;
+					if (seen.Add (type.FullName))
+						externalTypes.Add (type);
+				}
+			}
+
+			if (externalTypes.Count == 0)
+				return;
+
+			var holderType = new TypeDefinition ("", "<TypeReferences>", TypeAttributes.NotPublic | TypeAttributes.Abstract | TypeAttributes.Sealed, abr.System_Object);
+			module.Types.Add (holderType);
+
+			var method = holderType.AddMethod ("KeepTypeReferences", MethodAttributes.Private | MethodAttributes.HideBySig | MethodAttributes.Static, abr.System_Void);
+			method.CreateBody (out var il);
+			foreach (var type in externalTypes) {
+				// 'ldtoken' works for open generic types too, unlike a field or parameter of that type.
+				il.Append (il.Create (OpCodes.Ldtoken, type));
+				il.Append (il.Create (OpCodes.Pop));
+			}
+			il.Append (il.Create (OpCodes.Ret));
+		}
+
 		protected override void TryEndProcess (out List<Exception>? exceptions)
 		{
 			CustomAttribute attribute;
@@ -641,6 +697,8 @@ namespace Xamarin.Linker {
 						typeMapAssembly.CustomAttributes.Add (attribute);
 					}
 				}
+
+				EmitTypeReferencesForTypeMaps (typeMapAssembly);
 
 				abr.ClearCurrentAssembly ();
 


### PR DESCRIPTION
The types named by our type-map entries are only mentioned in the custom attribute blobs (as assembly-qualified names), so the generated type map assembly ends up without a `TypeRef` row for them.

crossgen2 assumes such a `TypeRef` row exists: it can't resolve the type back to a module token and crashes with a `NotImplementedException` in `ModuleTokenResolver.GetModuleTokenForType` when it ReadyToRun-compiles the type map assembly.

```
Unhandled exception. System.NotImplementedException: The method or operation is not implemented.
   at ILCompiler.DependencyAnalysis.ReadyToRun.ModuleTokenResolver.GetModuleTokenForType(EcmaType type, Boolean allowDynamicallyCreatedReference, Boolean throwIfNotFound)
```

Upstream issue: **https://github.com/dotnet/runtime/issues/131527**
Tracking issue to remove this workaround: **https://github.com/dotnet/macios/issues/26343**

## Is our metadata valid?

Yes — this is a crossgen2 bug, not a Cecil bug:

| Rule                                          | Says                                                                                         |
|-----------------------------------------------|----------------------------------------------------------------------------------------------|
| ECMA-335 §II.23.3 (custom attribute blob)     | A `System.Type` argument is stored as a `SerString` holding the canonical name. Nothing more.  |
| ECMA-335 §II.22.10 (CustomAttribute validity) | No requirement that a referenced type has a `TypeRef` row.                                     |
| ECMA-335 §II.22.38 (TypeRef validity)         | Constrains rows that exist; doesn't require rows to exist.                                     |
| `Ecma-335-Augments.md`                        | Silent on this.                                                                                |
| `typemap.md` (runtime design doc)             | Explicitly states the assembly name "does not need to map to an `AssemblyRef` row".            |

The runtime itself resolves these types by parsing the string, not via the `TypeRef` table.

## The workaround

Emit an unused `<TypeReferences>.KeepTypeReferences` method into the type map assembly that `ldtoken`s every externally defined type we name. That makes Cecil emit the corresponding `TypeRef` rows. The method is never called, so ILLink trims it away again.

This is scoped to CoreCLR — NativeAOT and MonoVM don't need it, and the extra metadata isn't free. It is deliberately *not* narrowed further to ReadyToRun-only builds, because ReadyToRun for CoreCLR is a .NET 11+ feature and that would mean the code behaves differently between branches; the cost for the interpreted CoreCLR configurations is small (~64 KB per runtime identifier in the platform type map assembly).

## App size impact

Only the CoreCLR + trimmable-static configuration changes: `MacOSX-CoreCLR-Interpreter-TrimmableStatic` grows by 128,000 bytes (2 RIDs × 64,000 bytes). All NativeAOT and MonoVM sizes are unchanged (verified: `tests-dotnet NativeAOT` reports ≤5 bytes of drift across all 8 NativeAOT configs).

🤖 Pull request created by Copilot
