### PR TITLE
[registrar] Import the framework for NSObject types used in method signatures.

### DIFF
--- a/tools/common/StaticRegistrar.cs
+++ b/tools/common/StaticRegistrar.cs
@@ -2479,6 +2479,8 @@ namespace Registrar {
 					if (!IsPlatformType (td))
 						return "id";
 
+					CheckNamespace (td, exceptions);
+
 					if (HasProtocolAttribute (td)) {
 						return "id<" + GetExportedTypeName (td) + ">";
 					} else {


### PR DESCRIPTION
The static registrar could emit method signatures referencing an Objective-C
type whose framework header wasn't imported in the generated code, which made
the generated code fail to compile:

    registrar.h:266:27: error: expected a type
      266 |         -(void) registerWebView:(WKWebView *)p0;
          |                                  ^

This happened for a wrapper type from a binding project (Google.MobileAds'
GADMobileAds) with a method taking a WebKit.WKWebView parameter, where nothing
else in the app pulled in the WebKit framework: 'CheckNamespace' is only called
for the types the registrar iterates over, not for the types showing up in the
generated method signatures.

Fix this by calling 'CheckNamespace' in 'ToObjCParameterType' for platform
NSObject types, so that the corresponding '#import <Framework/Framework.h>' is
always emitted.

Copilot-Session: ddb2f938-9d62-4ccf-8ce8-70056d74178b