### PR TITLE
[msbuild] Fix duplicate E7184 resource code

### DIFF
--- a/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
+++ b/msbuild/Xamarin.Localization.MSBuild/MSBStrings.resx
@@ -1710,7 +1710,7 @@
 {2} - The computed extraction path.
 {3} - The intended output directory.</comment>
     </data>
-    <data name="E7184" xml:space="preserve">
+    <data name="E7185" xml:space="preserve">
         <value>Could not determine the on-device destination path after copying '{0}' to the device. The 'xcrun devicectl' JSON output was: {1}</value>
         <comment>Shown when the DeviceCtl task copied a file to a device, but the on-device destination path could not be extracted from devicectl's JSON output.
 {0} - The path of the file that was copied to the device.

--- a/msbuild/Xamarin.MacDev.Tasks/Tasks/DeviceCtl.cs
+++ b/msbuild/Xamarin.MacDev.Tasks/Tasks/DeviceCtl.cs
@@ -92,7 +92,7 @@ namespace Xamarin.MacDev.Tasks {
 				// Fall through to the error below.
 			}
 
-			Log.LogError (MSBStrings.E7184 /* Could not determine the on-device destination path after copying '{0}' to the device. The 'xcrun devicectl' JSON output was: {1} */, CopySource, json);
+			Log.LogError (MSBStrings.E7185 /* Could not determine the on-device destination path after copying '{0}' to the device. The 'xcrun devicectl' JSON output was: {1} */, CopySource, json);
 			return "";
 		}
 	}


### PR DESCRIPTION
Renumber the net11.0-only DeviceCtl destination-path diagnostic from E7184 to E7185, preserving E7184 for the existing codesign diagnostic. Fixes the duplicate resource code.

🤖 Pull request created by Copilot