### PR TITLE
[docs] Improve XML docs for SCNGeometrySource, CVPixelBufferPool, INInteraction, GCExtendedGamepadSnapshotDataVersion, SCNMatrix4

### DIFF
--- a/src/CoreVideo/CVPixelBufferPool.cs
+++ b/src/CoreVideo/CVPixelBufferPool.cs
@@ -49,10 +49,6 @@ namespace CoreVideo {
 		[DllImport (Constants.CoreVideoLibrary)]
 		extern static nint CVPixelBufferPoolGetTypeID ();
 		/// <summary>CoreFoundation TypeID for the CVPixelBufferPool.</summary>
-		///         <value>
-		///         </value>
-		///         <remarks>
-		///         </remarks>
 		public nint TypeID {
 			get {
 				return CVPixelBufferPoolGetTypeID ();
@@ -65,9 +61,7 @@ namespace CoreVideo {
 
 		// TODO: Return type is CVPixelBufferAttributes but need different name when this one is not WeakXXXX
 		/// <summary>Loosely typed NSDictionary containing all of the PixelBuffer attributes in the pool, it is easier to use the strogly typed Settings property.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>
-		///         </remarks>
+		/// <value>The pixel buffer attributes dictionary.</value>
 		public NSDictionary? PixelBufferAttributes {
 			get {
 				return Runtime.GetNSObject<NSDictionary> (CVPixelBufferPoolGetPixelBufferAttributes (Handle));
@@ -201,9 +195,8 @@ namespace CoreVideo {
 		static extern void CVPixelBufferPoolFlush (/* CVPixelBufferPoolRef __nonnull */ IntPtr pool,
 			CVPixelBufferPoolFlushFlags options);
 
-		/// <param name="options">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <param name="options">The flush options specifying which buffers to flush.</param>
+		/// <summary>Flushes the pixel buffer pool with the specified options.</summary>
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("maccatalyst")]

--- a/src/GameController/Enums.cs
+++ b/src/GameController/Enums.cs
@@ -14,15 +14,15 @@ namespace GameController {
 	[Deprecated (PlatformName.MacCatalyst, 13, 1, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
 	[Native]
 	public enum GCExtendedGamepadSnapshotDataVersion : long {
-		/// <summary>To be added.</summary>
+		/// <summary>Indicates version1.</summary>
 		Version1 = 0x0100,
-		/// <summary>To be added.</summary>
+		/// <summary>Indicates version2.</summary>
 		Version2 = 0x0101,
 	}
 
 	[Native]
 	public enum GCMicroGamepadSnapshotDataVersion : long {
-		/// <summary>To be added.</summary>
+		/// <summary>Indicates version1.</summary>
 		Version1 = 0x0100,
 	}
 

--- a/src/GameController/Enums.cs
+++ b/src/GameController/Enums.cs
@@ -14,15 +14,15 @@ namespace GameController {
 	[Deprecated (PlatformName.MacCatalyst, 13, 1, message: "Use 'GCController.GetMicroGamepadController()' instead.")]
 	[Native]
 	public enum GCExtendedGamepadSnapshotDataVersion : long {
-		/// <summary>Indicates version1.</summary>
+		/// <summary>Indicates version 1.</summary>
 		Version1 = 0x0100,
-		/// <summary>Indicates version2.</summary>
+		/// <summary>Indicates version 2.</summary>
 		Version2 = 0x0101,
 	}
 
 	[Native]
 	public enum GCMicroGamepadSnapshotDataVersion : long {
-		/// <summary>Indicates version1.</summary>
+		/// <summary>Indicates version 1.</summary>
 		Version1 = 0x0100,
 	}
 

--- a/src/Intents/INInteraction.cs
+++ b/src/Intents/INInteraction.cs
@@ -14,11 +14,10 @@
 namespace Intents {
 	public partial class INInteraction {
 
-		/// <typeparam name="T">To be added.</typeparam>
-		///         <param name="parameter">To be added.</param>
-		///         <summary>Returns the specified <paramref name="parameter" /> as an instance of <typeparamref name="T" />.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Returns the specified <paramref name="parameter" /> as an instance of <typeparamref name="T" />.</summary>
+		/// <typeparam name="T">The type to return the parameter value as.</typeparam>
+		/// <param name="parameter">The parameter whose value to retrieve.</param>
+		/// <returns>The parameter value as an instance of <typeparamref name="T" />.</returns>
 		public T GetParameterValue<T> (INParameter parameter) where T : NSObject
 		{
 			return Runtime.GetNSObject<T> (_GetParameterValue (parameter))!;

--- a/src/SceneKit/SCNGeometrySource.cs
+++ b/src/SceneKit/SCNGeometrySource.cs
@@ -16,10 +16,8 @@ using Metal;
 namespace SceneKit {
 	public partial class SCNGeometrySource {
 
-		/// <param name="vertices">To be added.</param>
-		///         <summary>Factory method to create a source for vertex data.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Factory method to create a source for vertex data.</summary>
+		/// <param name="vertices">The array of vertices to use as the geometry source.</param>
 		public static unsafe SCNGeometrySource FromVertices (SCNVector3 [] vertices)
 		{
 			if (vertices is null)
@@ -29,12 +27,11 @@ namespace SceneKit {
 				return FromVertices ((IntPtr) ptr, vertices.Length);
 		}
 
-		/// <param name="normals">To be added.</param>
-		///         <summary>Factory method that creates a source for vertex normals.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>
-		///           <para>The <paramref name="normals" /> must correspond directly to their associated vertices (in another <see cref="SceneKit.SCNGeometrySource" />).</para>
-		///         </remarks>
+		/// <summary>Factory method that creates a source for vertex normals.</summary>
+		/// <param name="normals">The array of normal vectors for the geometry source.</param>
+		/// <remarks>
+		///   <para>The <paramref name="normals" /> must correspond directly to their associated vertices (in another <see cref="SceneKit.SCNGeometrySource" />).</para>
+		/// </remarks>
 		public static unsafe SCNGeometrySource FromNormals (SCNVector3 [] normals)
 		{
 			if (normals is null)
@@ -44,13 +41,12 @@ namespace SceneKit {
 				return FromNormals ((IntPtr) ptr, normals.Length);
 		}
 
-		/// <param name="texcoords">To be added.</param>
-		///         <summary>Factory method that creates a source for texture coordinates.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>
-		///           <para>The <paramref name="texcoords" /> must correspond directly to their associated vertices (in another <see cref="SceneKit.SCNGeometrySource" />).</para>
-		///           <para>For non-tiling textures, texture coordinates are values between 0 and 1 that describe the mapping between a texture location and a geometry location. A value of [0,0] represents the origin of the texture while [1,1] represents the point at its furthest extent.</para>
-		///         </remarks>
+		/// <summary>Factory method that creates a source for texture coordinates.</summary>
+		/// <param name="texcoords">The array of texture coordinates for the geometry source.</param>
+		/// <remarks>
+		///   <para>The <paramref name="texcoords" /> must correspond directly to their associated vertices (in another <see cref="SceneKit.SCNGeometrySource" />).</para>
+		///   <para>For non-tiling textures, texture coordinates are values between 0 and 1 that describe the mapping between a texture location and a geometry location. A value of [0,0] represents the origin of the texture while [1,1] represents the point at its furthest extent.</para>
+		/// </remarks>
 		public static unsafe SCNGeometrySource FromTextureCoordinates (CGPoint [] texcoords)
 		{
 			if (texcoords is null)
@@ -84,31 +80,27 @@ namespace SceneKit {
 			}
 		}
 
-		/// <param name="data">To be added.</param>
-		/// <param name="semantic">To be added.</param>
-		/// <param name="vectorCount">To be added.</param>
-		/// <param name="floatComponents">To be added.</param>
-		/// <param name="componentsPerVector">To be added.</param>
-		/// <param name="bytesPerComponent">To be added.</param>
-		/// <param name="offset">To be added.</param>
-		/// <param name="stride">To be added.</param>
-		/// <summary>To be added.</summary>
-		/// <returns>To be added.</returns>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Creates a geometry source from raw data with the specified layout.</summary>
+		/// <param name="data">The data buffer containing the geometry source values.</param>
+		/// <param name="semantic">The semantic type of the geometry source data.</param>
+		/// <param name="vectorCount">The number of vectors in the data.</param>
+		/// <param name="floatComponents">Whether the component values are floating-point.</param>
+		/// <param name="componentsPerVector">The number of scalar components in each vector.</param>
+		/// <param name="bytesPerComponent">The size, in bytes, of each component.</param>
+		/// <param name="offset">The offset, in bytes, from the beginning of the data to the first vector.</param>
+		/// <param name="stride">The number of bytes between vectors in the data.</param>
 		public static SCNGeometrySource FromData (NSData data, SCNGeometrySourceSemantics semantic, nint vectorCount, bool floatComponents, nint componentsPerVector, nint bytesPerComponent, nint offset, nint stride)
 		{
 			return FromData (data, SemanticToToken (semantic), vectorCount, floatComponents, componentsPerVector, bytesPerComponent, offset, stride);
 		}
 
-		/// <param name="mtlBuffer">To be added.</param>
-		/// <param name="vertexFormat">To be added.</param>
-		/// <param name="semantic">To be added.</param>
-		/// <param name="vertexCount">To be added.</param>
-		/// <param name="offset">To be added.</param>
-		/// <param name="stride">To be added.</param>
-		/// <summary>Factory method to create a new <see cref="SceneKit.SCNGeometrySource" /> from a data buffer.</summary>
-		/// <returns>To be added.</returns>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Factory method to create a new <see cref="SceneKit.SCNGeometrySource" /> from a Metal buffer.</summary>
+		/// <param name="mtlBuffer">The Metal buffer containing the vertex data.</param>
+		/// <param name="vertexFormat">The vertex format describing the data layout.</param>
+		/// <param name="semantic">The semantic type of the geometry source data.</param>
+		/// <param name="vertexCount">The number of vertices in the buffer.</param>
+		/// <param name="offset">The offset, in bytes, to the first vertex in the buffer.</param>
+		/// <param name="stride">The number of bytes between vertices in the buffer.</param>
 		public static SCNGeometrySource FromMetalBuffer (IMTLBuffer mtlBuffer, MTLVertexFormat vertexFormat, SCNGeometrySourceSemantics semantic, nint vertexCount, nint offset, nint stride)
 		{
 			return FromMetalBuffer (mtlBuffer, vertexFormat, SemanticToToken (semantic), vertexCount, offset, stride);

--- a/src/SceneKit/SCNMatrix4_dotnet.cs
+++ b/src/SceneKit/SCNMatrix4_dotnet.cs
@@ -147,9 +147,8 @@ namespace SceneKit {
 			Column3 = new SCNVector4 (m03, m13, m23, m33);
 		}
 
-		/// <param name="transform">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Creates a new <see cref="SCNMatrix4" /> from a <see cref="CoreAnimation.CATransform3D" />.</summary>
+		/// <param name="transform">The Core Animation transform to convert.</param>
 		public SCNMatrix4 (CoreAnimation.CATransform3D transform)
 		{
 			Column0 = new SCNVector4 ((pfloat) transform.M11, (pfloat) transform.M12, (pfloat) transform.M13, (pfloat) transform.M14);


### PR DESCRIPTION
Improve XML documentation for 5 types:

| Type                                  | Changes                                                          |
|---------------------------------------|------------------------------------------------------------------|
| SCNGeometrySource                     | Fix tag ordering/indentation, replace placeholders with docs     |
| CVPixelBufferPool                     | Remove empty value/remarks elements                              |
| INInteraction                         | Fix tag ordering (summary before typeparam/param)                |
| GCExtendedGamepadSnapshotDataVersion  | Replace placeholder summaries for enum values                    |
| SCNMatrix4                            | Fix tag ordering/indentation, add meaningful summary             |

🤖 Pull request created by Copilot