### PR TITLE
[dotnet] Make trimmable-static the default registrar for CoreCLR too in .NET 11+.

### DIFF
--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -61,10 +61,10 @@
 
 		<!--
 			Enable the PrepareAssemblies flow by default for CoreCLR and NativeAOT on .NET 11+. This runs our
-			custom linker steps in the assembly-preparer, and for the (CoreCLR/NativeAOT-default) trimmable-static
-			registrar it also generates the native static registrar code *after* the NativeAOT compiler (ILC) has
-			run (see _PostprocessAssembliesAfterIlc), so the registrar can drop the native code for
-			UnmanagedCallersOnly trampolines ILC trimmed away (an app-size optimization).
+			custom linker steps in the assembly-preparer. For NativeAOT it additionally generates the native
+			static registrar code *after* the NativeAOT compiler (ILC) has run (see
+			_PostprocessAssembliesAfterIlc, which is NativeAOT-only), so the registrar can drop the native code
+			for the UnmanagedCallersOnly trampolines ILC trimmed away (an app-size optimization).
 
 			This is *required* for the trimmable-static registrar to produce a small app: the assembly-preparer
 			writes the generated type map assemblies to disk (marked with [AssemblyMetadata ("IsTrimmable", "True")])
@@ -73,8 +73,9 @@
 			action - which means they're not trimmed, and since they reference every Objective-C type in the app,
 			nothing else can be trimmed either (that made apps ~3x larger).
 
-			The $(Registrar) check means an app that explicitly opts back in to the managed-static registrar
-			doesn't get PrepareAssemblies enabled - that combination makes apps *larger*.
+			The $(Registrar) check means a CoreCLR app that explicitly opts back in to the managed-static
+			registrar doesn't get PrepareAssemblies enabled - that combination makes apps *larger*. NativeAOT
+			always gets PrepareAssemblies regardless of the registrar, which is the pre-existing behavior.
 		-->
 		<PrepareAssemblies Condition="'$(PrepareAssemblies)' == '' And '$(UseMonoRuntime)' != 'true' And ('$(_UseNativeAot)' == 'true' Or '$(Registrar)' == 'trimmable-static') And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '11.0'))">true</PrepareAssemblies>
 

--- a/dotnet/targets/Xamarin.Shared.Sdk.props
+++ b/dotnet/targets/Xamarin.Shared.Sdk.props
@@ -41,37 +41,49 @@
 		<_UseNativeAot Condition="'$(PublishAot)' == 'true' And '$(_IsPublishing)' == 'true'">true</_UseNativeAot>
 
 		<!--
-			On .NET 11+, make the trimmable-static registrar the default for NativeAOT (it used to be
-			managed-static). This has to be set here, at evaluation time, and not only in the SelectRegistrar
-			target (which runs later), because the static _SkipILLink / _PostprocessAssembliesAfterIlc gates
-			check the registrar at evaluation time.
-
-			This is deliberately scoped to NativeAOT: the trimmable-static registrar only produces a *smaller*
-			app under NativeAOT (where the TypeMap feature and the post-ILC registrar reorder let us trim the
-			registered binding surface). On Mono/CoreCLR the trimmable-static registrar keeps the whole
-			registered NSObject surface and makes apps 2-3x *larger*, so those runtimes keep managed-static.
+			These have to be computed here, before the registrar defaults below, because those check
+			$(UseMonoRuntime) at evaluation time.
 		-->
-		<Registrar Condition="'$(Registrar)' == '' And '$(_UseNativeAot)' == 'true' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '11.0'))">trimmable-static</Registrar>
+		<UseMonoRuntime Condition=" '$(UseMonoRuntime)' == '' And '$(_PlatformName)' == 'macOS'">false</UseMonoRuntime>
+		<UseMonoRuntime Condition=" '$(UseMonoRuntime)' == '' And '$(_UseNativeAot)' == 'true'">false</UseMonoRuntime>
+		<UseMonoRuntime Condition=" '$(UseMonoRuntime)' == ''">true</UseMonoRuntime>
 
 		<!--
-			Enable the PrepareAssemblies flow by default for NativeAOT on .NET 11+. This runs our custom linker
-			steps in the assembly-preparer, and for the (NativeAOT-default) trimmable-static registrar it also
-			generates the native static registrar code *after* the NativeAOT compiler (ILC) has run (see
-			_PostprocessAssembliesAfterIlc), so the registrar can drop the native code for UnmanagedCallersOnly
-			trampolines ILC trimmed away (an app-size optimization).
+			On .NET 11+, make the trimmable-static registrar the default for both CoreCLR and NativeAOT (it used
+			to be managed-static, and before that the trimmable-static registrar was only the default for
+			NativeAOT). This has to be set here, at evaluation time, and not only in the SelectRegistrar target
+			(which runs later), because the static _SkipILLink / _PostprocessAssembliesAfterIlc gates check the
+			registrar at evaluation time.
+
+			Mono keeps the managed-static registrar.
 		-->
-		<PrepareAssemblies Condition="'$(PrepareAssemblies)' == '' And '$(_UseNativeAot)' == 'true' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '11.0'))">true</PrepareAssemblies>
+		<Registrar Condition="'$(Registrar)' == '' And '$(UseMonoRuntime)' != 'true' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '11.0'))">trimmable-static</Registrar>
+
+		<!--
+			Enable the PrepareAssemblies flow by default for CoreCLR and NativeAOT on .NET 11+. This runs our
+			custom linker steps in the assembly-preparer, and for the (CoreCLR/NativeAOT-default) trimmable-static
+			registrar it also generates the native static registrar code *after* the NativeAOT compiler (ILC) has
+			run (see _PostprocessAssembliesAfterIlc), so the registrar can drop the native code for
+			UnmanagedCallersOnly trampolines ILC trimmed away (an app-size optimization).
+
+			This is *required* for the trimmable-static registrar to produce a small app: the assembly-preparer
+			writes the generated type map assemblies to disk (marked with [AssemblyMetadata ("IsTrimmable", "True")])
+			before the trimmer runs, so the trimmer treats them as ordinary trimmable input assemblies. Without it
+			the type map assemblies are created from inside the trimmer, where they end up with the 'copy' assembly
+			action - which means they're not trimmed, and since they reference every Objective-C type in the app,
+			nothing else can be trimmed either (that made apps ~3x larger).
+
+			The $(Registrar) check means an app that explicitly opts back in to the managed-static registrar
+			doesn't get PrepareAssemblies enabled - that combination makes apps *larger*.
+		-->
+		<PrepareAssemblies Condition="'$(PrepareAssemblies)' == '' And '$(UseMonoRuntime)' != 'true' And ('$(_UseNativeAot)' == 'true' Or '$(Registrar)' == 'trimmable-static') And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '11.0'))">true</PrepareAssemblies>
 
 		<!--
 			PostProcessAssemblies defaults to $(PrepareAssemblies) (see Xamarin.Shared.targets), but the static
 			_PostprocessAssembliesAfterIlc gate reads it at evaluation time - earlier than that default runs - so
 			apply the same $(PrepareAssemblies) default here too, otherwise the gate wouldn't see it.
 		-->
-		<PostProcessAssemblies Condition="'$(PostProcessAssemblies)' == '' And '$(_UseNativeAot)' == 'true' And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '11.0'))">$(PrepareAssemblies)</PostProcessAssemblies>
-
-		<UseMonoRuntime Condition=" '$(UseMonoRuntime)' == '' And '$(_PlatformName)' == 'macOS'">false</UseMonoRuntime>
-		<UseMonoRuntime Condition=" '$(UseMonoRuntime)' == '' And '$(_UseNativeAot)' == 'true'">false</UseMonoRuntime>
-		<UseMonoRuntime Condition=" '$(UseMonoRuntime)' == ''">true</UseMonoRuntime>
+		<PostProcessAssemblies Condition="'$(PostProcessAssemblies)' == '' And '$(UseMonoRuntime)' != 'true' And ('$(_UseNativeAot)' == 'true' Or '$(Registrar)' == 'trimmable-static') And $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '11.0'))">$(PrepareAssemblies)</PostProcessAssemblies>
 
 		<AfterMicrosoftNETSdkTargets>$(AfterMicrosoftNETSdkTargets);$(MSBuildThisFileDirectory)Microsoft.$(_PlatformName).Sdk.targets</AfterMicrosoftNETSdkTargets>
 

--- a/dotnet/targets/Xamarin.Shared.Sdk.targets
+++ b/dotnet/targets/Xamarin.Shared.Sdk.targets
@@ -554,9 +554,8 @@
 					- NativeAOT supported platforms in all configurations
 					- ios/tvos device builds in all configurations
 					- macOS/MacCatalyst builds in release configuration
-				  (On .NET 11+ NativeAOT defaults to 'trimmable-static' instead - that's set earlier, at
-				  evaluation time, in Xamarin.Shared.Sdk.props. The trimmable-static registrar is only smaller
-				  under NativeAOT, so the other runtimes keep managed-static.)
+				  (On .NET 11+ CoreCLR and NativeAOT default to 'trimmable-static' instead - that's set earlier,
+				  at evaluation time, in Xamarin.Shared.Sdk.props. Mono keeps managed-static.)
 				- Set 'partial-static' for:
 					- when no assemblies are trimmed and when MarshalManagedExceptionMode is default (or not set)
 				- Otherwise set 'dynamic' 


### PR DESCRIPTION
The trimmable-static registrar has been the default for NativeAOT on .NET 11+ since #26346. This makes it the default for **CoreCLR** as well, and enables the `PrepareAssemblies` flow along with it.

Mono keeps the managed-static registrar — only CoreCLR and NativeAOT were measured and tested.

## Why `PrepareAssemblies` has to come along

`PrepareAssemblies=true` is *required* for the trimmable-static registrar to produce a small app.

The assembly-preparer writes the generated type map assemblies to disk (marked with `[AssemblyMetadata ("IsTrimmable", "True")]`) *before* the trimmer runs, so the trimmer treats them as ordinary trimmable input assemblies. Without it, the type map assemblies are created from inside the trimmer, where they end up with the `copy` assembly action — which means they're never trimmed, and since they reference every Objective-C type in the app, nothing else can be trimmed either.

That's what made trimmable-static apps ~3x larger on CoreCLR, and it's why the old comment claimed the trimmable-static registrar couldn't be used outside of NativeAOT. That comment was simply wrong, and has been rewritten.

## Notes

- The `$(UseMonoRuntime)` defaults had to be **moved above** the registrar defaults, because the latter now check `$(UseMonoRuntime)` at evaluation time and would otherwise read an empty value. This also matches the layout on `net11.0`, which reduces the merge conflict when this flows.
- The `$(Registrar)` check on `PrepareAssemblies`/`PostProcessAssemblies` means a CoreCLR app that explicitly opts back in to the managed-static registrar doesn't get `PrepareAssemblies` enabled — that combination makes apps *larger*. NativeAOT keeps getting `PrepareAssemblies` regardless of the registrar (pre-existing behavior).
- **This is inert on `main`**, since `main` is still .NET 10. It takes effect when it flows into `net11.0`.

## Verification

Verified by evaluating the properties with the version gate temporarily lowered to `10.0`:

| Configuration                     | Registrar          | PrepareAssemblies |
|-----------------------------------|--------------------|-------------------|
| macOS (CoreCLR)                   | `trimmable-static` | `true`            |
| iOS (Mono, the default)           | (unset)            | `false`           |
| iOS `UseMonoRuntime=false`        | `trimmable-static` | `true`            |
| iOS `PublishAot=true`             | `trimmable-static` | `true`            |
| macOS `Registrar=managed-static`  | `managed-static`   | `false`           |

Functionally, monotouch-test was run in the trimmable-static + `PrepareAssemblies` configuration while the three bugs fixed in #26403 were being tracked down: 3672 tests on Mac Catalyst and 3580 on macOS, with no failures attributable to this configuration.

## Two consequences worth a reviewer's opinion

1. **Debug builds are affected too.** Because `Registrar` is set in `.props` at evaluation time, this bypasses `SelectRegistrar`, including for Debug builds and for plain `dotnet build` (the old `_UseNativeAot` gate only applied on *publish*). A macOS Debug build goes from `partial-static` to `trimmable-static` + `PrepareAssemblies`, so the assembly-preparer/post-processor now runs on every incremental Debug build. On `main` that's macOS only; on `net11.0`, where `UseMonoRuntime` defaults to `false` everywhere, it's all Debug builds. This looked functionally fine in testing, but if we'd rather keep Debug builds on the cheaper registrar, that's easy to add.

2. **Default macOS builds now skip ILLink.** With `_LinkMode=None` → `TrimMode=copy` plus the now-default `PrepareAssemblies`/`PostProcessAssemblies`, `_CanSkipTrimmer` is satisfied and ILLink becomes a no-op — our custom steps all run in the assembly-preparer instead. This is the intended `_CanSkipTrimmer` optimization from #26193 and the path the app-size tests already exercise, but it does become the default for macOS apps here.

🤖 Pull request created by Copilot
