### PR TITLE
[registrar] Look up trimmed-away protocol interface methods in the pre-trim assemblies.

### DIFF
--- a/tests/xharness/Jenkins/TestVariationsFactory.cs
+++ b/tests/xharness/Jenkins/TestVariationsFactory.cs
@@ -96,6 +96,12 @@ namespace Xharness.Jenkins {
 				yield return new TestData { Variation = "Release (link sdk)", TestVariation = "release|linksdk", Ignored = ignore };
 				yield return new TestData { Variation = "Release (link all)", TestVariation = "release|linkall", Ignored = ignore };
 				yield return new TestData { Variation = $"{test.ProjectConfiguration} (PrepareAssemblies)", TestVariation = "prepare-assemblies", Ignored = ignore };
+				// With PrepareAssemblies the registrar runs in a separate process after the trimmer, so it
+				// can't get any information from the trimmer directly, and has to look up trimmed-away
+				// metadata in the pre-trim assemblies instead. Enable the trimmer (linksdk), because
+				// otherwise nothing is trimmed away and none of this is exercised.
+				if (supports_coreclr)
+					yield return new TestData { Variation = $"{test.ProjectConfiguration} (PrepareAssemblies, Trimmable Static Registrar, link sdk)", TestVariation = "linksdk|prepare-assemblies|trimmable-static-registrar", Ignored = ignore };
 				// Explicitly disable the trimmer (dontlink) and enable InlineDlfcnMethods together with
 				// PrepareAssemblies to exercise the inlined-dlfcn native symbol generation when the trimmer
 				// is skipped. On .NET 11+ this is already covered by the plain 'prepare-assemblies' variation

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -416,13 +416,21 @@ namespace Registrar {
 
 				foreach (var ifaceMethod in impl.Overrides) {
 					var ifaceMethodDef = ifaceMethod.Resolve ();
-					if (!iface_methods.Contains (ifaceMethodDef)) {
-						// The type may implement interfaces which aren't protocol interfaces, so this is OK.
-					} else {
-						iface_methods.Remove (ifaceMethodDef);
-
-						AddMethodMapping (ref rv, impl, ifaceMethodDef);
+					if (ifaceMethodDef is null || !iface_methods.Contains (ifaceMethodDef)) {
+						// 'iface_methods' may contain methods from the pre-trim assemblies, which won't be
+						// reference-equal to the resolved method (and the resolved method may not even exist
+						// anymore if it's been trimmed away), so also try matching by name.
+						ifaceMethodDef = iface_methods.FirstOrDefault (v => v.FullName == ifaceMethod.FullName);
 					}
+
+					if (ifaceMethodDef is null) {
+						// The type may implement interfaces which aren't protocol interfaces, so this is OK.
+						continue;
+					}
+
+					iface_methods.Remove (ifaceMethodDef);
+
+					AddMethodMapping (ref rv, impl, ifaceMethodDef);
 				}
 			}
 

--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -390,13 +390,21 @@ namespace Registrar {
 						if (!iface_methods.Contains (imethod))
 							iface_methods.Add (imethod);
 				}
-				if (!iface.HasMethods)
-					continue;
-
-				foreach (var imethod in iface.Methods) {
-					if (!iface_methods.Contains (imethod))
+				if (iface.HasMethods) {
+					foreach (var imethod in iface.Methods) {
+						if (!iface_methods.Contains (imethod))
+							iface_methods.Add (imethod);
+					}
+				}
+#if ASSEMBLY_PREPARER
+				// When post-processing assemblies, the protocol interface methods may have been trimmed
+				// away, and we're not in the same process as the trimmer, so we can't use the methods the
+				// trimmer stored for us. Instead look up any missing methods in the pre-trim assemblies.
+				foreach (var imethod in GetPreTrimMethods (iface)) {
+					if (!iface_methods.Any (v => v.FullName == imethod.FullName))
 						iface_methods.Add (imethod);
 				}
+#endif
 			}
 
 			// We only care about implementators declared in 'type'.
@@ -1533,6 +1541,23 @@ namespace Registrar {
 			}
 			return result;
 		}
+
+#if ASSEMBLY_PREPARER
+		// Returns the methods the given type had before it was trimmed. Returns an empty enumerable if the
+		// pre-trim assemblies aren't available (which is the case unless we're post-processing assemblies).
+		IEnumerable<MethodDefinition> GetPreTrimMethods (TypeDefinition type)
+		{
+			if (!App.IsPostProcessingAssemblies || App.PreTrimAssemblyResolver is null)
+				return [];
+
+			var preTrimAssembly = App.PreTrimAssemblyResolver.Resolve (type.Module.Assembly.Name);
+			var preTrimType = preTrimAssembly?.MainModule.GetType (type.FullName);
+			if (preTrimType is null || !preTrimType.HasMethods)
+				return [];
+
+			return preTrimType.Methods;
+		}
+#endif
 
 		protected override IEnumerable<ProtocolMemberAttribute> GetProtocolMemberAttributes (TypeReference type)
 		{

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -237,7 +237,10 @@ namespace Xamarin.Linker {
 			var process = false;
 			var isNSObject = IsNSObject (type);
 
-			if (App.Registrar == RegistrarMode.TrimmableStatic && !type.IsAbstract && !type.IsInterface && App.PrepareAssemblies == false) {
+			// The factory methods must be added before trimming: either in the assembly preparer (when
+			// PrepareAssemblies=true), or inside ILLink itself (when PrepareAssemblies=false). They must not
+			// be added again when post-processing assemblies, since they're already there at that point.
+			if (App.Registrar == RegistrarMode.TrimmableStatic && !type.IsAbstract && !type.IsInterface && !App.IsPostProcessingAssemblies) {
 				if (isNSObject) {
 					var ctorRef = AppBundleRewriter.FindNSObjectConstructor (type);
 					if (ctorRef is not null) {


### PR DESCRIPTION
The static registrar needs the protocol interface methods to figure out which
selector an implicit protocol implementation should be registered with (the
implementing method typically has no `[Export]` attribute of its own):

```csharp
class MyDataSource : NSObject, IUITableViewDataSource {
    // No [Export] here - the selector comes from IUITableViewDataSource.RowsInSection
    public nint RowsInSection (UITableView tableView, nint section) => 1;
}
```

The trimmer removes these interface methods, so `CollectUnmarkedMembersSubStep`
stores them in the `DerivedLinkContext` for the registrar to use later. That
handoff is in-memory, so it only works when the registrar runs in the same
process as the trimmer - which isn't the case when post-processing assemblies.

The result was that no selector was registered at all for implicit protocol
implementations in that flow, and calling the method from Objective-C failed
with `unrecognized selector sent to instance`.

Look the missing methods up in the pre-trim assemblies instead, which we
already have access to when post-processing assemblies (`GetProtocolMemberAttributes`
already uses them to read `[ProtocolMember]` attributes that have been trimmed away).

### Testing

Verified on a branch where the trimmable-static registrar is the default for CoreCLR.

🤖 Pull request created by Copilot
