### PR TITLE
[docs] Improve XML docs for ten types

### DIFF
--- a/src/MapKit/MKEnums.cs
+++ b/src/MapKit/MKEnums.cs
@@ -37,7 +37,6 @@ namespace MapKit {
 
 	// NSUInteger -> MKTypes.h
 	/// <summary>The type of map.</summary>
-	/// <remarks>To be added.</remarks>
 	[MacCatalyst (13, 1)]
 	[Native]
 	public enum MKMapType : ulong {
@@ -51,7 +50,7 @@ namespace MapKit {
 		SatelliteFlyover,
 		/// <summary>A flyover that combines satellite and cartographic imagery.</summary>
 		HybridFlyover,
-		/// <summary>A muted map that emphasized developer data.</summary>
+		/// <summary>A muted map that emphasizes developer data.</summary>
 		[MacCatalyst (13, 1)]
 		MutedStandard,
 	}

--- a/src/PdfKit/Enums.cs
+++ b/src/PdfKit/Enums.cs
@@ -33,8 +33,7 @@
 
 namespace PdfKit {
 
-	/// <summary>Enumerates named PDF action names.</summary>
-	/// <remarks>To be added.</remarks>
+	/// <summary>Enumerates named actions that can be performed in a PDF document.</summary>
 	[Native]
 	[TV (18, 2)]
 	public enum PdfActionNamedName : long {

--- a/src/PdfKit/Enums.cs
+++ b/src/PdfKit/Enums.cs
@@ -130,7 +130,6 @@ namespace PdfKit {
 	}
 
 	/// <summary>Enumerates annotation border styles.</summary>
-	/// <remarks>To be added.</remarks>
 	[Native]
 	[TV (18, 2)]
 	public enum PdfBorderStyle : long {

--- a/src/PdfKit/Enums.cs
+++ b/src/PdfKit/Enums.cs
@@ -171,7 +171,6 @@ namespace PdfKit {
 	}
 
 	/// <summary>Enumerates Adobe-specified PDF display box boundaries.</summary>
-	/// <remarks>To be added.</remarks>
 	[Native]
 	[TV (18, 2)]
 	public enum PdfDisplayBox : long {

--- a/src/PdfKit/Enums.cs
+++ b/src/PdfKit/Enums.cs
@@ -64,7 +64,6 @@ namespace PdfKit {
 	}
 
 	/// <summary>Enumerates annotation widget controls.</summary>
-	/// <remarks>To be added.</remarks>
 	[Native]
 	[TV (18, 2)]
 	public enum PdfWidgetControlType : long {

--- a/src/PdfKit/Enums.cs
+++ b/src/PdfKit/Enums.cs
@@ -110,7 +110,6 @@ namespace PdfKit {
 	}
 
 	/// <summary>Enumerates annotation icon types.</summary>
-	/// <remarks>To be added.</remarks>
 	[Native]
 	[TV (18, 2)]
 	public enum PdfTextAnnotationIconType : long {

--- a/src/PdfKit/Enums.cs
+++ b/src/PdfKit/Enums.cs
@@ -186,8 +186,7 @@ namespace PdfKit {
 		Art = 4,
 	}
 
-	/// <summary>Enumerated PDF display modes.</summary>
-	/// <remarks>To be added.</remarks>
+	/// <summary>Enumerates PDF display modes.</summary>
 	[Native]
 	[TV (18, 2)]
 	public enum PdfDisplayMode : long {

--- a/src/PdfKit/Enums.cs
+++ b/src/PdfKit/Enums.cs
@@ -95,8 +95,7 @@ namespace PdfKit {
 		ClosedArrow = 5,
 	}
 
-	/// <summary>Indicates annotation markup types.</summary>
-	/// <remarks>To be added.</remarks>
+	/// <summary>Enumerates annotation markup types.</summary>
 	[Native]
 	[TV (18, 2)]
 	public enum PdfMarkupType : long {
@@ -106,6 +105,7 @@ namespace PdfKit {
 		StrikeOut = 1,
 		/// <summary>Indicates an underline markup.</summary>
 		Underline = 2,
+		/// <summary>Indicates a redaction markup.</summary>
 		Redact = 3,
 	}
 

--- a/src/PdfKit/Enums.cs
+++ b/src/PdfKit/Enums.cs
@@ -77,8 +77,7 @@ namespace PdfKit {
 		CheckBox = 2,
 	}
 
-	/// <summary>Enumerates line ending styles</summary>
-	/// <remarks>To be added.</remarks>
+	/// <summary>Enumerates line ending styles.</summary>
 	[Native]
 	[TV (18, 2)]
 	public enum PdfLineStyle : long {

--- a/src/PdfKit/Enums.cs
+++ b/src/PdfKit/Enums.cs
@@ -200,8 +200,7 @@ namespace PdfKit {
 		TwoUpContinuous = 3,
 	}
 
-	/// <summary>Orable flags that describe areas of interest for a touch position.</summary>
-	/// <remarks>To be added.</remarks>
+	/// <summary>Bitwise flags that describe areas of interest for a touch position.</summary>
 	[Flags]
 	[Native]
 	[TV (18, 2)]
@@ -226,6 +225,7 @@ namespace PdfKit {
 		PopupArea = 1 << 7,
 		/// <summary>Indicates that the touch position is over an image.</summary>
 		ImageArea = 1 << 8,
+		/// <summary>Indicates all areas of interest.</summary>
 		[iOS (15, 0), MacCatalyst (15, 0)]
 		AnyArea = Int64.MaxValue,
 	}

--- a/src/PdfKit/Enums.cs
+++ b/src/PdfKit/Enums.cs
@@ -225,7 +225,7 @@ namespace PdfKit {
 		PopupArea = 1 << 7,
 		/// <summary>Indicates that the touch position is over an image.</summary>
 		ImageArea = 1 << 8,
-		/// <summary>Indicates all areas of interest.</summary>
+		/// <summary>Indicates that all areas of interest are included.</summary>
 		[iOS (15, 0), MacCatalyst (15, 0)]
 		AnyArea = Int64.MaxValue,
 	}

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -5812,7 +5812,6 @@ F:PdfKit.PdfAccessPermissions.FormFieldEntry
 F:PdfKit.PdfAccessPermissions.HighQualityPrinting
 F:PdfKit.PdfAccessPermissions.LowQualityPrinting
 F:PdfKit.PdfAreaOfInterest.AnyArea
-F:PdfKit.PdfMarkupType.Redact
 F:PdfKit.PdfSelectionGranularity.Character
 F:PdfKit.PdfSelectionGranularity.Line
 F:PdfKit.PdfSelectionGranularity.Word

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -5811,7 +5811,6 @@ F:PdfKit.PdfAccessPermissions.DocumentChanges
 F:PdfKit.PdfAccessPermissions.FormFieldEntry
 F:PdfKit.PdfAccessPermissions.HighQualityPrinting
 F:PdfKit.PdfAccessPermissions.LowQualityPrinting
-F:PdfKit.PdfAreaOfInterest.AnyArea
 F:PdfKit.PdfSelectionGranularity.Character
 F:PdfKit.PdfSelectionGranularity.Line
 F:PdfKit.PdfSelectionGranularity.Word


### PR DESCRIPTION
Improve XML documentation for:

- `PdfActionNamedName`
- `PdfWidgetControlType`
- `PdfLineStyle`
- `PdfMarkupType`
- `PdfTextAnnotationIconType`
- `PdfBorderStyle`
- `PdfDisplayBox`
- `PdfDisplayMode`
- `PdfAreaOfInterest`
- `MKMapType`

Each type is documented in a separate commit. The Cecil documentation baseline is updated for the newly documented `PdfMarkupType.Redact` and `PdfAreaOfInterest.AnyArea` APIs.

🤖 Pull request created by Copilot