### PR TITLE
[release/11.0.1xx-preview7] Update dependencies from dotnet/macios

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -12,7 +12,9 @@
     <!--  Begin: Package sources from dotnet-dotnet -->
     <!--  End: Package sources from dotnet-dotnet -->
     <!--  Begin: Package sources from dotnet-macios -->
-    <add key="darc-pub-dotnet-macios-e972726" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-e9727264/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-macios-ac895e1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-ac895e19/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-macios-ac895e1-2" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-ac895e19-2/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-macios-ac895e1-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-ac895e19-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-macios -->
     <!--  Begin: Package sources from dotnet-emsdk -->
     <!--  End: Package sources from dotnet-emsdk -->

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -18,16 +18,16 @@ This file should be imported by eng/Versions.props
     <MicrosoftTemplateEngineAuthoringTasksPackageVersion>11.0.100-preview.7.26378.119</MicrosoftTemplateEngineAuthoringTasksPackageVersion>
     <!-- dotnet-macios dependencies -->
     <MicrosoftiOSSdknet100_260PackageVersion>26.0.11017</MicrosoftiOSSdknet100_260PackageVersion>
-    <MicrosoftiOSSdknet100_265PackageVersion>26.5.10310</MicrosoftiOSSdknet100_265PackageVersion>
+    <MicrosoftiOSSdknet100_265PackageVersion>26.5.10315</MicrosoftiOSSdknet100_265PackageVersion>
     <MicrosoftiOSSdknet100_270PackageVersion>27.0.10241-xcode27.0</MicrosoftiOSSdknet100_270PackageVersion>
     <MicrosoftMacCatalystSdknet100_260PackageVersion>26.0.11017</MicrosoftMacCatalystSdknet100_260PackageVersion>
-    <MicrosoftMacCatalystSdknet100_265PackageVersion>26.5.10310</MicrosoftMacCatalystSdknet100_265PackageVersion>
+    <MicrosoftMacCatalystSdknet100_265PackageVersion>26.5.10315</MicrosoftMacCatalystSdknet100_265PackageVersion>
     <MicrosoftMacCatalystSdknet100_270PackageVersion>27.0.10241-xcode27.0</MicrosoftMacCatalystSdknet100_270PackageVersion>
     <MicrosoftmacOSSdknet100_260PackageVersion>26.0.11017</MicrosoftmacOSSdknet100_260PackageVersion>
-    <MicrosoftmacOSSdknet100_265PackageVersion>26.5.10310</MicrosoftmacOSSdknet100_265PackageVersion>
+    <MicrosoftmacOSSdknet100_265PackageVersion>26.5.10315</MicrosoftmacOSSdknet100_265PackageVersion>
     <MicrosoftmacOSSdknet100_270PackageVersion>27.0.10241-xcode27.0</MicrosoftmacOSSdknet100_270PackageVersion>
     <MicrosofttvOSSdknet100_260PackageVersion>26.0.11017</MicrosofttvOSSdknet100_260PackageVersion>
-    <MicrosofttvOSSdknet100_265PackageVersion>26.5.10310</MicrosofttvOSSdknet100_265PackageVersion>
+    <MicrosofttvOSSdknet100_265PackageVersion>26.5.10315</MicrosofttvOSSdknet100_265PackageVersion>
     <MicrosofttvOSSdknet100_270PackageVersion>27.0.10241-xcode27.0</MicrosofttvOSSdknet100_270PackageVersion>
     <!-- dotnet-xharness dependencies -->
     <MicrosoftDotNetXHarnessiOSSharedPackageVersion>11.0.0-prerelease.26217.1</MicrosoftDotNetXHarnessiOSSharedPackageVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -43,21 +43,21 @@
       <Sha>23eb1c2c9465fe76c810c8a69982c1254161f4b0</Sha>
     </Dependency>
     <!-- This is a subscription of the .NET 10/Xcode 26.5 versions of our packages -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.5" Version="26.5.10310">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.5" Version="26.5.10315">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>e9727264cfecafbedcd0fbd0c89eac245058812a</Sha>
+      <Sha>ac895e19154cd3305df029b18849b2e5ed98e036</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.5" Version="26.5.10310">
+    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.5" Version="26.5.10315">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>e9727264cfecafbedcd0fbd0c89eac245058812a</Sha>
+      <Sha>ac895e19154cd3305df029b18849b2e5ed98e036</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.5" Version="26.5.10310">
+    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.5" Version="26.5.10315">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>e9727264cfecafbedcd0fbd0c89eac245058812a</Sha>
+      <Sha>ac895e19154cd3305df029b18849b2e5ed98e036</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.5" Version="26.5.10310">
+    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.5" Version="26.5.10315">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>e9727264cfecafbedcd0fbd0c89eac245058812a</Sha>
+      <Sha>ac895e19154cd3305df029b18849b2e5ed98e036</Sha>
     </Dependency>
     <!-- This is a subscription of the .NET 10/Xcode 27.0 versions of our packages -->
     <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_27.0" Version="27.0.10241-xcode27.0">


### PR DESCRIPTION
Updates the .NET 10/Xcode 26.5 SDK references to the latest `release/10.0.1xx` build.

- Source commit: [`ac895e19154cd3305df029b18849b2e5ed98e036`](https://github.com/dotnet/macios/commit/ac895e19154cd3305df029b18849b2e5ed98e036)
- Build: `20260730.9` (BAR build `325067`)
- Package version: `26.5.10315`
- Updates all matching `darc-pub-dotnet-macios-ac895e19` feeds in `NuGet.config`

This carries the same dependency update as #26319 to `release/11.0.1xx-preview7`, using the latest source build.