### PR TITLE
[api] Rename methods for adding and removing content key recipients

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -23812,7 +23812,7 @@ namespace AVFoundation {
 		/// <param name="recipient">The content key recipient to add to the session.</param>
 		/// <summary>Adds a content key recipient to the session.</summary>
 		[Wrap ("Add (recipient)")]
-		void AddContentKeyRecipient (AVUrlAsset recipient);
+		void AddContentKeyRecipient (IAVContentKeyRecipient recipient);
 
 		/// <param name="recipient">To be added.</param>
 		/// <summary>To be added.</summary>

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -23823,7 +23823,7 @@ namespace AVFoundation {
 		/// <param name="recipient">The content key recipient to remove from the session.</param>
 		/// <summary>Removes a content key recipient from the session.</summary>
 		[Wrap ("Remove (recipient)")]
-		void RemoveContentKeyRecipient (AVUrlAsset recipient);
+		void RemoveContentKeyRecipient (IAVContentKeyRecipient recipient);
 
 		/// <summary>To be added.</summary>
 		/// <returns>To be added.</returns>

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -23809,11 +23809,21 @@ namespace AVFoundation {
 		[Export ("addContentKeyRecipient:")]
 		void Add (IAVContentKeyRecipient recipient);
 
+		/// <param name="recipient">The content key recipient to add to the session.</param>
+		/// <summary>Adds a content key recipient to the session.</summary>
+		[Wrap ("Add (recipient)")]
+		void AddContentKeyRecipient (AVUrlAsset recipient);
+
 		/// <param name="recipient">To be added.</param>
 		/// <summary>To be added.</summary>
 		/// <remarks>To be added.</remarks>
 		[Export ("removeContentKeyRecipient:")]
 		void Remove (IAVContentKeyRecipient recipient);
+
+		/// <param name="recipient">The content key recipient to remove from the session.</param>
+		/// <summary>Removes a content key recipient from the session.</summary>
+		[Wrap ("Remove (recipient)")]
+		void RemoveContentKeyRecipient (AVUrlAsset recipient);
 
 		/// <summary>To be added.</summary>
 		/// <returns>To be added.</returns>


### PR DESCRIPTION
This pull request adds convenience methods to the `AVContentKeySession_AVContentKeyRecipients` interface to simplify working with content key recipients of type `AVUrlAsset`. These methods provide more descriptive names and improved documentation for adding and removing recipients.

Enhancements to API usability and documentation:

* Added `AddContentKeyRecipient` and `RemoveContentKeyRecipient` methods that accept an `AVUrlAsset` as the recipient, along with XML documentation comments for better clarity and usability.…n AVFoundation
* This adds expected naming for function that was named incorrectly and does not match IOS API specifications.

Fixes: https://github.com/dotnet/macios/issues/26386