### PR TITLE
[ci] Fix apply-gist workflow failing on gist diffs with CRLF line endings

### DIFF
--- a/.github/workflows/apply-gist.yml
+++ b/.github/workflows/apply-gist.yml
@@ -180,6 +180,9 @@ jobs:
                 # Large files need to be fetched from raw_url
                 raw_url = file_info['raw_url']
                 content = urllib.request.urlopen(raw_url).read().decode('utf-8')
+            # Gist content can be served with CRLF line endings; normalize to LF
+            # so 'git apply' doesn't fail against the repo's LF expected files.
+            content = content.replace('\r\n', '\n').replace('\r', '\n')
             if is_diff:
                 # The diff for '<name>.txt.diff' is only allowed to touch 'tests/dotnet/UnitTests/expected/<name>.txt'.
                 expected_target = 'tests/dotnet/UnitTests/expected/' + filename[:-len('.diff')]


### PR DESCRIPTION
The `/apply-gist <gist-url>` PR command downloads unified `*.txt.diff` files from a gist and applies them to `tests/dotnet/UnitTests/expected/*.txt` with `git apply -p1`.

GitHub can serve gist file content with CRLF line endings. The workflow wrote the downloaded content to disk verbatim, so on the Linux runner the diffs retained embedded `\r` characters. Because the expected files in the repo use LF, `git apply` failed with `patch does not apply` — see [run 30468376709](https://github.com/dotnet/macios/actions/runs/30468376709).

This normalizes the downloaded gist content to LF before writing it, so the diffs apply cleanly regardless of how the gist stored its line endings. Verified manually: stripping `\r` from the same gist's diffs let all of them apply cleanly.

🤖 Pull request created by Copilot