### PR TITLE
[docs] Improve XML docs for CIAutoAdjustmentFilterOptions, PKAddPassButtonStyle, AVKitError, NSThread, INSetDefrosterSettingsInCarIntent, MPSCnnNeuronPReLU, and ILClassificationUIExtensionContext

### DIFF
--- a/src/AVKit/Enums.cs
+++ b/src/AVKit/Enums.cs
@@ -24,18 +24,17 @@ namespace AVKit {
 	// The version of the AVError.h header file in the tvOS SDK is much newer than in the iOS SDKs,
 	// (copyright 2016 vs 2019), so this is reflecting the tvOS SDK.
 	/// <summary>Enumeration of error states that can occur while using AVKit.</summary>
-	/// <remarks>To be added.</remarks>
 	[TV (13, 0)]
 	[NoMac]
 	[MacCatalyst (13, 1)]
 	[Native]
 	[ErrorDomain ("AVKitErrorDomain")]
 	public enum AVKitError : long {
-		/// <summary>To be added.</summary>
+		/// <summary>No error occurred.</summary>
 		None = 0,
-		/// <summary>To be added.</summary>
+		/// <summary>An unknown error occurred.</summary>
 		Unknown = -1000,
-		/// <summary>To be added.</summary>
+		/// <summary>Picture in Picture failed to start.</summary>
 		PictureInPictureStartFailed = -1001,
 		ContentRatingUnknown = -1100,
 		ContentDisallowedByPasscode = -1101,

--- a/src/CoreImage/CIImage.cs
+++ b/src/CoreImage/CIImage.cs
@@ -87,7 +87,6 @@ namespace CoreImage {
 		public CIImageOrientation? ImageOrientation;
 
 		/// <summary>Whether or not to automatically crop the image.</summary>
-		///         <remarks>To be added.</remarks>
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
@@ -95,7 +94,6 @@ namespace CoreImage {
 		public bool? AutoAdjustCrop;
 
 		/// <summary>Gets or sets the automatic adjustment level.</summary>
-		///         <remarks>To be added.</remarks>
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
@@ -170,11 +168,9 @@ namespace CoreImage {
 			return ret;
 		}
 
-		/// <param name="image">CoreGraphics image.</param>
-		///         <param name="colorSpace">Colorspace to use.</param>
-		///         <summary>Creates a <see cref="CoreImage.CIImage" /> in <paramref name="colorSpace" /> from a <see cref="CoreGraphics.CGImage" />.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Creates a <see cref="CIImage" /> in <paramref name="colorSpace" /> from a <see cref="CGImage" />.</summary>
+		/// <param name="image">The CoreGraphics image to use as the source.</param>
+		/// <param name="colorSpace">The color space for the resulting image.</param>
 		public static CIImage FromCGImage (CGImage image, CGColorSpace colorSpace)
 		{
 			if (colorSpace is null)
@@ -257,10 +253,6 @@ namespace CoreImage {
 
 		/// <param name="image">CoreGraphics image</param>
 		/// <summary>Implicit constructor that wraps a CGImage as a CIImage.</summary>
-		/// <returns>
-		///         </returns>
-		/// <remarks>
-		///         </remarks>
 		public static implicit operator CIImage (CGImage image)
 		{
 			return FromCGImage (image);
@@ -278,41 +270,36 @@ namespace CoreImage {
 			return rv.Value;
 		}
 
-		/// <param name="bitmapData">To be added.</param>
-		/// <param name="bytesPerRow">To be added.</param>
-		/// <param name="size">To be added.</param>
-		/// <param name="pixelFormat">To be added.</param>
-		/// <param name="colorSpace">To be added.</param>
-		/// <summary>To be added.</summary>
-		/// <returns>To be added.</returns>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Creates a <see cref="CIImage" /> from raw bitmap data with the specified pixel format and color space.</summary>
+		/// <param name="bitmapData">The raw bitmap data for the image.</param>
+		/// <param name="bytesPerRow">The number of bytes per row in <paramref name="bitmapData" />.</param>
+		/// <param name="size">The dimensions of the image in pixels.</param>
+		/// <param name="pixelFormat">The pixel format of the bitmap data.</param>
+		/// <param name="colorSpace">The color space for the resulting image.</param>
 		public static CIImage FromData (NSData bitmapData, nint bytesPerRow, CGSize size, CIFormat pixelFormat, CGColorSpace colorSpace)
 		{
 			return FromData (bitmapData, bytesPerRow, size, CIImage.CIFormatToInt (pixelFormat), colorSpace);
 		}
 
-		/// <param name="provider">To be added.</param>
-		/// <param name="width">To be added.</param>
-		/// <param name="height">To be added.</param>
-		/// <param name="pixelFormat">To be added.</param>
-		/// <param name="colorSpace">To be added.</param>
-		/// <param name="options">To be added.</param>
-		/// <summary>To be added.</summary>
-		/// <returns>To be added.</returns>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Creates a <see cref="CIImage" /> from an image provider with the specified dimensions, pixel format, and color space.</summary>
+		/// <param name="provider">The image data provider.</param>
+		/// <param name="width">The width of the image in pixels.</param>
+		/// <param name="height">The height of the image in pixels.</param>
+		/// <param name="pixelFormat">The pixel format of the image data.</param>
+		/// <param name="colorSpace">The color space for the resulting image.</param>
+		/// <param name="options">Options that configure the image creation, or <see langword="null" />.</param>
 		public static CIImage FromProvider (ICIImageProvider provider, nuint width, nuint height, CIFormat pixelFormat, CGColorSpace colorSpace, CIImageProviderOptions options)
 		{
 			return FromProvider (provider, width, height, CIImage.CIFormatToInt (pixelFormat), colorSpace, options?.Dictionary);
 		}
 
-		/// <param name="provider">To be added.</param>
-		/// <param name="width">To be added.</param>
-		/// <param name="height">To be added.</param>
-		/// <param name="pixelFormat">To be added.</param>
-		/// <param name="colorSpace">To be added.</param>
-		/// <param name="options">To be added.</param>
-		/// <summary>To be added.</summary>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Initializes a new <see cref="CIImage" /> from an image provider with the specified dimensions, pixel format, and color space.</summary>
+		/// <param name="provider">The image data provider.</param>
+		/// <param name="width">The width of the image in pixels.</param>
+		/// <param name="height">The height of the image in pixels.</param>
+		/// <param name="pixelFormat">The pixel format of the image data.</param>
+		/// <param name="colorSpace">The color space for the resulting image.</param>
+		/// <param name="options">Options that configure the image creation, or <see langword="null" />.</param>
 		public CIImage (ICIImageProvider provider, nuint width, nuint height, CIFormat pixelFormat, CGColorSpace colorSpace, CIImageProviderOptions options)
 			: this (provider, width, height, CIImage.CIFormatToInt (pixelFormat), colorSpace, options?.Dictionary)
 		{

--- a/src/CoreImage/CIImage.cs
+++ b/src/CoreImage/CIImage.cs
@@ -287,7 +287,7 @@ namespace CoreImage {
 		/// <param name="height">The height of the image in pixels.</param>
 		/// <param name="pixelFormat">The pixel format of the image data.</param>
 		/// <param name="colorSpace">The color space for the resulting image.</param>
-		/// <param name="options">Options that configure the image creation, or <see langword="null" />.</param>
+		/// <param name="options">Options that configure the image creation.</param>
 		public static CIImage FromProvider (ICIImageProvider provider, nuint width, nuint height, CIFormat pixelFormat, CGColorSpace colorSpace, CIImageProviderOptions options)
 		{
 			return FromProvider (provider, width, height, CIImage.CIFormatToInt (pixelFormat), colorSpace, options?.Dictionary);
@@ -299,7 +299,7 @@ namespace CoreImage {
 		/// <param name="height">The height of the image in pixels.</param>
 		/// <param name="pixelFormat">The pixel format of the image data.</param>
 		/// <param name="colorSpace">The color space for the resulting image.</param>
-		/// <param name="options">Options that configure the image creation, or <see langword="null" />.</param>
+		/// <param name="options">Options that configure the image creation.</param>
 		public CIImage (ICIImageProvider provider, nuint width, nuint height, CIFormat pixelFormat, CGColorSpace colorSpace, CIImageProviderOptions options)
 			: this (provider, width, height, CIImage.CIFormatToInt (pixelFormat), colorSpace, options?.Dictionary)
 		{

--- a/src/Foundation/NSThread.mac.cs
+++ b/src/Foundation/NSThread.mac.cs
@@ -24,10 +24,9 @@ namespace Foundation {
 			}
 		}
 
-		/// <param name="action">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Starts a new thread that executes the specified action.</summary>
+		/// <param name="action">The action to perform on the new thread.</param>
+		/// <returns>The newly created and started thread.</returns>
 		public static NSThread Start (Action action)
 		{
 			if (action is null) {

--- a/src/Intents/INSetDefrosterSettingsInCarIntent.cs
+++ b/src/Intents/INSetDefrosterSettingsInCarIntent.cs
@@ -6,10 +6,9 @@ using Intents;
 namespace Intents {
 
 	public partial class INSetDefrosterSettingsInCarIntent {
-		/// <param name="enable">To be added.</param>
-		///         <param name="defroster">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Initializes a new intent to change the defroster settings in a car.</summary>
+		/// <param name="enable">Whether to enable the defroster, or <see langword="null" /> if unchanged.</param>
+		/// <param name="defroster">The defroster to configure.</param>
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[ObsoletedOSPlatform ("ios12.0", "Use the overload that takes 'INSpeakableString carName'.")]

--- a/src/MetalPerformanceShaders/MPSCnnNeuron.cs
+++ b/src/MetalPerformanceShaders/MPSCnnNeuron.cs
@@ -4,10 +4,9 @@ using Metal;
 
 namespace MetalPerformanceShaders {
 	public partial class MPSCnnNeuronPReLU {
-		/// <param name="device">To be added.</param>
-		///         <param name="a">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Initializes a new PReLU neuron with the specified device and alpha values.</summary>
+		/// <param name="device">The Metal device to use for computation.</param>
+		/// <param name="a">The per-feature-channel alpha values for the PReLU activation function.</param>
 		[SupportedOSPlatform ("tvos")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios")]

--- a/src/PassKit/PKEnums.cs
+++ b/src/PassKit/PKEnums.cs
@@ -302,9 +302,9 @@ namespace PassKit {
 	[MacCatalyst (13, 1)]
 	[Native]
 	public enum PKAddPassButtonStyle : long {
-		/// <summary>A black button style.</summary>
+		/// <summary>A black "Add Pass" button.</summary>
 		Black = 0,
-		/// <summary>An outline button style.</summary>
+		/// <summary>An outlined "Add Pass" button.</summary>
 		Outline,
 	}
 

--- a/src/PassKit/PKEnums.cs
+++ b/src/PassKit/PKEnums.cs
@@ -302,9 +302,9 @@ namespace PassKit {
 	[MacCatalyst (13, 1)]
 	[Native]
 	public enum PKAddPassButtonStyle : long {
-		/// <summary>To be added.</summary>
+		/// <summary>A black button style.</summary>
 		Black = 0,
-		/// <summary>To be added.</summary>
+		/// <summary>An outline button style.</summary>
 		Outline,
 	}
 
@@ -328,9 +328,9 @@ namespace PassKit {
 	[MacCatalyst (13, 1)]
 	[Native]
 	public enum PKAddPaymentPassStyle : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>A payment pass style.</summary>
 		Payment,
-		/// <summary>To be added.</summary>
+		/// <summary>An access pass style.</summary>
 		Access,
 	}
 

--- a/src/identitylookupui.cs
+++ b/src/identitylookupui.cs
@@ -19,7 +19,6 @@ namespace IdentityLookupUI {
 
 		/// <summary>Gets or sets a Boolean value that tells whether the report is ready to be submitted.</summary>
 		///         <value>A Boolean value that tells whether the report is ready to be submitted.</value>
-		///         <remarks>To be added.</remarks>
 		[Export ("readyForClassificationResponse")]
 		bool ReadyForClassificationResponse { [Bind ("isReadyForClassificationResponse")] get; set; }
 	}


### PR DESCRIPTION
Improve XML documentation for 7 types:

| Type                              | File                                             | Changes                                                  |
|-----------------------------------|--------------------------------------------------|----------------------------------------------------------|
| CIAutoAdjustmentFilterOptions     | src/CoreImage/CIImage.cs                         | Fix summaries, params, tag ordering, remove empty elems  |
| PKAddPassButtonStyle              | src/PassKit/PKEnums.cs                           | Replace placeholder summaries                            |
| ILClassificationUIExtensionContext| src/identitylookupui.cs                          | Remove empty remarks                                     |
| AVKitError                        | src/AVKit/Enums.cs                               | Replace placeholder summaries, remove empty remarks      |
| NSThread.Start                    | src/Foundation/NSThread.mac.cs                   | Fix tag ordering, add meaningful descriptions            |
| INSetDefrosterSettingsInCarIntent  | src/Intents/INSetDefrosterSettingsInCarIntent.cs | Fix tag ordering, add meaningful descriptions            |
| MPSCnnNeuronPReLU                 | src/MetalPerformanceShaders/MPSCnnNeuron.cs      | Fix tag ordering, add meaningful descriptions            |

🤖 Pull request created by Copilot