### PR TITLE
[dotnet-linker] Relocate generic registrar trampolines into the companion assembly for Hot Reload

### DIFF
--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -2718,11 +2718,12 @@ namespace ObjCRuntime {
 		// it. This reflection-based dispatch is only ever used under a Hot-Reload-compatible build,
 		// which always runs under the JIT (never NativeAOT), so MakeGenericMethod is safe.
 		//
-		// 'args' holds the leading arguments of the helper (the instance followed by the native
-		// arguments); this method appends the trailing 'out IntPtr exception_gchandle' slot, invokes
-		// the closed helper, and returns its (boxed) native return value. Any failure is caught and
-		// reported through 'exception_gchandle' so no exception escapes the UnmanagedCallersOnly
-		// boundary.
+		// 'args' holds all the arguments of the helper: the instance, followed by the native
+		// arguments, followed by the trailing 'out IntPtr exception_gchandle' slot. The callback
+		// allocates the array with that extra slot so that no copy is needed here. This method
+		// invokes the closed helper and returns its (boxed) native return value. Any failure is
+		// caught and reported through 'exception_gchandle' so no exception escapes the
+		// UnmanagedCallersOnly boundary.
 		internal static object? InvokeGenericRegistrarTrampoline (object instance, RuntimeTypeHandle open_user_type_handle, RuntimeMethodHandle open_impl_method_handle, object? [] args, out IntPtr exception_gchandle)
 		{
 			// This method uses reflection (MakeGenericMethod + MethodInfo.Invoke), which requires
@@ -2754,14 +2755,13 @@ namespace ObjCRuntime {
 					ClosedGenericRegistrarTrampolines.Cache.TryAdd (cache_key, closed_impl);
 				}
 
-				// Append the trailing 'out IntPtr exception_gchandle' slot and invoke the closed helper.
-				// The slot is pre-initialized to IntPtr.Zero so that the (success) code path, which
-				// leaves the byref output untouched, reports "no exception".
-				var full = new object? [args.Length + 1];
-				Array.Copy (args, full, args.Length);
-				full [args.Length] = IntPtr.Zero;
-				var rv = closed_impl.Invoke (null, full);
-				exception_gchandle = (IntPtr) (full [args.Length] ?? IntPtr.Zero);
+				// The trailing 'out IntPtr exception_gchandle' slot is pre-initialized to IntPtr.Zero so
+				// that the (success) code path, which leaves the byref output untouched, reports "no
+				// exception".
+				var exception_slot = args.Length - 1;
+				args [exception_slot] = IntPtr.Zero;
+				var rv = closed_impl.Invoke (null, args);
+				exception_gchandle = (IntPtr) (args [exception_slot] ?? IntPtr.Zero);
 				return rv;
 			} catch (Exception e) {
 				exception_gchandle = AllocGCHandle (e);

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -2690,6 +2690,21 @@ namespace ObjCRuntime {
 			return parameters [parameter].ParameterType.GetElementType ()!; // FIX NAMING
 		}
 
+		// Caches the closed generic helper method per (open helper method, closed instance type), so
+		// that the reflection cost (FindClosedTypeInHierarchy + MakeGenericMethod) is only paid once
+		// per instantiation instead of on every call.
+		//
+		// The cache lives in a nested type (rather than as a field initializer on Runtime) so its
+		// ConcurrentDictionary instantiation is constructed by the nested type's static constructor
+		// - which only runs the first time InvokeGenericRegistrarTrampoline actually accesses it.
+		// InvokeGenericRegistrarTrampoline is only ever reachable under a Hot-Reload-compatible
+		// build, so in every other configuration (e.g. Release/NativeAOT) the trampoline is trimmed
+		// and this nested type - together with the ConcurrentDictionary instantiation - is trimmed
+		// with it, keeping it out of Runtime's static constructor and out of the app.
+		static class ClosedGenericRegistrarTrampolines {
+			internal static readonly ConcurrentDictionary<(RuntimeMethodHandle OpenImplMethod, RuntimeTypeHandle ClosedInstanceType), MethodInfo> Cache = new ();
+		}
+
 		// Invokes a relocated generic registrar trampoline helper.
 		//
 		// When the trimmable static registrar relocates the registrar trampolines into a companion
@@ -2708,21 +2723,6 @@ namespace ObjCRuntime {
 		// the closed helper, and returns its (boxed) native return value. Any failure is caught and
 		// reported through 'exception_gchandle' so no exception escapes the UnmanagedCallersOnly
 		// boundary.
-		// Caches the closed generic helper method per (open helper method, closed instance type), so
-		// that the reflection cost (FindClosedTypeInHierarchy + MakeGenericMethod) is only paid once
-		// per instantiation instead of on every call.
-		//
-		// The cache lives in a nested type (rather than as a field initializer on Runtime) so its
-		// ConcurrentDictionary instantiation is constructed by the nested type's static constructor
-		// - which only runs the first time InvokeGenericRegistrarTrampoline actually accesses it.
-		// InvokeGenericRegistrarTrampoline is only ever reachable under a Hot-Reload-compatible
-		// build, so in every other configuration (e.g. Release/NativeAOT) the trampoline is trimmed
-		// and this nested type - together with the ConcurrentDictionary instantiation - is trimmed
-		// with it, keeping it out of Runtime's static constructor and out of the app.
-		static class ClosedGenericRegistrarTrampolines {
-			internal static readonly ConcurrentDictionary<(RuntimeMethodHandle OpenImplMethod, RuntimeTypeHandle ClosedInstanceType), MethodInfo> Cache = new ();
-		}
-
 		internal static object? InvokeGenericRegistrarTrampoline (object instance, RuntimeTypeHandle open_user_type_handle, RuntimeMethodHandle open_impl_method_handle, object? [] args, out IntPtr exception_gchandle)
 		{
 			// This method uses reflection (MakeGenericMethod + MethodInfo.Invoke), which requires
@@ -2739,7 +2739,7 @@ namespace ObjCRuntime {
 				var closed_instance_type = instance.GetType ();
 				var cache_key = (open_impl_method_handle, closed_instance_type.TypeHandle);
 				MethodInfo closed_impl;
-				if (ClosedGenericRegistrarTrampolines.Cache.TryGetValue (cache_key, out var cached_impl) && cached_impl is not null) {
+				if (ClosedGenericRegistrarTrampolines.Cache.TryGetValue (cache_key, out var cached_impl)) {
 					closed_impl = cached_impl;
 				} else {
 					var open_user_type = Type.GetTypeFromHandle (open_user_type_handle);

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -10,6 +10,7 @@
 
 #nullable enable
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -2707,17 +2708,27 @@ namespace ObjCRuntime {
 		// the closed helper, and returns its (boxed) native return value. Any failure is caught and
 		// reported through 'exception_gchandle' so no exception escapes the UnmanagedCallersOnly
 		// boundary.
+		// Caches the closed generic helper method per (open helper method, closed instance type), so
+		// that the reflection cost (FindClosedTypeInHierarchy + MakeGenericMethod) is only paid once
+		// per instantiation instead of on every call.
+		static readonly ConcurrentDictionary<(RuntimeMethodHandle OpenImplMethod, RuntimeTypeHandle ClosedInstanceType), MethodInfo> closedGenericRegistrarTrampolines = new ();
+
 		[UnconditionalSuppressMessage ("", "IL2060", Justification = "This code is only reachable under a Hot-Reload-compatible build, which always runs under the JIT (never NativeAOT), so MakeGenericMethod is safe. The generic helper and its instantiations are kept alive by the companion assembly.")]
 		[UnconditionalSuppressMessage ("", "IL3050", Justification = "This code is only reachable under a Hot-Reload-compatible build, which always runs under the JIT (never NativeAOT), so MakeGenericMethod is safe.")]
 		internal static object? InvokeGenericRegistrarTrampoline (object instance, RuntimeTypeHandle open_user_type_handle, RuntimeMethodHandle open_impl_method_handle, object? [] args, out IntPtr exception_gchandle)
 		{
 			exception_gchandle = IntPtr.Zero;
 			try {
-				var open_user_type = Type.GetTypeFromHandle (open_user_type_handle)!;
-				var closed_user_type = FindClosedTypeInHierarchy (open_user_type, instance.GetType ())!;
-				var type_arguments = closed_user_type.GetGenericArguments ();
-				var open_impl = (MethodInfo) MethodBase.GetMethodFromHandle (open_impl_method_handle)!;
-				var closed_impl = open_impl.MakeGenericMethod (type_arguments);
+				var closed_instance_type = instance.GetType ();
+				var cache_key = (open_impl_method_handle, closed_instance_type.TypeHandle);
+				if (!closedGenericRegistrarTrampolines.TryGetValue (cache_key, out var closed_impl)) {
+					var open_user_type = Type.GetTypeFromHandle (open_user_type_handle)!;
+					var closed_user_type = FindClosedTypeInHierarchy (open_user_type, closed_instance_type)!;
+					var type_arguments = closed_user_type.GetGenericArguments ();
+					var open_impl = (MethodInfo) MethodBase.GetMethodFromHandle (open_impl_method_handle)!;
+					closed_impl = open_impl.MakeGenericMethod (type_arguments);
+					closedGenericRegistrarTrampolines.TryAdd (cache_key, closed_impl);
+				}
 
 				// Append the trailing 'out IntPtr exception_gchandle' slot and invoke the closed helper.
 				// The slot is pre-initialized to IntPtr.Zero so that the (success) code path, which

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -2711,7 +2711,17 @@ namespace ObjCRuntime {
 		// Caches the closed generic helper method per (open helper method, closed instance type), so
 		// that the reflection cost (FindClosedTypeInHierarchy + MakeGenericMethod) is only paid once
 		// per instantiation instead of on every call.
-		static readonly ConcurrentDictionary<(RuntimeMethodHandle OpenImplMethod, RuntimeTypeHandle ClosedInstanceType), MethodInfo> closedGenericRegistrarTrampolines = new ();
+		//
+		// The cache lives in a nested type (rather than as a field initializer on Runtime) so its
+		// ConcurrentDictionary instantiation is constructed by the nested type's static constructor
+		// - which only runs the first time InvokeGenericRegistrarTrampoline actually accesses it.
+		// InvokeGenericRegistrarTrampoline is only ever reachable under a Hot-Reload-compatible
+		// build, so in every other configuration (e.g. Release/NativeAOT) the trampoline is trimmed
+		// and this nested type - together with the ConcurrentDictionary instantiation - is trimmed
+		// with it, keeping it out of Runtime's static constructor and out of the app.
+		static class ClosedGenericRegistrarTrampolines {
+			internal static readonly ConcurrentDictionary<(RuntimeMethodHandle OpenImplMethod, RuntimeTypeHandle ClosedInstanceType), MethodInfo> Cache = new ();
+		}
 
 		[UnconditionalSuppressMessage ("", "IL2060", Justification = "This code is only reachable under a Hot-Reload-compatible build, which always runs under the JIT (never NativeAOT), so MakeGenericMethod is safe. The generic helper and its instantiations are kept alive by the companion assembly.")]
 		[UnconditionalSuppressMessage ("", "IL3050", Justification = "This code is only reachable under a Hot-Reload-compatible build, which always runs under the JIT (never NativeAOT), so MakeGenericMethod is safe.")]
@@ -2722,7 +2732,7 @@ namespace ObjCRuntime {
 				var closed_instance_type = instance.GetType ();
 				var cache_key = (open_impl_method_handle, closed_instance_type.TypeHandle);
 				MethodInfo closed_impl;
-				if (closedGenericRegistrarTrampolines.TryGetValue (cache_key, out var cached_impl) && cached_impl is not null) {
+				if (ClosedGenericRegistrarTrampolines.Cache.TryGetValue (cache_key, out var cached_impl) && cached_impl is not null) {
 					closed_impl = cached_impl;
 				} else {
 					var open_user_type = Type.GetTypeFromHandle (open_user_type_handle);
@@ -2734,7 +2744,7 @@ namespace ObjCRuntime {
 					if (MethodBase.GetMethodFromHandle (open_impl_method_handle) is not MethodInfo open_impl)
 						throw new InvalidOperationException ("Could not resolve the generic helper method of a relocated registrar trampoline.");
 					closed_impl = open_impl.MakeGenericMethod (closed_user_type.GetGenericArguments ());
-					closedGenericRegistrarTrampolines.TryAdd (cache_key, closed_impl);
+					ClosedGenericRegistrarTrampolines.Cache.TryAdd (cache_key, closed_impl);
 				}
 
 				// Append the trailing 'out IntPtr exception_gchandle' slot and invoke the closed helper.

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -2689,6 +2689,51 @@ namespace ObjCRuntime {
 			return parameters [parameter].ParameterType.GetElementType ()!; // FIX NAMING
 		}
 
+		// Invokes a relocated generic registrar trampoline helper.
+		//
+		// When the trimmable static registrar relocates the registrar trampolines into a companion
+		// assembly (for Hot Reload, so the user assembly stays unmodified), the trampoline for a
+		// method declared in a generic type can't be relocated as-is: the static UnmanagedCallersOnly
+		// callback doesn't know the generic parameters of the instance, and we can't add the
+		// virtual-dispatch proxy to the user type (that would modify the user assembly). Instead we
+		// emit a *generic* helper method ('open_impl' below) into the companion assembly whose body
+		// performs the type-parameter-aware conversions, and the static callback dispatches to it
+		// here: we close the generic helper over the instance's actual generic arguments and invoke
+		// it. This reflection-based dispatch is only ever used under a Hot-Reload-compatible build,
+		// which always runs under the JIT (never NativeAOT), so MakeGenericMethod is safe.
+		//
+		// 'args' holds the leading arguments of the helper (the instance followed by the native
+		// arguments); this method appends the trailing 'out IntPtr exception_gchandle' slot, invokes
+		// the closed helper, and returns its (boxed) native return value. Any failure is caught and
+		// reported through 'exception_gchandle' so no exception escapes the UnmanagedCallersOnly
+		// boundary.
+		[UnconditionalSuppressMessage ("", "IL2060", Justification = "This code is only reachable under a Hot-Reload-compatible build, which always runs under the JIT (never NativeAOT), so MakeGenericMethod is safe. The generic helper and its instantiations are kept alive by the companion assembly.")]
+		[UnconditionalSuppressMessage ("", "IL3050", Justification = "This code is only reachable under a Hot-Reload-compatible build, which always runs under the JIT (never NativeAOT), so MakeGenericMethod is safe.")]
+		internal static object? InvokeGenericRegistrarTrampoline (object instance, RuntimeTypeHandle open_user_type_handle, RuntimeMethodHandle open_impl_method_handle, object? [] args, out IntPtr exception_gchandle)
+		{
+			exception_gchandle = IntPtr.Zero;
+			try {
+				var open_user_type = Type.GetTypeFromHandle (open_user_type_handle)!;
+				var closed_user_type = FindClosedTypeInHierarchy (open_user_type, instance.GetType ())!;
+				var type_arguments = closed_user_type.GetGenericArguments ();
+				var open_impl = (MethodInfo) MethodBase.GetMethodFromHandle (open_impl_method_handle)!;
+				var closed_impl = open_impl.MakeGenericMethod (type_arguments);
+
+				// Append the trailing 'out IntPtr exception_gchandle' slot and invoke the closed helper.
+				// The slot is pre-initialized to IntPtr.Zero so that the (success) code path, which
+				// leaves the byref output untouched, reports "no exception".
+				var full = new object? [args.Length + 1];
+				Array.Copy (args, full, args.Length);
+				full [args.Length] = IntPtr.Zero;
+				var rv = closed_impl.Invoke (null, full);
+				exception_gchandle = (IntPtr) full [args.Length]!;
+				return rv;
+			} catch (Exception e) {
+				exception_gchandle = AllocGCHandle (e);
+				return null;
+			}
+		}
+
 		// This method might be called by the generated code from the managed static registrar.
 		static void TraceCaller (string message)
 		{

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -2723,10 +2723,17 @@ namespace ObjCRuntime {
 			internal static readonly ConcurrentDictionary<(RuntimeMethodHandle OpenImplMethod, RuntimeTypeHandle ClosedInstanceType), MethodInfo> Cache = new ();
 		}
 
-		[UnconditionalSuppressMessage ("", "IL2060", Justification = "This code is only reachable under a Hot-Reload-compatible build, which always runs under the JIT (never NativeAOT), so MakeGenericMethod is safe. The generic helper and its instantiations are kept alive by the companion assembly.")]
-		[UnconditionalSuppressMessage ("", "IL3050", Justification = "This code is only reachable under a Hot-Reload-compatible build, which always runs under the JIT (never NativeAOT), so MakeGenericMethod is safe.")]
 		internal static object? InvokeGenericRegistrarTrampoline (object instance, RuntimeTypeHandle open_user_type_handle, RuntimeMethodHandle open_impl_method_handle, object? [] args, out IntPtr exception_gchandle)
 		{
+			// This method uses reflection (MakeGenericMethod + MethodInfo.Invoke), which requires
+			// dynamic code and isn't supported by NativeAOT. It's only ever reached under a
+			// Hot-Reload-compatible build, which always runs under the JIT (never NativeAOT). The
+			// IsNativeAOT check is optimizable, so the linker folds it to a constant and removes the
+			// reflection code below as unreachable in a NativeAOT build - which also elides the
+			// IL2060/IL3050 trimmer/AOT warnings that MakeGenericMethod would otherwise produce.
+			if (IsNativeAOT)
+				throw CreateNativeAOTNotSupportedException ();
+
 			exception_gchandle = IntPtr.Zero;
 			try {
 				var closed_instance_type = instance.GetType ();

--- a/src/ObjCRuntime/Runtime.cs
+++ b/src/ObjCRuntime/Runtime.cs
@@ -2721,12 +2721,19 @@ namespace ObjCRuntime {
 			try {
 				var closed_instance_type = instance.GetType ();
 				var cache_key = (open_impl_method_handle, closed_instance_type.TypeHandle);
-				if (!closedGenericRegistrarTrampolines.TryGetValue (cache_key, out var closed_impl)) {
-					var open_user_type = Type.GetTypeFromHandle (open_user_type_handle)!;
-					var closed_user_type = FindClosedTypeInHierarchy (open_user_type, closed_instance_type)!;
-					var type_arguments = closed_user_type.GetGenericArguments ();
-					var open_impl = (MethodInfo) MethodBase.GetMethodFromHandle (open_impl_method_handle)!;
-					closed_impl = open_impl.MakeGenericMethod (type_arguments);
+				MethodInfo closed_impl;
+				if (closedGenericRegistrarTrampolines.TryGetValue (cache_key, out var cached_impl) && cached_impl is not null) {
+					closed_impl = cached_impl;
+				} else {
+					var open_user_type = Type.GetTypeFromHandle (open_user_type_handle);
+					if (open_user_type is null)
+						throw new InvalidOperationException ("Could not resolve the open generic type of a relocated registrar trampoline.");
+					var closed_user_type = FindClosedTypeInHierarchy (open_user_type, closed_instance_type);
+					if (closed_user_type is null)
+						throw new InvalidOperationException ($"Could not find the type '{open_user_type.FullName}' in the type hierarchy of '{closed_instance_type.FullName}'.");
+					if (MethodBase.GetMethodFromHandle (open_impl_method_handle) is not MethodInfo open_impl)
+						throw new InvalidOperationException ("Could not resolve the generic helper method of a relocated registrar trampoline.");
+					closed_impl = open_impl.MakeGenericMethod (closed_user_type.GetGenericArguments ());
 					closedGenericRegistrarTrampolines.TryAdd (cache_key, closed_impl);
 				}
 
@@ -2737,7 +2744,7 @@ namespace ObjCRuntime {
 				Array.Copy (args, full, args.Length);
 				full [args.Length] = IntPtr.Zero;
 				var rv = closed_impl.Invoke (null, full);
-				exception_gchandle = (IntPtr) full [args.Length]!;
+				exception_gchandle = (IntPtr) (full [args.Length] ?? IntPtr.Zero);
 				return rv;
 			} catch (Exception e) {
 				exception_gchandle = AllocGCHandle (e);

--- a/tests/assembly-preparer/PreserveBlockCodeHandlerTests.cs
+++ b/tests/assembly-preparer/PreserveBlockCodeHandlerTests.cs
@@ -45,8 +45,9 @@ public class PreserveBlockCodeHandlerTests : BaseClass {
 		Assert.That ((string) attribs [0].ConstructorArguments [1].Value, Is.EqualTo ("ObjCRuntime.Trampolines.SDInnerBlock"), "First attribute's second argument");
 		Assert.That ((string) attribs [0].ConstructorArguments [2].Value, Is.EqualTo ("Test"), "First attribute's third argument");
 
-		// Invoke method: DDA(string memberSignature) - same declaring type, so simpler constructor
+		// Invoke method: DDA(string memberSignature) - same declaring type, so simpler constructor.
+		// The signature doesn't include the parameter list, because there's only one method named 'Invoke'.
 		Assert.That (attribs [1].ConstructorArguments.Count, Is.EqualTo (1), "Second attribute's argument count");
-		Assert.That ((string) attribs [1].ConstructorArguments [0].Value, Is.EqualTo ("Invoke(System.IntPtr,System.Int32)"), "Second attribute's first argument");
+		Assert.That ((string) attribs [1].ConstructorArguments [0].Value, Is.EqualTo ("Invoke"), "Second attribute's first argument");
 	}
 }

--- a/tests/assembly-preparer/PreserveSmartEnumConversionsTest.cs
+++ b/tests/assembly-preparer/PreserveSmartEnumConversionsTest.cs
@@ -103,7 +103,8 @@ public class PreserveSmartEnumConversionsTests : BaseClass {
 
 		void AssertHasDynamicDependencies (ICustomAttributeProvider provider)
 		{
-			AssertHasDynamicDependency (provider, "GetConstant(CoreAnimation.CAToneMapMode)", "CoreAnimation.CAToneMapModeExtensions", $"Microsoft.{platform.AsString ()}");
+			// 'GetConstant' has no parameter list, because it's the only method with that name (unlike 'GetValue').
+			AssertHasDynamicDependency (provider, "GetConstant", "CoreAnimation.CAToneMapModeExtensions", $"Microsoft.{platform.AsString ()}");
 			AssertHasDynamicDependency (provider, "GetValue(Foundation.NSString)", "CoreAnimation.CAToneMapModeExtensions", $"Microsoft.{platform.AsString ()}");
 		}
 

--- a/tests/assembly-preparer/RelocateRegistrarTrampolinesTests.cs
+++ b/tests/assembly-preparer/RelocateRegistrarTrampolinesTests.cs
@@ -103,6 +103,12 @@ public class RelocateRegistrarTrampolinesTests : BaseClass {
 			{
 				return value;
 			}
+
+			[Export (""computeValue:result:"")]
+			public void ComputeValue (int value, out T result)
+			{
+				result = null;
+			}
 		}
 		";
 
@@ -161,6 +167,17 @@ public class RelocateRegistrarTrampolinesTests : BaseClass {
 		var doSomethingHelper = genericHelpers.Single (v => v.Name.Contains ("DoSomething"));
 		Assert.That (doSomethingHelper.Parameters.Count, Is.GreaterThanOrEqualTo (1), "The generic helper should have at least a 'self' parameter");
 		Assert.That (doSomethingHelper.Parameters [0].Name, Is.EqualTo ("self"), "The generic helper's first parameter should be 'self'");
+
+		// A generic helper for a method with an out/ref parameter represents that parameter as a
+		// plain IntPtr: a pointer can't round-trip through reflection's object[] (it isn't boxable
+		// and MethodInfo.Invoke can't marshal it), so the out/ref (native pointer) parameter is
+		// passed as an IntPtr and the write-back happens through that pointer inside the helper body.
+		var computeHelper = genericHelpers.Single (v => v.Name.Contains ("ComputeValue"));
+		var outParameter = computeHelper.Parameters.Single (v => v.Name == "p1");
+		Assert.That (outParameter.ParameterType.FullName, Is.EqualTo ("System.IntPtr"), "The generic helper's out parameter should be typed IntPtr");
+		// A normal by-value parameter is unaffected: it keeps its native value type.
+		var valueParameter = computeHelper.Parameters.Single (v => v.Name == "p0");
+		Assert.That (valueParameter.ParameterType.FullName, Is.EqualTo ("System.Int32"), "The generic helper's by-value parameter should keep its native value type");
 
 		// The companion must be granted access to the user assembly.
 		var ignoresAccessChecksTo = companionAssembly.CustomAttributes

--- a/tests/assembly-preparer/RelocateRegistrarTrampolinesTests.cs
+++ b/tests/assembly-preparer/RelocateRegistrarTrampolinesTests.cs
@@ -75,6 +75,101 @@ public class RelocateRegistrarTrampolinesTests : BaseClass {
 		Assert.That (ignoresAccessChecksTo, Does.Contain ("Test"), "The companion should have [IgnoresAccessChecksTo(\"Test\")]");
 	}
 
+	// When HotReloadCompatibleBuild is enabled with the TrimmableStatic registrar, the registrar
+	// trampolines for methods declared in a *generic* NSObject subclass must also be relocated into
+	// the companion assembly, without modifying the user assembly. Historically these were handled
+	// by adding a proxy interface (and its implementation) onto the user type, which modified the
+	// user assembly; instead they must now be dispatched via a generic helper + reflection emitted
+	// entirely into the companion.
+	[Test]
+	[TestCase (ApplePlatform.iOS, false)]
+	[TestCase (ApplePlatform.MacCatalyst, false)]
+	[TestCase (ApplePlatform.MacOSX, true)]
+	public void GenericTrampolinesAreRelocated (ApplePlatform platform, bool isCoreCLR)
+	{
+		var code = @"
+		using System;
+		using Foundation;
+		using ObjCRuntime;
+
+		public class MyGeneric<T> : NSObject where T : NSObject {
+			[Export (""doSomething:"")]
+			public void DoSomething (T value)
+			{
+			}
+
+			[Export (""roundtrip:"")]
+			public T Roundtrip (T value)
+			{
+				return value;
+			}
+		}
+		";
+
+		AssertPrepareHotReloadTrimmableStatic (platform, isCoreCLR, code, out var userAssemblyWasSaved, out var userAssembly, out var companionAssembly);
+
+		// The whole point of relocating the trampolines is to keep the user assembly
+		// byte-unmodified, so the assembly-preparer must not re-save it.
+		Assert.That (userAssemblyWasSaved, Is.False, "The user assembly should not have been modified/re-saved");
+
+		// The user assembly must not contain any registrar callback trampolines.
+		var userCallbackTypes = AllTypes (userAssembly).Where (v => v.Name == "__Registrar_Callbacks__").ToList ();
+		Assert.That (userCallbackTypes, Is.Empty, "The user assembly should not contain any __Registrar_Callbacks__ type");
+
+		// The user assembly must not contain any generated proxy interface type.
+		var proxyInterfaceTypes = AllTypes (userAssembly).Where (v => v.Name.StartsWith ("__IRegistrarGenericTypeProxy__", StringComparison.Ordinal)).ToList ();
+		Assert.That (proxyInterfaceTypes, Is.Empty, "The user assembly should not contain any generated proxy interface type");
+
+		var myGeneric = AllTypes (userAssembly).Single (v => v.Name == "MyGeneric`1");
+
+		// The user type must not implement any generated proxy interface.
+		var proxyInterfaceImpls = myGeneric.Interfaces.Where (v => v.InterfaceType.Name.StartsWith ("__IRegistrarGenericTypeProxy__", StringComparison.Ordinal)).ToList ();
+		Assert.That (proxyInterfaceImpls, Is.Empty, "The user type should not implement any generated proxy interface");
+
+		// The user type must not have a generated proxy implementation method.
+		var proxyImplMethods = myGeneric.Methods.Where (v => v.Name.StartsWith ("__IRegistrarGenericTypeProxy__", StringComparison.Ordinal)).ToList ();
+		Assert.That (proxyImplMethods, Is.Empty, "The user type should not have a generated proxy implementation method");
+
+		// The user methods must not have [DynamicDependency] attributes pointing at the trampolines.
+		foreach (var method in myGeneric.Methods) {
+			var dda = method.CustomAttributes.Where (v => v.AttributeType.Name == "DynamicDependencyAttribute" && v.ConstructorArguments.Any (a => a.Value is string s && s.StartsWith ("callback_", StringComparison.Ordinal))).ToList ();
+			Assert.That (dda, Is.Empty, $"The user method {method.Name} should not have a [DynamicDependency] attribute pointing at a trampoline");
+		}
+
+		// The user type's static constructor must not have been given a [DynamicDependency] attribute
+		// (that's how the proxy interface used to be kept alive - it modified the user assembly).
+		var staticCtor = myGeneric.Methods.SingleOrDefault (v => v.IsConstructor && v.IsStatic);
+		if (staticCtor is not null) {
+			var dda = staticCtor.CustomAttributes.Where (v => v.AttributeType.Name == "DynamicDependencyAttribute").ToList ();
+			Assert.That (dda, Is.Empty, "The user type's static constructor should not have a [DynamicDependency] attribute");
+		}
+
+		// The companion assembly must contain a top-level __Registrar_Callbacks__ type.
+		var companionCallbackType = companionAssembly.MainModule.Types.SingleOrDefault (v => v.Name == "__Registrar_Callbacks__" && v.DeclaringType is null);
+		Assert.That (companionCallbackType, Is.Not.Null, "The companion assembly should contain a top-level __Registrar_Callbacks__ type");
+
+		// The companion must contain the UnmanagedCallersOnly trampolines...
+		var trampolines = companionCallbackType.Methods.Where (v => v.CustomAttributes.Any (a => a.AttributeType.Name == "UnmanagedCallersOnlyAttribute")).ToList ();
+		Assert.That (trampolines.Count, Is.GreaterThanOrEqualTo (1), "The companion should contain at least one [UnmanagedCallersOnly] trampoline");
+
+		// ...as well as the generic helper methods the trampolines dispatch to via reflection.
+		var genericHelpers = companionCallbackType.Methods.Where (v => v.HasGenericParameters).ToList ();
+		Assert.That (genericHelpers.Count, Is.GreaterThanOrEqualTo (1), "The companion should contain at least one generic dispatch helper method");
+
+		// The generic helper's first parameter is the instance (self), typed as the user generic type
+		// closed over the helper's own generic parameters.
+		var doSomethingHelper = genericHelpers.Single (v => v.Name.Contains ("DoSomething"));
+		Assert.That (doSomethingHelper.Parameters.Count, Is.GreaterThanOrEqualTo (1), "The generic helper should have at least a 'self' parameter");
+		Assert.That (doSomethingHelper.Parameters [0].Name, Is.EqualTo ("self"), "The generic helper's first parameter should be 'self'");
+
+		// The companion must be granted access to the user assembly.
+		var ignoresAccessChecksTo = companionAssembly.CustomAttributes
+			.Where (v => v.AttributeType.Name == "IgnoresAccessChecksToAttribute")
+			.Select (v => (string) v.ConstructorArguments [0].Value)
+			.ToList ();
+		Assert.That (ignoresAccessChecksTo, Does.Contain ("Test"), "The companion should have [IgnoresAccessChecksTo(\"Test\")]");
+	}
+
 	static IEnumerable<TypeDefinition> AllTypes (AssemblyDefinition assembly)
 	{
 		foreach (var type in assembly.MainModule.Types) {

--- a/tests/assembly-preparer/RelocateRegistrarTrampolinesTests.cs
+++ b/tests/assembly-preparer/RelocateRegistrarTrampolinesTests.cs
@@ -163,20 +163,21 @@ public class RelocateRegistrarTrampolinesTests : BaseClass {
 		Assert.That (genericHelpers.Count, Is.GreaterThanOrEqualTo (1), "The companion should contain at least one generic dispatch helper method");
 
 		// The generic helper's first parameter is the instance (self), typed as the user generic type
-		// closed over the helper's own generic parameters.
+		// closed over the helper's own generic parameters. The remaining parameters are the native
+		// arguments ('sel', p0, ...), followed by the exception GCHandle.
 		var doSomethingHelper = genericHelpers.Single (v => v.Name.Contains ("DoSomething"));
-		Assert.That (doSomethingHelper.Parameters.Count, Is.GreaterThanOrEqualTo (1), "The generic helper should have at least a 'self' parameter");
-		Assert.That (doSomethingHelper.Parameters [0].Name, Is.EqualTo ("self"), "The generic helper's first parameter should be 'self'");
+		Assert.That (doSomethingHelper.Parameters.Count, Is.GreaterThanOrEqualTo (1), "The generic helper should have at least an instance parameter");
+		Assert.That (doSomethingHelper.Parameters [0].ParameterType.Name, Is.EqualTo ("MyGeneric`1"), "The generic helper's first parameter should be the instance");
 
 		// A generic helper for a method with an out/ref parameter represents that parameter as a
 		// plain IntPtr: a pointer can't round-trip through reflection's object[] (it isn't boxable
 		// and MethodInfo.Invoke can't marshal it), so the out/ref (native pointer) parameter is
 		// passed as an IntPtr and the write-back happens through that pointer inside the helper body.
 		var computeHelper = genericHelpers.Single (v => v.Name.Contains ("ComputeValue"));
-		var outParameter = computeHelper.Parameters.Single (v => v.Name == "p1");
+		var outParameter = computeHelper.Parameters [3];
 		Assert.That (outParameter.ParameterType.FullName, Is.EqualTo ("System.IntPtr"), "The generic helper's out parameter should be typed IntPtr");
 		// A normal by-value parameter is unaffected: it keeps its native value type.
-		var valueParameter = computeHelper.Parameters.Single (v => v.Name == "p0");
+		var valueParameter = computeHelper.Parameters [2];
 		Assert.That (valueParameter.ParameterType.FullName, Is.EqualTo ("System.Int32"), "The generic helper's by-value parameter should keep its native value type");
 
 		// The companion must be granted access to the user assembly.

--- a/tests/xharness/Jenkins/TestVariationsFactory.cs
+++ b/tests/xharness/Jenkins/TestVariationsFactory.cs
@@ -130,8 +130,10 @@ namespace Xharness.Jenkins {
 					if (supports_coreclr)
 						yield return new TestData { Variation = "Debug (trimmable static registrar)", TestVariation = "trimmable-static-registrar", Ignored = ignore };
 					yield return new TestData { Variation = "Release (managed static registrar, all optimizations)", TestVariation = "release|managed-static-registrar-all-optimizations-linkall", Ignored = ignore };
-					if (supports_coreclr)
-						yield return new TestData { Variation = "Release (trimmable static registrar, all optimizations)", TestVariation = "trimmable-static-registrar-all-optimizations-linkall", Ignored = ignore };
+					if (supports_coreclr) {
+						yield return new TestData { Variation = "Debug (trimmable static registrar, all optimizations)", TestVariation = "trimmable-static-registrar-all-optimizations-linkall", Ignored = ignore };
+						yield return new TestData { Variation = "Release (trimmable static registrar, all optimizations)", TestVariation = "release|trimmable-static-registrar-all-optimizations-linkall", Ignored = ignore };
+					}
 					yield return new TestData { Variation = "Release (NativeAOT)", TestVariation = "release|nativeaot", Ignored = ignore };
 					yield return new TestData { Variation = "Release (trimmable static registrar, NativeAOT)", TestVariation = "trimmable-static-registrar|release|nativeaot", Ignored = ignore };
 					break;
@@ -151,8 +153,10 @@ namespace Xharness.Jenkins {
 					if (supports_coreclr)
 						yield return new TestData { Variation = "Debug (trimmable static registrar)", TestVariation = "trimmable-static-registrar", Ignored = ignore };
 					yield return new TestData { Variation = "Release (managed static registrar, all optimizations)", TestVariation = "release|managed-static-registrar-all-optimizations-linkall", Ignored = ignore };
-					if (supports_coreclr)
-						yield return new TestData { Variation = "Release (trimmable static registrar, all optimizations)", TestVariation = "trimmable-static-registrar-all-optimizations-linkall", Ignored = ignore };
+					if (supports_coreclr) {
+						yield return new TestData { Variation = "Debug (trimmable static registrar, all optimizations)", TestVariation = "trimmable-static-registrar-all-optimizations-linkall", Ignored = ignore };
+						yield return new TestData { Variation = "Release (trimmable static registrar, all optimizations)", TestVariation = "release|trimmable-static-registrar-all-optimizations-linkall", Ignored = ignore };
+					}
 					yield return new TestData { Variation = "Release (NativeAOT, x64)", TestVariation = "release|nativeaot", Ignored = !supports_x64 ? true : ignore, RuntimeIdentifier = x64_sim_runtime_identifier };
 					yield return new TestData { Variation = "Release (trimmable static registrar, NativeAOT, x64)", TestVariation = "trimmable-static-registrar|release|nativeaot", Ignored = !supports_x64 ? true : ignore, RuntimeIdentifier = x64_sim_runtime_identifier };
 					if (supports_interpreter) {
@@ -189,8 +193,10 @@ namespace Xharness.Jenkins {
 					if (supports_coreclr)
 						yield return new TestData { Variation = "Release (trimmable static registrar)", TestVariation = "trimmable-static-registrar", Ignored = ignore };
 					yield return new TestData { Variation = "Release (managed static registrar, all optimizations)", TestVariation = "release|managed-static-registrar-all-optimizations-linkall", Ignored = ignore };
-					if (supports_coreclr)
-						yield return new TestData { Variation = "Release (trimmable static registrar, all optimizations)", TestVariation = "trimmable-static-registrar-all-optimizations-linkall", Ignored = ignore };
+					if (supports_coreclr) {
+						yield return new TestData { Variation = "Debug (trimmable static registrar, all optimizations)", TestVariation = "trimmable-static-registrar-all-optimizations-linkall", Ignored = ignore };
+						yield return new TestData { Variation = "Release (trimmable static registrar, all optimizations)", TestVariation = "release|trimmable-static-registrar-all-optimizations-linkall", Ignored = ignore };
+					}
 					yield return new TestData { Variation = "Release (NativeAOT)", TestVariation = "release|nativeaot", Ignored = ignore };
 					yield return new TestData { Variation = "Release (NativeAOT, x64)", TestVariation = "release|nativeaot", Ignored = !supports_x64 ? true : ignore, RuntimeIdentifier = x64_runtime_identifier };
 					yield return new TestData { Variation = $"Release (NativeAOT, .NET 11 defaults)", TestVariation = "release|nativeaot-net11-defaults", Ignored = ignore };

--- a/tools/dotnet-linker/AppBundleRewriter.cs
+++ b/tools/dotnet-linker/AppBundleRewriter.cs
@@ -1133,6 +1133,20 @@ namespace Xamarin.Linker {
 			}
 		}
 
+		public MethodReference Runtime_InvokeGenericRegistrarTrampoline {
+			get {
+				return GetMethodReference (PlatformAssembly,
+						ObjCRuntime_Runtime, "InvokeGenericRegistrarTrampoline",
+						nameof (Runtime_InvokeGenericRegistrarTrampoline),
+						isStatic: true,
+						System_Object,
+						System_RuntimeTypeHandle,
+						System_RuntimeMethodHandle,
+						new ArrayType (System_Object),
+						new ByReferenceType (System_IntPtr));
+			}
+		}
+
 		public MethodReference BlockLiteral_CreateBlockForDelegate {
 			get {
 				return GetMethodReference (PlatformAssembly,

--- a/tools/dotnet-linker/AppBundleRewriter.cs
+++ b/tools/dotnet-linker/AppBundleRewriter.cs
@@ -1549,8 +1549,8 @@ namespace Xamarin.Linker {
 
 		/// <summary>
 		/// Returns the signature to use in a <c>[DynamicDependency]</c> attribute for a method: the
-		/// method name if no other method in the same type has that name, otherwise the full signature
-		/// (including the parameter list).
+		/// method name (and generic arity) if no other method in the same type has that name and
+		/// arity, otherwise the full signature (including the parameter list).
 		/// </summary>
 		/// <remarks>
 		///   <para>
@@ -1559,12 +1559,19 @@ namespace Xamarin.Linker {
 		///     reference (see <see cref="DocumentationComments.GetNameSignature (MethodDefinition)" />),
 		///     so use the name alone whenever it's unambiguous.
 		///   </para>
+		///   <para>
+		///     The trimmer matches a signature without a parameter list on both the name and the generic
+		///     arity, so methods that differ in arity (<c>Foo ()</c> vs <c>Foo&lt;T&gt; ()</c>) don't
+		///     collide and don't need a parameter list either.
+		///   </para>
 		/// </remarks>
 		static string GetDynamicDependencySignature (MethodDefinition method)
 		{
 			var count = 0;
 			foreach (var candidate in method.DeclaringType.Methods) {
 				if (candidate.Name != method.Name)
+					continue;
+				if (candidate.GenericParameters.Count != method.GenericParameters.Count)
 					continue;
 				if (++count > 1)
 					return DocumentationComments.GetSignature (method);

--- a/tools/dotnet-linker/AppBundleRewriter.cs
+++ b/tools/dotnet-linker/AppBundleRewriter.cs
@@ -1547,19 +1547,45 @@ namespace Xamarin.Linker {
 			return action == AssemblyAction.Link;
 		}
 
+		/// <summary>
+		/// Returns the signature to use in a <c>[DynamicDependency]</c> attribute for a method: the
+		/// method name if no other method in the same type has that name, otherwise the full signature
+		/// (including the parameter list).
+		/// </summary>
+		/// <remarks>
+		///   <para>
+		///     The trimmer only compares the parameter lists when the signature has one, and computing
+		///     the signature of a parameter crashes the trimmer if the parameter's type is a nested type
+		///     reference (see <see cref="DocumentationComments.GetNameSignature (MethodDefinition)" />),
+		///     so use the name alone whenever it's unambiguous.
+		///   </para>
+		/// </remarks>
+		static string GetDynamicDependencySignature (MethodDefinition method)
+		{
+			var count = 0;
+			foreach (var candidate in method.DeclaringType.Methods) {
+				if (candidate.Name != method.Name)
+					continue;
+				if (++count > 1)
+					return DocumentationComments.GetSignature (method);
+			}
+			return DocumentationComments.GetNameSignature (method);
+		}
+
 		public bool AddDynamicDependencyAttribute (MethodDefinition addToMethod, MethodDefinition dependsOn)
 		{
 			if (!IsAssemblyTrimmed (dependsOn))
 				return false;
 
+			var signature = GetDynamicDependencySignature (dependsOn);
 			if (addToMethod.DeclaringType == dependsOn.DeclaringType) {
-				var attribute = CreateDynamicDependencyAttribute (DocumentationComments.GetSignature (dependsOn));
+				var attribute = CreateDynamicDependencyAttribute (signature);
 				return AddAttributeOnlyOnce (addToMethod, attribute);
 			} else if (addToMethod.DeclaringType.Module == dependsOn.DeclaringType.Module) {
-				var attribute = CreateDynamicDependencyAttribute (DocumentationComments.GetSignature (dependsOn), dependsOn.DeclaringType);
+				var attribute = CreateDynamicDependencyAttribute (signature, dependsOn.DeclaringType);
 				return AddAttributeOnlyOnce (addToMethod, attribute);
 			} else {
-				var attribute = CreateDynamicDependencyAttribute (DocumentationComments.GetSignature (dependsOn), dependsOn.DeclaringType, dependsOn.DeclaringType.Module.Assembly);
+				var attribute = CreateDynamicDependencyAttribute (signature, dependsOn.DeclaringType, dependsOn.DeclaringType.Module.Assembly);
 				return AddAttributeOnlyOnce (addToMethod, attribute);
 			}
 		}
@@ -1625,6 +1651,11 @@ namespace Xamarin.Linker {
 		///     Instead add one DynamicDependency attribute per member declared on the type itself, and a single
 		///     DynamicDependency attribute for the interfaces the type implements.
 		///   </para>
+		///   <para>
+		///     Methods are preserved by name (without the parameter list), which preserves every overload -
+		///     which is what we want here anyway (and it avoids a trimmer crash, see
+		///     <see cref="DocumentationComments.GetNameSignature (MethodDefinition)" />).
+		///   </para>
 		/// </remarks>
 		/// <param name="addToMethod">The method on which to add the dynamic dependency attributes.</param>
 		/// <param name="type">The type whose members should be preserved.</param>
@@ -1638,7 +1669,7 @@ namespace Xamarin.Linker {
 			}
 			foreach (var method in type.Methods) {
 				if (!method.HasCustomAttribute ("System.Runtime.CompilerServices", "CompilerGeneratedAttribute"))
-					signatures.Add (DocumentationComments.GetSignature (method));
+					signatures.Add (DocumentationComments.GetNameSignature (method));
 			}
 			// Properties and events don't have a documentation comment signature helper, but the trimmer will
 			// match any member with the given name, which is good enough (and it's what we want here anyway).
@@ -1697,13 +1728,14 @@ namespace Xamarin.Linker {
 		public bool AddDynamicDependencyAttributeToStaticConstructor (TypeDefinition onType, MethodDefinition forMethod)
 		{
 			CustomAttribute attrib;
+			var signature = GetDynamicDependencySignature (forMethod);
 
 			if (onType == forMethod.DeclaringType) {
-				attrib = CreateDynamicDependencyAttribute (DocumentationComments.GetSignature (forMethod));
+				attrib = CreateDynamicDependencyAttribute (signature);
 			} else if (onType.Module == forMethod.DeclaringType.Module) {
-				attrib = CreateDynamicDependencyAttribute (DocumentationComments.GetSignature (forMethod), forMethod.DeclaringType);
+				attrib = CreateDynamicDependencyAttribute (signature, forMethod.DeclaringType);
 			} else {
-				attrib = CreateDynamicDependencyAttribute (DocumentationComments.GetSignature (forMethod), forMethod.DeclaringType, forMethod.Module.Assembly);
+				attrib = CreateDynamicDependencyAttribute (signature, forMethod.DeclaringType, forMethod.Module.Assembly);
 			}
 
 			return AddAttributeToStaticConstructor (onType, attrib);

--- a/tools/dotnet-linker/DocumentionComments.cs
+++ b/tools/dotnet-linker/DocumentionComments.cs
@@ -55,5 +55,27 @@ namespace Xamarin.Utils {
 
 			return docCommentId.Substring (methodNameStart);
 		}
+
+		/// <summary>
+		/// Returns the signature for a method without the parameter list (the method name, and the
+		/// generic arity if the method is generic). The trimmer will match any method with the given
+		/// name (and arity), which means every overload is preserved.
+		/// </summary>
+		/// <remarks>
+		///   <para>
+		///     This must be used when every overload should be preserved anyway, because the trimmer
+		///     crashes (NullReferenceException in DocumentationSignatureGenerator) when computing the
+		///     signature of a method whose parameters are nested types from another assembly, because
+		///     it only handles nested type definitions, not nested type references.
+		///   </para>
+		/// </remarks>
+		public static string GetNameSignature (MethodDefinition method)
+		{
+			var signature = GetSignature (method);
+			var parameterListStart = signature.IndexOf ('(');
+			if (parameterListStart == -1)
+				return signature;
+			return signature.Substring (0, parameterListStart);
+		}
 	}
 }

--- a/tools/dotnet-linker/DocumentionComments.cs
+++ b/tools/dotnet-linker/DocumentionComments.cs
@@ -68,6 +68,9 @@ namespace Xamarin.Utils {
 		///     signature of a method whose parameters are nested types from another assembly, because
 		///     it only handles nested type definitions, not nested type references.
 		///   </para>
+		///   <para>
+		///     Ref: https://github.com/dotnet/runtime/issues/131892
+		///   </para>
 		/// </remarks>
 		public static string GetNameSignature (MethodDefinition method)
 		{

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -1529,7 +1529,10 @@ namespace Xamarin.Linker {
 					if (toManaged) {
 						var gim = new GenericInstanceMethod (abr.NSArray_ArrayFromHandle_1);
 						if (gp is not null) {
-							var gemericParameter = method.DeclaringType.GenericParameters.Single (x => x.Name == gp.Name);
+							// When emitting the relocated generic companion helper, the generic parameter has
+							// already been remapped to one of the helper method's own generic parameters, and
+							// must be used as-is (a type generic parameter isn't valid in a static method).
+							var gemericParameter = gp.Type == GenericParameterType.Method ? gp : method.DeclaringType.GenericParameters.Single (x => x.Name == gp.Name);
 							gim.GenericArguments.Add (gemericParameter);
 						} else {
 							gim.GenericArguments.Add (elementType);

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -724,8 +724,31 @@ namespace Xamarin.Linker {
 
 			// return (<nativeReturnType>) rv;
 			if (!isVoid) {
-				il.Emit (OpCodes.Ldloc, resultVar);
-				il.Emit (OpCodes.Unbox_Any, callback.ReturnType);
+				var returnType = callback.ReturnType;
+				if (returnType.IsValueType) {
+					// InvokeGenericRegistrarTrampoline returns null on failure (the exception is
+					// reported through exception_gchandle). Unbox_Any on a null value type would
+					// throw a NullReferenceException that escapes the UnmanagedCallersOnly boundary,
+					// so return default (<nativeReturnType>) instead when the result is null.
+					var unboxResult = il.Create (OpCodes.Nop);
+					var returnResult = il.Create (OpCodes.Nop);
+					var defaultVar = body.AddVariable (returnType);
+					il.Emit (OpCodes.Ldloc, resultVar);
+					il.Emit (OpCodes.Brtrue, unboxResult);
+					// rv == null: return default (<nativeReturnType>)
+					il.Emit (OpCodes.Ldloca, defaultVar);
+					il.Emit (OpCodes.Initobj, returnType);
+					il.Emit (OpCodes.Ldloc, defaultVar);
+					il.Emit (OpCodes.Br, returnResult);
+					// rv != null: return (<nativeReturnType>) rv
+					il.Append (unboxResult);
+					il.Emit (OpCodes.Ldloc, resultVar);
+					il.Emit (OpCodes.Unbox_Any, returnType);
+					il.Append (returnResult);
+				} else {
+					il.Emit (OpCodes.Ldloc, resultVar);
+					il.Emit (OpCodes.Unbox_Any, returnType);
+				}
 			}
 			il.Emit (OpCodes.Ret);
 

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -89,12 +89,13 @@ namespace Xamarin.Linker {
 		// Whether the registrar trampolines for the given method should be relocated into the
 		// per-assembly companion assembly (_<Asm>.TypeMap.dll) instead of being emitted into the
 		// user assembly. This is required for Hot Reload (user assemblies must stay unmodified).
-		// Only non-generic types are relocated for now; generic-type proxies are a follow-up.
+		// This applies to both non-generic and generic declaring types (generic types dispatch to
+		// a relocated generic helper by reflection, see the generic branch in
+		// CreateUnmanagedCallersMethod).
 		bool ShouldRelocateTrampolines (MethodDefinition method)
 		{
 			return Configuration.HotReloadCompatibleBuild
-				&& App.Registrar == RegistrarMode.TrimmableStatic
-				&& !method.DeclaringType.HasGenericParameters;
+				&& App.Registrar == RegistrarMode.TrimmableStatic;
 		}
 
 		// Finds the companion assembly (_<Asm>.TypeMap) for the given user assembly among the loaded
@@ -483,6 +484,15 @@ namespace Xamarin.Linker {
 			var isGeneric = method.DeclaringType.HasGenericParameters;
 			if (isGeneric && method.IsStatic) {
 				throw ErrorHelper.CreateError (4130 /* The registrar cannot export static methods in generic classes ('{0}'). */, method.FullName);
+			} else if (relocate && isGeneric && !method.IsConstructor) {
+				// When relocating trampolines for Hot Reload we must not modify the user assembly,
+				// so the proxy-interface trick used below (which adds an interface implementation to
+				// the user type) is not an option. Instead we emit a *generic* helper method into
+				// the companion whose body performs the same type-parameter-aware conversions, and
+				// the static UnmanagedCallersOnly callback dispatches to it by reflection (closing
+				// the helper over the instance's actual generic arguments at runtime). This is only
+				// used under a Hot-Reload-compatible build, which always runs under the JIT.
+				EmitGenericCompanionTrampoline (method, callback, callbackType);
 			} else if (isGeneric && !method.IsConstructor) {
 				// We generate a proxy interface for each generic NSObject subclass. In the static UnmanagedCallersOnly methods we don't
 				// know the generic parameters of the type we're working with and we need to use this trick to be able to call methods on the
@@ -577,6 +587,181 @@ namespace Xamarin.Linker {
 			}
 
 			return modified;
+		}
+
+		// Emits the relocated generic trampoline for a method declared in a generic type, when
+		// relocating into the companion assembly for Hot Reload. Rather than adding a proxy
+		// interface implementation to the user type (which would modify the user assembly), we emit
+		// a generic helper method into the companion whose body performs the type-parameter-aware
+		// conversions, and make the static callback dispatch to it by reflection (closing the helper
+		// over the instance's actual generic arguments at runtime). The 'callback' passed in is the
+		// UnmanagedCallersOnly trampoline (with only its 'pobj' parameter added so far).
+		void EmitGenericCompanionTrampoline (MethodDefinition method, MethodDefinition callback, TypeDefinition callbackType)
+		{
+			var module = callback.Module;
+			var placeholderType = abr.System_IntPtr;
+
+			// Create the generic helper method, mirroring the user type's generic parameters.
+			var implMethod = new MethodDefinition (callback.Name + "__impl", MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig, placeholderType);
+			callbackType.Methods.Add (implMethod);
+
+			var genericParameterMap = new Dictionary<GenericParameter, GenericParameter> ();
+			foreach (var userGenericParameter in method.DeclaringType.GenericParameters) {
+				var implGenericParameter = new GenericParameter (userGenericParameter.Name, implMethod) {
+					Attributes = userGenericParameter.Attributes,
+				};
+				implMethod.GenericParameters.Add (implGenericParameter);
+				genericParameterMap [userGenericParameter] = implGenericParameter;
+			}
+
+			// Copy the generic parameter constraints in a second pass, since a constraint may
+			// reference another generic parameter of the same type. Constraints must be copied so
+			// that the closed instantiations we create at runtime (via MakeGenericMethod) are valid,
+			// and so that the 'castclass' to the user generic type inside the body verifies.
+			for (var i = 0; i < method.DeclaringType.GenericParameters.Count; i++) {
+				var userGenericParameter = method.DeclaringType.GenericParameters [i];
+				var implGenericParameter = implMethod.GenericParameters [i];
+				foreach (var constraint in userGenericParameter.Constraints) {
+					var constraintType = ImportTypeReference (module, RemapGenericParameter (constraint.ConstraintType, genericParameterMap));
+					implGenericParameter.Constraints.Add (new GenericParameterConstraint (constraintType));
+				}
+			}
+
+			// Add the 'self' parameter (arg0), typed as the user generic type closed over the
+			// helper's own generic parameters (e.g. CustomNSObject<T>). This mirrors the 'this' of
+			// the instance implementation, so EmitCallToExportedMethod can push it with 'ldarg.0'.
+			var selfType = ImportTypeReference (module, method.DeclaringType.CreateGenericInstanceType (implMethod.GenericParameters.ToArray ()));
+			implMethod.AddParameter (selfType); // self
+
+			// Emit the body (parameter/return conversions + the call to the exported method). Because
+			// implMethod has its own generic parameters, EmitCallToExportedMethod remaps the user
+			// type's generic parameters to the helper's parameters and uses them for the call.
+			EmitCallToExportedMethod (method, implMethod);
+			ImportCallbackReferences (implMethod);
+
+			// Build the static UnmanagedCallersOnly callback that dispatches to the helper. Its
+			// signature mirrors the helper's (minus 'self', plus the native 'exception_gchandle'
+			// pointer): [pobj, sel, p0..., IntPtr* exception_gchandle].
+			callback.ReturnType = implMethod.ReturnType;
+			for (var i = 1; i < implMethod.Parameters.Count - 1; i++) {
+				callback.AddParameter (implMethod.Parameters [i].ParameterType);
+			}
+			callback.AddParameter (new PointerType (abr.System_IntPtr)); // exception_gchandle
+
+			EmitGenericReflectionDispatch (method, callback, implMethod);
+
+			// Keep the helper (and everything its body references, including the user method) alive
+			// through trimming. This is emitted on the companion side only; the user assembly is not
+			// modified. The 'ldtoken' reference to implMethod from the callback also keeps it alive.
+			abr.AddDynamicDependencyAttribute (callback, implMethod);
+		}
+
+		// Emits the body of the UnmanagedCallersOnly callback for a relocated generic trampoline. It
+		// resolves the instance, boxes the native arguments into an object array, and calls the
+		// runtime helper which closes the generic helper method over the instance's actual generic
+		// arguments and invokes it. The exception GCHandle is returned by the helper (reflection
+		// can't marshal an 'IntPtr*' output) and written back through the native pointer here.
+		void EmitGenericReflectionDispatch (MethodDefinition method, MethodDefinition callback, MethodDefinition implMethod)
+		{
+			var body = callback.CreateBody (out var il);
+
+			// The helper's leading arguments: 'self' followed by the native arguments ('sel', p0...).
+			// This excludes the trailing 'out IntPtr exception_gchandle' slot.
+			var leadingCount = implMethod.Parameters.Count - 1;
+
+			// var self = Runtime.GetNSObject (pobj);
+			var selfVar = body.AddVariable (abr.Foundation_NSObject);
+			il.Emit (OpCodes.Ldarg_0);
+			il.Emit (OpCodes.Call, abr.Runtime_GetNSObject__System_IntPtr);
+			il.Emit (OpCodes.Stloc, selfVar);
+
+			// var args = new object [leadingCount];
+			var argsVar = body.AddVariable (new ArrayType (abr.System_Object));
+			il.Emit (OpCodes.Ldc_I4, leadingCount);
+			il.Emit (OpCodes.Newarr, abr.System_Object);
+			il.Emit (OpCodes.Stloc, argsVar);
+
+			// args [0] = self;
+			il.Emit (OpCodes.Ldloc, argsVar);
+			il.Emit (OpCodes.Ldc_I4_0);
+			il.Emit (OpCodes.Ldloc, selfVar);
+			il.Emit (OpCodes.Stelem_Ref);
+
+			// args [i] = (object) <native argument i>;   (i: 1..leadingCount-1 -> sel, p0, ...)
+			for (var i = 1; i < leadingCount; i++) {
+				var parameterType = callback.Parameters [i].ParameterType;
+				il.Emit (OpCodes.Ldloc, argsVar);
+				il.Emit (OpCodes.Ldc_I4, i);
+				il.EmitLoadArgument (i);
+				il.Emit (OpCodes.Box, parameterType);
+				il.Emit (OpCodes.Stelem_Ref);
+			}
+
+			// IntPtr exception_gchandle;
+			var exceptionVar = body.AddVariable (abr.System_IntPtr);
+
+			// var rv = Runtime.InvokeGenericRegistrarTrampoline (self, ldtoken (UserType), ldtoken (implMethod), args, out exception_gchandle);
+			il.Emit (OpCodes.Ldloc, selfVar);
+			il.Emit (OpCodes.Ldtoken, method.DeclaringType);
+			il.Emit (OpCodes.Ldtoken, implMethod);
+			il.Emit (OpCodes.Ldloc, argsVar);
+			il.Emit (OpCodes.Ldloca, exceptionVar);
+			il.Emit (OpCodes.Call, abr.Runtime_InvokeGenericRegistrarTrampoline);
+
+			var isVoid = callback.ReturnType.Is ("System", "Void");
+			VariableDefinition? resultVar = null;
+			if (isVoid) {
+				il.Emit (OpCodes.Pop);
+			} else {
+				resultVar = body.AddVariable (abr.System_Object);
+				il.Emit (OpCodes.Stloc, resultVar);
+			}
+
+			// *exception_gchandle = exception_gchandle;
+			il.EmitLoadArgument (callback.Parameters.Count - 1);
+			il.Emit (OpCodes.Ldloc, exceptionVar);
+			il.Emit (OpCodes.Stind_I);
+
+			// return (<nativeReturnType>) rv;
+			if (!isVoid) {
+				il.Emit (OpCodes.Ldloc, resultVar);
+				il.Emit (OpCodes.Unbox_Any, callback.ReturnType);
+			}
+			il.Emit (OpCodes.Ret);
+
+			body.GenerateILOffsets ();
+		}
+
+		// Recursively substitutes generic parameters in a type reference according to the given map.
+		// Used when relocating a generic type's trampoline into a companion generic helper method:
+		// the user type's generic parameters (owned by the type) are remapped to the helper method's
+		// generic parameters.
+		static TypeReference RemapGenericParameter (TypeReference type, IDictionary<GenericParameter, GenericParameter> map)
+		{
+			switch (type) {
+			case GenericParameter genericParameter:
+				return map.TryGetValue (genericParameter, out var mapped) ? mapped : genericParameter;
+			case GenericInstanceType git: {
+				var result = new GenericInstanceType (RemapGenericParameter (git.ElementType, map));
+				foreach (var argument in git.GenericArguments)
+					result.GenericArguments.Add (RemapGenericParameter (argument, map));
+				return result;
+			}
+			case ArrayType array:
+				return new ArrayType (RemapGenericParameter (array.ElementType, map), array.Rank);
+			case PointerType pointer:
+				return new PointerType (RemapGenericParameter (pointer.ElementType, map));
+			case ByReferenceType byReference:
+				return new ByReferenceType (RemapGenericParameter (byReference.ElementType, map));
+			case PinnedType pinned:
+				return new PinnedType (RemapGenericParameter (pinned.ElementType, map));
+			case RequiredModifierType required:
+				return new RequiredModifierType (RemapGenericParameter (required.ModifierType, map), RemapGenericParameter (required.ElementType, map));
+			case OptionalModifierType optional:
+				return new OptionalModifierType (RemapGenericParameter (optional.ModifierType, map), RemapGenericParameter (optional.ElementType, map));
+			default:
+				return type;
+			}
 		}
 
 		// Re-imports every type/method/field reference used by the trampoline (its signature, local
@@ -742,6 +927,21 @@ namespace Xamarin.Linker {
 			var isInstanceCategory = isCategory && StaticRegistrar.HasThisAttribute (method);
 			var isGeneric = method.DeclaringType.HasGenericParameters;
 
+			// When 'callback' is itself a generic method (i.e. it has its own generic parameters), we
+			// are emitting the relocated generic helper into the companion assembly: a static method
+			// mirroring the user type's generic parameters, whose 'self' argument (arg0) is the user
+			// type closed over the helper's own generic parameters. The body is identical to the
+			// instance implementation, except every reference to the user type's generic parameters
+			// must be remapped to the helper's generic parameters.
+			var genericCompanionImpl = callback.HasGenericParameters;
+			Dictionary<GenericParameter, GenericParameter>? genericParameterMap = null;
+			if (genericCompanionImpl) {
+				genericParameterMap = new Dictionary<GenericParameter, GenericParameter> ();
+				for (var i = 0; i < method.DeclaringType.GenericParameters.Count; i++)
+					genericParameterMap [method.DeclaringType.GenericParameters [i]] = callback.GenericParameters [i];
+			}
+			TypeReference RemapType (TypeReference tr) => genericParameterMap is null ? tr : RemapGenericParameter (tr, genericParameterMap);
+
 			Trace (il, $"ENTER");
 
 			if (!isVoid || method.IsConstructor)
@@ -889,7 +1089,7 @@ namespace Xamarin.Linker {
 				for (var p = parameterStart; p < managedParameterCount; p++) {
 					var nativeParameter = callback.AddParameter (placeholderType); // p{p}
 					var nativeParameterIndex = p + nativeParameterOffset;
-					var managedParameterType = method.Parameters [p].ParameterType;
+					var managedParameterType = RemapType (method.Parameters [p].ParameterType);
 					var baseParameter = baseMethod.Parameters [p];
 					var isOutParameter = IsOutParameter (method, p, baseParameter);
 
@@ -909,7 +1109,15 @@ namespace Xamarin.Linker {
 			if (callSuperParameter is not null)
 				callback.Parameters.Add (callSuperParameter);
 
-			callback.AddParameter (new PointerType (abr.System_IntPtr)); // exception_gchandle
+			// For the relocated generic companion helper the trampoline is dispatched via reflection,
+			// which can't marshal an 'IntPtr*' (pointer) argument, so we use a byref 'out IntPtr'
+			// (which reflection handles as a standard output parameter). The runtime helper writes the
+			// resulting GCHandle into the UnmanagedCallersOnly callback's native 'IntPtr*' pointer.
+			if (genericCompanionImpl) {
+				callback.AddParameter (new ByReferenceType (abr.System_IntPtr)); // exception_gchandle
+			} else {
+				callback.AddParameter (new PointerType (abr.System_IntPtr)); // exception_gchandle
+			}
 
 			if (relocatedCtorObjVar is not null) {
 				// The object was allocated earlier and pushed onto the stack (underneath the
@@ -925,7 +1133,10 @@ namespace Xamarin.Linker {
 				il.Emit (OpCodes.Ldnull);
 				il.Emit (OpCodes.Newobj, ctor);
 			} else if (isGeneric && !method.IsConstructor) {
-				var targetMethod = method.DeclaringType.CreateMethodReferenceOnGenericType (method, method.DeclaringType.GenericParameters.ToArray ());
+				var genericArguments = genericCompanionImpl
+					? callback.GenericParameters.ToArray ()
+					: method.DeclaringType.GenericParameters.ToArray ();
+				var targetMethod = method.DeclaringType.CreateMethodReferenceOnGenericType (method, genericArguments);
 				il.Emit (OpCodes.Call, targetMethod);
 			} else if (method.IsStatic) {
 				il.Emit (OpCodes.Call, method);
@@ -934,7 +1145,7 @@ namespace Xamarin.Linker {
 			}
 
 			if (returnVariable is not null) {
-				if (EmitConversion (method, il, method.ReturnType, false, -1, out var nativeReturnType, postProcessing)) {
+				if (EmitConversion (method, il, RemapType (method.ReturnType), false, -1, out var nativeReturnType, postProcessing)) {
 					returnVariable.VariableType = nativeReturnType;
 					callback.ReturnType = nativeReturnType;
 				} else {
@@ -958,7 +1169,7 @@ namespace Xamarin.Linker {
 					body.Instructions.RemoveAt (i);
 			}
 
-			AddExceptionHandler (il, returnVariable, placeholderNextInstruction, isGeneric && !method.IsConstructor, out var eh, out var leaveEHInstruction);
+			AddExceptionHandler (il, returnVariable, placeholderNextInstruction, out var eh, out var leaveEHInstruction);
 
 			// Generate code to return null/default value/void
 			if (returnVariable is not null) {
@@ -998,7 +1209,7 @@ namespace Xamarin.Linker {
 			body.GenerateILOffsets ();
 		}
 
-		void AddExceptionHandler (ILProcessor il, VariableDefinition? returnVariable, Instruction placeholderNextInstruction, bool isGeneric, out ExceptionHandler eh, out Instruction leaveEHInstruction)
+		void AddExceptionHandler (ILProcessor il, VariableDefinition? returnVariable, Instruction placeholderNextInstruction, out ExceptionHandler eh, out Instruction leaveEHInstruction)
 		{
 			var body = il.Body;
 			var method = body.Method;
@@ -1013,7 +1224,10 @@ namespace Xamarin.Linker {
 			il.Emit (OpCodes.Stloc, exceptionVariable);
 			eh.HandlerStart = il.Body.Instructions.Last ();
 			eh.TryEnd = eh.HandlerStart;
-			il.Emit (OpCodes.Ldarg, isGeneric ? method.Parameters.Count : method.Parameters.Count - 1);
+			// The exception_gchandle output pointer is always the last parameter of the trampoline
+			// (whether the trampoline is a static callback or an instance/static implementation
+			// method). Account for the implicit 'this' argument when the method has one.
+			il.Emit (OpCodes.Ldarg, (method.HasThis ? 1 : 0) + method.Parameters.Count - 1);
 			il.Emit (OpCodes.Ldloc, exceptionVariable);
 			il.Emit (OpCodes.Call, abr.Runtime_AllocGCHandle);
 			il.Emit (OpCodes.Stind_I);

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -1098,7 +1098,18 @@ namespace Xamarin.Linker {
 					}
 
 					if (EmitConversion (method, il, managedParameterType, true, p, out var nativeType, postProcessing, isOutParameter, nativeParameterIndex)) {
-						nativeParameter.ParameterType = nativeType;
+						// In the generic companion helper the trampoline is dispatched via reflection,
+						// which boxes each native argument into an 'object []' and calls
+						// MethodInfo.Invoke. A pointer-typed native parameter (which is what
+						// out/ref/pointer parameters produce) can't survive that round-trip: a pointer
+						// isn't boxable and Invoke can't marshal it. Represent such parameters as a
+						// plain 'IntPtr' instead - it's a boxable, pointer-sized value type, and loading
+						// it with 'ldarg' yields a native int that the already-emitted body uses
+						// directly as the pointer (native int is usable wherever an unmanaged pointer is
+						// expected, for both reads and writes). The native ABI is unchanged since a
+						// pointer and an IntPtr are both pointer-sized, and the out/ref write-back still
+						// happens through that same pointer value inside the helper body.
+						nativeParameter.ParameterType = genericCompanionImpl && nativeType is PointerType ? abr.System_IntPtr : nativeType;
 					} else {
 						nativeParameter.ParameterType = placeholderType;
 						AddException (ErrorHelper.CreateError (99, "Unable to emit conversion for parameter {2} of type {0}. Method: {1}", method.Parameters [p].ParameterType, GetMethodSignatureWithSourceCode (method), p));

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -675,9 +675,12 @@ namespace Xamarin.Linker {
 			il.Emit (OpCodes.Call, abr.Runtime_GetNSObject__System_IntPtr);
 			il.Emit (OpCodes.Stloc, selfVar);
 
-			// var args = new object [leadingCount];
+			// var args = new object [leadingCount + 1];
+			// The array is allocated with one extra (trailing) slot for the helper's
+			// 'out IntPtr exception_gchandle' parameter, so that the runtime helper can pass the
+			// array straight to MethodInfo.Invoke without having to allocate and copy a larger one.
 			var argsVar = body.AddVariable (new ArrayType (abr.System_Object));
-			il.Emit (OpCodes.Ldc_I4, leadingCount);
+			il.Emit (OpCodes.Ldc_I4, leadingCount + 1);
 			il.Emit (OpCodes.Newarr, abr.System_Object);
 			il.Emit (OpCodes.Stloc, argsVar);
 

--- a/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
+++ b/tools/dotnet-linker/Steps/ManagedRegistrarStep.cs
@@ -735,12 +735,12 @@ namespace Xamarin.Linker {
 					var defaultVar = body.AddVariable (returnType);
 					il.Emit (OpCodes.Ldloc, resultVar);
 					il.Emit (OpCodes.Brtrue, unboxResult);
-					// rv == null: return default (<nativeReturnType>)
+					// rv is null: return default (<nativeReturnType>)
 					il.Emit (OpCodes.Ldloca, defaultVar);
 					il.Emit (OpCodes.Initobj, returnType);
 					il.Emit (OpCodes.Ldloc, defaultVar);
 					il.Emit (OpCodes.Br, returnResult);
-					// rv != null: return (<nativeReturnType>) rv
+					// rv is not null: return (<nativeReturnType>) rv
 					il.Append (unboxResult);
 					il.Emit (OpCodes.Ldloc, resultVar);
 					il.Emit (OpCodes.Unbox_Any, returnType);


### PR DESCRIPTION
The trimmable static registrar can relocate its registrar trampolines into a per-assembly companion assembly (`_<Asm>.TypeMap.dll`) so that user assemblies stay unmodified, which is a requirement for Hot Reload. Until now generic declaring types were excluded, because the existing implementation adds a proxy interface implementation to the user type - and that modifies the user assembly.

This PR lifts that restriction.

## How it works

For a method declared in a generic type we now emit a *generic* helper method into the companion assembly, mirroring the user type's generic parameters (including their constraints). Its body performs the same type-parameter-aware conversions as the regular trampoline, with the user type's generic parameters remapped to the helper method's own generic parameters.

The static `UnmanagedCallersOnly` callback - which doesn't know the instance's generic arguments - boxes the native arguments into an `object []` and calls the new `Runtime.InvokeGenericRegistrarTrampoline`, which closes the helper over the instance's actual generic arguments (`MakeGenericMethod`) and invokes it. This path is only ever reachable in a Hot-Reload-compatible build, which always runs under the JIT, so `MakeGenericMethod` is safe; it's guarded with `Runtime.IsNativeAOT` so the linker folds it away (and elides the IL2060/IL3050 warnings) everywhere else.

The closed helper is cached per (open helper method, closed instance type) in a nested type, so the reflection cost is paid once per instantiation, and so the `ConcurrentDictionary` instantiation is trimmed away together with the trampoline in every other configuration.

## Notable details

| Detail                        | Why                                                                                                                                                                       |
|-------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `out`/`ref` parameters        | Pointer-typed native parameters can't be boxed into an `object []`, so they're represented as a plain `IntPtr` in the helper (same size, same native ABI).                   |
| `exception_gchandle`          | Reflection can't marshal an `IntPtr*`, so the helper takes an `out IntPtr` and the callback writes it back through the native pointer.                                       |
| Value-type returns            | The helper returns `null` on failure, so the callback returns `default (T)` instead of unboxing `null` (which would throw across the `UnmanagedCallersOnly` boundary).       |
| `[DynamicDependency]`         | The trimmer crashes when comparing a signature's parameter list against a method with a nested type parameter, so signatures now omit the parameter list when unambiguous.   |

The `[DynamicDependency]` change works around https://github.com/dotnet/runtime/issues/131892.

## Tests

* New assembly-preparer tests covering the relocated generic trampolines.
* A new `Debug (trimmable static registrar, all optimizations)` test variation. This also fixes the existing `Release (trimmable static registrar, all optimizations)` variation, which was actually running a Debug build.

🤖 Pull request created by Copilot
