### PR TITLE
[docs] Improve XML docs for ten types

### DIFF
--- a/src/Foundation/NSRunLoop.cs
+++ b/src/Foundation/NSRunLoop.cs
@@ -26,15 +26,13 @@ namespace Foundation {
 
 	public partial class NSRunLoop {
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Stops the receiver's underlying run loop.</summary>
 		public void Stop ()
 		{
 			GetCFRunLoop ().Stop ();
 		}
 
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Wakes the receiver's underlying run loop.</summary>
 		public void WakeUp ()
 		{
 			GetCFRunLoop ().WakeUp ();

--- a/src/Foundation/NSRunLoop.cs
+++ b/src/Foundation/NSRunLoop.cs
@@ -45,6 +45,7 @@ namespace Foundation {
 		/// <summary>Gets the native constants for a collection of run loop modes.</summary>
 		/// <param name="self">The run loop modes to convert.</param>
 		/// <returns>The native constants corresponding to the specified run loop modes.</returns>
+		/// <exception cref="ArgumentNullException"><paramref name="self" /> is <see langword="null" />.</exception>
 		public static NSString [] GetConstants (this NSRunLoopMode [] self)
 		{
 			if (self is null)

--- a/src/Foundation/NSRunLoop.cs
+++ b/src/Foundation/NSRunLoop.cs
@@ -42,10 +42,9 @@ namespace Foundation {
 	static public partial class NSRunLoopModeExtensions {
 
 		// this is a less common pattern so it's not automatically generated
-		/// <param name="self">The instance on which this method operates.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets the native constants for a collection of run loop modes.</summary>
+		/// <param name="self">The run loop modes to convert.</param>
+		/// <returns>The native constants corresponding to the specified run loop modes.</returns>
 		public static NSString [] GetConstants (this NSRunLoopMode [] self)
 		{
 			if (self is null)

--- a/src/Foundation/NSZone.cs
+++ b/src/Foundation/NSZone.cs
@@ -8,7 +8,6 @@ namespace Foundation {
 
 	// Helper to (mostly) support NS[Mutable]Copying protocols
 	/// <summary>An OS-controlled area within memory from which objects are allocated.</summary>
-	///     <remarks>To be added.</remarks>
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("maccatalyst")]
 	[SupportedOSPlatform ("macos")]
@@ -36,9 +35,8 @@ namespace Foundation {
 		public NativeHandle Handle { get; private set; }
 
 #if !COREBUILD
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets or sets the name of the zone.</summary>
+		/// <value>The zone name, or <see langword="null" /> if the zone has no name.</value>
 		public string? Name {
 			get {
 				return CFString.FromHandle (NSZoneName (Handle));
@@ -52,10 +50,9 @@ namespace Foundation {
 				}
 			}
 		}
-
 		// note: Copy(NSZone) and MutableCopy(NSZone) with a nil pointer == default
-		/// <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		// note: Copy(NSZone) and MutableCopy(NSZone) with a nil pointer == default
+		/// <summary>The default memory allocation zone.</summary>
 		public static readonly NSZone Default = new NSZone (NSDefaultMallocZone (), false);
 #endif
 	}

--- a/src/Foundation/NSZone.cs
+++ b/src/Foundation/NSZone.cs
@@ -50,7 +50,7 @@ namespace Foundation {
 				}
 			}
 		}
-		// note: Copy(NSZone) and MutableCopy(NSZone) with a nil pointer == default
+
 		// note: Copy(NSZone) and MutableCopy(NSZone) with a nil pointer == default
 		/// <summary>The default memory allocation zone.</summary>
 		public static readonly NSZone Default = new NSZone (NSDefaultMallocZone (), false);

--- a/src/GLKit/GLKMesh.cs
+++ b/src/GLKit/GLKMesh.cs
@@ -7,12 +7,11 @@ using ModelIO;
 namespace GLKit {
 
 	public partial class GLKMesh {
-		/// <param name="asset">To be added.</param>
-		///         <param name="sourceMeshes">To be added.</param>
-		///         <param name="error">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Creates GLKit meshes from the meshes in a Model I/O asset.</summary>
+		/// <param name="asset">The asset containing the source meshes.</param>
+		/// <param name="sourceMeshes">The Model I/O meshes corresponding to the returned GLKit meshes.</param>
+		/// <param name="error">On failure, contains an error that describes the problem.</param>
+		/// <returns>The created GLKit meshes, or <see langword="null" /> if they could not be created.</returns>
 		public static GLKMesh []? FromAsset (MDLAsset asset, out MDLMesh []? sourceMeshes, out NSError? error)
 		{
 			var ret = FromAsset (asset, out NSArray? aret, out error);

--- a/src/HomeKit/HMService.cs
+++ b/src/HomeKit/HMService.cs
@@ -7,19 +7,17 @@ namespace HomeKit {
 	public partial class HMService {
 
 #if !TVOS
-		/// <param name="serviceType">To be added.</param>
-		///         <param name="completion">To be added.</param>
-		///         <summary>Specifies that the device attached to a switch or outlet is of type <paramref name="serviceType" />. After the system sets the association, the system runs <paramref name="completion" />.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Updates the type of device associated with the service.</summary>
+		/// <param name="serviceType">The associated service type.</param>
+		/// <param name="completion">The handler to invoke after the update completes.</param>
 		public void UpdateAssociatedServiceType (HMServiceType serviceType, Action<NSError> completion)
 		{
 			UpdateAssociatedServiceType (serviceType.GetConstant (), completion);
 		}
 
-		/// <param name="serviceType">To be added.</param>
-		///         <summary>Asynchronously updates the associated service type to  <paramref name="serviceType" /></summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Asynchronously updates the type of device associated with the service.</summary>
+		/// <param name="serviceType">The associated service type.</param>
+		/// <returns>A task that represents the update operation.</returns>
 		public Task UpdateAssociatedServiceTypeAsync (HMServiceType serviceType)
 		{
 			return UpdateAssociatedServiceTypeAsync (serviceType.GetConstant ());

--- a/src/Intents/INPriceRange.cs
+++ b/src/Intents/INPriceRange.cs
@@ -13,7 +13,6 @@
 
 namespace Intents {
 	/// <summary>Enumerates the minimum and maximum values of a price range.</summary>
-	///     <remarks>To be added.</remarks>
 	public enum INPriceRangeOption {
 		/// <summary>The greatest price.</summary>
 		Maximum,

--- a/src/Intents/INPriceRange.cs
+++ b/src/Intents/INPriceRange.cs
@@ -22,11 +22,11 @@ namespace Intents {
 
 	public partial class INPriceRange {
 
-		/// <param name="option">To be added.</param>
-		///         <param name="price">To be added.</param>
-		///         <param name="currencyCode">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Creates a price range with either a minimum or maximum price.</summary>
+		/// <param name="option">Whether <paramref name="price" /> is the minimum or maximum price.</param>
+		/// <param name="price">The price at the selected range boundary.</param>
+		/// <param name="currencyCode">The ISO 4217 currency code for <paramref name="price" />.</param>
+		/// <exception cref="ArgumentOutOfRangeException"><paramref name="option" /> is not a valid value.</exception>
 		public INPriceRange (INPriceRangeOption option, NSDecimalNumber price, string currencyCode)
 			: base (NSObjectFlag.Empty)
 		{

--- a/src/MetalKit/MTKMesh.cs
+++ b/src/MetalKit/MTKMesh.cs
@@ -9,13 +9,12 @@ using Metal;
 namespace MetalKit {
 
 	public partial class MTKMesh {
-		/// <param name="asset">To be added.</param>
-		///         <param name="device">To be added.</param>
-		///         <param name="sourceMeshes">To be added.</param>
-		///         <param name="error">To be added.</param>
-		///         <summary>Creates and returns a new Metal Kit mesh from the supplied Model IO asset.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Creates MetalKit meshes from the meshes in a Model I/O asset.</summary>
+		/// <param name="asset">The asset containing the source meshes.</param>
+		/// <param name="device">The Metal device on which to create the mesh resources.</param>
+		/// <param name="sourceMeshes">The Model I/O meshes corresponding to the returned MetalKit meshes.</param>
+		/// <param name="error">On failure, contains an error that describes the problem.</param>
+		/// <returns>The created MetalKit meshes, or <see langword="null" /> if they could not be created.</returns>
 		public static MTKMesh []? FromAsset (MDLAsset asset, IMTLDevice device, out MDLMesh []? sourceMeshes, out NSError error)
 		{
 			NSArray aret;

--- a/src/VideoToolbox/VTPropertyOptions.cs
+++ b/src/VideoToolbox/VTPropertyOptions.cs
@@ -17,9 +17,8 @@ using CoreVideo;
 namespace VideoToolbox {
 
 	public partial class VTPropertyOptions {
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets or sets the property's value type.</summary>
+		/// <value>The property value type.</value>
 		public VTPropertyType Type {
 			get {
 				var key = GetNSStringValue (VTPropertyKeys.Type);
@@ -52,9 +51,8 @@ namespace VideoToolbox {
 			}
 		}
 
-		/// <summary>To be added.</summary>
-		///         <value>To be added.</value>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets or sets whether the property can be read or written.</summary>
+		/// <value>The property's read/write status.</value>
 		public VTReadWriteStatus ReadWriteStatus {
 			get {
 				var key = GetNSStringValue (VTPropertyKeys.ReadWriteStatus);

--- a/src/VideoToolbox/VTUtilities.cs
+++ b/src/VideoToolbox/VTUtilities.cs
@@ -15,7 +15,6 @@ using CoreVideo;
 
 namespace VideoToolbox {
 	/// <summary>Extensions class for <see cref="CoreVideo.CVPixelBuffer" />.</summary>
-	///     <remarks>To be added.</remarks>
 	[SupportedOSPlatform ("macos")]
 	[SupportedOSPlatform ("ios")]
 	[SupportedOSPlatform ("tvos")]
@@ -30,11 +29,10 @@ namespace VideoToolbox {
 		// intentionally not exposing the (NSDictionary options) argument
 		// since header docs indicate that there are no options available
 		// as of 9.0/10.11 and to always pass NULL
-		/// <param name="pixelBuffer">To be added.</param>
-		///         <param name="image">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Creates a Core Graphics image from a pixel buffer.</summary>
+		/// <param name="pixelBuffer">The pixel buffer to convert.</param>
+		/// <param name="image">On success, the created image; otherwise, <see langword="null" />.</param>
+		/// <returns>A status code that indicates whether the conversion succeeded.</returns>
 		public static VTStatus ToCGImage (this CVPixelBuffer pixelBuffer, out CGImage? image)
 		{
 			if (pixelBuffer is null)
@@ -61,6 +59,8 @@ namespace VideoToolbox {
 		[DllImport (Constants.VideoToolboxLibrary)]
 		static extern void VTRegisterSupplementalVideoDecoderIfAvailable (uint codecType);
 
+		/// <summary>Registers the supplemental video decoder for a codec if one is available.</summary>
+		/// <param name="codecType">The video codec for which to register a supplemental decoder.</param>
 		[SupportedOSPlatform ("macos")]
 		[SupportedOSPlatform ("ios26.4")]
 		[SupportedOSPlatform ("tvos26.4")]

--- a/src/VideoToolbox/VTUtilities.cs
+++ b/src/VideoToolbox/VTUtilities.cs
@@ -33,6 +33,7 @@ namespace VideoToolbox {
 		/// <param name="pixelBuffer">The pixel buffer to convert.</param>
 		/// <param name="image">On success, the created image; otherwise, <see langword="null" />.</param>
 		/// <returns>A status code that indicates whether the conversion succeeded.</returns>
+		/// <exception cref="ArgumentNullException"><paramref name="pixelBuffer" /> is <see langword="null" />.</exception>
 		public static VTStatus ToCGImage (this CVPixelBuffer pixelBuffer, out CGImage? image)
 		{
 			if (pixelBuffer is null)

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -15835,7 +15835,6 @@ M:VideoToolbox.VTSuperResolutionScalerParameters.#ctor(VideoToolbox.VTFrameProce
 M:VideoToolbox.VTSupportedEncoderProperties.#ctor
 M:VideoToolbox.VTTemporalNoiseFilterConfiguration.#ctor(System.IntPtr,System.IntPtr,CoreMedia.CMPixelFormat)
 M:VideoToolbox.VTTemporalNoiseFilterParameters.#ctor(VideoToolbox.VTFrameProcessorFrame,VideoToolbox.VTFrameProcessorFrame[],VideoToolbox.VTFrameProcessorFrame[],VideoToolbox.VTFrameProcessorFrame,System.Single,System.Byte)
-M:VideoToolbox.VTUtilities.RegisterSupplementalVideoDecoder(CoreMedia.CMVideoCodecType)
 M:Vision.VNDetectBarcodesRequest.GetSupportedSymbologies(Foundation.NSError@)
 M:Vision.VNFeaturePrintObservation.ComputeDistance(System.Single[]@,Vision.VNFeaturePrintObservation,Foundation.NSError@)
 M:Vision.VNGenerateOpticalFlowRequest.#ctor(CoreGraphics.CGImage,ImageIO.CGImagePropertyOrientation,Vision.VNImageOptions,Vision.VNRequestCompletionHandler)


### PR DESCRIPTION
Improve XML documentation for:

- `NSZone`
- `GLKMesh`
- `MTKMesh`
- `HMService`
- `VTPropertyOptions`
- `VTUtilities`
- `INPriceRangeOption`
- `INPriceRange`
- `NSRunLoop`
- `NSRunLoopModeExtensions`

Each type is documented in a separate commit. The Cecil documentation baseline is updated for the newly documented `VTUtilities` API.

🤖 Pull request created by Copilot