### PR TITLE
[src] Fix availability analyzer errors

### DIFF
--- a/src/CoreGraphics/CGBitmapContext.cs
+++ b/src/CoreGraphics/CGBitmapContext.cs
@@ -302,6 +302,10 @@ namespace CoreGraphics {
 		public delegate bool OnResolveCallback (ref CGContentInfo contentInfo, ref CGBitmapParameters bitmapParameters);
 
 		[UnmanagedCallersOnly]
+		[SupportedOSPlatform ("ios26.0")]
+		[SupportedOSPlatform ("tvos26.0")]
+		[SupportedOSPlatform ("maccatalyst26.0")]
+		[SupportedOSPlatform ("macos26.0")]
 		unsafe static byte CGBitmapContextCreateAdaptive_OnResolve (IntPtr block, CGContentInfo* contentInfo, CGBitmapParameters* bitmapParameters)
 		{
 			var del = BlockLiteral.GetTarget<OnResolveCallback> (block);
@@ -315,6 +319,10 @@ namespace CoreGraphics {
 		public delegate CGRenderingBufferProvider /* CGRenderingBufferProviderRef */ OnAllocateCallback (ref CGContentInfo contentInfo, ref CGBitmapParameters bitmapParameters);
 
 		[UnmanagedCallersOnly]
+		[SupportedOSPlatform ("ios26.0")]
+		[SupportedOSPlatform ("tvos26.0")]
+		[SupportedOSPlatform ("maccatalyst26.0")]
+		[SupportedOSPlatform ("macos26.0")]
 		unsafe static IntPtr CGBitmapContextCreateAdaptive_OnAllocate (IntPtr block, CGContentInfo* contentInfo, CGBitmapParameters* bitmapParameters)
 		{
 			var del = BlockLiteral.GetTarget<OnAllocateCallback> (block);
@@ -328,6 +336,10 @@ namespace CoreGraphics {
 		public delegate void OnFreeCallback (CGRenderingBufferProvider /* CGRenderingBufferProviderRef */ renderingBufferProvider, ref CGContentInfo contentInfo, ref CGBitmapParameters bitmapParameters);
 
 		[UnmanagedCallersOnly]
+		[SupportedOSPlatform ("ios26.0")]
+		[SupportedOSPlatform ("tvos26.0")]
+		[SupportedOSPlatform ("maccatalyst26.0")]
+		[SupportedOSPlatform ("macos26.0")]
 		unsafe static void CGBitmapContextCreateAdaptive_OnFree (IntPtr block, IntPtr /* CGRenderingBufferProviderRef */ bufferingProviderRef, CGContentInfo* contentInfo, CGBitmapParameters* bitmapParameters)
 		{
 			var del = BlockLiteral.GetTarget<OnFreeCallback> (block);
@@ -340,6 +352,10 @@ namespace CoreGraphics {
 		public delegate void OnErrorCallback (NSError error, ref CGContentInfo contentInfo, ref CGBitmapParameters bitmapParameters);
 
 		[UnmanagedCallersOnly]
+		[SupportedOSPlatform ("ios26.0")]
+		[SupportedOSPlatform ("tvos26.0")]
+		[SupportedOSPlatform ("maccatalyst26.0")]
+		[SupportedOSPlatform ("macos26.0")]
 		unsafe static void CGBitmapContextCreateAdaptive_OnError (IntPtr block, IntPtr errorHandle, CGContentInfo* contentInfo, CGBitmapParameters* bitmapParameters)
 		{
 			var del = BlockLiteral.GetTarget<OnErrorCallback> (block);

--- a/src/CoreMedia/CMFormatDescription.cs
+++ b/src/CoreMedia/CMFormatDescription.cs
@@ -816,6 +816,10 @@ namespace CoreMedia {
 		/// <summary>Get any multi-image properties as an array of <see cref="CMTagCollection" /> values.</summary>
 		/// <param name="tagCollections">Upon output, and if successful, the format description's array of <see cref="CMTagCollection" /> values.</param>
 		/// <returns><see cref="CMFormatDescriptionError.None" /> if succcessful, or an error code otherwise.</returns>
+		[SupportedOSPlatform ("ios17.0")]
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("tvos17.0")]
+		[SupportedOSPlatform ("maccatalyst")]
 		public CMFormatDescriptionError GetTagCollections (out CMTagCollection []? tagCollections)
 		{
 			IntPtr array;
@@ -834,6 +838,10 @@ namespace CoreMedia {
 		}
 
 		/// <summary>Get any multi-image properties as an array of <see cref="CMTagCollection" /> values.</summary>
+		[SupportedOSPlatform ("ios17.0")]
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("tvos17.0")]
+		[SupportedOSPlatform ("maccatalyst")]
 		public CMTagCollection []? TagCollections {
 			get {
 				GetTagCollections (out var tagCollections);

--- a/src/CoreMedia/CMTaggedBufferGroup.cs
+++ b/src/CoreMedia/CMTaggedBufferGroup.cs
@@ -372,6 +372,10 @@ namespace CoreMedia {
 		/// <param name="extensions">A dictionary of extension properties.</param>
 		/// <param name="status">An error code in case of failure, 0 in case of success.</param>
 		/// <returns>A <see cref="CMFormatDescription" /> for this tagged buffer group, or null in case of failure.</returns>
+		[SupportedOSPlatform ("ios26.0")]
+		[SupportedOSPlatform ("maccatalyst26.0")]
+		[SupportedOSPlatform ("macos26.0")]
+		[SupportedOSPlatform ("tvos26.0")]
 		public CMFormatDescription? CreateFormatDescription (NSDictionary? extensions, out CMTaggedBufferGroupError status)
 		{
 			IntPtr formatDescription;

--- a/src/CoreVideo/CVBuffer.cs
+++ b/src/CoreVideo/CVBuffer.cs
@@ -148,7 +148,9 @@ namespace CoreVideo {
 			if (key is null)
 				ObjCRuntime.ThrowHelper.ThrowArgumentNullException (nameof (key));
 			if (!SystemVersion.IsAtLeastXcode13) {
+#pragma warning disable CA1422 // The analyzer doesn't recognize SupportedOSPlatformGuard attributes when guarding obsoleted APIs (https://github.com/dotnet/roslyn-analyzers/issues/7665).
 				T? result = Runtime.GetINativeObject<T> (CVBufferGetAttachment (Handle, key.Handle, out attachmentMode), false);
+#pragma warning restore CA1422
 				GC.KeepAlive (key);
 				return result;
 			}
@@ -203,8 +205,11 @@ namespace CoreVideo {
 		///         <remarks>To be added.</remarks>
 		public NSDictionary? GetAttachments (CVAttachmentMode attachmentMode)
 		{
-			if (!SystemVersion.IsAtLeastXcode13)
+			if (!SystemVersion.IsAtLeastXcode13) {
+#pragma warning disable CA1422 // The analyzer doesn't recognize SupportedOSPlatformGuard attributes when guarding obsoleted APIs (https://github.com/dotnet/roslyn-analyzers/issues/7665).
 				return Runtime.GetNSObject<NSDictionary> (CVBufferGetAttachments (Handle, attachmentMode), false);
+#pragma warning restore CA1422
+			}
 			return Runtime.GetINativeObject<NSDictionary> (CVBufferCopyAttachments (Handle, attachmentMode), true);
 		}
 
@@ -222,7 +227,9 @@ namespace CoreVideo {
 		{
 			if (SystemVersion.IsAtLeastXcode13)
 				return Runtime.GetNSObject<NSDictionary<TKey, TValue>> (CVBufferCopyAttachments (Handle, attachmentMode), true);
+#pragma warning disable CA1422 // The analyzer doesn't recognize SupportedOSPlatformGuard attributes when guarding obsoleted APIs (https://github.com/dotnet/roslyn-analyzers/issues/7665).
 			return Runtime.GetNSObject<NSDictionary<TKey, TValue>> (CVBufferGetAttachments (Handle, attachmentMode), false);
+#pragma warning restore CA1422
 		}
 
 		[DllImport (Constants.CoreVideoLibrary)]

--- a/src/Foundation/NSObject2.cs
+++ b/src/Foundation/NSObject2.cs
@@ -179,7 +179,9 @@ namespace Foundation {
 
 #if !COREBUILD
 	/// <include file="../../docs/api/Foundation/NSObject.xml" path="/Documentation/Docs[@DocId='T:Foundation.NSObject']/*" />
+#pragma warning disable CA1416 // https://github.com/dotnet/runtime/pull/131583
 	[ObjectiveCTrackedType]
+#pragma warning restore CA1416
 #endif
 	[StructLayout (LayoutKind.Sequential)]
 	public partial class NSObject : INativeObject

--- a/src/ObjCRuntime/Runtime.CoreCLR.cs
+++ b/src/ObjCRuntime/Runtime.CoreCLR.cs
@@ -224,7 +224,9 @@ namespace ObjCRuntime {
 			// can just call that new API instead of calling ObjectiveCMarshal.CreateReferenceTrackingHandle and
 			// freeing the returned handle.
 
+#pragma warning disable CA1416 // https://github.com/dotnet/runtime/pull/131583
 			var gchandle = ObjectiveCMarshal.CreateReferenceTrackingHandle (obj, out var info);
+#pragma warning restore CA1416
 			// We only care about the tagged memory ('info'), so just free the GCHandle.
 			// We might want to request an API to just get the tagged memory at some point.
 			gchandle.Free ();

--- a/src/PdfKit/PdfViewAnnotationHitEventArgs.cs
+++ b/src/PdfKit/PdfViewAnnotationHitEventArgs.cs
@@ -1,5 +1,9 @@
 namespace PdfKit;
 
+[SupportedOSPlatform ("maccatalyst")]
+[SupportedOSPlatform ("tvos18.2")]
+[SupportedOSPlatform ("ios")]
+[SupportedOSPlatform ("macos")]
 partial class PdfViewAnnotationHitEventArgs : NSNotificationEventArgs {
 	// This property needs a manual binding, because it's not using a constant string value,
 	// it's using a literal string value (as per Apple's documentation).

--- a/src/VideoToolbox/VTDecompressionSession.cs
+++ b/src/VideoToolbox/VTDecompressionSession.cs
@@ -361,6 +361,10 @@ namespace VideoToolbox {
 		}
 
 		[UnmanagedCallersOnly]
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios17.0")]
+		[SupportedOSPlatform ("maccatalyst")]
+		[UnsupportedOSPlatform ("tvos")]
 		unsafe static void VTDecompressionMultiImageCapableOutputBlockCallback (BlockLiteral* block, VTStatus status, VTDecodeInfoFlags infoFlags, IntPtr imageBuffer, IntPtr taggedBufferGroup, CMTime presentationTimeStamp, CMTime presentationDuration)
 		{
 			var del = BlockLiteral.GetTarget<VTDecompressionMultiImageCapableOutputHandler> ((IntPtr) block);
@@ -416,6 +420,10 @@ namespace VideoToolbox {
 		}
 
 		[UnmanagedCallersOnly]
+		[SupportedOSPlatform ("macos")]
+		[SupportedOSPlatform ("ios17.0")]
+		[SupportedOSPlatform ("maccatalyst")]
+		[UnsupportedOSPlatform ("tvos")]
 		unsafe static void VTDecompressionOutputMultiImageCallbackBlock (BlockLiteral* block, IntPtr decompressionOutputMultiImageRefCon, IntPtr sourceFrameRefCon, VTStatus status, VTDecodeInfoFlags infoFlags, IntPtr taggedBufferGroup, CMTime presentationTimeStamp, CMTime presentationDuration)
 		{
 			var del = BlockLiteral.GetTarget<VTDecompressionOutputMultiImageCallback> ((IntPtr) block);


### PR DESCRIPTION
Add the missing platform contracts to version-gated wrappers and native callbacks. Suppress CA1422 where the analyzer cannot understand the existing SupportedOSPlatformGuard checks around legacy CoreVideo APIs.

Copilot-Session: 6987672a-aa50-405c-a61a-3656b3e567ca