### PR TITLE
[src] Add missing nullability to strongly-typed dictionary parameters

### DIFF
--- a/src/CoreGraphics/CGContextPDF.cs
+++ b/src/CoreGraphics/CGContextPDF.cs
@@ -422,7 +422,7 @@ namespace CoreGraphics {
 		[SupportedOSPlatform ("ios13.0")]
 		[SupportedOSPlatform ("tvos13.0")]
 		[SupportedOSPlatform ("maccatalyst")]
-		public void BeginTag (CGPdfTagType tagType, NSDictionary tagProperties)
+		public void BeginTag (CGPdfTagType tagType, NSDictionary? tagProperties)
 		{
 			CGPDFContextBeginTag (Handle, tagType, tagProperties.GetHandle ());
 			GC.KeepAlive (tagProperties);

--- a/src/CoreGraphics/CGContextPDF.cs
+++ b/src/CoreGraphics/CGContextPDF.cs
@@ -414,6 +414,10 @@ namespace CoreGraphics {
 		[DllImport (Constants.CoreGraphicsLibrary)]
 		static extern void CGPDFContextBeginTag (/* CGContextRef* */ IntPtr context, CGPdfTagType tagType, /* CFDictionaryRef* _Nullable */ IntPtr tagProperties);
 
+		/// <summary>Opens a tagged content sequence of the specified <paramref name="tagType" /> in the PDF context.</summary>
+		/// <param name="tagType">The type of the tag to open.</param>
+		/// <param name="tagProperties">A dictionary of properties for the tag, or <see langword="null" /> if there are none.</param>
+		/// <remarks>Every call to <c>BeginTag</c> must be balanced by a matching call to <see cref="EndTag" />.</remarks>
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios13.0")]
 		[SupportedOSPlatform ("tvos13.0")]
@@ -424,11 +428,15 @@ namespace CoreGraphics {
 			GC.KeepAlive (tagProperties);
 		}
 
+		/// <summary>Opens a tagged content sequence of the specified <paramref name="tagType" /> in the PDF context.</summary>
+		/// <param name="tagType">The type of the tag to open.</param>
+		/// <param name="tagProperties">The properties for the tag, or <see langword="null" /> if there are none.</param>
+		/// <remarks>Every call to <c>BeginTag</c> must be balanced by a matching call to <see cref="EndTag" />.</remarks>
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios13.0")]
 		[SupportedOSPlatform ("tvos13.0")]
 		[SupportedOSPlatform ("maccatalyst")]
-		public void BeginTag (CGPdfTagType tagType, CGPdfTagProperties tagProperties)
+		public void BeginTag (CGPdfTagType tagType, CGPdfTagProperties? tagProperties)
 		{
 			var d = tagProperties?.Dictionary;
 			CGPDFContextBeginTag (Handle, tagType, d.GetHandle ());

--- a/src/CoreImage/CIContext.cs
+++ b/src/CoreImage/CIContext.cs
@@ -72,14 +72,13 @@ namespace CoreImage {
 	}
 
 	public partial class CIContext {
-		/// <param name="options">The context options to use.</param>
-		///         <summary>Creates a new Core Image context with the specified <paramref name="options" />.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Creates a new Core Image context with the specified <paramref name="options" />.</summary>
+		/// <param name="options">The context options to use, or <see langword="null" /> to use the default options.</param>
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("tvos")]
-		public CIContext (CIContextOptions options) :
+		public CIContext (CIContextOptions? options) :
 			this (options?.Dictionary)
 		{
 		}

--- a/src/CoreImage/CIImage.cs
+++ b/src/CoreImage/CIImage.cs
@@ -291,29 +291,27 @@ namespace CoreImage {
 			return FromData (bitmapData, bytesPerRow, size, CIImage.CIFormatToInt (pixelFormat), colorSpace);
 		}
 
-		/// <param name="provider">To be added.</param>
-		/// <param name="width">To be added.</param>
-		/// <param name="height">To be added.</param>
-		/// <param name="pixelFormat">To be added.</param>
-		/// <param name="colorSpace">To be added.</param>
-		/// <param name="options">To be added.</param>
-		/// <summary>To be added.</summary>
-		/// <returns>To be added.</returns>
-		/// <remarks>To be added.</remarks>
-		public static CIImage FromProvider (ICIImageProvider provider, nuint width, nuint height, CIFormat pixelFormat, CGColorSpace colorSpace, CIImageProviderOptions options)
+		/// <summary>Creates a new image that lazily obtains its data from the specified <paramref name="provider" />.</summary>
+		/// <param name="provider">The provider that supplies the image data on demand.</param>
+		/// <param name="width">The width of the image, in pixels.</param>
+		/// <param name="height">The height of the image, in pixels.</param>
+		/// <param name="pixelFormat">The pixel format of the image data supplied by <paramref name="provider" />.</param>
+		/// <param name="colorSpace">The color space of the image.</param>
+		/// <param name="options">Options that control how the image is created, or <see langword="null" /> to use the default options.</param>
+		/// <returns>A new <see cref="CoreImage.CIImage" /> backed by <paramref name="provider" />.</returns>
+		public static CIImage FromProvider (ICIImageProvider provider, nuint width, nuint height, CIFormat pixelFormat, CGColorSpace colorSpace, CIImageProviderOptions? options)
 		{
 			return FromProvider (provider, width, height, CIImage.CIFormatToInt (pixelFormat), colorSpace, options?.Dictionary);
 		}
 
-		/// <param name="provider">To be added.</param>
-		/// <param name="width">To be added.</param>
-		/// <param name="height">To be added.</param>
-		/// <param name="pixelFormat">To be added.</param>
-		/// <param name="colorSpace">To be added.</param>
-		/// <param name="options">To be added.</param>
-		/// <summary>To be added.</summary>
-		/// <remarks>To be added.</remarks>
-		public CIImage (ICIImageProvider provider, nuint width, nuint height, CIFormat pixelFormat, CGColorSpace colorSpace, CIImageProviderOptions options)
+		/// <summary>Creates a new image that lazily obtains its data from the specified <paramref name="provider" />.</summary>
+		/// <param name="provider">The provider that supplies the image data on demand.</param>
+		/// <param name="width">The width of the image, in pixels.</param>
+		/// <param name="height">The height of the image, in pixels.</param>
+		/// <param name="pixelFormat">The pixel format of the image data supplied by <paramref name="provider" />.</param>
+		/// <param name="colorSpace">The color space of the image.</param>
+		/// <param name="options">Options that control how the image is created, or <see langword="null" /> to use the default options.</param>
+		public CIImage (ICIImageProvider provider, nuint width, nuint height, CIFormat pixelFormat, CGColorSpace colorSpace, CIImageProviderOptions? options)
 			: this (provider, width, height, CIImage.CIFormatToInt (pixelFormat), colorSpace, options?.Dictionary)
 		{
 		}

--- a/src/UserNotifications/UNNotificationAttachment.cs
+++ b/src/UserNotifications/UNNotificationAttachment.cs
@@ -14,14 +14,13 @@
 namespace UserNotifications {
 	public partial class UNNotificationAttachment {
 
-		/// <param name="identifier">To be added.</param>
-		///         <param name="url">To be added.</param>
-		///         <param name="attachmentOptions">To be added.</param>
-		///         <param name="error">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
-		public static UNNotificationAttachment? FromIdentifier (string identifier, NSUrl url, UNNotificationAttachmentOptions attachmentOptions, out NSError? error)
+		/// <summary>Creates a new attachment for a notification from the file at the specified <paramref name="url" />.</summary>
+		/// <param name="identifier">The unique identifier for the attachment, or an empty string to have one generated automatically.</param>
+		/// <param name="url">The URL of the file to attach.</param>
+		/// <param name="attachmentOptions">Options that describe how the attachment should be handled, or <see langword="null" /> to use the default options.</param>
+		/// <param name="error">On failure, contains the error that describes why the attachment could not be created.</param>
+		/// <returns>A new <see cref="UserNotifications.UNNotificationAttachment" />, or <see langword="null" /> if the attachment could not be created.</returns>
+		public static UNNotificationAttachment? FromIdentifier (string identifier, NSUrl url, UNNotificationAttachmentOptions? attachmentOptions, out NSError? error)
 		{
 			return FromIdentifier (identifier, url, attachmentOptions?.Dictionary, out error);
 		}

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -10317,8 +10317,6 @@ M:CoreGraphics.CGContext.ShowTextAtPoint(System.Runtime.InteropServices.NFloat,S
 M:CoreGraphics.CGContext.ShowTextAtPoint(System.Runtime.InteropServices.NFloat,System.Runtime.InteropServices.NFloat,System.String)
 M:CoreGraphics.CGContext.StrokeRectWithWidth(CoreGraphics.CGRect,System.Runtime.InteropServices.NFloat)
 M:CoreGraphics.CGContext.TranslateCTM(System.Runtime.InteropServices.NFloat,System.Runtime.InteropServices.NFloat)
-M:CoreGraphics.CGContextPDF.BeginTag(CoreGraphics.CGPdfTagType,CoreGraphics.CGPdfTagProperties)
-M:CoreGraphics.CGContextPDF.BeginTag(CoreGraphics.CGPdfTagType,Foundation.NSDictionary)
 M:CoreGraphics.CGContextPDF.EndTag
 M:CoreGraphics.CGContextPDF.SetIdTree(CoreGraphics.CGPDFDictionary)
 M:CoreGraphics.CGContextPDF.SetPageTagStructureTree(Foundation.NSDictionary)


### PR DESCRIPTION
Several public APIs bind a native optional NSDictionary as a strongly-typed dictionary parameter, but the C# parameter itself was missing the `?` nullability annotation. In every case the code already handled null (via `param?.Dictionary`) and the underlying native API is `_Nullable` / `[NullAllowed]`, so the missing annotation was simply an oversight that surfaced unnecessary nullable-context warnings for callers passing `null`.

Adding the annotation is not a breaking change: it only makes the parameter more permissive, so existing callers keep compiling.

Fixed parameters:

* `CGContextPDF.BeginTag` (`CGPdfTagProperties`)
* `CIContext` constructor (`CIContextOptions`)
* `CIImage.FromProvider` and the `CIImage` constructor (`CIImageProviderOptions`)
* `UNNotificationAttachment.FromIdentifier` (`UNNotificationAttachmentOptions`)

While here, the placeholder XML docs on these APIs were filled in (and the two `CGContextPDF.BeginTag` overloads, previously undocumented, were documented and dropped from the cecil-tests documentation known-failures list).

I deliberately did not touch `CVPixelFormatDescription.Register`: its native API is `__nonnull` (the sibling `NSDictionary` overload throws on null), so its parameter is correctly non-nullable.

🤖 Pull request created by Copilot