### PR TITLE
[tools] Report warnings as warnings in ErrorHelper.ShowInternal.

### DIFF
--- a/tools/common/ErrorHelper.tools.cs
+++ b/tools/common/ErrorHelper.tools.cs
@@ -331,8 +331,16 @@ namespace Xamarin.Bundler {
 
 				ShowInner (log, e);
 
-				if (log.Verbosity > 2 && !string.IsNullOrEmpty (e.StackTrace))
-					log.LogError (e.StackTrace);
+				if (log.Verbosity > 2 && !string.IsNullOrEmpty (e.StackTrace)) {
+					// Report the stack trace as an error or a message depending on
+					// whether we're showing an error or a warning, otherwise warnings
+					// would end up failing the build when the log is an MSBuild task.
+					if (error) {
+						log.LogError (e.StackTrace);
+					} else {
+						log.Log (e.StackTrace);
+					}
+				}
 			} else {
 				log.LogError ("error " + GetPrefix (log) + "0000: Unexpected error - Please file a bug report at https://github.com/dotnet/macios/issues/new");
 				log.LogError (e.ToString ());

--- a/tools/common/ErrorHelper.tools.cs
+++ b/tools/common/ErrorHelper.tools.cs
@@ -321,7 +321,13 @@ namespace Xamarin.Bundler {
 				if (!error && GetWarningLevel (log, mte.Code) == WarningLevel.Disable)
 					return false; // This is an ignored warning.
 
-				log.LogError (mte.ToString ());
+				// Report warnings as warnings, otherwise they'd end up failing the build when
+				// the log is an MSBuild task (which is the case for the assembly preparer).
+				if (error) {
+					log.LogError (mte);
+				} else {
+					log.LogWarning (mte);
+				}
 
 				ShowInner (log, e);
 


### PR DESCRIPTION
ErrorHelper.ShowInternal always logged through IToolLog.LogError, even for
warnings. That was mostly harmless when the log was the console (the message
text itself says "warning MTxxxx: ..."), but when the log is an MSBuild task -
which is the case for the assembly preparer (the PrepareAssemblies task, used
for NativeAOT) - every warning became an MSBuild error and failed the build.

This made it impossible to build monotouch-test for macOS with NativeAOT,
because the (correct) MT2387 warning about not being able to remove the dynamic
registrar failed the build:

    error : warning MT2387: It's not safe to remove the dynamic registrar,
    because monotouchtest references 'ObjCRuntime.Runtime.RegisterAssembly
    (System.Reflection.Assembly)'.

Use IToolLog.LogWarning for warnings instead, which each IToolLog
implementation already handles correctly.