### PR TITLE
[msbuild] Reword the message about using DEVELOPER_DIR or XcodeLocation to choose Xcode.

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1629,19 +1629,19 @@
     </data>
 
     <data name="W7171" xml:space="preserve">
-        <value>The environment variable '{0}' is deprecated, and will be ignored in .NET 11+. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode.</value>
+        <value>The environment variable '{0}' is deprecated, and will be ignored in .NET 11+. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use an Xcode other than the system's current default Xcode.</value>
     </data>
 
     <data name="W7172" xml:space="preserve">
-        <value>The environment variable '{0}' is deprecated, and will be ignored. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode.</value>
+        <value>The environment variable '{0}' is deprecated, and will be ignored. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use an Xcode other than the system's current default Xcode.</value>
     </data>
 
     <data name="W7173" xml:space="preserve">
-        <value>The settings file '{0}' is deprecated, and will be ignored in .NET 11+. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode.</value>
+        <value>The settings file '{0}' is deprecated, and will be ignored in .NET 11+. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use an Xcode other than the system's current default Xcode.</value>
     </data>
 
     <data name="W7174" xml:space="preserve">
-        <value>The settings file '{0}' is deprecated, and will be ignored. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode.</value>
+        <value>The settings file '{0}' is deprecated, and will be ignored. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use an Xcode other than the system's current default Xcode.</value>
     </data>
 
     <data name="E7175" xml:space="preserve">

--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1629,19 +1629,19 @@
     </data>
 
     <data name="W7171" xml:space="preserve">
-        <value>The environment variable '{0}' is deprecated, and will be ignored in .NET 11+. Please use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to choose which Xcode to use.</value>
+        <value>The environment variable '{0}' is deprecated, and will be ignored in .NET 11+. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode.</value>
     </data>
 
     <data name="W7172" xml:space="preserve">
-        <value>The environment variable '{0}' is deprecated, and will be ignored. Please use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to choose which Xcode to use.</value>
+        <value>The environment variable '{0}' is deprecated, and will be ignored. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode.</value>
     </data>
 
     <data name="W7173" xml:space="preserve">
-        <value>The settings file '{0}' is deprecated, and will be ignored in .NET 11+. Please use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to choose which Xcode to use.</value>
+        <value>The settings file '{0}' is deprecated, and will be ignored in .NET 11+. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode.</value>
     </data>
 
     <data name="W7174" xml:space="preserve">
-        <value>The settings file '{0}' is deprecated, and will be ignored. Please use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to choose which Xcode to use.</value>
+        <value>The settings file '{0}' is deprecated, and will be ignored. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode.</value>
     </data>
 
     <data name="E7175" xml:space="preserve">

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSdkLocation.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSdkLocation.cs
@@ -151,16 +151,16 @@ namespace Xamarin.MacDev.Tasks {
 
 			if (appleSdkSettings.SystemHasEnvironmentVariable) {
 				if (isNet11OrNewer) {
-					Log.LogWarning (MSBStrings.W7172 /* The environment variable '{0}' is deprecated, and will be ignored. Please set use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to choose which Xcode to use. */, XcodeLocator.EnvironmentVariableName);
+					Log.LogWarning (MSBStrings.W7172 /* The environment variable '{0}' is deprecated, and will be ignored. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode. */, XcodeLocator.EnvironmentVariableName);
 				} else {
-					Log.LogWarning (MSBStrings.W7171 /* The environment variable '{0}' is deprecated, and will be ignored in .NET 11+. Please set use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to choose which Xcode to use. */, XcodeLocator.EnvironmentVariableName);
+					Log.LogWarning (MSBStrings.W7171 /* The environment variable '{0}' is deprecated, and will be ignored in .NET 11+. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode. */, XcodeLocator.EnvironmentVariableName);
 				}
 			}
 			foreach (var file in appleSdkSettings.SystemExistingSettingsFiles) {
 				if (isNet11OrNewer) {
-					Log.LogWarning (MSBStrings.W7174 /* The settings file '{0}' is deprecated, and will be ignored. Please set use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to choose which Xcode to use. */, file);
+					Log.LogWarning (MSBStrings.W7174 /* The settings file '{0}' is deprecated, and will be ignored. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode. */, file);
 				} else {
-					Log.LogWarning (MSBStrings.W7173 /* The settings file '{0}' is deprecated, and will be ignored in .NET 11+. Please set use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to choose which Xcode to use. */, file);
+					Log.LogWarning (MSBStrings.W7173 /* The settings file '{0}' is deprecated, and will be ignored in .NET 11+. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode. */, file);
 				}
 			}
 

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSdkLocation.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/DetectSdkLocation.cs
@@ -151,16 +151,16 @@ namespace Xamarin.MacDev.Tasks {
 
 			if (appleSdkSettings.SystemHasEnvironmentVariable) {
 				if (isNet11OrNewer) {
-					Log.LogWarning (MSBStrings.W7172 /* The environment variable '{0}' is deprecated, and will be ignored. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode. */, XcodeLocator.EnvironmentVariableName);
+					Log.LogWarning (MSBStrings.W7172 /* The environment variable '{0}' is deprecated, and will be ignored. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use an Xcode other than the system's current default Xcode. */, XcodeLocator.EnvironmentVariableName);
 				} else {
-					Log.LogWarning (MSBStrings.W7171 /* The environment variable '{0}' is deprecated, and will be ignored in .NET 11+. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode. */, XcodeLocator.EnvironmentVariableName);
+					Log.LogWarning (MSBStrings.W7171 /* The environment variable '{0}' is deprecated, and will be ignored in .NET 11+. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use an Xcode other than the system's current default Xcode. */, XcodeLocator.EnvironmentVariableName);
 				}
 			}
 			foreach (var file in appleSdkSettings.SystemExistingSettingsFiles) {
 				if (isNet11OrNewer) {
-					Log.LogWarning (MSBStrings.W7174 /* The settings file '{0}' is deprecated, and will be ignored. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode. */, file);
+					Log.LogWarning (MSBStrings.W7174 /* The settings file '{0}' is deprecated, and will be ignored. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use an Xcode other than the system's current default Xcode. */, file);
 				} else {
-					Log.LogWarning (MSBStrings.W7173 /* The settings file '{0}' is deprecated, and will be ignored in .NET 11+. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode. */, file);
+					Log.LogWarning (MSBStrings.W7173 /* The settings file '{0}' is deprecated, and will be ignored in .NET 11+. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use an Xcode other than the system's current default Xcode. */, file);
 				}
 			}
 

--- a/tests/dotnet/UnitTests/Extensions.cs
+++ b/tests/dotnet/UnitTests/Extensions.cs
@@ -131,13 +131,13 @@ namespace Xamarin.Tests {
 				return true;
 
 			if (filterXcodeLocation) {
-				if (v.Contains ("The environment variable 'MD_APPLE_SDK_ROOT' is deprecated, and will be ignored. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode."))
+				if (v.Contains ("The environment variable 'MD_APPLE_SDK_ROOT' is deprecated, and will be ignored. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use an Xcode other than the system's current default Xcode."))
 					return true;
-				if (v.Contains ("The environment variable 'MD_APPLE_SDK_ROOT' is deprecated, and will be ignored in .NET 11+. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode."))
+				if (v.Contains ("The environment variable 'MD_APPLE_SDK_ROOT' is deprecated, and will be ignored in .NET 11+. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use an Xcode other than the system's current default Xcode."))
 					return true;
-				if (Regex.IsMatch (v, @"The settings file '/.*/Library/Preferences/maui/Settings\.plist' is deprecated, and will be ignored\. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode\."))
+				if (Regex.IsMatch (v, @"The settings file '/.*/Library/Preferences/maui/Settings\.plist' is deprecated, and will be ignored\. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use an Xcode other than the system's current default Xcode\."))
 					return true;
-				if (Regex.IsMatch (v, @"The settings file '/.*/Library/Preferences/Xamarin/Settings\.plist' is deprecated, and will be ignored\. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode\."))
+				if (Regex.IsMatch (v, @"The settings file '/.*/Library/Preferences/Xamarin/Settings\.plist' is deprecated, and will be ignored\. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use an Xcode other than the system's current default Xcode\."))
 					return true;
 			}
 

--- a/tests/dotnet/UnitTests/Extensions.cs
+++ b/tests/dotnet/UnitTests/Extensions.cs
@@ -131,13 +131,13 @@ namespace Xamarin.Tests {
 				return true;
 
 			if (filterXcodeLocation) {
-				if (v.Contains ("The environment variable 'MD_APPLE_SDK_ROOT' is deprecated, and will be ignored. Please use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to choose which Xcode to use."))
+				if (v.Contains ("The environment variable 'MD_APPLE_SDK_ROOT' is deprecated, and will be ignored. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode."))
 					return true;
-				if (v.Contains ("The environment variable 'MD_APPLE_SDK_ROOT' is deprecated, and will be ignored in .NET 11+. Please use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to choose which Xcode to use."))
+				if (v.Contains ("The environment variable 'MD_APPLE_SDK_ROOT' is deprecated, and will be ignored in .NET 11+. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode."))
 					return true;
-				if (Regex.IsMatch (v, @"The settings file '/.*/Library/Preferences/maui/Settings\.plist' is deprecated, and will be ignored\. Please use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to choose which Xcode to use\."))
+				if (Regex.IsMatch (v, @"The settings file '/.*/Library/Preferences/maui/Settings\.plist' is deprecated, and will be ignored\. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode\."))
 					return true;
-				if (Regex.IsMatch (v, @"The settings file '/.*/Library/Preferences/Xamarin/Settings\.plist' is deprecated, and will be ignored\. Please use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to choose which Xcode to use\."))
+				if (Regex.IsMatch (v, @"The settings file '/.*/Library/Preferences/Xamarin/Settings\.plist' is deprecated, and will be ignored\. Use the 'DEVELOPER_DIR' environment variable or the 'XcodeLocation' MSBuild property to use another Xcode than the system's current default version of Xcode\."))
 					return true;
 			}
 


### PR DESCRIPTION
Trying to clarify that it's not necessary to set these variables, we'll use the system's default Xcode if neither are specified.