### PR TITLE
[docs] Improve XML docs for various types

### DIFF
--- a/src/AVFoundation/AVAssetDownloadStorageManagementPolicy.cs
+++ b/src/AVFoundation/AVAssetDownloadStorageManagementPolicy.cs
@@ -5,8 +5,8 @@
 namespace AVFoundation {
 	public partial class AVAssetDownloadStorageManagementPolicy {
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
+		/// <summary>Gets the eviction priority for the downloaded asset.</summary>
+		/// <value>The eviction priority that determines when the downloaded asset may be purged.</value>
 		public virtual AVAssetDownloadedAssetEvictionPriority Priority {
 			get { return AVAssetDownloadedAssetEvictionPriorityExtensions.GetValue (_Priority); }
 			set { throw new NotImplementedException (); }
@@ -15,8 +15,8 @@ namespace AVFoundation {
 
 	public partial class AVMutableAssetDownloadStorageManagementPolicy {
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
+		/// <summary>Gets or sets the eviction priority for the downloaded asset.</summary>
+		/// <value>The eviction priority that determines when the downloaded asset may be purged.</value>
 		public override AVAssetDownloadedAssetEvictionPriority Priority {
 			get { return AVAssetDownloadedAssetEvictionPriorityExtensions.GetValue (_Priority); }
 			set { _Priority = value.GetConstant () ?? throw new ArgumentOutOfRangeException (nameof (Priority)); }

--- a/src/AVFoundation/AVAssetDownloadStorageManagementPolicy.cs
+++ b/src/AVFoundation/AVAssetDownloadStorageManagementPolicy.cs
@@ -7,7 +7,6 @@ namespace AVFoundation {
 
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public virtual AVAssetDownloadedAssetEvictionPriority Priority {
 			get { return AVAssetDownloadedAssetEvictionPriorityExtensions.GetValue (_Priority); }
 			set { throw new NotImplementedException (); }
@@ -18,7 +17,6 @@ namespace AVFoundation {
 
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public override AVAssetDownloadedAssetEvictionPriority Priority {
 			get { return AVAssetDownloadedAssetEvictionPriorityExtensions.GetValue (_Priority); }
 			set { _Priority = value.GetConstant () ?? throw new ArgumentOutOfRangeException (nameof (Priority)); }

--- a/src/AVFoundation/AVCaptureFileOutput.cs
+++ b/src/AVFoundation/AVCaptureFileOutput.cs
@@ -38,7 +38,7 @@ namespace AVFoundation {
 		/// <param name="outputFileUrl">The URL of the output file to record to.</param>
 		///         <param name="startRecordingFromConnections">A callback invoked when recording starts, receiving the active connections.</param>
 		///         <param name="finishedRecording">A callback invoked when recording finishes, receiving the connections and any error that occurred.</param>
-		///         <summary>To be added.</summary>
+		/// <summary>Starts recording to the specified output file URL with the given callbacks.</summary>
 		public void StartRecordingToOutputFile (NSUrl outputFileUrl, Action<NSObject []> startRecordingFromConnections, Action<NSObject [], NSError?> finishedRecording)
 		{
 			StartRecordingToOutputFile (outputFileUrl, new recordingProxy (startRecordingFromConnections, finishedRecording));

--- a/src/AVFoundation/AVCaptureFileOutput.cs
+++ b/src/AVFoundation/AVCaptureFileOutput.cs
@@ -35,11 +35,10 @@ namespace AVFoundation {
 
 		}
 
-		/// <param name="outputFileUrl">To be added.</param>
-		///         <param name="startRecordingFromConnections">To be added.</param>
-		///         <param name="finishedRecording">To be added.</param>
+		/// <param name="outputFileUrl">The output file url.</param>
+		///         <param name="startRecordingFromConnections">The start recording from connections.</param>
+		///         <param name="finishedRecording">The finished recording.</param>
 		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
 		public void StartRecordingToOutputFile (NSUrl outputFileUrl, Action<NSObject []> startRecordingFromConnections, Action<NSObject [], NSError?> finishedRecording)
 		{
 			StartRecordingToOutputFile (outputFileUrl, new recordingProxy (startRecordingFromConnections, finishedRecording));

--- a/src/AVFoundation/AVCaptureFileOutput.cs
+++ b/src/AVFoundation/AVCaptureFileOutput.cs
@@ -35,10 +35,10 @@ namespace AVFoundation {
 
 		}
 
-		/// <param name="outputFileUrl">The URL of the output file to record to.</param>
-		///         <param name="startRecordingFromConnections">A callback invoked when recording starts, receiving the active connections.</param>
-		///         <param name="finishedRecording">A callback invoked when recording finishes, receiving the connections and any error that occurred.</param>
 		/// <summary>Starts recording to the specified output file URL with the given callbacks.</summary>
+		/// <param name="outputFileUrl">The URL of the output file to record to.</param>
+		/// <param name="startRecordingFromConnections">A callback invoked when recording starts, receiving the active connections.</param>
+		/// <param name="finishedRecording">A callback invoked when recording finishes, receiving the connections and any error that occurred.</param>
 		public void StartRecordingToOutputFile (NSUrl outputFileUrl, Action<NSObject []> startRecordingFromConnections, Action<NSObject [], NSError?> finishedRecording)
 		{
 			StartRecordingToOutputFile (outputFileUrl, new recordingProxy (startRecordingFromConnections, finishedRecording));

--- a/src/AVFoundation/AVCaptureFileOutput.cs
+++ b/src/AVFoundation/AVCaptureFileOutput.cs
@@ -35,9 +35,9 @@ namespace AVFoundation {
 
 		}
 
-		/// <param name="outputFileUrl">The output file url.</param>
-		///         <param name="startRecordingFromConnections">The start recording from connections.</param>
-		///         <param name="finishedRecording">The finished recording.</param>
+		/// <param name="outputFileUrl">The URL of the output file to record to.</param>
+		///         <param name="startRecordingFromConnections">A callback invoked when recording starts, receiving the active connections.</param>
+		///         <param name="finishedRecording">A callback invoked when recording finishes, receiving the connections and any error that occurred.</param>
 		///         <summary>To be added.</summary>
 		public void StartRecordingToOutputFile (NSUrl outputFileUrl, Action<NSObject []> startRecordingFromConnections, Action<NSObject [], NSError?> finishedRecording)
 		{

--- a/src/AVFoundation/AVUrlAssetOptions.cs
+++ b/src/AVFoundation/AVUrlAssetOptions.cs
@@ -40,15 +40,13 @@ namespace AVFoundation {
 	public class AVUrlAssetOptions : DictionaryContainer {
 #if !COREBUILD
 		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
 		public AVUrlAssetOptions ()
 			: base (new NSMutableDictionary ())
 		{
 		}
 
-		/// <param name="dictionary">To be added.</param>
+		/// <param name="dictionary">The dictionary.</param>
 		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
 		public AVUrlAssetOptions (NSDictionary dictionary)
 			: base (dictionary)
 		{

--- a/src/AVFoundation/AVUrlAssetOptions.cs
+++ b/src/AVFoundation/AVUrlAssetOptions.cs
@@ -45,8 +45,8 @@ namespace AVFoundation {
 		{
 		}
 
-		/// <param name="dictionary">The dictionary containing the asset options.</param>
 		/// <summary>Creates a new instance of <see cref="AVUrlAssetOptions" /> from the specified dictionary.</summary>
+		/// <param name="dictionary">The dictionary containing the asset options.</param>
 		public AVUrlAssetOptions (NSDictionary dictionary)
 			: base (dictionary)
 		{

--- a/src/AVFoundation/AVUrlAssetOptions.cs
+++ b/src/AVFoundation/AVUrlAssetOptions.cs
@@ -39,14 +39,14 @@ namespace AVFoundation {
 	[SupportedOSPlatform ("tvos")]
 	public class AVUrlAssetOptions : DictionaryContainer {
 #if !COREBUILD
-		/// <summary>To be added.</summary>
+		/// <summary>Creates a new instance of <see cref="AVUrlAssetOptions" /> with an empty dictionary.</summary>
 		public AVUrlAssetOptions ()
 			: base (new NSMutableDictionary ())
 		{
 		}
 
 		/// <param name="dictionary">The dictionary containing the asset options.</param>
-		///         <summary>To be added.</summary>
+		/// <summary>Creates a new instance of <see cref="AVUrlAssetOptions" /> from the specified dictionary.</summary>
 		public AVUrlAssetOptions (NSDictionary dictionary)
 			: base (dictionary)
 		{

--- a/src/AVFoundation/AVUrlAssetOptions.cs
+++ b/src/AVFoundation/AVUrlAssetOptions.cs
@@ -45,7 +45,7 @@ namespace AVFoundation {
 		{
 		}
 
-		/// <param name="dictionary">The dictionary.</param>
+		/// <param name="dictionary">The dictionary containing the asset options.</param>
 		///         <summary>To be added.</summary>
 		public AVUrlAssetOptions (NSDictionary dictionary)
 			: base (dictionary)

--- a/src/AddressBookUI/ABAddressFormatting.cs
+++ b/src/AddressBookUI/ABAddressFormatting.cs
@@ -40,10 +40,10 @@ namespace AddressBookUI {
 		[DllImport (Constants.AddressBookUILibrary)]
 		static extern IntPtr /* NSString */ ABCreateStringWithAddressDictionary (IntPtr /* NSDictionary */ address, byte addCountryName);
 
+		/// <summary>Creates a formatted, human-readable address string from the given address dictionary.</summary>
 		/// <param name="address">A dictionary containing the address fields.</param>
-		///         <param name="addCountryName">Whether to include the country name in the formatted string.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
+		/// <param name="addCountryName">Whether to include the country name in the formatted string.</param>
+		/// <returns>A formatted string representing the address.</returns>
 		static public string ToString (NSDictionary address, bool addCountryName)
 		{
 			if (address is null)

--- a/src/AddressBookUI/ABAddressFormatting.cs
+++ b/src/AddressBookUI/ABAddressFormatting.cs
@@ -40,11 +40,10 @@ namespace AddressBookUI {
 		[DllImport (Constants.AddressBookUILibrary)]
 		static extern IntPtr /* NSString */ ABCreateStringWithAddressDictionary (IntPtr /* NSDictionary */ address, byte addCountryName);
 
-		/// <param name="address">To be added.</param>
-		///         <param name="addCountryName">To be added.</param>
+		/// <param name="address">The address.</param>
+		///         <param name="addCountryName">The add country name.</param>
 		///         <summary>To be added.</summary>
 		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		static public string ToString (NSDictionary address, bool addCountryName)
 		{
 			if (address is null)

--- a/src/AddressBookUI/ABAddressFormatting.cs
+++ b/src/AddressBookUI/ABAddressFormatting.cs
@@ -40,8 +40,8 @@ namespace AddressBookUI {
 		[DllImport (Constants.AddressBookUILibrary)]
 		static extern IntPtr /* NSString */ ABCreateStringWithAddressDictionary (IntPtr /* NSDictionary */ address, byte addCountryName);
 
-		/// <param name="address">The address.</param>
-		///         <param name="addCountryName">The add country name.</param>
+		/// <param name="address">A dictionary containing the address fields.</param>
+		///         <param name="addCountryName">Whether to include the country name in the formatted string.</param>
 		///         <summary>To be added.</summary>
 		///         <returns>To be added.</returns>
 		static public string ToString (NSDictionary address, bool addCountryName)

--- a/src/BusinessChat/Enums.cs
+++ b/src/BusinessChat/Enums.cs
@@ -6,9 +6,9 @@ namespace BusinessChat {
 	[MacCatalyst (13, 1)]
 	[Native]
 	public enum BCChatButtonStyle : long {
-		/// <summary>Indicates light.</summary>
+		/// <summary>A light-themed chat button.</summary>
 		Light = 0,
-		/// <summary>Indicates dark.</summary>
+		/// <summary>A dark-themed chat button.</summary>
 		Dark,
 	}
 
@@ -18,15 +18,15 @@ namespace BusinessChat {
 	[Deprecated (PlatformName.MacCatalyst, 16, 2)]
 	public enum BCParameterName {
 
-		/// <summary>Indicates intent.</summary>
+		/// <summary>The intent parameter for the chat session.</summary>
 		[Field ("BCParameterNameIntent")]
 		Intent,
 
-		/// <summary>Indicates group.</summary>
+		/// <summary>The group parameter for the chat session.</summary>
 		[Field ("BCParameterNameGroup")]
 		Group,
 
-		/// <summary>Indicates body.</summary>
+		/// <summary>The body parameter for the chat session.</summary>
 		[Field ("BCParameterNameBody")]
 		Body,
 	}

--- a/src/BusinessChat/Enums.cs
+++ b/src/BusinessChat/Enums.cs
@@ -6,9 +6,9 @@ namespace BusinessChat {
 	[MacCatalyst (13, 1)]
 	[Native]
 	public enum BCChatButtonStyle : long {
-		/// <summary>To be added.</summary>
+		/// <summary>Indicates light.</summary>
 		Light = 0,
-		/// <summary>To be added.</summary>
+		/// <summary>Indicates dark.</summary>
 		Dark,
 	}
 
@@ -18,15 +18,15 @@ namespace BusinessChat {
 	[Deprecated (PlatformName.MacCatalyst, 16, 2)]
 	public enum BCParameterName {
 
-		/// <summary>To be added.</summary>
+		/// <summary>Indicates intent.</summary>
 		[Field ("BCParameterNameIntent")]
 		Intent,
 
-		/// <summary>To be added.</summary>
+		/// <summary>Indicates group.</summary>
 		[Field ("BCParameterNameGroup")]
 		Group,
 
-		/// <summary>To be added.</summary>
+		/// <summary>Indicates body.</summary>
 		[Field ("BCParameterNameBody")]
 		Body,
 	}

--- a/src/CoreBluetooth/AdvertisementDataOptions.cs
+++ b/src/CoreBluetooth/AdvertisementDataOptions.cs
@@ -43,15 +43,13 @@ namespace CoreBluetooth {
 	public class StartAdvertisingOptions : DictionaryContainer {
 #if !COREBUILD
 		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
 		public StartAdvertisingOptions ()
 			: base (new NSMutableDictionary ())
 		{
 		}
 
-		/// <param name="dictionary">To be added.</param>
+		/// <param name="dictionary">The dictionary.</param>
 		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
 		public StartAdvertisingOptions (NSDictionary dictionary)
 			: base (dictionary)
 		{

--- a/src/CoreBluetooth/AdvertisementDataOptions.cs
+++ b/src/CoreBluetooth/AdvertisementDataOptions.cs
@@ -48,7 +48,7 @@ namespace CoreBluetooth {
 		{
 		}
 
-		/// <param name="dictionary">The dictionary.</param>
+		/// <param name="dictionary">The dictionary containing the advertising options.</param>
 		///         <summary>To be added.</summary>
 		public StartAdvertisingOptions (NSDictionary dictionary)
 			: base (dictionary)

--- a/src/CoreBluetooth/AdvertisementDataOptions.cs
+++ b/src/CoreBluetooth/AdvertisementDataOptions.cs
@@ -42,14 +42,14 @@ namespace CoreBluetooth {
 	[SupportedOSPlatform ("tvos")]
 	public class StartAdvertisingOptions : DictionaryContainer {
 #if !COREBUILD
-		/// <summary>To be added.</summary>
+		/// <summary>Creates a new instance of <see cref="StartAdvertisingOptions" /> with an empty dictionary.</summary>
 		public StartAdvertisingOptions ()
 			: base (new NSMutableDictionary ())
 		{
 		}
 
 		/// <param name="dictionary">The dictionary containing the advertising options.</param>
-		///         <summary>To be added.</summary>
+		/// <summary>Creates a new instance of <see cref="StartAdvertisingOptions" /> from the specified dictionary.</summary>
 		public StartAdvertisingOptions (NSDictionary dictionary)
 			: base (dictionary)
 		{

--- a/src/CoreBluetooth/AdvertisementDataOptions.cs
+++ b/src/CoreBluetooth/AdvertisementDataOptions.cs
@@ -48,8 +48,8 @@ namespace CoreBluetooth {
 		{
 		}
 
-		/// <param name="dictionary">The dictionary containing the advertising options.</param>
 		/// <summary>Creates a new instance of <see cref="StartAdvertisingOptions" /> from the specified dictionary.</summary>
+		/// <param name="dictionary">The dictionary containing the advertising options.</param>
 		public StartAdvertisingOptions (NSDictionary dictionary)
 			: base (dictionary)
 		{

--- a/src/CoreVideo/CVMetalTextureAttributes.cs
+++ b/src/CoreVideo/CVMetalTextureAttributes.cs
@@ -11,11 +11,11 @@ using Metal;
 #nullable enable
 
 namespace CoreVideo {
-	/// <summary>To be added.</summary>
+	/// <summary>Provides attributes for configuring Metal texture caches.</summary>
 	public partial class CVMetalTextureAttributes : DictionaryContainer {
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
+		/// <summary>Gets or sets the intended Metal texture usage flags.</summary>
+		/// <value>The Metal texture usage flags, or <see langword="null" /> if not set.</value>
 		public MTLTextureUsage? Usage {
 			get {
 				return (MTLTextureUsage?) (uint?) GetNUIntValue (CVMetalTextureAttributesKeys.UsageKey);

--- a/src/CoreVideo/CVMetalTextureAttributes.cs
+++ b/src/CoreVideo/CVMetalTextureAttributes.cs
@@ -12,12 +12,10 @@ using Metal;
 
 namespace CoreVideo {
 	/// <summary>To be added.</summary>
-	///     <remarks>To be added.</remarks>
 	public partial class CVMetalTextureAttributes : DictionaryContainer {
 
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public MTLTextureUsage? Usage {
 			get {
 				return (MTLTextureUsage?) (uint?) GetNUIntValue (CVMetalTextureAttributesKeys.UsageKey);

--- a/src/CoreWlan/CWConfiguration.cs
+++ b/src/CoreWlan/CWConfiguration.cs
@@ -7,11 +7,9 @@ using CoreFoundation;
 
 namespace CoreWlan {
 	/// <summary>To be added.</summary>
-	///     <remarks>To be added.</remarks>
 	public unsafe partial class CWConfiguration {
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public CWNetworkProfile []? NetworkProfiles {
 			get {
 				NSOrderedSet profiles = _NetworkProfiles;

--- a/src/CoreWlan/CWConfiguration.cs
+++ b/src/CoreWlan/CWConfiguration.cs
@@ -6,10 +6,10 @@
 using CoreFoundation;
 
 namespace CoreWlan {
-	/// <summary>To be added.</summary>
+	/// <summary>Encapsulates a CoreWLAN network configuration.</summary>
 	public unsafe partial class CWConfiguration {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
+		/// <summary>Gets the ordered list of preferred network profiles.</summary>
+		/// <value>An array of network profiles, or <see langword="null" /> if none are configured.</value>
 		public CWNetworkProfile []? NetworkProfiles {
 			get {
 				NSOrderedSet profiles = _NetworkProfiles;

--- a/src/EventKitUI/EKUIBundle.cs
+++ b/src/EventKitUI/EKUIBundle.cs
@@ -11,7 +11,6 @@
 
 namespace EventKitUI {
 	/// <summary>To be added.</summary>
-	///     <remarks>To be added.</remarks>
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("maccatalyst")]
 	public static class EKUIBundle {
@@ -21,7 +20,6 @@ namespace EventKitUI {
 
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public static NSBundle? UIBundle {
 			get {
 				return Runtime.GetNSObject<NSBundle> (EventKitUIBundle ());

--- a/src/EventKitUI/EKUIBundle.cs
+++ b/src/EventKitUI/EKUIBundle.cs
@@ -10,7 +10,7 @@
 #nullable enable
 
 namespace EventKitUI {
-	/// <summary>To be added.</summary>
+	/// <summary>Provides access to the EventKit UI framework bundle.</summary>
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("maccatalyst")]
 	public static class EKUIBundle {
@@ -18,8 +18,8 @@ namespace EventKitUI {
 		[DllImport (Constants.EventKitUILibrary)]
 		static extern IntPtr EventKitUIBundle ();
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
+		/// <summary>Gets the EventKit UI framework bundle.</summary>
+		/// <value>The <see cref="NSBundle" /> for the EventKit UI framework, or <see langword="null" /> if unavailable.</value>
 		public static NSBundle? UIBundle {
 			get {
 				return Runtime.GetNSObject<NSBundle> (EventKitUIBundle ());

--- a/src/Foundation/NSBundle.cs
+++ b/src/Foundation/NSBundle.cs
@@ -6,18 +6,18 @@ using System.Collections;
 
 namespace Foundation {
 	public partial class NSBundle : NSObject {
-		/// <param name="key">The key for the string</param>
-		///         <param name="value">The value to use if no string exists at the key.</param>
-		///         <param name="table">The table in which to look up the keyed value.</param>
-		///         <summary>Gets the localized string for the string that is identified by the provided <paramref name="key" /> into <paramref name="table" />, or <paramref name="value" /> if no string is found.</summary>
-		///         <returns>The localized string for the string that is identified by the provided <paramref name="key" /> into <paramref name="table" />, or <paramref name="value" /> if no string is found.</returns>
+		/// <summary>Gets the localized string identified by the specified key and table.</summary>
+		/// <param name="key">The key for the localized string.</param>
+		/// <param name="value">The value to return if no localized string exists for <paramref name="key" />.</param>
+		/// <param name="table">The table in which to look up <paramref name="key" />.</param>
+		/// <returns>The localized string, or <paramref name="value" /> if no localized string is found.</returns>
 		public NSString GetLocalizedString (string key, string? value = null, string? table = null)
 		{
 			return GetLocalizedString ((NSString) key, (NSString?) value, (NSString?) table);
 		}
 
-		/// <param name="fileExtension">The file extension to filter resources by.</param>
 		/// <summary>Returns the paths for all bundle resources with the specified extension.</summary>
+		/// <param name="fileExtension">The file extension to filter resources by.</param>
 		/// <returns>An array of file paths for matching resources.</returns>
 		public string [] PathsForResources (string fileExtension)
 		{

--- a/src/Foundation/NSBundle.cs
+++ b/src/Foundation/NSBundle.cs
@@ -17,8 +17,8 @@ namespace Foundation {
 		}
 
 		/// <param name="fileExtension">The file extension to filter resources by.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
+		/// <summary>Returns the paths for all bundle resources with the specified extension.</summary>
+		/// <returns>An array of file paths for matching resources.</returns>
 		public string [] PathsForResources (string fileExtension)
 		{
 			return PathsForResources (fileExtension, null);

--- a/src/Foundation/NSBundle.cs
+++ b/src/Foundation/NSBundle.cs
@@ -11,16 +11,14 @@ namespace Foundation {
 		///         <param name="table">The table in which to look up the keyed value.</param>
 		///         <summary>Gets the localized string for the string that is identified by the provided <paramref name="key" /> into <paramref name="table" />, or <paramref name="value" /> if no string is found.</summary>
 		///         <returns>The localized string for the string that is identified by the provided <paramref name="key" /> into <paramref name="table" />, or <paramref name="value" /> if no string is found.</returns>
-		///         <remarks>To be added.</remarks>
 		public NSString GetLocalizedString (string key, string? value = null, string? table = null)
 		{
 			return GetLocalizedString ((NSString) key, (NSString?) value, (NSString?) table);
 		}
 
-		/// <param name="fileExtension">To be added.</param>
+		/// <param name="fileExtension">The file extension.</param>
 		///         <summary>To be added.</summary>
 		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public string [] PathsForResources (string fileExtension)
 		{
 			return PathsForResources (fileExtension, null);

--- a/src/Foundation/NSBundle.cs
+++ b/src/Foundation/NSBundle.cs
@@ -16,7 +16,7 @@ namespace Foundation {
 			return GetLocalizedString ((NSString) key, (NSString?) value, (NSString?) table);
 		}
 
-		/// <param name="fileExtension">The file extension.</param>
+		/// <param name="fileExtension">The file extension to filter resources by.</param>
 		///         <summary>To be added.</summary>
 		///         <returns>To be added.</returns>
 		public string [] PathsForResources (string fileExtension)

--- a/src/Intents/INSetProfileInCarIntent.cs
+++ b/src/Intents/INSetProfileInCarIntent.cs
@@ -8,10 +8,9 @@ namespace Intents {
 
 	public partial class INSetProfileInCarIntent {
 		/// <param name="profileNumber">The number identifying the car profile.</param>
-		///         <param name="profileLabel">The display label for the car profile.</param>
-		///         <param name="defaultProfile">Whether this is the default car profile.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <param name="profileLabel">The display label for the car profile.</param>
+		/// <param name="defaultProfile">Whether this is the default car profile.</param>
+		/// <summary>Creates a new intent to set a car profile with the specified parameters.</summary>
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[ObsoletedOSPlatform ("ios12.0", "Use the overload that takes 'INSpeakableString carName'.")]

--- a/src/Intents/INSetProfileInCarIntent.cs
+++ b/src/Intents/INSetProfileInCarIntent.cs
@@ -7,9 +7,9 @@ using UIKit;
 namespace Intents {
 
 	public partial class INSetProfileInCarIntent {
-		/// <param name="profileNumber">The profile number.</param>
-		///         <param name="profileLabel">The profile label.</param>
-		///         <param name="defaultProfile">The default profile.</param>
+		/// <param name="profileNumber">The number identifying the car profile.</param>
+		///         <param name="profileLabel">The display label for the car profile.</param>
+		///         <param name="defaultProfile">Whether this is the default car profile.</param>
 		///         <summary>To be added.</summary>
 		///         <remarks>To be added.</remarks>
 		[SupportedOSPlatform ("ios")]

--- a/src/Intents/INSetProfileInCarIntent.cs
+++ b/src/Intents/INSetProfileInCarIntent.cs
@@ -7,10 +7,10 @@ using UIKit;
 namespace Intents {
 
 	public partial class INSetProfileInCarIntent {
+		/// <summary>Creates a new intent to set a car profile with the specified parameters.</summary>
 		/// <param name="profileNumber">The number identifying the car profile.</param>
 		/// <param name="profileLabel">The display label for the car profile.</param>
 		/// <param name="defaultProfile">Whether this is the default car profile.</param>
-		/// <summary>Creates a new intent to set a car profile with the specified parameters.</summary>
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("maccatalyst")]
 		[ObsoletedOSPlatform ("ios12.0", "Use the overload that takes 'INSpeakableString carName'.")]

--- a/src/Intents/INSetProfileInCarIntent.cs
+++ b/src/Intents/INSetProfileInCarIntent.cs
@@ -7,9 +7,9 @@ using UIKit;
 namespace Intents {
 
 	public partial class INSetProfileInCarIntent {
-		/// <param name="profileNumber">To be added.</param>
-		///         <param name="profileLabel">To be added.</param>
-		///         <param name="defaultProfile">To be added.</param>
+		/// <param name="profileNumber">The profile number.</param>
+		///         <param name="profileLabel">The profile label.</param>
+		///         <param name="defaultProfile">The default profile.</param>
 		///         <summary>To be added.</summary>
 		///         <remarks>To be added.</remarks>
 		[SupportedOSPlatform ("ios")]

--- a/src/Network/NWProtocolOptions.cs
+++ b/src/Network/NWProtocolOptions.cs
@@ -17,7 +17,6 @@ using IntPtr = System.IntPtr;
 
 namespace Network {
 	/// <summary>To be added.</summary>
-	///     <remarks>To be added.</remarks>
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
@@ -31,7 +30,6 @@ namespace Network {
 
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public NWProtocolDefinition ProtocolDefinition => new NWProtocolDefinition (nw_protocol_options_copy_definition (GetCheckedHandle ()), owns: true);
 
 		[DllImport (Constants.NetworkLibrary)]

--- a/src/Network/NWProtocolOptions.cs
+++ b/src/Network/NWProtocolOptions.cs
@@ -16,7 +16,7 @@ using OS_nw_protocol_definition = System.IntPtr;
 using IntPtr = System.IntPtr;
 
 namespace Network {
-	/// <summary>To be added.</summary>
+	/// <summary>Represents configuration options for a network protocol.</summary>
 	[SupportedOSPlatform ("tvos")]
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
@@ -28,8 +28,8 @@ namespace Network {
 		[DllImport (Constants.NetworkLibrary)]
 		internal static extern OS_nw_protocol_definition nw_protocol_options_copy_definition (IntPtr options);
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
+		/// <summary>Gets the protocol definition associated with these options.</summary>
+		/// <value>The <see cref="NWProtocolDefinition" /> for the protocol these options configure.</value>
 		public NWProtocolDefinition ProtocolDefinition => new NWProtocolDefinition (nw_protocol_options_copy_definition (GetCheckedHandle ()), owns: true);
 
 		[DllImport (Constants.NetworkLibrary)]

--- a/src/NetworkExtension/NEHotspotEapSettings.cs
+++ b/src/NetworkExtension/NEHotspotEapSettings.cs
@@ -13,11 +13,11 @@
 
 namespace NetworkExtension {
 
-	/// <summary>To be added.</summary>
+	/// <summary>Provides EAP settings for configuring hotspot networks.</summary>
 	public partial class NEHotspotEapSettings {
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
+		/// <summary>Gets or sets the supported EAP types for hotspot authentication.</summary>
+		/// <value>An array of supported EAP authentication types.</value>
 		public NEHotspotConfigurationEapType [] SupportedEapTypes {
 			get {
 				return NSArray.NonNullEnumsFromHandle<NEHotspotConfigurationEapType> (_SupportedEapTypes);

--- a/src/NetworkExtension/NEHotspotEapSettings.cs
+++ b/src/NetworkExtension/NEHotspotEapSettings.cs
@@ -14,12 +14,10 @@
 namespace NetworkExtension {
 
 	/// <summary>To be added.</summary>
-	///     <remarks>To be added.</remarks>
 	public partial class NEHotspotEapSettings {
 
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public NEHotspotConfigurationEapType [] SupportedEapTypes {
 			get {
 				return NSArray.NonNullEnumsFromHandle<NEHotspotConfigurationEapType> (_SupportedEapTypes);

--- a/src/ObjCRuntime/DelayedRegistrationAttribute.cs
+++ b/src/ObjCRuntime/DelayedRegistrationAttribute.cs
@@ -30,8 +30,7 @@ namespace ObjCRuntime {
 	[AttributeUsage (AttributeTargets.Assembly)]
 	public abstract class DelayedRegistrationAttribute : Attribute {
 		/// <summary>Gets a value indicating whether registration should be delayed.</summary>
-		/// <value>
-		///   <see langword="true" /> if registration should be delayed; otherwise, <see langword="false" />.</value>
+		/// <value><see langword="true" /> if registration should be delayed; otherwise, <see langword="false" />.</value>
 		public abstract bool Delay { get; }
 	}
 }

--- a/src/ObjCRuntime/DelayedRegistrationAttribute.cs
+++ b/src/ObjCRuntime/DelayedRegistrationAttribute.cs
@@ -27,12 +27,10 @@ using System.IO;
 
 namespace ObjCRuntime {
 	/// <summary>To be added.</summary>
-	///     <remarks>To be added.</remarks>
 	[AttributeUsage (AttributeTargets.Assembly)]
 	public abstract class DelayedRegistrationAttribute : Attribute {
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public abstract bool Delay { get; }
 	}
 }

--- a/src/ObjCRuntime/DelayedRegistrationAttribute.cs
+++ b/src/ObjCRuntime/DelayedRegistrationAttribute.cs
@@ -26,11 +26,12 @@
 using System.IO;
 
 namespace ObjCRuntime {
-	/// <summary>To be added.</summary>
+	/// <summary>An attribute that controls whether Objective-C class registration is delayed.</summary>
 	[AttributeUsage (AttributeTargets.Assembly)]
 	public abstract class DelayedRegistrationAttribute : Attribute {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
+		/// <summary>Gets a value indicating whether registration should be delayed.</summary>
+		/// <value>
+		///   <see langword="true" /> if registration should be delayed; otherwise, <see langword="false" />.</value>
 		public abstract bool Delay { get; }
 	}
 }

--- a/src/SceneKit/SCNJavaScript.cs
+++ b/src/SceneKit/SCNJavaScript.cs
@@ -23,7 +23,7 @@ namespace SceneKit {
 		static extern void SCNExportJavaScriptModule (IntPtr context);
 
 		/// <param name="context">The JavaScript context to export SceneKit classes into.</param>
-		///         <summary>To be added.</summary>
+		/// <summary>Exports SceneKit classes into the specified JavaScript context.</summary>
 		public static void ExportModule (JSContext context)
 		{
 			if (context is null)

--- a/src/SceneKit/SCNJavaScript.cs
+++ b/src/SceneKit/SCNJavaScript.cs
@@ -13,7 +13,6 @@ using JavaScriptCore;
 
 namespace SceneKit {
 	/// <summary>Static class that contains a method to export JavaScript modules.</summary>
-	///     <remarks>To be added.</remarks>
 	///     <!-- TODO: Probably https://developer.apple.com/library/prerelease/mac/documentation/SceneKit/Reference/SCNAction_Class/index.html#//apple_ref/occ/clm/SCNAction/javaScriptActionWithScript:duration: -->
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
@@ -23,9 +22,8 @@ namespace SceneKit {
 		[DllImport (Constants.SceneKitLibrary)]
 		static extern void SCNExportJavaScriptModule (IntPtr context);
 
-		/// <param name="context">To be added.</param>
+		/// <param name="context">The context to use.</param>
 		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
 		public static void ExportModule (JSContext context)
 		{
 			if (context is null)

--- a/src/SceneKit/SCNJavaScript.cs
+++ b/src/SceneKit/SCNJavaScript.cs
@@ -13,7 +13,7 @@ using JavaScriptCore;
 
 namespace SceneKit {
 	/// <summary>Static class that contains a method to export JavaScript modules.</summary>
-	///     <!-- TODO: Probably https://developer.apple.com/library/prerelease/mac/documentation/SceneKit/Reference/SCNAction_Class/index.html#//apple_ref/occ/clm/SCNAction/javaScriptActionWithScript:duration: -->
+	/// <!-- TODO: Probably https://developer.apple.com/library/prerelease/mac/documentation/SceneKit/Reference/SCNAction_Class/index.html#//apple_ref/occ/clm/SCNAction/javaScriptActionWithScript:duration: -->
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("maccatalyst")]
@@ -22,8 +22,8 @@ namespace SceneKit {
 		[DllImport (Constants.SceneKitLibrary)]
 		static extern void SCNExportJavaScriptModule (IntPtr context);
 
-		/// <param name="context">The JavaScript context to export SceneKit classes into.</param>
 		/// <summary>Exports SceneKit classes into the specified JavaScript context.</summary>
+		/// <param name="context">The JavaScript context to export SceneKit classes into.</param>
 		public static void ExportModule (JSContext context)
 		{
 			if (context is null)

--- a/src/SceneKit/SCNJavaScript.cs
+++ b/src/SceneKit/SCNJavaScript.cs
@@ -22,7 +22,7 @@ namespace SceneKit {
 		[DllImport (Constants.SceneKitLibrary)]
 		static extern void SCNExportJavaScriptModule (IntPtr context);
 
-		/// <param name="context">The context to use.</param>
+		/// <param name="context">The JavaScript context to export SceneKit classes into.</param>
 		///         <summary>To be added.</summary>
 		public static void ExportModule (JSContext context)
 		{

--- a/src/Security/SecIdentity.cs
+++ b/src/Security/SecIdentity.cs
@@ -19,8 +19,8 @@ namespace Security {
 		[DllImport (Constants.SecurityLibrary)]
 		unsafe extern static SecStatusCode /* OSStatus */ SecIdentityCopyPrivateKey (IntPtr /* SecIdentityRef */ identity, IntPtr* /* SecKeyRef* */ privatekey);
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
+		/// <summary>Gets the private key associated with this identity.</summary>
+		/// <value>The <see cref="SecKey" /> representing the private key for this identity.</value>
 		public SecKey PrivateKey {
 			get {
 				IntPtr p;

--- a/src/Security/SecIdentity.cs
+++ b/src/Security/SecIdentity.cs
@@ -14,7 +14,6 @@ using CoreFoundation;
 namespace Security {
 
 	/// <summary>Encapsulate a security identity. A security identity comprises a certificate and its private key.</summary>
-	///     <remarks>To be added.</remarks>
 	public partial class SecIdentity {
 
 		[DllImport (Constants.SecurityLibrary)]
@@ -22,7 +21,6 @@ namespace Security {
 
 		/// <summary>To be added.</summary>
 		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		public SecKey PrivateKey {
 			get {
 				IntPtr p;

--- a/src/SpriteKit/SKAction.cs
+++ b/src/SpriteKit/SKAction.cs
@@ -15,11 +15,10 @@ using CoreFoundation;
 namespace SpriteKit {
 	public partial class SKAction {
 
-		/// <param name="size">To be added.</param>
-		///         <param name="duration">To be added.</param>
+		/// <param name="size">The size.</param>
+		///         <param name="duration">The duration.</param>
 		///         <summary>To be added.</summary>
 		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public static SKAction ResizeTo (CGSize size, double duration)
 		{
 			return SKAction.ResizeTo (size.Width, size.Height, duration);

--- a/src/SpriteKit/SKAction.cs
+++ b/src/SpriteKit/SKAction.cs
@@ -15,9 +15,9 @@ using CoreFoundation;
 namespace SpriteKit {
 	public partial class SKAction {
 
+		/// <summary>Creates an action that resizes a node to the specified size over the given duration.</summary>
 		/// <param name="size">The target size to resize to.</param>
 		/// <param name="duration">The duration of the resize animation in seconds.</param>
-		/// <summary>Creates an action that resizes a node to the specified size over the given duration.</summary>
 		/// <returns>A new resize action.</returns>
 		public static SKAction ResizeTo (CGSize size, double duration)
 		{

--- a/src/SpriteKit/SKAction.cs
+++ b/src/SpriteKit/SKAction.cs
@@ -15,8 +15,8 @@ using CoreFoundation;
 namespace SpriteKit {
 	public partial class SKAction {
 
-		/// <param name="size">The size.</param>
-		///         <param name="duration">The duration.</param>
+		/// <param name="size">The target size to resize to.</param>
+		///         <param name="duration">The duration of the resize animation in seconds.</param>
 		///         <summary>To be added.</summary>
 		///         <returns>To be added.</returns>
 		public static SKAction ResizeTo (CGSize size, double duration)

--- a/src/SpriteKit/SKAction.cs
+++ b/src/SpriteKit/SKAction.cs
@@ -16,9 +16,9 @@ namespace SpriteKit {
 	public partial class SKAction {
 
 		/// <param name="size">The target size to resize to.</param>
-		///         <param name="duration">The duration of the resize animation in seconds.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
+		/// <param name="duration">The duration of the resize animation in seconds.</param>
+		/// <summary>Creates an action that resizes a node to the specified size over the given duration.</summary>
+		/// <returns>A new resize action.</returns>
 		public static SKAction ResizeTo (CGSize size, double duration)
 		{
 			return SKAction.ResizeTo (size.Width, size.Height, duration);

--- a/src/UIKit/UICollectionViewLayout.cs
+++ b/src/UIKit/UICollectionViewLayout.cs
@@ -19,8 +19,8 @@ namespace UIKit {
 			RegisterClassForDecorationView (Class.GetHandle (viewType), kind);
 		}
 
-		/// <param name="section">The section.</param>
-		///         <param name="indexPath">The index path.</param>
+		/// <param name="section">The section kind of the supplementary view.</param>
+		///         <param name="indexPath">The index path of the supplementary view.</param>
 		///         <summary>The attributes for the supplementary view at the specified indexPath.</summary>
 		///         <returns>To be added.</returns>
 		public UICollectionViewLayoutAttributes LayoutAttributesForSupplementaryView (UICollectionElementKindSection section, NSIndexPath indexPath)

--- a/src/UIKit/UICollectionViewLayout.cs
+++ b/src/UIKit/UICollectionViewLayout.cs
@@ -14,17 +14,15 @@ namespace UIKit {
 		/// <param name="viewType">The type of the class that will provide the decoration.   Use null to unregister the previous.</param>
 		///         <param name="kind">The element kind for which the registered type will be used.</param>
 		///         <summary>Registers the class identified by kind as a decoration view.</summary>
-		///         <remarks>To be added.</remarks>
 		public void RegisterClassForDecorationView (Type viewType, NSString kind)
 		{
 			RegisterClassForDecorationView (Class.GetHandle (viewType), kind);
 		}
 
-		/// <param name="section">To be added.</param>
-		///         <param name="indexPath">To be added.</param>
+		/// <param name="section">The section.</param>
+		///         <param name="indexPath">The index path.</param>
 		///         <summary>The attributes for the supplementary view at the specified indexPath.</summary>
 		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
 		public UICollectionViewLayoutAttributes LayoutAttributesForSupplementaryView (UICollectionElementKindSection section, NSIndexPath indexPath)
 		{
 			NSString kind;

--- a/src/UIKit/UICollectionViewLayout.cs
+++ b/src/UIKit/UICollectionViewLayout.cs
@@ -11,18 +11,18 @@ namespace UIKit {
 
 	public partial class UICollectionViewLayout {
 
-		/// <param name="viewType">The type of the class that will provide the decoration.   Use null to unregister the previous.</param>
-		///         <param name="kind">The element kind for which the registered type will be used.</param>
-		///         <summary>Registers the class identified by kind as a decoration view.</summary>
+		/// <summary>Registers a class to use when creating decoration views of the specified kind.</summary>
+		/// <param name="viewType">The class to use for the decoration view, or <see langword="null" /> to unregister the current class.</param>
+		/// <param name="kind">The element kind for which to use the registered class.</param>
 		public void RegisterClassForDecorationView (Type viewType, NSString kind)
 		{
 			RegisterClassForDecorationView (Class.GetHandle (viewType), kind);
 		}
 
+		/// <summary>Gets the layout attributes for the supplementary view at the specified index path.</summary>
 		/// <param name="section">The section kind of the supplementary view.</param>
-		///         <param name="indexPath">The index path of the supplementary view.</param>
-		///         <summary>The attributes for the supplementary view at the specified indexPath.</summary>
-		/// <returns>The layout attributes for the supplementary view, or <see langword="null" /> if no supplementary view exists at the specified index path.</returns>
+		/// <param name="indexPath">The index path of the supplementary view.</param>
+		/// <returns>The layout attributes for the supplementary view.</returns>
 		public UICollectionViewLayoutAttributes LayoutAttributesForSupplementaryView (UICollectionElementKindSection section, NSIndexPath indexPath)
 		{
 			NSString kind;

--- a/src/UIKit/UICollectionViewLayout.cs
+++ b/src/UIKit/UICollectionViewLayout.cs
@@ -22,7 +22,7 @@ namespace UIKit {
 		/// <param name="section">The section kind of the supplementary view.</param>
 		///         <param name="indexPath">The index path of the supplementary view.</param>
 		///         <summary>The attributes for the supplementary view at the specified indexPath.</summary>
-		///         <returns>To be added.</returns>
+		/// <returns>The layout attributes for the supplementary view, or <see langword="null" /> if no supplementary view exists at the specified index path.</returns>
 		public UICollectionViewLayoutAttributes LayoutAttributesForSupplementaryView (UICollectionElementKindSection section, NSIndexPath indexPath)
 		{
 			NSString kind;

--- a/src/UIKit/UINavigationController.cs
+++ b/src/UIKit/UINavigationController.cs
@@ -6,10 +6,9 @@ namespace UIKit {
 			return Class.GetHandle (t);
 		}
 
-		/// <param name="navigationBarType">To be added.</param>
-		///         <param name="toolbarType">To be added.</param>
+		/// <param name="navigationBarType">The navigation bar type.</param>
+		///         <param name="toolbarType">The toolbar type.</param>
 		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
 		public UINavigationController (Type navigationBarType, Type toolbarType) : this (LookupClass (navigationBarType), LookupClass (toolbarType))
 		{
 		}

--- a/src/UIKit/UINavigationController.cs
+++ b/src/UIKit/UINavigationController.cs
@@ -6,8 +6,8 @@ namespace UIKit {
 			return Class.GetHandle (t);
 		}
 
-		/// <param name="navigationBarType">The navigation bar type.</param>
-		///         <param name="toolbarType">The toolbar type.</param>
+		/// <param name="navigationBarType">The type of navigation bar to use.</param>
+		///         <param name="toolbarType">The type of toolbar to use.</param>
 		///         <summary>To be added.</summary>
 		public UINavigationController (Type navigationBarType, Type toolbarType) : this (LookupClass (navigationBarType), LookupClass (toolbarType))
 		{

--- a/src/UIKit/UINavigationController.cs
+++ b/src/UIKit/UINavigationController.cs
@@ -7,8 +7,8 @@ namespace UIKit {
 		}
 
 		/// <param name="navigationBarType">The type of navigation bar to use.</param>
-		///         <param name="toolbarType">The type of toolbar to use.</param>
-		///         <summary>To be added.</summary>
+		/// <param name="toolbarType">The type of toolbar to use.</param>
+		/// <summary>Creates a navigation controller with the specified navigation bar and toolbar types.</summary>
 		public UINavigationController (Type navigationBarType, Type toolbarType) : this (LookupClass (navigationBarType), LookupClass (toolbarType))
 		{
 		}

--- a/src/UIKit/UINavigationController.cs
+++ b/src/UIKit/UINavigationController.cs
@@ -6,9 +6,9 @@ namespace UIKit {
 			return Class.GetHandle (t);
 		}
 
+		/// <summary>Creates a navigation controller with the specified navigation bar and toolbar types.</summary>
 		/// <param name="navigationBarType">The type of navigation bar to use.</param>
 		/// <param name="toolbarType">The type of toolbar to use.</param>
-		/// <summary>Creates a navigation controller with the specified navigation bar and toolbar types.</summary>
 		public UINavigationController (Type navigationBarType, Type toolbarType) : this (LookupClass (navigationBarType), LookupClass (toolbarType))
 		{
 		}

--- a/src/UIKit/UIPushBehavior.cs
+++ b/src/UIKit/UIPushBehavior.cs
@@ -1,9 +1,8 @@
 namespace UIKit {
 	public partial class UIPushBehavior {
-		/// <param name="mode">To be added.</param>
-		///         <param name="items">To be added.</param>
+		/// <param name="mode">The mode.</param>
+		///         <param name="items">The items.</param>
 		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
 		public UIPushBehavior (UIPushBehaviorMode mode, params IUIDynamicItem [] items) : this (items, mode) { }
 	}
 }

--- a/src/UIKit/UIPushBehavior.cs
+++ b/src/UIKit/UIPushBehavior.cs
@@ -1,8 +1,8 @@
 namespace UIKit {
 	public partial class UIPushBehavior {
 		/// <param name="mode">The push behavior mode (continuous or instantaneous).</param>
-		///         <param name="items">The dynamic items to apply the push behavior to.</param>
-		///         <summary>To be added.</summary>
+		/// <param name="items">The dynamic items to apply the push behavior to.</param>
+		/// <summary>Creates a push behavior with the specified mode and dynamic items.</summary>
 		public UIPushBehavior (UIPushBehaviorMode mode, params IUIDynamicItem [] items) : this (items, mode) { }
 	}
 }

--- a/src/UIKit/UIPushBehavior.cs
+++ b/src/UIKit/UIPushBehavior.cs
@@ -1,7 +1,7 @@
 namespace UIKit {
 	public partial class UIPushBehavior {
-		/// <param name="mode">The mode.</param>
-		///         <param name="items">The items.</param>
+		/// <param name="mode">The push behavior mode (continuous or instantaneous).</param>
+		///         <param name="items">The dynamic items to apply the push behavior to.</param>
 		///         <summary>To be added.</summary>
 		public UIPushBehavior (UIPushBehaviorMode mode, params IUIDynamicItem [] items) : this (items, mode) { }
 	}

--- a/src/UIKit/UIPushBehavior.cs
+++ b/src/UIKit/UIPushBehavior.cs
@@ -1,8 +1,8 @@
 namespace UIKit {
 	public partial class UIPushBehavior {
+		/// <summary>Creates a push behavior with the specified mode and dynamic items.</summary>
 		/// <param name="mode">The push behavior mode (continuous or instantaneous).</param>
 		/// <param name="items">The dynamic items to apply the push behavior to.</param>
-		/// <summary>Creates a push behavior with the specified mode and dynamic items.</summary>
 		public UIPushBehavior (UIPushBehaviorMode mode, params IUIDynamicItem [] items) : this (items, mode) { }
 	}
 }

--- a/src/WebKit/WebKit.cs
+++ b/src/WebKit/WebKit.cs
@@ -6,8 +6,8 @@ namespace WebKit {
 
 	public partial class WebFrame {
 		/// <param name="htmlString">The HTML content to load.</param>
-		///         <param name="baseUrl">The base URL used to resolve relative URLs in the HTML content.</param>
-		///         <summary>To be added.</summary>
+		/// <param name="baseUrl">The base URL used to resolve relative URLs in the HTML content.</param>
+		/// <summary>Loads the given HTML string into the web frame.</summary>
 		public void LoadHtmlString (string htmlString, NSUrl baseUrl)
 		{
 			LoadHtmlString ((NSString) htmlString, baseUrl);

--- a/src/WebKit/WebKit.cs
+++ b/src/WebKit/WebKit.cs
@@ -5,8 +5,8 @@
 namespace WebKit {
 
 	public partial class WebFrame {
-		/// <param name="htmlString">The html string.</param>
-		///         <param name="baseUrl">The base url.</param>
+		/// <param name="htmlString">The HTML content to load.</param>
+		///         <param name="baseUrl">The base URL used to resolve relative URLs in the HTML content.</param>
 		///         <summary>To be added.</summary>
 		public void LoadHtmlString (string htmlString, NSUrl baseUrl)
 		{

--- a/src/WebKit/WebKit.cs
+++ b/src/WebKit/WebKit.cs
@@ -5,9 +5,9 @@
 namespace WebKit {
 
 	public partial class WebFrame {
+		/// <summary>Loads the given HTML string into the web frame.</summary>
 		/// <param name="htmlString">The HTML content to load.</param>
 		/// <param name="baseUrl">The base URL used to resolve relative URLs in the HTML content.</param>
-		/// <summary>Loads the given HTML string into the web frame.</summary>
 		public void LoadHtmlString (string htmlString, NSUrl baseUrl)
 		{
 			LoadHtmlString ((NSString) htmlString, baseUrl);

--- a/src/WebKit/WebKit.cs
+++ b/src/WebKit/WebKit.cs
@@ -5,10 +5,9 @@
 namespace WebKit {
 
 	public partial class WebFrame {
-		/// <param name="htmlString">To be added.</param>
-		///         <param name="baseUrl">To be added.</param>
+		/// <param name="htmlString">The html string.</param>
+		///         <param name="baseUrl">The base url.</param>
 		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
 		public void LoadHtmlString (string htmlString, NSUrl baseUrl)
 		{
 			LoadHtmlString ((NSString) htmlString, baseUrl);

--- a/src/devicecheck.cs
+++ b/src/devicecheck.cs
@@ -40,7 +40,8 @@ namespace DeviceCheck {
 		DCDevice CurrentDevice { get; }
 
 		/// <summary>Gets a Boolean value that tells whether the <see cref="DeviceCheck.DCDevice.CurrentDevice" /> supports the DeviceCheck API.</summary>
-		///         <value>To be added.</value>
+		/// <value>
+		///   <see langword="true" /> if the current device supports the DeviceCheck API; otherwise, <see langword="false" />.</value>
 		[Export ("supported")]
 		bool Supported { [Bind ("isSupported")] get; }
 
@@ -51,7 +52,6 @@ namespace DeviceCheck {
 			        </returns>
 			<remarks>
 			          <para copied="true">The GenerateTokenAsync method is suitable to be used with C# async by returning control to the caller with a Task representing the operation.</para>
-			          <para copied="true">To be added.</para>
 			        </remarks>
 			""")]
 		[Export ("generateTokenWithCompletionHandler:")]

--- a/src/devicecheck.cs
+++ b/src/devicecheck.cs
@@ -14,9 +14,9 @@ namespace DeviceCheck {
 	[ErrorDomain ("DCErrorDomain")]
 	[Native]
 	public enum DCError : long {
-		/// <summary>To be added.</summary>
+		/// <summary>Indicates unknown system failure.</summary>
 		UnknownSystemFailure,
-		/// <summary>To be added.</summary>
+		/// <summary>Indicates feature unsupported.</summary>
 		FeatureUnsupported,
 		InvalidInput,
 		InvalidKey,
@@ -41,7 +41,6 @@ namespace DeviceCheck {
 
 		/// <summary>Gets a Boolean value that tells whether the <see cref="DeviceCheck.DCDevice.CurrentDevice" /> supports the DeviceCheck API.</summary>
 		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
 		[Export ("supported")]
 		bool Supported { [Bind ("isSupported")] get; }
 

--- a/src/devicecheck.cs
+++ b/src/devicecheck.cs
@@ -40,19 +40,18 @@ namespace DeviceCheck {
 		DCDevice CurrentDevice { get; }
 
 		/// <summary>Gets a Boolean value that tells whether the <see cref="DeviceCheck.DCDevice.CurrentDevice" /> supports the DeviceCheck API.</summary>
-		/// <value>
-		///   <see langword="true" /> if the current device supports the DeviceCheck API; otherwise, <see langword="false" />.</value>
+		/// <value><see langword="true" /> if the current device supports the DeviceCheck API; otherwise, <see langword="false" />.</value>
 		[Export ("supported")]
 		bool Supported { [Bind ("isSupported")] get; }
 
 		[Async (XmlDocs = """
-			<summary>Generates an identification token for <see cref="DeviceCheck.DCDevice.CurrentDevice" /> and runs a handlere after the operation is complete.</summary>
+			<summary>Generates an identification token for <see cref="DeviceCheck.DCDevice.CurrentDevice" /> and invokes a handler after the operation completes.</summary>
 			<returns>
-			          <para>A task that represents the asynchronous GenerateToken operation.   The value of the TResult parameter is a DeviceCheck.DCDeviceGenerateTokenCompletionHandler.</para>
-			        </returns>
+			  <para>A task that represents the asynchronous GenerateToken operation. The value of the TResult parameter is a DeviceCheck.DCDeviceGenerateTokenCompletionHandler.</para>
+			</returns>
 			<remarks>
-			          <para copied="true">The GenerateTokenAsync method is suitable to be used with C# async by returning control to the caller with a Task representing the operation.</para>
-			        </remarks>
+			  <para copied="true">The GenerateTokenAsync method can be used with C# async by returning control to the caller with a Task that represents the operation.</para>
+			</remarks>
 			""")]
 		[Export ("generateTokenWithCompletionHandler:")]
 		void GenerateToken (DCDeviceGenerateTokenCompletionHandler completion);

--- a/src/devicecheck.cs
+++ b/src/devicecheck.cs
@@ -14,9 +14,9 @@ namespace DeviceCheck {
 	[ErrorDomain ("DCErrorDomain")]
 	[Native]
 	public enum DCError : long {
-		/// <summary>Indicates unknown system failure.</summary>
+		/// <summary>An unknown system failure occurred.</summary>
 		UnknownSystemFailure,
-		/// <summary>Indicates feature unsupported.</summary>
+		/// <summary>The DeviceCheck feature is not supported on this device.</summary>
 		FeatureUnsupported,
 		InvalidInput,
 		InvalidKey,

--- a/src/network.cs
+++ b/src/network.cs
@@ -5,15 +5,15 @@ namespace Network {
 
 	[MacCatalyst (13, 1)]
 	public enum NWErrorDomain {
-		/// <summary>Indicates invalid.</summary>
+		/// <summary>An invalid error domain.</summary>
 		Invalid = 0,
-		/// <summary>Indicates posix.</summary>
+		/// <summary>A POSIX error domain.</summary>
 		[Field ("kNWErrorDomainPOSIX")]
 		Posix = 1,
-		/// <summary>Indicates dns.</summary>
+		/// <summary>A DNS error domain.</summary>
 		[Field ("kNWErrorDomainDNS")]
 		Dns = 2,
-		/// <summary>Indicates tls.</summary>
+		/// <summary>A TLS error domain.</summary>
 		[Field ("kNWErrorDomainTLS")]
 		Tls = 3,
 

--- a/src/network.cs
+++ b/src/network.cs
@@ -5,15 +5,15 @@ namespace Network {
 
 	[MacCatalyst (13, 1)]
 	public enum NWErrorDomain {
-		/// <summary>To be added.</summary>
+		/// <summary>Indicates invalid.</summary>
 		Invalid = 0,
-		/// <summary>To be added.</summary>
+		/// <summary>Indicates posix.</summary>
 		[Field ("kNWErrorDomainPOSIX")]
 		Posix = 1,
-		/// <summary>To be added.</summary>
+		/// <summary>Indicates dns.</summary>
 		[Field ("kNWErrorDomainDNS")]
 		Dns = 2,
-		/// <summary>To be added.</summary>
+		/// <summary>Indicates tls.</summary>
 		[Field ("kNWErrorDomainTLS")]
 		Tls = 3,
 


### PR DESCRIPTION
Improve XML documentation for 23 types across multiple frameworks.

**Types documented:**
SCNJavaScript, SecIdentity, UINavigationController, UIPushBehavior, WebFrame, NWErrorDomain, AVCaptureFileOutput, AVUrlAssetOptions, ABAddressFormatting, BCChatButtonStyle, StartAdvertisingOptions, CVMetalTextureAttributes, CWConfiguration, EKUIBundle, NSBundle, INSetProfileInCarIntent, NWProtocolOptions, NEHotspotEapSettings, DelayedRegistrationAttribute, SKAction, UICollectionViewLayout, DCError, AVAssetDownloadStorageManagementPolicy

**Changes:**
- Replace placeholder parameter descriptions with meaningful descriptions
- Replace generic enum summaries with specific descriptions
- Remove empty remarks elements
- Fix tag ordering

🤖 Pull request created by Copilot