### PR TITLE
[docs] Improve XML docs for ten types

### DIFF
--- a/src/AVFoundation/AVAudioBuffer.cs
+++ b/src/AVFoundation/AVAudioBuffer.cs
@@ -20,7 +20,7 @@ namespace AVFoundation {
 				return new AudioBuffers (audioBufferList);
 			}
 		}
-		/// <summary>Gets a mutable version of the underlying <see cref="AudioToolbox.AudioBuffers" />.</summary>
+
 		/// <summary>Gets a mutable version of the underlying <see cref="AudioToolbox.AudioBuffers" />.</summary>
 		/// <value>The mutable audio buffer list.</value>
 		public AudioBuffers MutableAudioBufferList {

--- a/src/AVFoundation/AVAudioBuffer.cs
+++ b/src/AVFoundation/AVAudioBuffer.cs
@@ -11,21 +11,18 @@ using AudioToolbox;
 
 namespace AVFoundation {
 	/// <summary>A buffer for audio data.</summary>
-	///     <remarks>To be added.</remarks>
 	/// <related type="externalDocumentation" href="https://developer.apple.com/documentation/avfaudio/avaudiobuffer">Apple documentation for <c>AVAudioBuffer</c></related>
 	public partial class AVAudioBuffer {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets the audio buffer list containing the buffer's audio data.</summary>
+		/// <value>The audio buffer list.</value>
 		public AudioBuffers AudioBufferList {
 			get {
 				return new AudioBuffers (audioBufferList);
 			}
 		}
-
 		/// <summary>Gets a mutable version of the underlying <see cref="AudioToolbox.AudioBuffers" />.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets a mutable version of the underlying <see cref="AudioToolbox.AudioBuffers" />.</summary>
+		/// <value>The mutable audio buffer list.</value>
 		public AudioBuffers MutableAudioBufferList {
 			get {
 				return new AudioBuffers (mutableAudioBufferList);

--- a/src/Darwin/TimeSpec.cs
+++ b/src/Darwin/TimeSpec.cs
@@ -2,16 +2,13 @@
 #nullable enable
 
 namespace Darwin {
-	/// <summary>To be added.</summary>
-	///     <remarks>To be added.</remarks>
+	/// <summary>Represents a POSIX time value with nanosecond precision.</summary>
 	[StructLayout (LayoutKind.Sequential)]
 	[NativeName ("timespec")]
 	public struct TimeSpec {
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>The number of whole seconds.</summary>
 		public nint Seconds;
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>The additional number of nanoseconds.</summary>
 		public nint NanoSeconds;
 	}
 }

--- a/src/FinderSync/Enums.cs
+++ b/src/FinderSync/Enums.cs
@@ -1,17 +1,16 @@
 #nullable enable
 
 namespace FinderSync {
-	/// <summary>To be added.</summary>
-	///     <remarks>To be added.</remarks>
+	/// <summary>Specifies the Finder location where a Finder Sync extension menu appears.</summary>
 	[Native]
 	public enum FIMenuKind : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>A contextual menu for selected items.</summary>
 		ContextualMenuForItems = 0,
-		/// <summary>To be added.</summary>
+		/// <summary>A contextual menu for the monitored folder containing the selected items.</summary>
 		ContextualMenuForContainer = 1,
-		/// <summary>To be added.</summary>
+		/// <summary>A contextual menu for an item in the Finder sidebar.</summary>
 		ContextualMenuForSidebar = 2,
-		/// <summary>To be added.</summary>
+		/// <summary>The menu associated with the extension's Finder toolbar item.</summary>
 		ToolbarItemMenu = 3,
 	}
 }

--- a/src/FinderSync/Enums.cs
+++ b/src/FinderSync/Enums.cs
@@ -6,7 +6,7 @@ namespace FinderSync {
 	public enum FIMenuKind : ulong {
 		/// <summary>A contextual menu for selected items.</summary>
 		ContextualMenuForItems = 0,
-		/// <summary>A contextual menu for the monitored folder containing the selected items.</summary>
+		/// <summary>A contextual menu for the background of a monitored folder.</summary>
 		ContextualMenuForContainer = 1,
 		/// <summary>A contextual menu for an item in the Finder sidebar.</summary>
 		ContextualMenuForSidebar = 2,

--- a/src/Foundation/AdviceAttribute.cs
+++ b/src/Foundation/AdviceAttribute.cs
@@ -37,17 +37,15 @@ namespace Foundation {
 		AttributeTargets.Interface | AttributeTargets.Delegate,
 		Inherited = false, AllowMultiple = true)]
 	public class AdviceAttribute : Attribute {
-		/// <param name="message">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Creates an advice attribute with the specified message.</summary>
+		/// <param name="message">The programming advice to present to developers.</param>
 		public AdviceAttribute (string message)
 		{
 			Message = message;
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets the programming advice.</summary>
+		/// <value>The message to present to developers.</value>
 		public string Message { get; private set; }
 	}
 }

--- a/src/Foundation/AdviceAttribute.cs
+++ b/src/Foundation/AdviceAttribute.cs
@@ -29,7 +29,7 @@
 
 namespace Foundation {
 	/// <summary>An attribute that can be used to give programming advice to a user of a function or class.</summary>
-	///     <remarks>This attribute is intended to give developers some guidance as to what to do.   The contents of the attribute are displayed by the IDE when the user is using a feature like code analysis to give hints as to how to improve the code.</remarks>
+	/// <remarks>Development tools can display the advice during code analysis to suggest improvements.</remarks>
 	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Struct |
 		AttributeTargets.Enum | AttributeTargets.Constructor |
 		AttributeTargets.Method | AttributeTargets.Property |

--- a/src/MediaLibrary/Enums.cs
+++ b/src/MediaLibrary/Enums.cs
@@ -33,7 +33,7 @@ namespace MediaLibrary {
 		Movie = 1 << 2,
 	}
 
-	/// <summary>Specifies a kind of media object.</summary>
+	/// <summary>A bitmask specifying one or more kinds of media objects.</summary>
 	[Native]
 	public enum MLMediaType : ulong {
 		/// <summary>Audio media.</summary>

--- a/src/MediaLibrary/Enums.cs
+++ b/src/MediaLibrary/Enums.cs
@@ -33,13 +33,14 @@ namespace MediaLibrary {
 		Movie = 1 << 2,
 	}
 
+	/// <summary>Specifies a kind of media object.</summary>
 	[Native]
 	public enum MLMediaType : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Audio media.</summary>
 		Audio = 1 << 0,
-		/// <summary>To be added.</summary>
+		/// <summary>Image media.</summary>
 		Image = 1 << 1,
-		/// <summary>To be added.</summary>
+		/// <summary>Movie media.</summary>
 		Movie = 1 << 2,
 	}
 }

--- a/src/MediaLibrary/Enums.cs
+++ b/src/MediaLibrary/Enums.cs
@@ -22,13 +22,14 @@
 //
 
 namespace MediaLibrary {
+	/// <summary>Specifies the kinds of media provided by a media source.</summary>
 	[Native]
 	public enum MLMediaSourceType : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>The source provides audio media.</summary>
 		Audio = 1 << 0,
-		/// <summary>To be added.</summary>
+		/// <summary>The source provides image media.</summary>
 		Image = 1 << 1,
-		/// <summary>To be added.</summary>
+		/// <summary>The source provides movie media.</summary>
 		Movie = 1 << 2,
 	}
 

--- a/src/MediaLibrary/Enums.cs
+++ b/src/MediaLibrary/Enums.cs
@@ -22,7 +22,7 @@
 //
 
 namespace MediaLibrary {
-	/// <summary>Specifies the kinds of media provided by a media source.</summary>
+	/// <summary>A bitmask specifying the kinds of media provided by a media source.</summary>
 	[Native]
 	public enum MLMediaSourceType : ulong {
 		/// <summary>The source provides audio media.</summary>

--- a/src/ObjCRuntime/RequiredFrameworkAttribute.cs
+++ b/src/ObjCRuntime/RequiredFrameworkAttribute.cs
@@ -27,18 +27,15 @@ using System.IO;
 
 namespace ObjCRuntime {
 
-	/// <summary>To be added.</summary>
-	///     <remarks>To be added.</remarks>
+	/// <summary>Specifies a native framework required by an assembly.</summary>
 	[AttributeUsage (AttributeTargets.Assembly, AllowMultiple = true)]
 	public class RequiredFrameworkAttribute : Attribute {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets the name of the required framework.</summary>
+		/// <value>The framework name.</value>
 		public string Name { get; private set; }
 
-		/// <param name="name">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Creates an attribute for the specified required framework.</summary>
+		/// <param name="name">The framework name.</param>
 		public RequiredFrameworkAttribute (string name)
 		{
 			Name = name;

--- a/src/Security/SecStatusCodeExtensions.cs
+++ b/src/Security/SecStatusCodeExtensions.cs
@@ -10,8 +10,7 @@
 #nullable enable
 
 namespace Security {
-	/// <summary>To be added.</summary>
-	///     <remarks>To be added.</remarks>
+	/// <summary>Provides convenience methods for security status codes.</summary>
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("macos")]
@@ -26,10 +25,9 @@ namespace Security {
 			/* OSStatus */ SecStatusCode status,
 			/* void * */ IntPtr reserved); /* always null */
 
-		/// <param name="status">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets a human-readable description of a security status code.</summary>
+		/// <param name="status">The security status code to describe.</param>
+		/// <returns>A description of <paramref name="status" />, or <see langword="null" /> if no description is available.</returns>
 		[SupportedOSPlatform ("ios")]
 		[SupportedOSPlatform ("tvos")]
 		[SupportedOSPlatform ("maccatalyst")]

--- a/src/Social/Enums.cs
+++ b/src/Social/Enums.cs
@@ -29,9 +29,9 @@ namespace Social {
 	[MacCatalyst (13, 1)]
 	[Native]
 	public enum SLComposeViewControllerResult : long {
-		/// <summary>To be added.</summary>
+		/// <summary>The user cancelled composition.</summary>
 		Cancelled,
-		/// <summary>To be added.</summary>
+		/// <summary>The user completed composition.</summary>
 		Done,
 	}
 }

--- a/src/Social/Enums.cs
+++ b/src/Social/Enums.cs
@@ -13,13 +13,13 @@ namespace Social {
 	/// <summary>The HTTP verb associated with a social service request.</summary>
 	[Native]
 	public enum SLRequestMethod : long {
-		/// <summary>To be added.</summary>
+		/// <summary>An HTTP GET request.</summary>
 		Get,
-		/// <summary>To be added.</summary>
+		/// <summary>An HTTP POST request.</summary>
 		Post,
-		/// <summary>To be added.</summary>
+		/// <summary>An HTTP DELETE request.</summary>
 		Delete,
-		/// <summary>To be added.</summary>
+		/// <summary>An HTTP PUT request.</summary>
 		Put,
 	}
 

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -24607,7 +24607,6 @@ T:MediaLibrary.MLMediaGroup
 T:MediaLibrary.MLMediaLibrary
 T:MediaLibrary.MLMediaObject
 T:MediaLibrary.MLMediaSource
-T:MediaLibrary.MLMediaSourceType
 T:MediaLibrary.MLMediaType
 T:MediaPlayer.AVMediaSelectionGroup_MPNowPlayingInfoLanguageOptionAdditions
 T:MediaPlayer.AVMediaSelectionOption_MPNowPlayingInfoLanguageOptionAdditions

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -24607,7 +24607,6 @@ T:MediaLibrary.MLMediaGroup
 T:MediaLibrary.MLMediaLibrary
 T:MediaLibrary.MLMediaObject
 T:MediaLibrary.MLMediaSource
-T:MediaLibrary.MLMediaType
 T:MediaPlayer.AVMediaSelectionGroup_MPNowPlayingInfoLanguageOptionAdditions
 T:MediaPlayer.AVMediaSelectionOption_MPNowPlayingInfoLanguageOptionAdditions
 T:MediaPlayer.MPAdTimeRange


### PR DESCRIPTION
Improve XML documentation for:

- `AVAudioBuffer`
- `TimeSpec`
- `AdviceAttribute`
- `FIMenuKind`
- `SecStatusCodeExtensions`
- `RequiredFrameworkAttribute`
- `MLMediaSourceType`
- `SLRequestMethod`
- `MLMediaType`
- `SLComposeViewControllerResult`

Each type is documented in a separate commit.

🤖 Pull request created by Copilot