### PR TITLE
[mono-api-html] Fix placeholder leak and add a test project

### DIFF
--- a/tools/api-tools/api-tools.slnx
+++ b/tools/api-tools/api-tools.slnx
@@ -1,0 +1,5 @@
+<Solution>
+  <Project Path="mono-api-info/mono-api-info.csproj" />
+  <Project Path="mono-api-html/mono-api-html.csproj" />
+  <Project Path="mono-api-html-tests/mono-api-html-tests.csproj" />
+</Solution>

--- a/tools/api-tools/mono-api-html-tests/ApiDiffTests.cs
+++ b/tools/api-tools/mono-api-html-tests/ApiDiffTests.cs
@@ -57,8 +57,10 @@ namespace MonoApiHtmlTests {
 				var html = File.ReadAllText (htmlFile);
 				var markdown = File.ReadAllText (markdownFile);
 
-				Assert.That (html, Does.Not.Contain ("THANREPLACEMENT"), "html placeholders");
-				Assert.That (markdown, Does.Not.Contain ("THANREPLACEMENT"), "markdown placeholders");
+				Assert.That (html, Does.Not.Contain ("%LESSERTHANREPLACEMENT%"), "html LesserThan placeholder");
+				Assert.That (html, Does.Not.Contain ("%GREATERTHANREPLACEMENT%"), "html GreaterThan placeholder");
+				Assert.That (markdown, Does.Not.Contain ("%LESSERTHANREPLACEMENT%"), "markdown LesserThan placeholder");
+				Assert.That (markdown, Does.Not.Contain ("%GREATERTHANREPLACEMENT%"), "markdown GreaterThan placeholder");
 
 				Assert.That (html, Does.Contain ("IEnumerable&lt;AuthorizationRight&gt;"), "html generic");
 				Assert.That (markdown, Does.Contain ("IEnumerable<AuthorizationRight>"), "markdown generic");

--- a/tools/api-tools/mono-api-html-tests/ApiDiffTests.cs
+++ b/tools/api-tools/mono-api-html-tests/ApiDiffTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.IO;
+
+using NUnit.Framework;
+
+using Mono.ApiTools;
+
+namespace MonoApiHtmlTests {
+
+	[TestFixture]
+	public class ApiDiffTests {
+
+		static string CreateApiInfo (string classes)
+		{
+			return $@"<assemblies>
+  <assembly name=""Microsoft.macOS"" version=""0.0.0.0"">
+    <namespaces>
+      <namespace name=""Security"">
+        <classes>{classes}</classes>
+      </namespace>
+    </namespaces>
+  </assembly>
+</assemblies>";
+		}
+
+		// A new type that implements generic interfaces used to leak the
+		// %LESSERTHANREPLACEMENT% / %GREATERTHANREPLACEMENT% placeholders into the
+		// generated output (see the MultiplexedFormatter raw Write path).
+		[Test]
+		public void GenericInterfacesDoNotLeakPlaceholders ()
+		{
+			var source = CreateApiInfo ("");
+			var target = CreateApiInfo (@"
+          <class name=""AuthorizationRights"" type=""class"" sealed=""true"" base=""ObjCRuntime.DisposableObject"">
+            <interfaces>
+              <interface name=""System.Collections.Generic.IEnumerable`1[Security.AuthorizationRight]"" />
+              <interface name=""System.Collections.Generic.IReadOnlyCollection`1[Security.AuthorizationRight]"" />
+            </interfaces>
+          </class>");
+
+			var sourceFile = Path.GetTempFileName ();
+			var targetFile = Path.GetTempFileName ();
+			var htmlFile = Path.GetTempFileName ();
+			var markdownFile = Path.GetTempFileName ();
+			try {
+				File.WriteAllText (sourceFile, source);
+				File.WriteAllText (targetFile, target);
+
+				var config = new ApiDiffFormattedConfig {
+					HtmlOutput = htmlFile,
+					MarkdownOutput = markdownFile,
+				};
+				ApiDiffFormatted.Generate (sourceFile, targetFile, config);
+
+				var html = File.ReadAllText (htmlFile);
+				var markdown = File.ReadAllText (markdownFile);
+
+				Assert.That (html, Does.Not.Contain ("THANREPLACEMENT"), "html placeholders");
+				Assert.That (markdown, Does.Not.Contain ("THANREPLACEMENT"), "markdown placeholders");
+
+				Assert.That (html, Does.Contain ("IEnumerable&lt;AuthorizationRight&gt;"), "html generic");
+				Assert.That (markdown, Does.Contain ("IEnumerable<AuthorizationRight>"), "markdown generic");
+			} finally {
+				File.Delete (sourceFile);
+				File.Delete (targetFile);
+				File.Delete (htmlFile);
+				File.Delete (markdownFile);
+			}
+		}
+	}
+}

--- a/tools/api-tools/mono-api-html-tests/mono-api-html-tests.csproj
+++ b/tools/api-tools/mono-api-html-tests/mono-api-html-tests.csproj
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net$(BundledNETCoreAppTargetFrameworkVersion)</TargetFramework>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
+		<PackageReference Include="NUnit" Version="$(NUnitPackageVersion)" />
+		<PackageReference Include="NUnit3TestAdapter" Version="$(NUnit3TestAdapterPackageVersion)" />
+		<PackageReference Include="NUnit.Analyzers" Version="$(NUnitAnalyzersPackageVersion)" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\mono-api-html\mono-api-html.csproj" />
+	</ItemGroup>
+</Project>

--- a/tools/api-tools/mono-api-html/MultiplexedFormatter.cs
+++ b/tools/api-tools/mono-api-html/MultiplexedFormatter.cs
@@ -242,14 +242,16 @@ namespace Mono.ApiTools {
 
 		public override void WriteLine (string format, params object [] arguments)
 		{
+			var line = string.Format (format, arguments);
 			foreach (var formatter in formatters)
-				formatter.WriteLine (Replace (formatter, string.Format (format, arguments)));
+				formatter.WriteLine (Replace (formatter, line));
 		}
 
 		public override void WriteLine (StringBuilder sb)
 		{
+			var line = sb.ToString ();
 			foreach (var formatter in formatters)
-				formatter.WriteLine (Replace (formatter, sb.ToString ()));
+				formatter.WriteLine (Replace (formatter, line));
 		}
 
 		public override void Write (char value)
@@ -266,14 +268,16 @@ namespace Mono.ApiTools {
 
 		public override void Write (string format, params object [] arguments)
 		{
+			var line = string.Format (format, arguments);
 			foreach (var formatter in formatters)
-				formatter.Write (Replace (formatter, string.Format (format, arguments)));
+				formatter.Write (Replace (formatter, line));
 		}
 
 		public override void Write (StringBuilder sb)
 		{
+			var line = sb.ToString ();
 			foreach (var formatter in formatters)
-				formatter.Write (Replace (formatter, sb.ToString ()));
+				formatter.Write (Replace (formatter, line));
 		}
 	}
 }

--- a/tools/api-tools/mono-api-html/MultiplexedFormatter.cs
+++ b/tools/api-tools/mono-api-html/MultiplexedFormatter.cs
@@ -237,19 +237,19 @@ namespace Mono.ApiTools {
 		public override void WriteLine (string line)
 		{
 			foreach (var formatter in formatters)
-				formatter.WriteLine (line);
+				formatter.WriteLine (Replace (formatter, line));
 		}
 
 		public override void WriteLine (string format, params object [] arguments)
 		{
 			foreach (var formatter in formatters)
-				formatter.WriteLine (format, arguments);
+				formatter.WriteLine (Replace (formatter, string.Format (format, arguments)));
 		}
 
 		public override void WriteLine (StringBuilder sb)
 		{
 			foreach (var formatter in formatters)
-				formatter.WriteLine (sb);
+				formatter.WriteLine (Replace (formatter, sb.ToString ()));
 		}
 
 		public override void Write (char value)
@@ -261,19 +261,19 @@ namespace Mono.ApiTools {
 		public override void Write (string line)
 		{
 			foreach (var formatter in formatters)
-				formatter.Write (line);
+				formatter.Write (Replace (formatter, line));
 		}
 
 		public override void Write (string format, params object [] arguments)
 		{
 			foreach (var formatter in formatters)
-				formatter.Write (format, arguments);
+				formatter.Write (Replace (formatter, string.Format (format, arguments)));
 		}
 
 		public override void Write (StringBuilder sb)
 		{
 			foreach (var formatter in formatters)
-				formatter.Write (sb);
+				formatter.Write (Replace (formatter, sb.ToString ()));
 		}
 	}
 }


### PR DESCRIPTION
We've had a few regressions in mono-api-html, so this fixes the latest one and adds a unit test project to guard against future ones.

## The bug

The `MultiplexedFormatter` builds descriptions using the placeholder tokens `%LESSERTHANREPLACEMENT%` / `%GREATERTHANREPLACEMENT%`, because a single shared description string must be converted into each sub-formatter's own representation (`&lt;`/`&gt;` for HTML, `<`/`>` for markdown). The structured methods already convert these via `Replace ()`, but the raw `Write`/`WriteLine` string overloads did not.

The "New Type" addition path (`ClassComparer.AddedInner`) writes generic interface lists such as `IEnumerable<AuthorizationRight>` directly through `Output.Write`, so the placeholders leaked verbatim into the generated HTML (and markdown), e.g.:

    IEnumerable%LESSERTHANREPLACEMENT%AuthorizationRight%GREATERTHANREPLACEMENT%

Applying `Replace ()` in the six string-based `Write`/`WriteLine` overloads converts the placeholders per sub-formatter on this path too.

## Tests & solution

* Added `tools/api-tools/mono-api-html-tests`, an NUnit test project that references `mono-api-html`. The first test drives the public `ApiDiffFormatted.Generate` over in-memory api-info XML (the exact `AuthorizationRights` case), producing both HTML and markdown, and asserts no `*THANREPLACEMENT` tokens leak and that the generic interface renders correctly in both formats. Verified the test fails without the fix.

* Added `tools/api-tools/api-tools.slnx` referencing `mono-api-info`, `mono-api-html` and the new test project, so `dotnet test` in `tools/api-tools` builds all three and runs the tests.

🤖 Pull request created by Copilot