### PR TITLE
[docs] Improve XML docs for ten types

### DIFF
--- a/src/CoreMotion/Defs.cs
+++ b/src/CoreMotion/Defs.cs
@@ -168,7 +168,6 @@ namespace CoreMotion {
 
 	// untyped enum -> CMDeviceMotion.h
 	/// <summary>An enumeration whose values specify the quality of the magnetometer calibration.</summary>
-	///     <remarks>To be added.</remarks>
 	public enum CMMagneticFieldCalibrationAccuracy {
 		/// <summary>Magnetic calibration has not occurred.</summary>
 		Uncalibrated = -1,

--- a/src/CoreTelephony/CTEnums.cs
+++ b/src/CoreTelephony/CTEnums.cs
@@ -27,15 +27,17 @@ namespace CoreTelephony {
 		NotRestricted,
 	}
 
+	/// <summary>Enumerates the results of adding a cellular plan.</summary>
 	[MacCatalyst (13, 1)]
 	[Native]
 	public enum CTCellularPlanProvisioningAddPlanResult : long {
-		/// <summary>To be added.</summary>
+		/// <summary>The result is unknown.</summary>
 		Unknown,
-		/// <summary>To be added.</summary>
+		/// <summary>The cellular plan could not be added.</summary>
 		Fail,
-		/// <summary>To be added.</summary>
+		/// <summary>The cellular plan was added successfully.</summary>
 		Success,
+		/// <summary>The operation was canceled.</summary>
 		[iOS (17, 0)]
 		Cancel,
 	}

--- a/src/CoreTelephony/CTEnums.cs
+++ b/src/CoreTelephony/CTEnums.cs
@@ -19,11 +19,11 @@ namespace CoreTelephony {
 	[MacCatalyst (13, 1)]
 	[Native]
 	public enum CTCellularDataRestrictedState : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>The cellular data restriction state is unknown.</summary>
 		Unknown,
-		/// <summary>To be added.</summary>
+		/// <summary>Cellular data access is restricted.</summary>
 		Restricted,
-		/// <summary>To be added.</summary>
+		/// <summary>Cellular data access is not restricted.</summary>
 		NotRestricted,
 	}
 

--- a/src/CoreTelephony/CTEnums.cs
+++ b/src/CoreTelephony/CTEnums.cs
@@ -7,11 +7,11 @@ namespace CoreTelephony {
 	// in header file this is used inside a CTError structure where the domain is a SInt32
 	/// <summary>An enumeration whose values specify an error domain.</summary>
 	public enum CTErrorDomain {
-		/// <summary>To be added.</summary>
+		/// <summary>No error occurred.</summary>
 		NoError = 0,
-		/// <summary>To be added.</summary>
+		/// <summary>The error is in the POSIX error domain.</summary>
 		Posix = 1,
-		/// <summary>To be added.</summary>
+		/// <summary>The error is in the Mach error domain.</summary>
 		Mach = 2,
 	}
 

--- a/src/EventKitUI/Defs.cs
+++ b/src/EventKitUI/Defs.cs
@@ -14,12 +14,11 @@ namespace EventKitUI {
 	// untyped enum -> EKCalendarChooser.h
 	// iOS 9 promoted this to an NSInteger - which breaks compatibility
 	/// <summary>An enumeration whose values specify whether a single or multiple calendars can be chosen by an <see cref="EventKitUI.EKCalendarChooser" /> object.</summary>
-	///     <remarks>To be added.</remarks>
 	[Native]
 	public enum EKCalendarChooserSelectionStyle : long {
-		/// <summary>To be added.</summary>
+		/// <summary>Allows the user to select one calendar.</summary>
 		Single,
-		/// <summary>To be added.</summary>
+		/// <summary>Allows the user to select multiple calendars.</summary>
 		Multiple,
 	}
 

--- a/src/EventKitUI/Defs.cs
+++ b/src/EventKitUI/Defs.cs
@@ -25,12 +25,11 @@ namespace EventKitUI {
 	// untyped enum -> EKCalendarChooser.h
 	// iOS 9 promoted this to an NSInteger - which breaks compatibility
 	/// <summary>An enumeration whose values specify which calendars are displayed by a <see cref="EventKitUI.EKCalendarChooser" />.</summary>
-	///     <remarks>To be added.</remarks>
 	[Native]
 	public enum EKCalendarChooserDisplayStyle : long {
-		/// <summary>To be added.</summary>
+		/// <summary>Displays all calendars.</summary>
 		AllCalendars,
-		/// <summary>To be added.</summary>
+		/// <summary>Displays only calendars that the user can modify.</summary>
 		WritableCalendarsOnly,
 	}
 

--- a/src/EventKitUI/Defs.cs
+++ b/src/EventKitUI/Defs.cs
@@ -36,7 +36,6 @@ namespace EventKitUI {
 	// untyped enum -> EKEventViewController.h
 	// iOS 9 promoted this to an NSInteger - which breaks compatibility
 	/// <summary>Enumerates actions that a user can take to dismiss an event view controller.</summary>
-	///     <remarks>To be added.</remarks>
 	[Native]
 	public enum EKEventViewAction : long {
 		/// <summary>The user tapped "Done".</summary>

--- a/src/EventKitUI/Defs.cs
+++ b/src/EventKitUI/Defs.cs
@@ -49,7 +49,6 @@ namespace EventKitUI {
 	// untyped enum -> EKEventEditViewController.h
 	// iOS 9 promoted this to an NSInteger - which breaks compatibility
 	/// <summary>Enumerates possible actions that a user can take when editing a view.</summary>
-	///     <remarks>To be added.</remarks>
 	[Native]
 	public enum EKEventEditViewAction : long {
 		/// <summary>The user canceled the change to the event.</summary>

--- a/src/SafariServices/SSEnums.cs
+++ b/src/SafariServices/SSEnums.cs
@@ -11,7 +11,7 @@
 namespace SafariServices {
 
 	// NSInteger -> SSReadingList.h
-	/// <summary>An enumeration that specify possible errors associated with adding a URL to the Safari Reading List.</summary>
+	/// <summary>Enumerates errors that can occur when adding a URL to the Safari Reading List.</summary>
 	[NoMac]
 	[MacCatalyst (14, 0)]
 	[Native ("SSReadingListErrorCode")]

--- a/src/SafariServices/SSEnums.cs
+++ b/src/SafariServices/SSEnums.cs
@@ -17,7 +17,7 @@ namespace SafariServices {
 	[Native ("SSReadingListErrorCode")]
 	[ErrorDomain ("SSReadingListErrorDomain")]
 	public enum SSReadingListError : long {
-		/// <summary>To be added.</summary>
+		/// <summary>The URL scheme is not supported by the Safari Reading List.</summary>
 		UrlSchemeNotAllowed = 1,
 	}
 

--- a/src/VideoSubscriberAccount/VSAccountProviderAuthenticationScheme.cs
+++ b/src/VideoSubscriberAccount/VSAccountProviderAuthenticationScheme.cs
@@ -12,7 +12,7 @@ namespace VideoSubscriberAccount {
 
 		/// <summary>Gets the native constants for the specified authentication schemes.</summary>
 		/// <param name="self">The authentication schemes to convert.</param>
-		/// <returns>The native constant for each authentication scheme.</returns>
+		/// <returns>The native constant for each authentication scheme. An element is <see langword="null" /> if the corresponding authentication scheme has no associated native constant on the current platform.</returns>
 		/// <exception cref="ArgumentNullException"><paramref name="self" /> is <see langword="null" />.</exception>
 		public static NSString? [] GetConstants (this VSAccountProviderAuthenticationScheme [] self)
 		{
@@ -29,6 +29,7 @@ namespace VideoSubscriberAccount {
 		/// <param name="constants">The native constants to convert.</param>
 		/// <returns>The authentication scheme for each native constant.</returns>
 		/// <exception cref="ArgumentNullException"><paramref name="constants" /> is <see langword="null" />.</exception>
+		/// <exception cref="NotSupportedException">An element in <paramref name="constants" /> has no associated authentication scheme on the current platform.</exception>
 		public static VSAccountProviderAuthenticationScheme [] GetValues (NSString [] constants)
 		{
 			if (constants is null)

--- a/src/VideoSubscriberAccount/VSAccountProviderAuthenticationScheme.cs
+++ b/src/VideoSubscriberAccount/VSAccountProviderAuthenticationScheme.cs
@@ -5,14 +5,15 @@ using System.Threading.Tasks;
 
 namespace VideoSubscriberAccount {
 
+	/// <summary>Provides conversions between authentication scheme values and their native constants.</summary>
 	public static partial class VSAccountProviderAuthenticationSchemeExtensions {
 
 		// these are less common pattern so it's not automatically generated
 
-		/// <param name="self">The instance on which this method operates.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets the native constants for the specified authentication schemes.</summary>
+		/// <param name="self">The authentication schemes to convert.</param>
+		/// <returns>The native constant for each authentication scheme.</returns>
+		/// <exception cref="ArgumentNullException"><paramref name="self" /> is <see langword="null" />.</exception>
 		public static NSString? [] GetConstants (this VSAccountProviderAuthenticationScheme [] self)
 		{
 			if (self is null)
@@ -24,10 +25,10 @@ namespace VideoSubscriberAccount {
 			return array;
 		}
 
-		/// <param name="constants">To be added.</param>
-		///         <summary>To be added.</summary>
-		///         <returns>To be added.</returns>
-		///         <remarks>To be added.</remarks>
+		/// <summary>Gets the authentication schemes for the specified native constants.</summary>
+		/// <param name="constants">The native constants to convert.</param>
+		/// <returns>The authentication scheme for each native constant.</returns>
+		/// <exception cref="ArgumentNullException"><paramref name="constants" /> is <see langword="null" />.</exception>
 		public static VSAccountProviderAuthenticationScheme [] GetValues (NSString [] constants)
 		{
 			if (constants is null)

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -2758,7 +2758,6 @@ F:CoreSpotlight.CSUserInteraction.Focus
 F:CoreSpotlight.CSUserInteraction.Select
 F:CoreTelephony.CTCellularPlanCapability.AndVoice
 F:CoreTelephony.CTCellularPlanCapability.Only
-F:CoreTelephony.CTCellularPlanProvisioningAddPlanResult.Cancel
 F:CoreText.CTFontManagerError.AssetNotFound
 F:CoreText.CTFontManagerError.CancelledByUser
 F:CoreText.CTFontManagerError.DuplicatedName
@@ -23903,7 +23902,6 @@ T:CoreTelephony.CTCellularPlanCapability
 T:CoreTelephony.CTCellularPlanProperties
 T:CoreTelephony.CTCellularPlanProvisioning
 T:CoreTelephony.CTCellularPlanProvisioningAddPlanCompletionHandler
-T:CoreTelephony.CTCellularPlanProvisioningAddPlanResult
 T:CoreTelephony.CTCellularPlanProvisioningRequest
 T:CoreTelephony.CTCellularPlanProvisioningUpdateCellularPlanCompletionHandler
 T:CoreTelephony.CTCellularPlanStatus


### PR DESCRIPTION
Improve XML documentation for:

- `VSAccountProviderAuthenticationSchemeExtensions`
- `EKCalendarChooserSelectionStyle`
- `EKCalendarChooserDisplayStyle`
- `EKEventViewAction`
- `EKEventEditViewAction`
- `CMMagneticFieldCalibrationAccuracy`
- `SSReadingListError`
- `CTErrorDomain`
- `CTCellularDataRestrictedState`
- `CTCellularPlanProvisioningAddPlanResult`

Each type is documented in a separate commit. The Cecil documentation baseline is updated for the newly documented `CTCellularPlanProvisioningAddPlanResult` API.

🤖 Pull request created by Copilot