### PR TITLE
[api] Improve xml docs for AVContentKeySession content key recipient methods

### DIFF
--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -23803,21 +23803,21 @@ namespace AVFoundation {
 	[Category]
 	[BaseType (typeof (AVContentKeySession))]
 	interface AVContentKeySession_AVContentKeyRecipients {
-		/// <param name="recipient">To be added.</param>
-		/// <summary>To be added.</summary>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Associates the specified recipient with this content key session so that the session can supply it with content keys.</summary>
+		/// <param name="recipient">The recipient to associate with this content key session, for example an <see cref="AVUrlAsset" />.</param>
+		/// <remarks>This method maps to the native <c>addContentKeyRecipient:</c> selector. Add a recipient before starting playback or processing that requires the decryption keys managed by this session.</remarks>
 		[Export ("addContentKeyRecipient:")]
 		void Add (IAVContentKeyRecipient recipient);
 
-		/// <param name="recipient">To be added.</param>
-		/// <summary>To be added.</summary>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Removes the association between the specified recipient and this content key session.</summary>
+		/// <param name="recipient">The recipient to disassociate from this content key session.</param>
+		/// <remarks>This method maps to the native <c>removeContentKeyRecipient:</c> selector. After removal, the session no longer supplies content keys to the recipient.</remarks>
 		[Export ("removeContentKeyRecipient:")]
 		void Remove (IAVContentKeyRecipient recipient);
 
-		/// <summary>To be added.</summary>
-		/// <returns>To be added.</returns>
-		/// <remarks>To be added.</remarks>
+		/// <summary>Gets the recipients that are currently associated with this content key session.</summary>
+		/// <returns>An array of the recipients associated with this session, or an empty array if there are none.</returns>
+		/// <remarks>This method maps to the native <c>contentKeyRecipients</c> property.</remarks>
 		[Export ("contentKeyRecipients")]
 		IAVContentKeyRecipient [] GetContentKeyRecipients ();
 	}

--- a/src/avfoundation.cs
+++ b/src/avfoundation.cs
@@ -23803,8 +23803,8 @@ namespace AVFoundation {
 	[Category]
 	[BaseType (typeof (AVContentKeySession))]
 	interface AVContentKeySession_AVContentKeyRecipients {
-		/// <summary>Associates the specified recipient with this content key session so that the session can supply it with content keys.</summary>
-		/// <param name="recipient">The recipient to associate with this content key session, for example an <see cref="AVUrlAsset" />.</param>
+		/// <summary>Associates the specified recipient with this content key session so that the session can supply the recipient with content keys.</summary>
+		/// <param name="recipient">The recipient to associate with this content key session, for example, an <see cref="AVUrlAsset" />.</param>
 		/// <remarks>This method maps to the native <c>addContentKeyRecipient:</c> selector. Add a recipient before starting playback or processing that requires the decryption keys managed by this session.</remarks>
 		[Export ("addContentKeyRecipient:")]
 		void Add (IAVContentKeyRecipient recipient);


### PR DESCRIPTION
Improve the XML documentation for the `Add`, `Remove` and `GetContentKeyRecipients` methods in the `AVContentKeySession_AVContentKeyRecipients` category, replacing the `To be added.` placeholders with accurate descriptions.

This supersedes #26387: that PR added `AddContentKeyRecipient` / `RemoveContentKeyRecipient` `[Wrap]` aliases, but they add no new API — the existing `Add`/`Remove` overloads already accept any `IAVContentKeyRecipient`, including `AVUrlAsset` (which conforms to the `AVContentKeyRecipient` protocol). So `session.Add (urlAsset)` already binds `addContentKeyRecipient:` today. This PR keeps only the documentation improvements.

🤖 Pull request created by Copilot
