### PR TITLE
[docs] Improve XML docs for ten types

### DIFF
--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2925,11 +2925,12 @@ namespace AppKit {
 		RatingLevel,
 	}
 
+	/// <summary>Specifies options for creating or modifying font collections.</summary>
 	[NoMacCatalyst]
 	[Flags]
 	[Native]
 	public enum NSFontCollectionOptions : long {
-		/// <summary>To be added.</summary>
+		/// <summary>Limits the font collection to the current application.</summary>
 		ApplicationOnlyMask = 1,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -4038,11 +4038,12 @@ namespace AppKit {
 		Visible = 1 << 1,
 	}
 
+	/// <summary>Describes whether a window is visible to the user.</summary>
 	[NoMacCatalyst]
 	[Flags]
 	[Native]
 	public enum NSWindowOcclusionState : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>At least part of the window is visible.</summary>
 		Visible = 1 << 1,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -4459,11 +4459,12 @@ namespace AppKit {
 		Catalog,
 	}
 
+	/// <summary>Specifies options for requesting downloadable font assets.</summary>
 	[NoMacCatalyst]
 	[Native]
 	[Flags]
 	public enum NSFontAssetRequestOptions : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Displays the standard user interface while downloading fonts.</summary>
 		UsesStandardUI = 1 << 0,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -4321,10 +4321,11 @@ namespace AppKit {
 		Bezel,
 	}
 
+	/// <summary>Specifies options for replacing the contents of a pasteboard.</summary>
 	[NoMacCatalyst]
 	[Native]
 	public enum NSPasteboardContentsOptions : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>Restricts the pasteboard contents to the current host.</summary>
 		CurrentHostOnly = 1,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -4029,11 +4029,12 @@ namespace AppKit {
 		AllowUserInteraction = 0x1000,
 	}
 
+	/// <summary>Describes whether an application has visible content.</summary>
 	[NoMacCatalyst]
 	[Flags]
 	[Native]
 	public enum NSApplicationOcclusionState : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>At least part of the application's content is visible.</summary>
 		Visible = 1 << 1,
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -4185,11 +4185,12 @@ namespace AppKit {
 		NoHover = 1 << 3,
 	}
 
+	/// <summary>Specifies how to order windows in a window list.</summary>
 	[NoMacCatalyst]
 	[Flags]
 	[Native]
 	public enum NSWindowListOptions : long {
-		/// <summary>To be added.</summary>
+		/// <summary>Orders windows from front to back.</summary>
 		OrderedFrontToBack = (1 << 0),
 	}
 

--- a/src/AppKit/Enums.cs
+++ b/src/AppKit/Enums.cs
@@ -2537,11 +2537,12 @@ namespace AppKit {
 		Unitalic = 0x1000000,
 	}
 
+	/// <summary>Specifies options for writing objects to a pasteboard.</summary>
 	[NoMacCatalyst]
 	[Flags]
 	[Native]
 	public enum NSPasteboardWritingOptions : ulong {
-		/// <summary>To be added.</summary>
+		/// <summary>The object promises to provide its pasteboard data later.</summary>
 		WritingPromised = 1 << 9,
 	}
 

--- a/src/AudioUnit/AUEnums.cs
+++ b/src/AudioUnit/AUEnums.cs
@@ -1196,7 +1196,7 @@ namespace AudioUnit {
 		Cycling = 8,
 	}
 
-	/// <summary>Specifies when an audio unit event occurs.</summary>
+	/// <summary>Specifies sample times for scheduling audio unit events.</summary>
 	public enum AUEventSampleTime : long {
 		/// <summary>Schedules the event to occur immediately.</summary>
 		Immediate = unchecked((long) 0xffffffff00000000),

--- a/src/AudioUnit/AUEnums.cs
+++ b/src/AudioUnit/AUEnums.cs
@@ -1196,8 +1196,9 @@ namespace AudioUnit {
 		Cycling = 8,
 	}
 
+	/// <summary>Specifies when an audio unit event occurs.</summary>
 	public enum AUEventSampleTime : long {
-		/// <summary>To be added.</summary>
+		/// <summary>Schedules the event to occur immediately.</summary>
 		Immediate = unchecked((long) 0xffffffff00000000),
 	}
 

--- a/src/AudioUnit/AUEnums.cs
+++ b/src/AudioUnit/AUEnums.cs
@@ -358,11 +358,12 @@ namespace AudioUnit {
 		PlayThrough = 1886679669, // 'ptru'
 	}
 
+	/// <summary>Identifies an element of an audio object property.</summary>
 	[MacCatalyst (13, 1)]
 	[NoTV]
 	[NoiOS]
 	public enum AudioObjectPropertyElement : uint {
-		/// <summary>To be added.</summary>
+		/// <summary>The main element of the audio object.</summary>
 		Main = 0, // 0
 	}
 

--- a/src/VideoToolbox/VTDefs.cs
+++ b/src/VideoToolbox/VTDefs.cs
@@ -140,10 +140,10 @@ namespace VideoToolbox {
 	}
 
 	// uint32_t -> VTCompressionSession.h
-	/// <summary>Flags to control encoder in multi pass compression sessions</summary>
+	/// <summary>Specifies options for controlling an encoder in multipass compression sessions.</summary>
 	[Flags]
 	public enum VTCompressionSessionOptionFlags : uint {
-		/// <summary>To be added.</summary>
+		/// <summary>Begins the final pass of a multipass compression session.</summary>
 		BeginFinalPass = 1 << 0,
 	}
 

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22835,7 +22835,6 @@ T:AppKit.NSWindowDocumentDrag
 T:AppKit.NSWindowFrame
 T:AppKit.NSWindowFramePredicate
 T:AppKit.NSWindowLevel
-T:AppKit.NSWindowListOptions
 T:AppKit.NSWindowMenu
 T:AppKit.NSWindowNSWindow
 T:AppKit.NSWindowNumberListOptions

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22839,7 +22839,6 @@ T:AppKit.NSWindowListOptions
 T:AppKit.NSWindowMenu
 T:AppKit.NSWindowNSWindow
 T:AppKit.NSWindowNumberListOptions
-T:AppKit.NSWindowOcclusionState
 T:AppKit.NSWindowOrderingMode
 T:AppKit.NSWindowResize
 T:AppKit.NSWindowSharingType

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22913,7 +22913,6 @@ T:AudioToolbox.AUVoiceIOOtherAudioDuckingLevel
 T:AudioUnit.AU3DMixerRenderingFlags
 T:AudioUnit.AudioAggregateDriftCompensation
 T:AudioUnit.AudioComponentValidationResult
-T:AudioUnit.AudioObjectPropertyElement
 T:AudioUnit.AudioObjectPropertyScope
 T:AudioUnit.AudioObjectPropertySelector
 T:AudioUnit.AudioUnitBusType

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22386,7 +22386,6 @@ T:AppKit.NSApplicationFile
 T:AppKit.NSApplicationFileCommand
 T:AppKit.NSApplicationHandlesKey
 T:AppKit.NSApplicationMenu
-T:AppKit.NSApplicationOcclusionState
 T:AppKit.NSApplicationPredicate
 T:AppKit.NSApplicationPresentationOptions
 T:AppKit.NSApplicationPrint

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22594,7 +22594,6 @@ T:AppKit.NSPasteboardReadingOptions
 T:AppKit.NSPasteboardType
 T:AppKit.NSPasteboardTypeFindPanelSearchOptionKey
 T:AppKit.NSPasteboardTypeTextFinderOptionKey
-T:AppKit.NSPasteboardWritingOptions
 T:AppKit.NSPathStyle
 T:AppKit.NSPickerTouchBarItemControlRepresentation
 T:AppKit.NSPickerTouchBarItemSelectionMode

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22492,7 +22492,6 @@ T:AppKit.NSEventType
 T:AppKit.NSFocusRingPlacement
 T:AppKit.NSFocusRingType
 T:AppKit.NSFontAssetRequestOptions
-T:AppKit.NSFontCollectionOptions
 T:AppKit.NSFontCollectionVisibility
 T:AppKit.NSFontDescriptorSystemDesign
 T:AppKit.NSFontError

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22490,7 +22490,6 @@ T:AppKit.NSEventTrackHandler
 T:AppKit.NSEventType
 T:AppKit.NSFocusRingPlacement
 T:AppKit.NSFocusRingType
-T:AppKit.NSFontAssetRequestOptions
 T:AppKit.NSFontCollectionVisibility
 T:AppKit.NSFontDescriptorSystemDesign
 T:AppKit.NSFontError

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22919,7 +22919,6 @@ T:AudioUnit.AudioUnitBusType
 T:AudioUnit.AudioUnitEventType
 T:AudioUnit.AudioUnitParameterOptions
 T:AudioUnit.AudioUnitSubType
-T:AudioUnit.AUEventSampleTime
 T:AudioUnit.AUImplementorStringFromValueCallback
 T:AudioUnit.AUInternalRenderBlock
 T:AudioUnit.AUMidiCIProfileChangedCallback

--- a/tests/cecil-tests/Documentation.KnownFailures.txt
+++ b/tests/cecil-tests/Documentation.KnownFailures.txt
@@ -22578,7 +22578,6 @@ T:AppKit.NSPageControllerGetViewController
 T:AppKit.NSPageControllerTransitionStyle
 T:AppKit.NSPageLayoutResult
 T:AppKit.NSPasteboardAccessBehavior
-T:AppKit.NSPasteboardContentsOptions
 T:AppKit.NSPasteboardDetectionPattern
 T:AppKit.NSPasteboardDetectMetadataCompletionHandler
 T:AppKit.NSPasteboardDetectMetadataHandler


### PR DESCRIPTION
Improve XML documentation for:

- `NSPasteboardWritingOptions`
- `NSFontCollectionOptions`
- `NSApplicationOcclusionState`
- `NSWindowOcclusionState`
- `NSWindowListOptions`
- `NSPasteboardContentsOptions`
- `NSFontAssetRequestOptions`
- `VTCompressionSessionOptionFlags`
- `AudioObjectPropertyElement`
- `AUEventSampleTime`

Each type is documented in a separate commit. The Cecil documentation baseline is updated for the newly documented AppKit and AudioUnit types.

🤖 Pull request created by Copilot