### PR TITLE
[runtime] Use format attributes instead of ignoring -Wformat-nonliteral

### DIFF
--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -841,7 +841,7 @@ mono_object_unbox (MonoObject *obj)
 	void *rv = obj->struct_value;
 
 	if (rv == NULL)
-		xamarin_assertion_message ("%s (%p) => no struct value?\n", __func__);
+		xamarin_assertion_message ("%s (%p) => no struct value?\n", __func__, obj);
 
 	LOG_CORECLR (stderr, "%s (%p) => %p\n", __func__, obj, rv);
 

--- a/runtime/coreclr-bridge.m
+++ b/runtime/coreclr-bridge.m
@@ -508,7 +508,7 @@ xamarin_bridge_vm_initialize (int propertyCount, const char **propertyKeys, cons
 	LOG_CORECLR (stderr, "xamarin_vm_initialize (%i, %p, %p): rv: %i domainId: %i handle: %p\n", combinedPropertyCount, combinedPropertyKeys, combinedPropertyValues, rv, coreclr_domainId, coreclr_handle);
 
 	if (rv != 0) {
-		LOG (PRODUCT ": The call to 'coreclr_initialize' failed: %i (%p)\n", rv, rv);
+		LOG (PRODUCT ": The call to 'coreclr_initialize' failed: %i (%p)\n", rv, (void *) (intptr_t) rv);
 	}
 
 	return rv == 0;

--- a/runtime/monotouch-debug.m
+++ b/runtime/monotouch-debug.m
@@ -352,7 +352,7 @@ void monotouch_configure_debugging ()
 	if (captured_debug_port && *captured_debug_port) {
 		if (monodevelop_port == -1) {
 			monodevelop_port = strtol (captured_debug_port, NULL, 10);
-			LOG (PRODUCT ": Found port %i in environment variables\n", monodevelop_port);
+			LOG (PRODUCT ": Found port %i in environment variables\n", (int) monodevelop_port);
 		}
 	}
 	free (captured_debug_port);
@@ -374,7 +374,7 @@ void monotouch_configure_debugging ()
 	if (captured_debug_connect_timeout && *captured_debug_connect_timeout) {
 		if (sdb_timeout_time == -1) {
 			sdb_timeout_time = strtol (captured_debug_connect_timeout, NULL, 10);
-			LOG (PRODUCT ": Found connect timeout %i in environment variables\n", sdb_timeout_time);
+			LOG (PRODUCT ": Found connect timeout %i in environment variables\n", (int) sdb_timeout_time);
 		}
 	}
 	free (captured_debug_connect_timeout);
@@ -398,7 +398,7 @@ void monotouch_configure_debugging ()
 			if (ptr == NULL || ptr == (void *) -1) {
 				LOG (PRODUCT ": Could not map shared memory: %s\n", strerror (errno));
 			} else {
-				LOG (PRODUCT ": Read %i bytes from shared memory: %p with key %i and id %i\n", shmsize, ptr, shmkey, shmid);
+				LOG (PRODUCT ": Read %i bytes from shared memory: %p with key %i and id %i\n", (int) shmsize, ptr, shmkey, shmid);
 				// Make a local copy of the shared memory, so that it doesn't change while we're parsing it.
 				char *data = strndup ((const char *) ptr, shmsize); // strndup will null-terminate
 				char *line = data;
@@ -418,9 +418,9 @@ void monotouch_configure_debugging ()
 						long shm_monodevelop_port = strtol (line + 23, NULL, 10);
 						if (monodevelop_port == -1) {
 							monodevelop_port = shm_monodevelop_port;
-							LOG (PRODUCT ": Found port %i in shared memory\n", monodevelop_port);
+							LOG (PRODUCT ": Found port %i in shared memory\n", (int) monodevelop_port);
 						} else  {
-							LOG (PRODUCT ": Found port %i in shared memory, but not overriding existing port %i\n", shm_monodevelop_port, monodevelop_port);
+							LOG (PRODUCT ": Found port %i in shared memory, but not overriding existing port %i\n", (int) shm_monodevelop_port, (int) monodevelop_port);
 						}
 					} else {
 						LOG (PRODUCT ": Unknown data found in shared memory: %s\n", line);
@@ -490,9 +490,9 @@ void monotouch_configure_debugging ()
 		}
 
 		if (monodevelop_port <= 0) {
-			LOG (PRODUCT ": Invalid IDE Port: %i\n", monodevelop_port);
+			LOG (PRODUCT ": Invalid IDE Port: %i\n", (int) monodevelop_port);
 		} else {
-			LOG (PRODUCT ": IDE Port: %i Transport: %s Connect Timeout: %i\n", monodevelop_port, debugging_mode == DebuggingModeHttp ? "HTTP" : (debugging_mode == DebuggingModeUsb ? "USB" : "WiFi"), sdb_timeout_time);
+			LOG (PRODUCT ": IDE Port: %i Transport: %s Connect Timeout: %i\n", (int) monodevelop_port, debugging_mode == DebuggingModeHttp ? "HTTP" : (debugging_mode == DebuggingModeUsb ? "USB" : "WiFi"), (int) sdb_timeout_time);
 			if (debugging_mode == DebuggingModeUsb) {
 				monotouch_connect_usb ();
 			} else if (debugging_mode == DebuggingModeWifi) {
@@ -659,7 +659,7 @@ monotouch_connect_wifi (NSMutableArray *ips)
 			}
 			
 			if (rv < 0 && errno != EINPROGRESS) {
-				PRINT (PRODUCT ": Failed to connect to %s on port %d: %s", ip, listen_port, strerror (errno));
+				PRINT (PRODUCT ": Failed to connect to %s on port %d: %s", ip, (int) listen_port, strerror (errno));
 				close (sockets[i]);
 				sockets[i] = -1;
 				continue;
@@ -737,7 +737,7 @@ monotouch_connect_wifi (NSMutableArray *ips)
 				}
 				
 				if (error != 0) {
-					PRINT (PRODUCT ": Socket error while connecting to IDE on %s:%d: %s", [[ips objectAtIndex:i] UTF8String], listen_port, strerror (error));
+					PRINT (PRODUCT ": Socket error while connecting to IDE on %s:%d: %s", [[ips objectAtIndex:i] UTF8String], (int) listen_port, strerror (error));
 					close (sockets[i]);
 					sockets[i] = -1;
 					waiting--;
@@ -877,7 +877,7 @@ monotouch_connect_usb ()
 			// not a fatal failure
 		}
 
-		LOG (PRODUCT ": Successfully received USB connection from the IDE on port %i, fd: %i\n", listen_port, fd);
+		LOG (PRODUCT ": Successfully received USB connection from the IDE on port %i, fd: %i\n", (int) listen_port, fd);
 	} while (monotouch_process_connection (fd));
 
 	LOG (PRODUCT ": Successfully talked to the IDE. Will continue startup now.\n");
@@ -936,7 +936,7 @@ monotouch_load_debugger ()
 
 		char *options;
 		if (sdb_timeout_time != -1) {
-			options = xamarin_strdup_printf ("transport=custom_transport,address=dummy,embedding=1,timeout=%d", sdb_timeout_time);
+			options = xamarin_strdup_printf ("transport=custom_transport,address=dummy,embedding=1,timeout=%d", (int) sdb_timeout_time);
 		} else {
 			options = xamarin_strdup_printf ("transport=custom_transport,address=dummy,embedding=1");
 		}
@@ -1062,7 +1062,7 @@ monotouch_process_connection (int fd)
 				return true;
 		} else if (!strncmp (command, "set heapshot port: ", 19)) {
 			heapshot_port = strtol (command + 19, NULL, 0);
-			LOG (PRODUCT ": HeapShot port is now: %i\n", heapshot_port);
+			LOG (PRODUCT ": HeapShot port is now: %i\n", (int) heapshot_port);
 		} else if (!strcmp (command, "heapshot")) {
 			if (heapshot_fd == -1) {
 				struct sockaddr_in heapshot_addr;

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -603,18 +603,16 @@ xamarin_check_for_gced_object (MonoObject *obj, SEL sel, id self, MonoMethod *me
 		return;
 	}
 	
-	const char *m = "Failed to marshal the Objective-C object %p (type: %s). "
-	"Could not find an existing managed instance for this object, "
-	"nor was it possible to create a new managed instance "
-	"(because the type '%s' does not have a constructor that takes one NativeHandle argument).\n"
-	"Additional information:\n"
-	"\tSelector: %s\n"
-	"\tMethod: %s\n";
-	
 	char *method_full_name = mono_method_full_name (method, TRUE);
 	char *type_name = xamarin_lookup_managed_type_name ([self class], exception_gchandle);
 	if (*exception_gchandle == INVALID_GCHANDLE) {
-		char *msg = xamarin_strdup_printf (m, self, object_getClassName (self), type_name, sel_getName (sel), method_full_name);
+		char *msg = xamarin_strdup_printf ("Failed to marshal the Objective-C object %p (type: %s). "
+		"Could not find an existing managed instance for this object, "
+		"nor was it possible to create a new managed instance "
+		"(because the type '%s' does not have a constructor that takes one NativeHandle argument).\n"
+		"Additional information:\n"
+		"\tSelector: %s\n"
+		"\tMethod: %s\n", self, object_getClassName (self), type_name, sel_getName (sel), method_full_name);
 		GCHandle ex_handle = xamarin_create_runtime_exception (8027, msg, exception_gchandle);
 		xamarin_free (msg);
 		if (*exception_gchandle == INVALID_GCHANDLE)
@@ -1242,14 +1240,7 @@ xamarin_strdup_printf (const char *msg, ...)
 
 	va_start (args, msg);
 
-// Silence this warning:
-// runtime.m:1313:25: error: format string is not a string literal [-Werror,-Wformat-nonliteral]
-//  1313 |         vasprintf (&formatted, msg, args);
-//       |                                ^~~~~
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
 	vasprintf (&formatted, msg, args);
-#pragma clang diagnostic pop
 
 	va_end (args);
 

--- a/runtime/runtime.m
+++ b/runtime/runtime.m
@@ -983,7 +983,7 @@ xamarin_process_fatal_exception_gchandle (GCHandle gchandle, const char *message
 
 	NSString *fatal_message = [NSString stringWithFormat:@"%s\n%@", message, xamarin_print_all_exceptions (gchandle)];
 	NSLog (@PRODUCT ": %@", fatal_message);
-	xamarin_assertion_message ([fatal_message UTF8String]);
+	xamarin_assertion_message ("%s", [fatal_message UTF8String]);
 }
 
 // Because this function won't always return, it will take ownership of the GCHandle and free it.
@@ -1255,14 +1255,7 @@ xamarin_assertion_message (const char *msg, ...)
 
 	va_start (args, msg);
 
-// Silence this warning:
-// runtime.m:1335:25: error: format string is not a string literal [-Werror,-Wformat-nonliteral]
-//  1335 |         vasprintf (&formatted, msg, args);
-//       |                                ^~~
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
 	vasprintf (&formatted, msg, args);
-#pragma clang diagnostic pop
 
 	if (formatted) {
 		PRINT ( PRODUCT ": %s", formatted);
@@ -2563,14 +2556,7 @@ xamarin_printf (const char *format, ...)
 void
 xamarin_vprintf (const char *format, va_list args)
 {
-// Silence this warning:
-// runtime.m:2564:56: error: format string is not a string literal [-Werror,-Wformat-nonliteral]
-//  2564 |         NSString *message = [[NSString alloc] initWithFormat: [NSString stringWithUTF8String: format] arguments: args];
-//       |                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
 	NSString *message = [[NSString alloc] initWithFormat: [NSString stringWithUTF8String: format] arguments: args];
-#pragma clang diagnostic pop
 	
 	NSLog (@"%@", message);	
 

--- a/runtime/trampolines-varargs.m
+++ b/runtime/trampolines-varargs.m
@@ -47,7 +47,7 @@ param_iter_next (enum IteratorAction action, void *context, const char *type, si
 	if (target == NULL) {
 		LOGZ("skipping over %lu bytes\n", size);
 		if (size % sizeof (void *) != 0)
-			xamarin_assertion_message ("Cannot marshal structure of type '%s' with size %i since it's not a multiple of %i.\n", type, size, sizeof (void *));
+			xamarin_assertion_message ("Cannot marshal structure of type '%s' with size %i since it's not a multiple of %i.\n", type, (int) size, (int) sizeof (void *));
 
 		do {
 			va_arg (it->ap, void *);
@@ -59,7 +59,7 @@ param_iter_next (enum IteratorAction action, void *context, const char *type, si
 	void **target_ptr = (void **) target;
 	if (size > sizeof (void *)) {
 		if (size % sizeof (void *) != 0)
-			xamarin_assertion_message ("Cannot marshal structure of type '%s' with size %i since it's not a multiple of %i.\n", type, size, sizeof (void *));
+			xamarin_assertion_message ("Cannot marshal structure of type '%s' with size %i since it's not a multiple of %i.\n", type, (int) size, (int) sizeof (void *));
 
 		size_t size_left = size;
 		do {

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -160,7 +160,7 @@ struct AssemblyLocations {
 void xamarin_initialize ();
 void xamarin_initialize_dynamic_registrar ();
 
-void			xamarin_assertion_message (const char *msg, ...) __attribute__((__noreturn__));
+void			xamarin_assertion_message (const char *msg, ...) __attribute__((__noreturn__, format(printf, 1, 2)));
 // Gets the bundle path (where the managed executable is). This is *not* the path of the app bundle (.app/.appex).
 const char *	xamarin_get_bundle_path (); /* Public API */
 // Sets the bundle path (where the managed executable is). By default APP/Contents/MonoBundle.
@@ -298,8 +298,8 @@ bool			xamarin_locate_assembly_resource (const char *assembly_name, const char *
 bool			xamarin_locate_app_resource (const char *resource, char *path, size_t pathlen);
 
 // this functions support NSLog/NSString-style format specifiers.
-void			xamarin_printf (const char *format, ...);
-void			xamarin_vprintf (const char *format, va_list args);
+void			xamarin_printf (const char *format, ...) __attribute__((format(__NSString__, 1, 2)));
+void			xamarin_vprintf (const char *format, va_list args) __attribute__((format(__NSString__, 1, 0)));
 void			xamarin_install_log_callbacks ();
 
 bool			xamarin_is_user_type (Class cls);

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -195,7 +195,7 @@ void			xamarin_throw_nsexception (MonoException *exc);
 void			xamarin_rethrow_managed_exception (GCHandle original_gchandle, GCHandle *exception_gchandle);
 MonoException *	xamarin_create_exception (const char *msg);
 id				xamarin_get_handle (MonoObject *obj, GCHandle *exception_gchandle);
-char *			xamarin_strdup_printf (const char *msg, ...);
+char *			xamarin_strdup_printf (const char *msg, ...) __attribute__((format(printf, 1, 2)));
 void *			xamarin_calloc (size_t size);
 void			xamarin_free (void *ptr);
 MonoMethod *	xamarin_get_reflection_method_method (MonoReflectionMethod *method);

--- a/runtime/xamarin/runtime.h
+++ b/runtime/xamarin/runtime.h
@@ -297,7 +297,7 @@ bool			xamarin_locate_assembly_resource_for_root (const char *root, const char *
 bool			xamarin_locate_assembly_resource (const char *assembly_name, const char *culture, const char *resource, char *path, size_t pathlen);
 bool			xamarin_locate_app_resource (const char *resource, char *path, size_t pathlen);
 
-// this functions support NSLog/NSString-style format specifiers.
+// these functions support NSLog/NSString-style format specifiers.
 void			xamarin_printf (const char *format, ...) __attribute__((format(__NSString__, 1, 2)));
 void			xamarin_vprintf (const char *format, va_list args) __attribute__((format(__NSString__, 1, 0)));
 void			xamarin_install_log_callbacks ();


### PR DESCRIPTION
Several functions in the native runtime forward a `const char *` format argument to a printf/NSString-family function. This trips `-Wformat-nonliteral`, which the code previously silenced with a `#pragma clang diagnostic ignored "-Wformat-nonliteral"` around each call.

Instead, annotate each of these functions with the appropriate `format` attribute. This has two benefits:

* Callers now get proper compile-time format-string checking (`-Wformat`) of their format strings and arguments.
* Clang recognizes that forwarding the function's own format parameter is safe, so the `-Wformat-nonliteral` pragmas can be removed.

Functions changed (in `runtime/xamarin/runtime.h`):

* `xamarin_strdup_printf` and `xamarin_assertion_message` forward to `vasprintf`, so they get `format(printf, 1, 2)`.
* `xamarin_printf` / `xamarin_vprintf` use NSLog/NSString-style formats (`initWithFormat:arguments:`), so they get `format(__NSString__, ...)`. Both need the attribute because `xamarin_printf` forwards its format to `xamarin_vprintf`.

Two call sites that passed a runtime (non-literal) string as the format are updated to use an explicit `"%s"` format, which is also safer:

* `xamarin_check_for_gced_object` stored the literal in a local variable; it is inlined back into the call.
* `xamarin_process_fatal_exception_gchandle` passed `[fatal_message UTF8String]` directly as the format.

The `xamarin_localized_string_format_N` functions in `nsstring-localization.m` are intentionally left as-is: they are not variadic (fixed-arity P/Invoke targets), so a `format` attribute would trigger `-Wgcc-compat`, and they have no C callers that would benefit.

🤖 Pull request created by Copilot