### PR TITLE
[docs] Improve XML docs for ten types

### DIFF
--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -1151,11 +1151,10 @@ namespace AVFoundation {
 	}
 
 	/// <summary>Enumerates loop count limits.</summary>
-	/// <remarks>To be added.</remarks>
 	[MacCatalyst (13, 1)]
 	[Native]
 	public enum AVMusicTrackLoopCount : long {
-		/// <summary>To be added.</summary>
+		/// <summary>Loops the music track indefinitely.</summary>
 		Forever = -1,
 	}
 

--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -520,13 +520,12 @@ namespace AVFoundation {
 	}
 
 	/// <summary>An enumeration whose values define whether, after an audio session deactivates, previously interrupted audio sessions should or should not re-activate.</summary>
-	/// <remarks>To be added.</remarks>
 	[MacCatalyst (13, 1)]
 	[Flags]
 	[Native]
 	// NSUInteger - AVAudioSession.h
 	public enum AVAudioSessionSetActiveOptions : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Notifies other audio sessions that they can resume when this session deactivates.</summary>
 		NotifyOthersOnDeactivation = 1,
 	}
 

--- a/src/AVFoundation/Enums.cs
+++ b/src/AVFoundation/Enums.cs
@@ -1719,11 +1719,12 @@ namespace AVFoundation {
 		DolbyVision = 0x4,
 	}
 
+	/// <summary>Specifies options for activating an audio session.</summary>
 	[MacCatalyst (13, 1)]
 	[Flags]
 	[Native]
 	public enum AVAudioSessionActivationOptions : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>No activation options are specified.</summary>
 		None = 0x0,
 	}
 

--- a/src/CoreVideo/CVEnums.cs
+++ b/src/CoreVideo/CVEnums.cs
@@ -110,7 +110,7 @@ namespace CoreVideo {
 	[Flags]
 	[MacCatalyst (13, 1)]
 	public enum CVTimeFlags : int {
-		/// <summary>To be added.</summary>
+		/// <summary>The time value is indefinite.</summary>
 		IsIndefinite = 1 << 0,
 	}
 

--- a/src/CoreVideo/CVEnums.cs
+++ b/src/CoreVideo/CVEnums.cs
@@ -173,7 +173,7 @@ namespace CoreVideo {
 	/// <summary>Defines an option for <see cref="CoreVideo.CVPixelBufferPool.Flush(CoreVideo.CVPixelBufferPoolFlushFlags)" />.</summary>
 	[MacCatalyst (13, 1)]
 	public enum CVPixelBufferPoolFlushFlags : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Releases all unused buffers from the pool.</summary>
 		FlushExcessBuffers = 1,
 	}
 

--- a/src/CoreVideo/CVEnums.cs
+++ b/src/CoreVideo/CVEnums.cs
@@ -102,7 +102,7 @@ namespace CoreVideo {
 	/// <summary>A flagging enumeration. Currently only contains a <c>None</c> value of 0.</summary>
 	[MacCatalyst (13, 1)]
 	public enum CVOptionFlags : long {
-		/// <summary>To be added.</summary>
+		/// <summary>No options are specified.</summary>
 		None = 0,
 	}
 

--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -1265,11 +1265,10 @@ namespace Foundation {
 	}
 
 	/// <summary>Allows the application developer to specify that the old version of the file should be removed from the version store.</summary>
-	/// <remarks>To be added.</remarks>
 	[Flags]
 	[Native]
 	public enum NSFileVersionReplacingOptions : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Moves the replacement file instead of copying it.</summary>
 		ByMoving = 1 << 0,
 	}
 

--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -1273,11 +1273,10 @@ namespace Foundation {
 	}
 
 	/// <summary>Allows the application developer to specify that a new file version should be created by moving the source file.</summary>
-	/// <remarks>To be added.</remarks>
 	[Flags]
 	[Native]
 	public enum NSFileVersionAddingOptions : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Moves the source file instead of copying it.</summary>
 		ByMoving = 1 << 0,
 	}
 

--- a/src/Foundation/Enum.cs
+++ b/src/Foundation/Enum.cs
@@ -2263,10 +2263,11 @@ namespace Foundation {
 		OwnProcess = 3,
 	}
 
+	/// <summary>Specifies how an item provider supplies a file.</summary>
 	[MacCatalyst (13, 1)]
 	[Native]
 	public enum NSItemProviderFileOptions : long {
-		/// <summary>To be added.</summary>
+		/// <summary>Opens the file in place instead of copying it.</summary>
 		OpenInPlace = 1,
 	}
 

--- a/src/SceneKit/Defs.cs
+++ b/src/SceneKit/Defs.cs
@@ -12,11 +12,12 @@
 
 namespace SceneKit {
 
+	/// <summary>Identifies errors reported by SceneKit.</summary>
 	[MacCatalyst (13, 1)]
 	[Native] // untyped enum (SceneKitTypes.h) but described as the value of `code` for `NSError` which is an NSInteger
 	[ErrorDomain ("SCNErrorDomain")]
 	public enum SCNErrorCode : long {
-		/// <summary>To be added.</summary>
+		/// <summary>A shader program failed to compile.</summary>
 		ProgramCompilationError = 1,
 	}
 

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -24065,7 +24065,6 @@ T:Foundation.NSGrammaticalPartOfSpeech
 T:Foundation.NSGrammaticalPerson
 T:Foundation.NSGrammaticalPronounType
 T:Foundation.NSInlinePresentationIntent
-T:Foundation.NSItemProviderFileOptions
 T:Foundation.NSItemProviderRepresentationVisibility
 T:Foundation.NSItemProviderUTTypeLoadDelegate
 T:Foundation.NSKeyValueSharedObserverRegistration_NSObject

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -25728,7 +25728,6 @@ T:SceneKit.SCNAnimationDidStopHandler
 T:SceneKit.SCNBufferBindingHandler
 T:SceneKit.SCNCameraProjectionDirection
 T:SceneKit.SCNColorMask
-T:SceneKit.SCNErrorCode
 T:SceneKit.SCNFillMode
 T:SceneKit.SCNHitTestSearchMode
 T:SceneKit.SCNInteractionMode

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -23096,7 +23096,6 @@ T:AVFoundation.AVAudioRoutingArbiter
 T:AVFoundation.AVAudioRoutingArbitrationCategory
 T:AVFoundation.AVAudioSequencerInfoDictionary
 T:AVFoundation.AVAudioSequencerUserCallback
-T:AVFoundation.AVAudioSessionActivationOptions
 T:AVFoundation.AVAudioSessionCapability
 T:AVFoundation.AVAudioSessionInterruptionReason
 T:AVFoundation.AVAudioSessionIOType


### PR DESCRIPTION
Improve XML documentation for:

- `AVAudioSessionSetActiveOptions`
- `AVMusicTrackLoopCount`
- `AVAudioSessionActivationOptions`
- `SCNErrorCode`
- `NSFileVersionReplacingOptions`
- `NSFileVersionAddingOptions`
- `NSItemProviderFileOptions`
- `CVOptionFlags`
- `CVTimeFlags`
- `CVPixelBufferPoolFlushFlags`

Each type is documented in a separate commit. The Cecil documentation baseline is updated for the newly documented `AVAudioSessionActivationOptions`, `SCNErrorCode`, and `NSItemProviderFileOptions` APIs.

🤖 Pull request created by Copilot